### PR TITLE
add filter length condition to enable filter check

### DIFF
--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -184,7 +184,7 @@ class AdvancedFilters extends Component {
 		const { activeFilters, match } = this.state;
 		const availableFilterKeys = this.getAvailableFilterKeys();
 		const updateHref = this.getUpdateHref( activeFilters, match );
-		const updateDisabled = window.location.hash && window.location.hash.substr( 1 ) === updateHref;
+		const updateDisabled = window.location.hash && ( window.location.hash.substr( 1 ) === updateHref || 0 === activeFilters.length );
 		const isEnglish = this.isEnglish();
 		return (
 			<Card className="woocommerce-filters-advanced" title={ this.getTitle() }>


### PR DESCRIPTION
Fixes #1932

This PR adds a filter check to disable the filter button if there are no current filters.

### Detailed test instructions:

- Go to the Customer Report
- Click Advanced Filters
- Change from `All` to `Any`
- The `Filter` button should be disabled until a filter value is added 

