### PR TITLE
update requirements in GH readme, plugin header

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[Gutenberg](https://wordpress.org/plugins/gutenberg/) and [WooCommerce](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.0 or greater](https://wordpress.org/download/) and [WooCommerce 3.5.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -9,6 +9,9 @@
  * Domain Path: /languages
  * Version: 0.9.0
  *
+ * WC requires at least: 3.5.0
+ * WC tested up to: 3.5.7
+ *
  * @package WC_Admin
  */
 


### PR DESCRIPTION
Fixes #1940

In addition to updating the readme, this PR also adds the WC header lines to the plugin header to allow WooCommerce to signal compatibility to the site owner.

