### PR TITLE
Ensure the feature-config.php file is built with `npm run build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', tru
 After cloning the repo, install dependencies with `npm install`. Now you can build the files using one of these commands:
 
  - `npm run build` : Build a production version
+ - `npm run dev` : Build a development version
  - `npm start` : Build a development version, watch files for changes
  - `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
 

--- a/bin/generate-feature-config.php
+++ b/bin/generate-feature-config.php
@@ -5,9 +5,15 @@
  * @package WooCommerce Admin
  */
 
+/**
+ * Get phase for feature flags
+ * - development: All features should be enabled in development.
+ * - plugin: For the standalone feature plugin, for GitHub and WordPress.org.
+ * - core: Stable features for WooCommerce core merge.
+ */
 $phase = isset( $_SERVER['WC_ADMIN_PHASE'] ) ? $_SERVER['WC_ADMIN_PHASE'] : ''; // WPCS: sanitization ok.
 if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
-	$phase = 'development';
+	$phase = 'plugin'; // Default to plugin when running `npm run build`.
 }
 $config_json = file_get_contents( 'config/' . $phase . '.json' );
 $config      = json_decode( $config_json );

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "npm run build:feature-config && npm run build:packages && npm run build:core",
     "postbuild": "npm run -s i18n:php && npm run -s i18n:pot",
     "build:core": "cross-env NODE_ENV=production webpack",
-    "build:feature-config": "WC_ADMIN_PHASE=core php bin/generate-feature-config.php && WC_ADMIN_PHASE=plugin php bin/generate-feature-config.php",
+    "build:feature-config": "php bin/generate-feature-config.php",
     "build:packages": "node ./bin/packages/build.js",
     "build:release": "cross-env WC_ADMIN_PHASE=plugin ./bin/build-plugin-zip.sh",
     "clean": "rimraf ./dist ./packages/*/build ./packages/*/build-module ./packages/*/build-style",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "npm run build:feature-config && npm run build:packages && npm run build:core",
     "postbuild": "npm run -s i18n:php && npm run -s i18n:pot",
     "build:core": "cross-env NODE_ENV=production webpack",
-    "build:feature-config": "WC_ADMIN_PHASE=core php bin/generate-feature-config.php",
+    "build:feature-config": "WC_ADMIN_PHASE=core php bin/generate-feature-config.php && WC_ADMIN_PHASE=plugin php bin/generate-feature-config.php",
     "build:packages": "node ./bin/packages/build.js",
     "build:release": "cross-env WC_ADMIN_PHASE=plugin ./bin/build-plugin-zip.sh",
     "clean": "rimraf ./dist ./packages/*/build ./packages/*/build-module ./packages/*/build-style",


### PR DESCRIPTION
Fixes #2053

When setting up woocommerce-admin for the first time today, and running `npm run build` I was faced with the fatal error in #2053.

Diving in I could see that the plugin requires a `feature-config.php` file which can be built by `generate-feature-config.php`. However, the changes implemented in https://github.com/woocommerce/woocommerce-admin/pull/1863 made this script generate 2 different files depending on the phase:

- Core = `includes/feature-config.php` 
- Anything else = `dist/feature-config-core.php`

<del>The dist file is included in package.json. I guess the intention there is so if the plugin is included in WooCommerce core, the dist file is pulled in since it's defined in the package file? @justinshreve?</del>
 
<del>To solve this I modified `"build:feature-config"` to build both the core file (`dist/feature-config-core.php`) and the required feature-config.php file (`includes/feature-config.php`). But I'm not sure if this is correct because I presume you need one or the other depending on type of release...</del>

This PR resolves the issue by defaulting to the `plugin` phase, rather than the `core` phase. The `core` phase is only used during `prepack`.

`development` phase will work when using `npm start` or `npm run dev`.

Added some inline docs for clarification also.

### Detailed test instructions:

- Checkout repo for first time
- Run `npm install`
- Run `npm run build`
- Activate plugin. Before this patch there was a fatal error.
