### PR TITLE
Check for existence of orders before adding historical data note

### DIFF
--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -67,9 +67,8 @@ class WC_Admin_Install {
 		wc_maybe_define_constant( 'WC_ADMIN_INSTALLING', true );
 
 		self::create_tables();
-		self::update_wc_admin_version();
-
 		WC_Admin_Notes_Historical_Data::add_note();
+		self::update_wc_admin_version();
 
 		delete_transient( 'wc_admin_installing' );
 

--- a/includes/notes/class-wc-admin-notes-historical-data.php
+++ b/includes/notes/class-wc-admin-notes-historical-data.php
@@ -19,11 +19,15 @@ class WC_Admin_Notes_Historical_Data {
 	 * Creates a note for regenerating historical data.
 	 */
 	public static function add_note() {
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$is_upgrading = get_option( WC_Admin_Install::VERSION_OPTION );
+		if ( $is_upgrading ) {
+			return;
+		}
 
-		// First, see if we've already created this kind of note so we don't do it again.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		$orders   = wc_get_orders(
+		// First, see if orders exist and if we've already created this kind of note so we don't do it again.
+		$data_store = WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		$orders     = wc_get_orders(
 			array(
 				'limit' => 1,
 			)

--- a/includes/notes/class-wc-admin-notes-historical-data.php
+++ b/includes/notes/class-wc-admin-notes-historical-data.php
@@ -23,7 +23,12 @@ class WC_Admin_Notes_Historical_Data {
 
 		// First, see if we've already created this kind of note so we don't do it again.
 		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		$orders   = wc_get_orders(
+			array(
+				'limit' => 1,
+			)
+		);
+		if ( ! empty( $note_ids ) || count( $orders ) < 1 ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1935 

Prevents historical data notice on install if no orders are found.

### Screenshots
<img width="1035" alt="Screen Shot 2019-03-29 at 2 35 35 PM" src="https://user-images.githubusercontent.com/10561050/55213944-fb9fb880-522f-11e9-813c-746344480c07.png">

### Detailed test instructions:

1.  Create a new install without orders.
2. Activate the plugin.
3. Note that the above note is not displayed.
4. Add an order.
5. Note the note doesn't exist still as it should only run on install.
6. Bump your version (`wc_admin_version` in the options table).
7. Note the note still doesn't exist.
8.  Create a new install with an order.
9. Activate the plugin.
19. Note the note exists. 🗒