### PR TITLE
add a defaultValue parameter to the ReportFilters component

### DIFF
--- a/client/analytics/components/report-chart/utils.js
+++ b/client/analytics/components/report-chart/utils.js
@@ -22,7 +22,7 @@ export function getSelectedFilter( filters, query, selectedFilterArgs = {} ) {
 
 	if ( filterConfig.showFilters( query, selectedFilterArgs ) ) {
 		const allFilters = flattenFilters( filterConfig.filters );
-		const value = query[ filterConfig.param ] || DEFAULT_FILTER;
+		const value = query[ filterConfig.param ] || filterConfig.defaultValue || DEFAULT_FILTER;
 		return find( allFilters, { value } );
 	}
 

--- a/packages/components/src/filters/filter/index.js
+++ b/packages/components/src/filters/filter/index.js
@@ -110,7 +110,7 @@ class FilterPicker extends Component {
 		// Keep only time related queries when updating to a new filter
 		const persistedQuery = getPersistedQuery( query );
 		const update = {
-			[ config.param ]: 'all' === value ? undefined : value,
+			[ config.param ]: ( config.defaultValue || DEFAULT_FILTER ) === value ? undefined : value,
 			...additionalQueries,
 		};
 		// Keep any url parameters as designated by the config
@@ -120,7 +120,7 @@ class FilterPicker extends Component {
 		updateQueryString( update, path, persistedQuery );
 	}
 
-	onTagChange( filter, onClose, tags ) {
+	onTagChange( filter, onClose, config, tags ) {
 		const tag = last( tags );
 		const { value, settings } = filter;
 		const { param: filterParam } = settings;
@@ -128,12 +128,12 @@ class FilterPicker extends Component {
 			this.update( value, { [ filterParam ]: tag.id } );
 			onClose();
 		} else {
-			this.update( 'all' );
+			this.update( config.defaultValue || DEFAULT_FILTER );
 		}
 		this.updateSelectedTag( [ tag ] );
 	}
 
-	renderButton( filter, onClose ) {
+	renderButton( filter, onClose, config ) {
 		if ( filter.component ) {
 			const { type, labels } = filter.settings;
 			const persistedFilter = this.getFilter();
@@ -145,7 +145,7 @@ class FilterPicker extends Component {
 					type={ type }
 					placeholder={ labels.placeholder }
 					selected={ selectedTag ? [ selectedTag ] : [] }
-					onChange={ partial( this.onTagChange, filter, onClose ) }
+					onChange={ partial( this.onTagChange, filter, onClose, config ) }
 					inlineTags
 					staticResults
 				/>
@@ -202,7 +202,11 @@ class FilterPicker extends Component {
 						/>
 					) }
 					renderContent={ ( { onClose } ) => (
-						<AnimationSlider animationKey={ nav } animate={ animate } onExited={ this.onContentMount }>
+						<AnimationSlider
+							animationKey={ nav }
+							animate={ animate }
+							onExited={ this.onContentMount }
+						>
 							{ () => (
 								<ul className="woocommerce-filters-filter__content-list">
 									{ parentFilter && (
@@ -225,7 +229,7 @@ class FilterPicker extends Component {
 													( selectedFilter.path && includes( selectedFilter.path, filter.value ) ),
 											} ) }
 										>
-											{ this.renderButton( filter, onClose ) }
+											{ this.renderButton( filter, onClose, config ) }
 										</li>
 									) ) }
 								</ul>

--- a/packages/components/src/filters/filter/index.js
+++ b/packages/components/src/filters/filter/index.js
@@ -74,7 +74,7 @@ class FilterPicker extends Component {
 	getFilter( value ) {
 		const { config, query } = this.props;
 		const allFilters = flattenFilters( config.filters );
-		value = value || query[ config.param ] || DEFAULT_FILTER;
+		value = value || query[ config.param ] || config.defaultValue || DEFAULT_FILTER;
 		return find( allFilters, { value } ) || {};
 	}
 
@@ -255,6 +255,10 @@ FilterPicker.propTypes = {
 		 * The url paramter this filter will modify.
 		 */
 		param: PropTypes.string.isRequired,
+		/**
+		 * The default paramter value to use instead of 'all'.
+		 */
+		defaultValue: PropTypes.string,
 		/**
 		 * Determine if the filter should be shown. Supply a function with the query object as an argument returning a boolean.
 		 */


### PR DESCRIPTION
Fixes #2149

This PR adds an optional `defaultValue` parameter to the ReportFilters component to be used before the default `all` filter. This eliminates both the restrictions identified in the issue. 

### Detailed test instructions:

- Install my example component https://github.com/Prospress/action-scheduler-admin/pull/6
- Go to Analytics -> Scheduled Actions
- `Pending` status is selected in the Report Filters dropdown component
- Use sorting and filtering to verify the component continues to work as expected.

