### PR TITLE
remove unneeded build:feature-config from zip build

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -63,7 +63,6 @@ fi
 
 # Run the build.
 status "Generating build... 👷‍♀️"
-npm run build:feature-config
 npm run build
 npm run docs
 


### PR DESCRIPTION
The `npm run build:feature-config` is not needed in the plugin zip build process because the `npm run build` in the next line calls `npm run build:feature-config` first.


### Detailed test instructions:

- at the command line run `npm run build:release`
- Assuming you working tree is clean this should produce a `woocommerce-admin.zip` in the root folder of the repo.

