### PR TITLE
Products: Group API search items by id

### DIFF
--- a/includes/api/class-wc-admin-rest-product-variations-controller.php
+++ b/includes/api/class-wc-admin-rest-product-variations-controller.php
@@ -64,28 +64,11 @@ class WC_Admin_REST_Product_Variations_Controller extends WC_REST_Product_Variat
 	public function get_items( $request ) {
 		add_filter( 'posts_where', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_join' ), 10, 2 );
-		add_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_product_search_group_by' ), 10, 2 );
+		add_filter( 'posts_groupby', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_group_by' ), 10, 2 );
 		$response = parent::get_items( $request );
 		remove_filter( 'posts_where', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_filter' ), 10 );
 		remove_filter( 'posts_join', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_join' ), 10 );
-		remove_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_product_search_group_by' ), 10 );
+		remove_filter( 'posts_groupby', array( 'WC_Admin_REST_Products_Controller', 'add_wp_query_product_search_group_by' ), 10 );
 		return $response;
-	}
-
-	/**
-	 * Group by post ID to prevent duplicates.
-	 *
-	 * @param string $groupby Group by clause used to organize posts.
-	 * @param object $wp_query WP_Query object.
-	 * @return string
-	 */
-	public function add_wp_query_product_search_group_by( $groupby, $wp_query ) {
-		global $wpdb;
-
-		$search = trim( $wp_query->get( 'search' ) );
-		if ( $search && empty( $groupby ) ) {
-			$groupby = $wpdb->posts . '.ID';
-		}
-		return $groupby;
 	}
 }

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -91,9 +91,11 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	public function get_items( $request ) {
 		add_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10, 2 );
 		add_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10, 2 );
+		add_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_product_search_group_by' ), 10, 2 );
 		$response = parent::get_items( $request );
 		remove_filter( 'posts_where', array( __CLASS__, 'add_wp_query_product_search_filter' ), 10 );
 		remove_filter( 'posts_join', array( __CLASS__, 'add_wp_query_product_search_join' ), 10 );
+		remove_filter( 'posts_groupby', array( __CLASS__, 'add_wp_query_product_search_group_by' ), 10 );
 		return $response;
 	}
 
@@ -134,6 +136,23 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 		}
 
 		return $join;
+	}
+
+	/**
+	 * Group by post ID to prevent duplicates.
+	 *
+	 * @param string $groupby Group by clause used to organize posts.
+	 * @param object $wp_query WP_Query object.
+	 * @return string
+	 */
+	public function add_wp_query_product_search_group_by( $groupby, $wp_query ) {
+		global $wpdb;
+
+		$search = trim( $wp_query->get( 'search' ) );
+		if ( $search && empty( $groupby ) ) {
+			$groupby = $wpdb->posts . '.ID';
+		}
+		return $groupby;
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/1834

Before, searching for a product sometimes returned duplicate entries.

![Screen Shot 2019-03-19 at 1 55 43 PM](https://user-images.githubusercontent.com/1922453/54574430-22523800-4a55-11e9-9069-648148c7d96e.png)

This PR groups response items by id to avoid duplication.

### Detailed test instructions:

1. Product Report > Show > Single Product.
2. Search for a product.
3. Ensure the results don't include duplicated items.
