### PR TITLE
Fixed: Order Status filter: <select> is not vertically aligned when Gutenberg is installed

### DIFF
--- a/packages/components/src/filters/style.scss
+++ b/packages/components/src/filters/style.scss
@@ -104,3 +104,9 @@
 		}
 	}
 }
+
+.woocommerce-filters-advanced__list-item {
+	.components-base-control + .components-base-control {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
Fixes #1895 

Add new style rule to override Gutenberg style and make sure the select boxes of the Advance filter are always inline.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
As #1895 

### Detailed test instructions:

1. Install Gutenberg (https://wordpress.org/plugins/gutenberg/) — tested with 5.2.0 and 5.3.0.
2. Go to the Orders report.
3. Open the Advanced Filters.
4. Add an Order Status filter.
5. Notice the select is correctly aligned.