### PR TITLE
Include child category stats in parent

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-data-store.php
@@ -985,4 +985,18 @@ class WC_Admin_Reports_Data_Store {
 		return $operator;
 	}
 
+	/**
+	 * Returns the same array index by a given key
+	 *
+	 * @param array  $array Array to be looped over.
+	 * @param string $key Key of values used for new array.
+	 * @return array
+	 */
+	protected function map_array_by_key( $array, $key ) {
+		$mapped = array();
+		foreach ( $array as $item ) {
+			$mapped[ $item[ $key ] ] = $item;
+		}
+		return $mapped;
+	}
 }

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -297,21 +297,6 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	}
 
 	/**
-	 * Returns the same array index by a given key
-	 *
-	 * @param array  $array Array to be looped over.
-	 * @param string $key Key of values used for new array.
-	 * @return array
-	 */
-	protected function map_array_by_key( $array, $key ) {
-		$mapped = array();
-		foreach ( $array as $item ) {
-			$mapped[ $item[ $key ] ] = $item;
-		}
-		return $mapped;
-	}
-
-	/**
 	 * Get product IDs, names, and quantity from order IDs.
 	 *
 	 * @param array $order_ids Array of order IDs.


### PR DESCRIPTION
Fixes #1915

Adds child stats to the parents so that parent stats include child stats.

### Questions / Thoughts

I'm pretty sure I'll close this PR in favor of a better solution, but wanted to get some feedback first.

Aside from performance issues that exist here, the biggest issue is that any `_count` fields that grab unique values may be inaccurate due to the getting a distinct count and then merging stats together. (E.g., A parent category having Child Category A and Child Category B that contain products sharing at least one category will add the "unique" order count together which will be off by the number of shared orders.)

I'm thinking the most performant and structurally sound method here would be to create a category lookup table using something similar to a closure pattern built for hierarchical data.

Alternatively, we could prefetch all categories and category relationships (much like what this PR does but instead done before the db queries).  We could then join based on a number of conditions to simulate a hierarchical join.  This resolves the count issues, but retains many of the performance issues in this PR.

/cc @peterfabian 

### Before
<img width="924" alt="Screen Shot 2019-04-02 at 2 57 50 PM" src="https://user-images.githubusercontent.com/10561050/55382233-be9d3400-5557-11e9-9c43-cc9653f4c0da.png">

### After
<img width="921" alt="Screen Shot 2019-04-02 at 2 54 59 PM" src="https://user-images.githubusercontent.com/10561050/55382238-c1982480-5557-11e9-8f96-3d67f1e7a164.png">

### Detailed test instructions:

1.  Create a parent category and any number of child categories.
2.  Create orders that fall under the child categories.
3.  Check reports for the parent category and make sure they include stats from the child.
4.  Note the unique orders count is not accurate for any overlapping categories between products. 😞 