### PR TITLE
update default capability for analytics report to view_woocommerce_reports

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -142,12 +142,14 @@ class WC_Admin_Loader {
 	 * @todo The entry point for the embed needs moved to this class as well.
 	 */
 	public static function register_page_handler() {
+		$analytics_cap = apply_filters( 'woocommerce_admin_analytics_menu_capability', 'view_woocommerce_reports' );
 		wc_admin_register_page(
 			array(
-				'id'     => 'woocommerce-dashboard', // Expected to be overridden if dashboard is enabled.
-				'parent' => 'woocommerce',
-				'title'  => null,
-				'path'   => self::APP_ENTRY_POINT,
+				'id'         => 'woocommerce-dashboard', // Expected to be overridden if dashboard is enabled.
+				'parent'     => 'woocommerce',
+				'title'      => null,
+				'path'       => self::APP_ENTRY_POINT,
+				'capability' => $analytics_cap,
 			)
 		);
 

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -20,14 +20,16 @@ if ( ! function_exists( 'wc_admin_register_page' ) ) {
 	 */
 	function wc_admin_register_page( $options ) {
 		$defaults = array(
-			'parent' => '/analytics',
+			'parent'     => '/analytics',
+			'capability' => 'view_woocommerce_reports',
 		);
 		$options  = wp_parse_args( $options, $defaults );
+
 		add_submenu_page(
 			'/' === $options['parent'][0] ? "wc-admin#{$options['parent']}" : $options['parent'],
 			$options['title'],
 			$options['title'],
-			'manage_options',
+			$options['capability'],
 			"wc-admin#{$options['path']}",
 			array( 'WC_Admin_Loader', 'page_wrapper' )
 		);
@@ -171,11 +173,12 @@ class WC_Admin_Loader {
 			$menu_title = __( 'Dashboard', 'woocommerce-admin' );
 		}
 
+		$analytics_cap = apply_filters( 'woocommerce_admin_analytics_menu_capability', 'view_woocommerce_reports' );
 		add_submenu_page(
 			'woocommerce',
 			$page_title,
 			$menu_title,
-			'manage_options',
+			$analytics_cap,
 			'wc-admin',
 			array( 'WC_Admin_Loader', 'page_wrapper' )
 		);

--- a/includes/features/analytics/class-wc-admin-analytics.php
+++ b/includes/features/analytics/class-wc-admin-analytics.php
@@ -76,7 +76,7 @@ class WC_Admin_Analytics {
 		add_menu_page(
 			__( 'WooCommerce Analytics', 'woocommerce-admin' ),
 			__( 'Analytics', 'woocommerce-admin' ),
-			'manage_options',
+			'view_woocommerce_reports',
 			'wc-admin#/analytics/revenue',
 			array( 'WC_Admin_Loader', 'page_wrapper' ),
 			'dashicons-chart-bar',

--- a/includes/page-controller/class-wc-admin-page-controller.php
+++ b/includes/page-controller/class-wc-admin-page-controller.php
@@ -398,7 +398,7 @@ class WC_Admin_Page_Controller {
 			'id'         => null,
 			'parent'     => null,
 			'title'      => '',
-			'capability' => 'manage_options',
+			'capability' => 'view_woocommerce_reports',
 			'path'       => '',
 			'icon'       => '',
 			'position'   => null,


### PR DESCRIPTION
Fixes #1968

This PR updates the Analytics menu and submenu items capability permission to `view_woocommerce_reports`. Submenu item capability permission can be changed using the `woocommerce_admin_report_menu_items` filter.

### Detailed test instructions:

- Log in as a shop manager
- View various analytics screens
- Add a filter to `woocommerce_admin_report_menu_items` and add a `capability` => `manage_options` element to one of the menu items
- refresh the screen with to see that screen not included in the menu
