### PR TITLE
Fix EllipsisMenu misalignment in wide containers

### DIFF
--- a/packages/components/src/ellipsis-menu/style.scss
+++ b/packages/components/src/ellipsis-menu/style.scss
@@ -1,4 +1,7 @@
 /** @format */
+.woocommerce-ellipsis-menu {
+	text-align: center;
+}
 
 .woocommerce-ellipsis-menu__toggle {
 	height: 24px;


### PR DESCRIPTION
Fixes #2206.

The current `<EllipsisMenu>` component relies on being rendered in a 24px wide container, otherwise it's misaligned. This can be seen in _DevDocs_.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/57518556-8c7eaf00-7319-11e9-88ec-fe8688a82d43.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/57518521-72dd6780-7319-11e9-8dff-6ecb50adf608.png)

### Detailed test instructions:

* Go to _DevDocs_.
* Scroll down to the _EllipsisMenu_ and open it.
* Verify the button and the popover are now aligned.