### PR TITLE
Only check for unsnooze note scheduled action in admin_init

### DIFF
--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -18,16 +18,10 @@ class WC_Admin_Notes {
 	const UNSNOOZE_HOOK = 'wc_admin_unsnooze_admin_notes';
 
 	/**
-	 * Schedule events and hook appropriate actions.
+	 * Hook appropriate actions.
 	 */
 	public static function init() {
-		$queue = WC()->queue();
-		$next  = $queue->get_next( self::UNSNOOZE_HOOK );
-
-		if ( ! $next ) {
-			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK );
-		}
-
+		add_action( 'admin_init', array( __CLASS__, 'schedule_unsnooze_notes' ) );
 		add_action( self::UNSNOOZE_HOOK, array( __CLASS__, 'unsnooze_notes' ) );
 	}
 
@@ -126,6 +120,18 @@ class WC_Admin_Notes {
 				$note->set_date_reminder( null );
 				$note->save();
 			}
+		}
+	}
+
+	/**
+	 * Schedule unsnooze notes event.
+	 */
+	public static function schedule_unsnooze_notes() {
+		$queue = WC()->queue();
+		$next  = $queue->get_next( self::UNSNOOZE_HOOK );
+
+		if ( ! $next ) {
+			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1946

The current code checks for the scheduled action on every load. This PR moves that check to `admin_init`.

### Detailed test instructions:

- Use the query monitor plugin to check that the query identified in the issue is only being run in the dashboard.
