### PR TITLE
Fix#1768 Added a Margin of 40 pixel for better user interface, on mobile devices.

### DIFF
--- a/client/analytics/settings/index.scss
+++ b/client/analytics/settings/index.scss
@@ -11,9 +11,7 @@
 		margin-left: 15%;
 	}
 
-	@include breakpoint( '<782px' ) {
-		margin-bottom: 40px;
-	}
+		margin-bottom: $gap-largest;
 
 	button {
 		margin-right: $gap;

--- a/client/analytics/settings/index.scss
+++ b/client/analytics/settings/index.scss
@@ -11,6 +11,10 @@
 		margin-left: 15%;
 	}
 
+	@include breakpoint( '<782px' ) {
+		margin-bottom: 40px;
+	}
+
 	button {
 		margin-right: $gap;
 	}

--- a/client/analytics/settings/index.scss
+++ b/client/analytics/settings/index.scss
@@ -7,11 +7,11 @@
 }
 
 .woocommerce-settings__actions {
+	margin-bottom: $gap-largest;
+	
 	@include breakpoint( '>1280px' ) {
 		margin-left: 15%;
 	}
-
-		margin-bottom: $gap-largest;
 
 	button {
 		margin-right: $gap;


### PR DESCRIPTION
Fixes #1768 

_Replace this with a good description of your changes & reasoning._

### Screenshots
![screenshot-localhost-2019 03 19-15-34-11](https://user-images.githubusercontent.com/24435113/54597405-888e8900-4a5c-11e9-86ed-919c7ea03a4e.png)

### Detailed test instructions:

- Open Settings page in the analytics tab on mobile.
- Now it is visible properly. First, there was no bottom space.
