### PR TITLE
add check for woocommerce submenu item array

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -187,7 +187,7 @@ class WC_Admin_Loader {
 	public static function update_link_structure() {
 		global $submenu;
 		// User does not have capabilites to see the submenu.
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) || empty( $submenu['woocommerce'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2126

The `$submenu['woocommerce']` array doesn't exist in either network or user admin. This PR adds a check to ensure that the submenu item exists.

### Detailed test instructions:

- Enable multisite
- Load the network admin dashboard

