### PR TITLE
fix customer name logic on populating customer lookup data

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -525,25 +525,24 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 
 		if (
 			$user_id &&
-			get_user_meta( $user_id, 'first_name', true ) ||
-			get_user_meta( $user_id, 'last_name', true )
+			(
+				get_user_meta( $user_id, 'first_name', true ) ||
+				get_user_meta( $user_id, 'last_name', true )
+			)
 		) {
 			$first_name = get_user_meta( $user_id, 'first_name', true );
 			$last_name  = get_user_meta( $user_id, 'last_name', true );
-		} elseif (
-			$order &&
-			$order->get_billing_first_name( 'edit' ) ||
-			$order->get_billing_last_name( 'edit' )
-		) {
-			$first_name = $order->get_billing_first_name( 'edit' );
-			$last_name  = $order->get_billing_last_name( 'edit' );
-		} elseif (
-			$order &&
-			$order->get_shipping_first_name( 'edit' ) ||
-			$order->get_shipping_last_name( 'edit' )
-		) {
-			$first_name = $order->get_shipping_first_name( 'edit' );
-			$last_name  = $order->get_shipping_last_name( 'edit' );
+		} elseif ( $order ) {
+			if (
+				$order->get_billing_first_name( 'edit' ) ||
+				$order->get_billing_last_name( 'edit' )
+			) {
+				$first_name = $order->get_billing_first_name( 'edit' );
+				$last_name  = $order->get_billing_last_name( 'edit' );
+			} else {
+				$first_name = $order->get_shipping_first_name( 'edit' );
+				$last_name  = $order->get_shipping_last_name( 'edit' );
+			}
 		}
 
 		return apply_filters( 'woocommerce_reports_customer_name', array( $first_name, $last_name ), $order );


### PR DESCRIPTION
Fixes #2180

This PR fixes the logic for populating the customer first/last name in the customer lookup table. In PHP conditional evaluation `if ( $a && $b || $c ) {` when `$a` is false then `$c` is evaluated. The new logic only calls the last name lookup when there is a valid user ID/order.


### Detailed test instructions:

1. Create an order
2. Process the historical data
3. Manually delete the order from the database
4. Use #2177 to re-import the data
5. The scheduled action should complete

