### PR TITLE
center mobile icon vertically

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -151,7 +151,7 @@
 	max-width: 48px;
 	height: 46px;
 	position: fixed;
-	top: 46px;
+	top: 50px;
 	right: 0;
 	@include breakpoint( '>782px' ) {
 		display: none;


### PR DESCRIPTION
Fixes #1931

This PR changes the top position of the icon to centre it vertically. 

### Screenshots
<img width="239" alt="Screen Shot 2019-04-03 at 11 17 47 AM" src="https://user-images.githubusercontent.com/343847/55486164-33c54380-5602-11e9-8e45-323f8f6ea57b.png">

### Detailed test instructions:

- Use a mobile device or emulator
- Go to the WCA dashboard
- Check the position of the toggle icon on the right

