### PR TITLE
add WCA queue group to the unsnooze notes scheduled action

### DIFF
--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -131,7 +131,7 @@ class WC_Admin_Notes {
 		$next  = $queue->get_next( self::UNSNOOZE_HOOK );
 
 		if ( ! $next ) {
-			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK );
+			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK, array(), WC_Admin_Reports_Sync::QUEUE_GROUP );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #

I just noticed that the unsnooze notes scheduled action isn't running in the WooCommerce Admin action group. This PR adds the group.

### Detailed test instructions:

- Got to Tools -> Scheduled Actions -> Pending
- Delete the `wc_admin_unsnooze_admin_notes`
- The scheduled action should be recreated in the `wc-admin-data` group.
