### PR TITLE
Activity Panel: Persist read status for inbox notes

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -284,7 +284,8 @@ export default withSelect( select => {
 		! Boolean( getNotesError( notesQuery ) ) &&
 		! isGetNotesRequesting( notesQuery ) &&
 		latestNote[ 0 ] &&
-		new Date( latestNote[ 0 ].date_created ).getTime() > userData.activity_panel_inbox_last_read;
+		new Date( latestNote[ 0 ].date_created_gmt ).getTime() >
+			userData.activity_panel_inbox_last_read;
 
 	if ( ! orderStatuses.length ) {
 		return { unreadNotes, unreadOrders: false };

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -260,13 +260,14 @@ class ActivityPanel extends Component {
 }
 
 export default withSelect( select => {
-	const { getCurrentUserData,
+	const {
+		getCurrentUserData,
 		getNotes,
 		getNotesError,
 		getReportItems,
 		getReportItemsError,
 		isGetNotesRequesting,
-		isReportItemsRequesting
+		isReportItemsRequesting,
 	} = select( 'wc-api' );
 	const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
 		'processing',

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -276,13 +276,13 @@ export default withSelect( select => {
 
 	const notesQuery = {
 		page: 1,
-		per_page: 3,
+		per_page: 1,
 	};
 
 	const latestNote = getNotes( notesQuery );
 	const unreadNotes =
-		! getNotesError &&
-		! isGetNotesRequesting &&
+		! Boolean( getNotesError( notesQuery ) ) &&
+		! isGetNotesRequesting( notesQuery ) &&
 		latestNote[ 0 ] &&
 		new Date( latestNote[ 0 ].date_created ).getTime() > userData.activity_panel_inbox_last_read;
 

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -92,13 +92,13 @@ class ActivityPanel extends Component {
 
 	// @todo Pull in dynamic unread status/count
 	getTabs() {
-		const { unreadOrders } = this.props;
+		const { unreadNotes, unreadOrders } = this.props;
 		return [
 			{
 				name: 'inbox',
 				title: __( 'Inbox', 'woocommerce-admin' ),
 				icon: <Gridicon icon="mail" />,
-				unread: true,
+				unread: unreadNotes,
 			},
 			{
 				name: 'orders',
@@ -260,14 +260,34 @@ class ActivityPanel extends Component {
 }
 
 export default withSelect( select => {
-	const { getReportItems, getReportItemsError, isReportItemsRequesting } = select( 'wc-api' );
+	const { getCurrentUserData,
+		getNotes,
+		getNotesError,
+		getReportItems,
+		getReportItemsError,
+		isGetNotesRequesting,
+		isReportItemsRequesting
+	} = select( 'wc-api' );
 	const orderStatuses = wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [
 		'processing',
 		'on-hold',
 	];
+	const userData = getCurrentUserData();
+
+	const notesQuery = {
+		page: 1,
+		per_page: 3,
+	};
+
+	const latestNote = getNotes( notesQuery );
+	const unreadNotes =
+		! getNotesError &&
+		! isGetNotesRequesting &&
+		latestNote[ 0 ] &&
+		new Date( latestNote[ 0 ].date_created ).getTime() > userData.activity_panel_inbox_last_read;
 
 	if ( ! orderStatuses.length ) {
-		return { unreadOrders: false };
+		return { unreadNotes, unreadOrders: false };
 	}
 
 	const ordersQuery = {
@@ -290,5 +310,5 @@ export default withSelect( select => {
 		}
 	}
 
-	return { unreadOrders };
+	return { unreadNotes, unreadOrders };
 } )( clickOutside( ActivityPanel ) );

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -20,9 +20,14 @@ import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
 class InboxPanel extends Component {
+	constructor( props ) {
+		super( props );
+		this.mountTime = Date.now();
+	}
+
 	componentWillUnmount() {
 		const userDataFields = {
-			[ 'activity_panel_inbox_last_read' ]: Date.now(),
+			[ 'activity_panel_inbox_last_read' ]: this.mountTime,
 		};
 		this.props.updateCurrentUserData( userDataFields );
 	}

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -90,7 +90,7 @@ class InboxPanel extends Component {
 								title={ note.title }
 								date={ note.date_created }
 								icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-								unread={ ! lastRead || new Date( note.date_created ).getTime() > lastRead }
+								unread={ ! lastRead || new Date( note.date_created_gmt ).getTime() > lastRead }
 								actions={ getButtonsFromActions( note.actions ) }
 							>
 								<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -8,7 +8,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
 import { withDispatch } from '@wordpress/data';
-import withSelect from 'wc-api/with-select';
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import ActivityHeader from '../activity-header';
 import { EmptyContent, Section } from '@woocommerce/components';
 import sanitizeHTML from 'lib/sanitize-html';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
+import withSelect from 'wc-api/with-select';
 
 class InboxPanel extends Component {
 	componentWillUnmount() {

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -20,14 +20,7 @@ import sanitizeHTML from 'lib/sanitize-html';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 
 class InboxPanel extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			lastRead: props.lastRead,
-		};
-	}
-
-	componentDidMount() {
+	componentWillUnmount() {
 		const userDataFields = {
 			[ 'activity_panel_inbox_last_read' ]: Date.now(),
 		};
@@ -35,8 +28,7 @@ class InboxPanel extends Component {
 	}
 
 	render() {
-		const { isError, isRequesting, notes } = this.props;
-		const { lastRead } = this.state;
+		const { isError, isRequesting, lastRead, notes } = this.props;
 
 		if ( isError ) {
 			const title = __(

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -46,6 +46,7 @@ function updateCurrentUserData( resourceNames, data, fetch ) {
 		'dashboard_chart_interval',
 		'dashboard_leaderboards',
 		'dashboard_leaderboard_rows',
+		'activity_panel_inbox_last_read',
 	];
 
 	if ( resourceNames.includes( resourceName ) ) {

--- a/lib/admin.php
+++ b/lib/admin.php
@@ -447,6 +447,7 @@ function wc_admin_get_user_data_fields() {
 		'dashboard_chart_interval',
 		'dashboard_leaderboards',
 		'dashboard_leaderboard_rows',
+		'activity_panel_inbox_last_read',
 	);
 
 	return apply_filters( 'wc_admin_get_user_data_fields', $user_data_fields );


### PR DESCRIPTION
Fixes #1817 

Adds a user meta field for the last read time to compare against note creation date and add an "unread" icon.

### Screenshots
<img width="508" alt="Screen Shot 2019-03-18 at 4 50 37 PM" src="https://user-images.githubusercontent.com/10561050/54517977-15bed880-499e-11e9-8dcc-6ed70c5b84ed.png">

### Detailed test instructions:

1. Open the Inbox activity panel (user meta `wc_admin_activity_panel_inbox_last_read` should not yet be set) and make sure notes appear unread.
2. Close the panel and re-open.
3. Make sure notes are now all read and icon next to inbox disappears.
4. Add a new note and make sure it appears unread on first open of the activity panel.

### Questions
Do we want to limit updating the read time unless all notes are scrolled into the viewport?  My hunch is no, but further discussion [here](https://github.com/woocommerce/woocommerce-admin/issues/1817).