### PR TITLE
add defaultOrder field to tablecard header

### DIFF
--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -116,7 +116,7 @@ class Table extends Component {
 			'is-scrollable': isScrollable,
 		} );
 		const sortedBy = query.orderby || get( find( headers, { defaultSort: true } ), 'key', false );
-		const sortDir = query.order || DESC;
+		const sortDir = query.order || get( find( headers, { key: sortedBy } ), 'defaultOrder', DESC );
 
 		return (
 			<div
@@ -248,6 +248,10 @@ Table.propTypes = {
 			 * Boolean, true if this column is the default for sorting. Only one column should have this set.
 			 */
 			defaultSort: PropTypes.bool,
+			/**
+			 * String, asc|desc if this column is the default for sorting. Only one column should have this set.
+			 */
+			defaultOrder: PropTypes.string,
 			/**
 			 * Boolean, true if this column should be aligned to the left.
 			 */


### PR DESCRIPTION
Fixes #2136

This PR adds a `defaultOrder` field to the headers prototype to allow specifying whether the default sort column is initially sorted in ascending or descending order.


### Screenshots

Screenshot showing `query` is an empty object, header `defaultOrder` set, chevron showing ascending:

<img width="1106" alt="Screen Shot 2019-04-30 at 3 15 26 PM" src="https://user-images.githubusercontent.com/343847/56983764-d538aa00-6b5a-11e9-9c0e-f4044cf41496.png">

### Detailed test instructions:

- Tomorrow I'll update my example component branch to use `defaultOrder`
- Alternative would be to test by modifying the example component in this repo
