### PR TITLE
fix #2119 WordPress Upgrade Nag

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -22,3 +22,7 @@
 	padding-right: $gutter-large;
 	max-width: 100%;
 }
+
+.woocommerce-page .update-nag {
+	display: none;
+}


### PR DESCRIPTION
Fixes #2119

Fix the WordPress upgrade nag issue in  WooCommerce Pages.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [X] I' have tested using the older version of WordPress.

### Screenshots
![57502675-63a2ed80-730a-11e9-8f8b-567c4ef06eb4](https://user-images.githubusercontent.com/32254909/57563693-40d21100-73be-11e9-83e0-d7b3e1d409c1.png)
![57502676-67367480-730a-11e9-8034-37343df2641d](https://user-images.githubusercontent.com/32254909/57563698-5cd5b280-73be-11e9-8600-7b1a65b7bd9a.png)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
