### PR TITLE
Low stock handling inconsistencies with WooCommerce 3.6+

### DIFF
--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __, _n } from '@wordpress/i18n';
+import { __, _n, _x } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 
 /**
@@ -16,6 +16,7 @@ import { numberFormat } from '@woocommerce/number';
  * Internal dependencies
  */
 import ReportTable from 'analytics/components/report-table';
+import { isLowStock } from './utils';
 
 export default class StockReportTable extends Component {
 	constructor() {
@@ -60,7 +61,16 @@ export default class StockReportTable extends Component {
 		const { stockStatuses } = wcSettings;
 
 		return products.map( product => {
-			const { id, manage_stock, name, parent_id, sku, stock_quantity, stock_status } = product;
+			const {
+				id,
+				manage_stock,
+				name,
+				parent_id,
+				sku,
+				stock_quantity,
+				stock_status,
+				low_stock_amount,
+			} = product;
 
 			const productDetailLink = getNewPath( persistedQuery, '/analytics/products', {
 				filter: 'single_product',
@@ -73,7 +83,11 @@ export default class StockReportTable extends Component {
 				</Link>
 			);
 
-			const stockStatusLink = (
+			const stockStatusLink = isLowStock( stock_status, stock_quantity, low_stock_amount ) ? (
+				<Link href={ 'post.php?action=edit&post=' + ( parent_id || id ) } type="wp-admin">
+					{ _x( 'Low', 'Indication of a low quantity', 'woocommerce-admin' ) }
+				</Link>
+			) : (
 				<Link href={ 'post.php?action=edit&post=' + ( parent_id || id ) } type="wp-admin">
 					{ stockStatuses[ stock_status ] }
 				</Link>

--- a/client/analytics/report/stock/utils.js
+++ b/client/analytics/report/stock/utils.js
@@ -1,0 +1,15 @@
+/**
+ * Determine if a product or variation is in low stock.
+ *
+ * @format
+ * @param {number} threshold - The number at which stock is determined to be low.
+ * @returns {boolean} - Whether or not the stock is low.
+ */
+
+export function isLowStock( status, quantity, threshold ) {
+	if ( ! quantity ) {
+		// Sites that don't do inventory tracking will always return false.
+		return false;
+	}
+	return 'instock' === status && quantity <= threshold;
+}

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -131,6 +131,7 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 			$where           .= "
 			AND wc_product_meta_lookup.stock_quantity IS NOT NULL
+			AND wc_product_meta_lookup.stock_status = 'instock'
 			AND (
 				(
 					low_stock_amount_meta.meta_value > ''

--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -124,24 +124,24 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 			$search = $wpdb->esc_like( $search );
 			$search = "'%" . $search . "%'";
 			$where .= " AND ({$wpdb->posts}.post_title LIKE {$search}";
-			$where .= wc_product_sku_enabled() ? ' OR ps_post_meta.meta_key = "_sku" AND ps_post_meta.meta_value LIKE ' . $search . ')' : ')';
+			$where .= wc_product_sku_enabled() ? ' OR wc_product_meta_lookup.sku LIKE ' . $search . ')' : ')';
 		}
 
 		if ( $wp_query->get( 'low_in_stock' ) ) {
 			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 			$where           .= "
-			AND manage_stock_meta.meta_value = 'yes'
-			AND stock_meta.meta_value IS NOT NULL
+			AND wc_product_meta_lookup.stock_quantity IS NOT NULL
 			AND (
 				(
 					low_stock_amount_meta.meta_value > ''
-					AND CAST(stock_meta.meta_value AS SIGNED) <= CAST(stock_meta.meta_value AS SIGNED)
+					AND wc_product_meta_lookup.stock_quantity <= CAST(low_stock_amount_meta.meta_value AS SIGNED)
 				)
 				OR (
-					low_stock_amount_meta.meta_value <= ''
-					AND CAST(stock_meta.meta_value AS SIGNED) <= {$low_stock_amount}
+					(
+						low_stock_amount_meta.meta_value IS NULL OR low_stock_amount_meta.meta_value <= ''
+					)
+					AND wc_product_meta_lookup.stock_quantity <= {$low_stock_amount}
 				)
-				OR low_stock_amount_meta.meta_value IS NULL
 			)";
 		}
 
@@ -160,17 +160,30 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 
 		$search = $wp_query->get( 'search' );
 		if ( $search && wc_product_sku_enabled() ) {
-			$join .= " INNER JOIN {$wpdb->postmeta} AS ps_post_meta ON ps_post_meta.post_id = {$wpdb->posts}.ID";
+			$join = self::append_product_sorting_table_join( $join );
 		}
 
 		if ( $wp_query->get( 'low_in_stock' ) ) {
-			$join .= " INNER JOIN {$wpdb->postmeta} AS stock_meta ON {$wpdb->posts}.ID = stock_meta.post_id AND stock_meta.meta_key = '_stock'
-			INNER JOIN {$wpdb->postmeta} AS manage_stock_meta ON {$wpdb->posts}.ID = manage_stock_meta.post_id AND manage_stock_meta.meta_key = '_manage_stock'
-			LEFT JOIN {$wpdb->postmeta} AS low_stock_amount_meta ON {$wpdb->posts}.ID = low_stock_amount_meta.post_id AND low_stock_amount_meta.meta_key = '_low_stock_amount'
-			";
+			$join  = self::append_product_sorting_table_join( $join );
+			$join .= " LEFT JOIN {$wpdb->postmeta} AS low_stock_amount_meta ON {$wpdb->posts}.ID = low_stock_amount_meta.post_id AND low_stock_amount_meta.meta_key = '_low_stock_amount' ";
 		}
 
 		return $join;
+	}
+
+	/**
+	 * Join wc_product_meta_lookup to posts if not already joined.
+	 *
+	 * @param string $sql SQL join.
+	 * @return string
+	 */
+	protected static function append_product_sorting_table_join( $sql ) {
+		global $wpdb;
+
+		if ( ! strstr( $sql, 'wc_product_meta_lookup' ) ) {
+			$sql .= " LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON $wpdb->posts.ID = wc_product_meta_lookup.product_id ";
+		}
+		return $sql;
 	}
 
 	/**

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -170,6 +170,7 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 			$where           .= "
 			AND wc_product_meta_lookup.stock_quantity IS NOT NULL
+			AND wc_product_meta_lookup.stock_status = 'instock'
 			AND (
 				(
 					low_stock_amount_meta.meta_value > ''

--- a/includes/api/class-wc-admin-rest-reports-stock-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-stock-controller.php
@@ -283,14 +283,19 @@ class WC_Admin_REST_Reports_Stock_Controller extends WC_REST_Reports_Controller 
 	 */
 	public function prepare_item_for_response( $product, $request ) {
 		$data = array(
-			'id'             => $product->get_id(),
-			'parent_id'      => $product->get_parent_id(),
-			'name'           => $product->get_name(),
-			'sku'            => $product->get_sku(),
-			'stock_status'   => $product->get_stock_status(),
-			'stock_quantity' => (float) $product->get_stock_quantity(),
-			'manage_stock'   => $product->get_manage_stock(),
+			'id'               => $product->get_id(),
+			'parent_id'        => $product->get_parent_id(),
+			'name'             => $product->get_name(),
+			'sku'              => $product->get_sku(),
+			'stock_status'     => $product->get_stock_status(),
+			'stock_quantity'   => (float) $product->get_stock_quantity(),
+			'manage_stock'     => $product->get_manage_stock(),
+			'low_stock_amount' => $product->get_low_stock_amount(),
 		);
+
+		if ( '' === $data['low_stock_amount'] ) {
+			$data['low_stock_amount'] = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
+		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );

--- a/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
@@ -51,35 +51,45 @@ class WC_Admin_Reports_Stock_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 	}
 
 	/**
-	 * Get low stock count.
+	 * Get low stock count (products with stock < low stock amount, but greater than no stock amount).
 	 *
 	 * @return int Low stock count.
 	 */
 	private function get_low_stock_count() {
-		$query_args               = array();
-		$query_args['post_type']  = array( 'product', 'product_variation' );
-		$low_stock                = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
-		$no_stock                 = absint( max( get_option( 'woocommerce_notify_no_stock_amount' ), 0 ) );
-		$query_args['meta_query'] = array( // WPCS: slow query ok.
-			array(
-				'key'   => '_manage_stock',
-				'value' => 'yes',
-			),
-			array(
-				'key'     => '_stock',
-				'value'   => array( $no_stock, $low_stock ),
-				'compare' => 'BETWEEN',
-				'type'    => 'NUMERIC',
-			),
-			array(
-				'key'   => '_stock_status',
-				'value' => 'instock',
-			),
-		);
+		global $wpdb;
 
-		$query = new WP_Query();
-		$query->query( $query_args );
-		return intval( $query->found_posts );
+		$no_stock_amount  = absint( max( get_option( 'woocommerce_notify_no_stock_amount' ), 0 ) );
+		$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
+
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"
+				SELECT count( DISTINCT posts.ID ) FROM {$wpdb->posts} posts
+				LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON posts.ID = wc_product_meta_lookup.product_id
+				LEFT JOIN {$wpdb->postmeta} low_stock_amount_meta ON posts.ID = low_stock_amount_meta.post_id AND low_stock_amount_meta.meta_key = '_low_stock_amount'
+				WHERE posts.post_type IN ( 'product', 'product_variation' )
+				AND wc_product_meta_lookup.stock_quantity IS NOT NULL
+				AND wc_product_meta_lookup.stock_status = 'instock'
+				AND (
+					(
+						low_stock_amount_meta.meta_value > ''
+						AND wc_product_meta_lookup.stock_quantity <= CAST(low_stock_amount_meta.meta_value AS SIGNED)
+						AND wc_product_meta_lookup.stock_quantity > %d
+					)
+					OR (
+						(
+							low_stock_amount_meta.meta_value IS NULL OR low_stock_amount_meta.meta_value <= ''
+						)
+						AND wc_product_meta_lookup.stock_quantity <= %d
+						AND wc_product_meta_lookup.stock_quantity > %d
+					)
+				)
+				",
+				$no_stock_amount,
+				$low_stock_amount,
+				$no_stock_amount
+			)
+		);
 	}
 
 	/**

--- a/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-stock-stats-data-store.php
@@ -99,18 +99,19 @@ class WC_Admin_Reports_Stock_Stats_Data_Store extends WC_Admin_Reports_Data_Stor
 	 * @return int Count.
 	 */
 	private function get_count( $status ) {
-		$query_args               = array();
-		$query_args['post_type']  = array( 'product', 'product_variation' );
-		$query_args['meta_query'] = array( // WPCS: slow query ok.
-			array(
-				'key'   => '_stock_status',
-				'value' => $status,
-			),
-		);
+		global $wpdb;
 
-		$query = new WP_Query();
-		$query->query( $query_args );
-		return intval( $query->found_posts );
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"
+				SELECT count( DISTINCT posts.ID ) FROM {$wpdb->posts} posts
+				LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON posts.ID = wc_product_meta_lookup.product_id
+				WHERE posts.post_type IN ( 'product', 'product_variation' )
+				AND wc_product_meta_lookup.stock_status = %s
+				",
+				$status
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1553 and other issues noticed during testing (I was actually planning on doing #2175 but this blocked me first).

Low stock handling was broken, mostly due to changes in 3.6. _low_stock_amount meta data is no longer stored if null/empty, so the queries in wc-admin returned no products unless that amount was specifically set at product level.

Whilst fixing that, I noticed query inconsistencies between the `class-wc-admin-rest-products-controller.php` class and `class-wc-admin-rest-products-controller.php`. They also made heavy use of meta queries which could be improved with lookup table queries as of 3.6.

The resulting code fixes the low stock issue and uses the lookup tables for performance reasons which was an added benefit.

As for #1553, the rendering of "low" was specific to the product table.js so I just copied that logic into the stock report to make it render "low" there too. See https://github.com/woocommerce/woocommerce-admin/commit/0e81dba41807a6a436cfe1ed25a22be7295667b3 for that commit.

### Detailed test instructions:

On a clean install.

- Set global low stock threshold to 2.
- Set a product stock level to 1.
- Notice it's not shown in the stock report panel
- Apply PR. The product should now be listed.
- On Analytics > Stock, see how that product now shows "low" instead of "in stock" in the table.
- On Analytics > Products ensure you can still filter by stock/low stock and sort the columns.
