### PR TITLE
Replace Rebuild reports settings with Import Historical Data

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 import interpolateComponents from 'interpolate-components';
 
@@ -42,41 +41,6 @@ const orderStatuses = Object.keys( wcSettings.orderStatuses )
 	} );
 
 export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
-	{
-		name: 'woocommerce_rebuild_reports_data',
-		label: __( 'Rebuild reports data:', 'woocommerce-admin' ),
-		inputType: 'button',
-		inputText: __( 'Rebuild reports', 'woocommerce-admin' ),
-		helpText: __(
-			'This tool will rebuild all of the information used by the reports. ' +
-				'Data will be processed in the background and may take some time depending on the size of your store.',
-			'woocommerce-admin'
-		),
-		callback: ( resolve, reject, addNotice ) => {
-			const errorMessage = __(
-				'There was a problem rebuilding your report data.',
-				'woocommerce-admin'
-			);
-
-			apiFetch( { path: '/wc/v4/reports/import', method: 'PUT' } )
-				.then( response => {
-					if ( 'success' === response.status ) {
-						addNotice( { status: 'success', message: response.message } );
-						// @todo This should be changed to detect when the lookup table population is complete.
-						setTimeout( () => resolve(), 300000 );
-					} else {
-						addNotice( { status: 'error', message: errorMessage } );
-						reject();
-					}
-				} )
-				.catch( error => {
-					if ( error && error.message ) {
-						addNotice( { status: 'error', message: error.message } );
-					}
-					reject();
-				} );
-		},
-	},
 	{
 		name: 'woocommerce_excluded_report_order_statuses',
 		label: __( 'Excluded Statuses:', 'woocommerce-admin' ),

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -46,10 +46,18 @@ function HistoricalDataActions( {
 
 		// Has no imported data
 		if ( ! hasImportedData ) {
+			// @todo when the import status endpoint is hooked up, the
+			// 'Delete Previously Imported Data' button should be removed
+			// from this section
 			return (
-				<Button isPrimary onClick={ onStartImport }>
-					{ __( 'Start', 'woocommerce-admin' ) }
-				</Button>
+				<Fragment>
+					<Button isPrimary onClick={ onStartImport }>
+						{ __( 'Start', 'woocommerce-admin' ) }
+					</Button>
+					<Button isDefault onClick={ onDeletePreviousData }>
+						{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }
+					</Button>
+				</Fragment>
 			);
 		}
 

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -46,9 +46,9 @@ function HistoricalDataActions( {
 
 		// Has no imported data
 		if ( ! hasImportedData ) {
-			// @todo when the import status endpoint is hooked up, the
-			// 'Delete Previously Imported Data' button should be removed
-			// from this section
+			// @todo When the import status endpoint is hooked up,
+			// the 'Delete Previously Imported Data' button should be
+			// removed from this section.
 			return (
 				<Fragment>
 					<Button isPrimary onClick={ onStartImport }>

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -176,7 +176,7 @@ class HistoricalData extends Component {
 			hasImportedData &&
 			customersProgress === customersTotal &&
 			ordersProgress === ordersTotal;
-		// @todo Once we read the import status from the real endpoint,
+		// @todo When the import status endpoint is hooked up,
 		// this bool should be removed and assume it's true.
 		const showImportStatus = false;
 

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -30,6 +30,7 @@ class HistoricalData extends Component {
 		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
 
 		this.state = {
+			inProgress: false,
 			period: {
 				date: moment().format( this.dateFormat ),
 				label: 'all',
@@ -74,6 +75,9 @@ class HistoricalData extends Component {
 
 	onStartImport() {
 		const { period, skipChecked } = this.state;
+		this.setState( {
+			inProgress: true,
+		} );
 		const params = {};
 		if ( skipChecked ) {
 			params.skip_existing = true;
@@ -99,6 +103,9 @@ class HistoricalData extends Component {
 	}
 
 	onStopImport() {
+		this.setState( {
+			inProgress: false,
+		} );
 		const path = '/wc/v4/reports/import/cancel';
 		const errorMessage = __(
 			'There was a problem stopping your current import.',
@@ -132,13 +139,8 @@ class HistoricalData extends Component {
 	}
 
 	getStatus() {
-		const {
-			customersProgress,
-			customersTotal,
-			inProgress,
-			ordersProgress,
-			ordersTotal,
-		} = this.props;
+		const { customersProgress, customersTotal, ordersProgress, ordersTotal } = this.props;
+		const { inProgress } = this.state;
 
 		if ( inProgress ) {
 			if ( customersProgress < customersTotal ) {
@@ -165,16 +167,18 @@ class HistoricalData extends Component {
 			customersTotal,
 			hasImportedData,
 			importDate,
-			inProgress,
 			ordersProgress,
 			ordersTotal,
 		} = this.props;
-		const { period, skipChecked } = this.state;
+		const { inProgress, period, skipChecked } = this.state;
 		const hasImportedAllData =
 			! inProgress &&
 			hasImportedData &&
 			customersProgress === customersTotal &&
 			ordersProgress === ordersTotal;
+		// @todo Once we read the import status from the real endpoint,
+		// this bool should be removed and assume it's true.
+		const showImportStatus = false;
 
 		return (
 			<Fragment>
@@ -204,19 +208,25 @@ class HistoricalData extends Component {
 									checked={ skipChecked }
 									onChange={ this.onSkipChange }
 								/>
-								<HistoricalDataProgress
-									label={ __( 'Registered Customers', 'woocommerce-admin' ) }
-									progress={ customersProgress }
-									total={ customersTotal }
-								/>
-								<HistoricalDataProgress
-									label={ __( 'Orders', 'woocommerce-admin' ) }
-									progress={ ordersProgress }
-									total={ ordersTotal }
-								/>
+								{ showImportStatus && (
+									<Fragment>
+										<HistoricalDataProgress
+											label={ __( 'Registered Customers', 'woocommerce-admin' ) }
+											progress={ customersProgress }
+											total={ customersTotal }
+										/>
+										<HistoricalDataProgress
+											label={ __( 'Orders', 'woocommerce-admin' ) }
+											progress={ ordersProgress }
+											total={ ordersTotal }
+										/>
+									</Fragment>
+								) }
 							</Fragment>
 						) }
-						<HistoricalDataStatus importDate={ importDate } status={ this.getStatus() } />
+						{ showImportStatus && (
+							<HistoricalDataStatus importDate={ importDate } status={ this.getStatus() } />
+						) }
 					</div>
 				</div>
 				<HistoricalDataActions
@@ -241,7 +251,6 @@ export default withSelect( () => {
 		customersTotal: 0,
 		hasImportedData: false,
 		importDate: '2019-04-01',
-		inProgress: false,
 		ordersProgress: 0,
 		ordersTotal: 0,
 	};


### PR DESCRIPTION
Fixes #2172 and implementing the changes described in https://github.com/woocommerce/woocommerce-admin/pull/2177#issuecomment-490537695.

This PR:
- Removes the _Rebuild reports data_ section from _Settings_.
- Hides the progress bars and status from the new _Import Historical Data_ section for now, until the import status is hooked up.
- Adds a _Delete Previously Imported Data_ to the initial actions, so it can be tested/used without having the import status endpoint ready.

### Screenshots

![image](https://user-images.githubusercontent.com/3616980/57443041-87ecc480-724d-11e9-99ef-b9bc54f75fc5.png)

### Detailed test instructions:
- Go to _Settings_.
- Verify there is no _Rebuild reports data_ section.
- Interact with the _Import Historical Data_ section: starting an import, stopping it, removing previous data, etc. and verify it works as expected.