### PR TITLE
Add onboarding profile REST endpoints

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -21,7 +21,7 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-internal/v1';
+	protected $namespace = 'wc-admin/v1';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-levels-controller.php
@@ -21,7 +21,7 @@ class WC_Admin_REST_Onboarding_Levels_Controller extends WC_REST_Data_Controller
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v4';
+	protected $namespace = 'wc-internal/v1';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -21,7 +21,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-internal/v1';
+	protected $namespace = 'wc-admin/v1';
 
 	/**
 	 * Route base.

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -199,7 +199,14 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
-			'account_type'   => array(
+			'skipped'         => array(
+				'type'              => 'bool',
+				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'account_type'    => array(
 				'type'              => 'string',
 				'description'       => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -211,7 +218,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'google',
 				),
 			),
-			'industry'       => array(
+			'industry'        => array(
 				'type'              => 'array',
 				'description'       => __( 'Industry.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -230,7 +237,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'type' => 'string',
 				),
 			),
-			'product_types'  => array(
+			'product_types'   => array(
 				'type'              => 'array',
 				'description'       => __( 'Types of products sold.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -250,7 +257,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'type' => 'string',
 				),
 			),
-			'product_count'  => array(
+			'product_count'   => array(
 				'type'              => 'string',
 				'description'       => __( 'Number of products to be added.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -263,7 +270,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'1000+',
 				),
 			),
-			'selling_venues' => array(
+			'selling_venues'  => array(
 				'type'              => 'string',
 				'description'       => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -276,7 +283,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'brick-mortar-other',
 				),
 			),
-			'other_platform' => array(
+			'other_platform'  => array(
 				'type'              => 'string',
 				'description'       => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -290,7 +297,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'other',
 				),
 			),
-			'theme'          => array(
+			'theme'           => array(
 				'type'              => 'string',
 				'description'       => __( 'Selected store theme.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -298,7 +305,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'sanitize_callback' => 'sanitize_title_with_dashes',
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'purchase'       => array(
+			'items_purchased' => array(
 				'type'              => 'bool',
 				'description'       => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -200,58 +200,110 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	public static function get_profile_properties() {
 		$properties = array(
 			'account_type'   => array(
-				'type'        => 'string',
-				'description' => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
+				'type'              => 'string',
+				'description'       => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'new',
+					'existing',
+					'google',
+				),
 			),
 			'industry'       => array(
-				'type'        => 'string',
-				'description' => __( 'Industry.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
+				'type'              => 'array',
+				'description'       => __( 'Industry.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'sanitize_callback' => 'wp_parse_slug_list',
+				'validate_callback' => 'rest_validate_request_arg',
+				'items'             => array(
+					'enum' => array(
+						'fashion-apparel-accessories',
+						'health-beauty',
+						'art-music-photography',
+						'food-drink',
+						'home-furniture-garden',
+						'other',
+					),
+					'type' => 'string',
+				),
 			),
 			'product_types'  => array(
-				'type'        => 'array',
-				'description' => __( 'Types of products sold.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-				'items'       => array(
+				'type'              => 'array',
+				'description'       => __( 'Types of products sold.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'sanitize_callback' => 'wp_parse_slug_list',
+				'validate_callback' => 'rest_validate_request_arg',
+				'items'             => array(
+					'enum' => array(
+						'physical',
+						'downloads',
+						'subscriptions',
+						'memberships',
+						'composite',
+						'spaces',
+						'rentals',
+					),
 					'type' => 'string',
 				),
 			),
 			'product_count'  => array(
-				'type'        => 'integer',
-				'description' => __( 'Number of products to be added.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
+				'type'              => 'string',
+				'description'       => __( 'Number of products to be added.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'1-10',
+					'11-100',
+					'101-1000',
+					'1000+',
+				),
 			),
 			'selling_venues' => array(
-				'type'        => 'array',
-				'description' => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-				'items'       => array(
-					'type' => 'string',
+				'type'              => 'string',
+				'description'       => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'no',
+					'other',
+					'brick-mortar',
+					'brick-mortar-other',
 				),
 			),
 			'other_platform' => array(
-				'type'        => 'string',
-				'description' => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
+				'type'              => 'string',
+				'description'       => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'shopify',
+					'bigcommerce',
+					'magento',
+					'wix',
+					'other',
+				),
 			),
 			'theme'          => array(
-				'type'        => 'string',
-				'description' => __( 'Selected store theme.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
+				'type'              => 'string',
+				'description'       => __( 'Selected store theme.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'sanitize_callback' => 'sanitize_title_with_dashes',
+				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'purchase'       => array(
-				'type'        => 'bool',
-				'description' => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
+				'type'              => 'bool',
+				'description'       => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
 			),
 		);
 
@@ -268,6 +320,9 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 		$properties = self::get_profile_properties();
 		foreach ( $properties as $key => $property ) {
 			unset( $properties[ $key ]['default'] );
+			unset( $properties[ $key ]['items'] );
+			unset( $properties[ $key ]['validate_callback'] );
+			unset( $properties[ $key ]['sanitize_callback'] );
 		}
 
 		$schema = array(

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -46,6 +46,19 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_items' ),
+					'permission_callback' => array( $this, 'update_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -57,6 +70,20 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	public function get_items_permissions_check( $request ) {
 		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to edit onboarding profile data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot edit this resource.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -84,6 +111,66 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	}
 
 	/**
+	 * Update onboarding profile data.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_items( $request ) {
+		$query_args      = $this->prepare_objects_query( $request );
+		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
+		$update          = update_option( 'wc_onboarding_profile', array_merge( $onboarding_data, $query_args ) );
+
+		if ( $update ) {
+			$result = array(
+				'status'  => 'success',
+				'message' => __( 'Onboarding profile data has been updated.', 'woocommerce-admin' ),
+			);
+		} else {
+			$result = array(
+				'status'  => 'error',
+				'message' => __( 'There was an error updating the onboarding profile data.', 'woocommerce-admin' ),
+			);
+		}
+
+		$response = $this->prepare_item_for_response( $result, $request );
+		$data     = $this->prepare_response_for_collection( $response );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare objects query.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args       = array();
+		$properties = self::get_profile_properties();
+
+		foreach ( $properties as $key => $property ) {
+			if ( isset( $request[ $key ] ) ) {
+				$args[ $key ] = $request[ $key ];
+			}
+		}
+
+		/**
+		 * Filter the query arguments for a request.
+		 *
+		 * Enables adding extra arguments or setting defaults for a post
+		 * collection request.
+		 *
+		 * @param array           $args    Key value array of query var to query value.
+		 * @param WP_REST_Request $request The request used.
+		 */
+		$args = apply_filters( 'woocommerce_rest_onboarding_profile_object_query', $args, $request );
+
+		return $args;
+	}
+
+
+	/**
 	 * Prepare the data object for response.
 	 *
 	 * @param object          $item Data object.
@@ -106,103 +193,144 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	}
 
 	/**
+	 * Get onboarding profile properties.
+	 *
+	 * @return array
+	 */
+	public static function get_profile_properties() {
+		$properties = array(
+			'account_type'    => array(
+				'type'        => 'string',
+				'description' => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'store_address_1' => array(
+				'type'        => 'string',
+				'description' => __( 'Store address line 1.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'store_address_2' => array(
+				'type'        => 'string',
+				'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'store_zip'       => array(
+				'type'        => 'string',
+				'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'store_city'      => array(
+				'type'        => 'string',
+				'description' => __( 'Store city.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'store_state'     => array(
+				'type'        => 'string',
+				'description' => __( 'Store state.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'store_country'   => array(
+				'type'        => 'string',
+				'description' => __( 'Store country.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'industry'        => array(
+				'type'        => 'string',
+				'description' => __( 'Industry.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'product_types'   => array(
+				'type'        => 'array',
+				'description' => __( 'Types of products sold.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type' => 'string',
+				),
+			),
+			'product_count'  => array(
+				'type'        => 'integer',
+				'description' => __( 'Number of products to be added.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'selling_venues'  => array(
+				'type'        => 'array',
+				'description' => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type' => 'string',
+				),
+			),
+			'other_platform' => array(
+				'type'        => 'string',
+				'description' => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'theme'          => array(
+				'type'        => 'string',
+				'description' => __( 'Selected store theme.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+			'purchase'        => array(
+				'type'        => 'bool',
+				'description' => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
+				'context'     => array( 'view' ),
+				'readonly'    => true,
+			),
+		);
+
+		return apply_filters( 'woocommerce_onboarding_profile_properties', $properties );
+	}
+
+	/**
 	 * Get the schema, conforming to JSON Schema.
 	 *
 	 * @return array
 	 */
 	public function get_item_schema() {
+		// Unset properties used for collection params.
+		$properties = self::get_profile_properties();
+		foreach ( $properties as $key => $property ) {
+			unset( $properties[ $key ]['default'] );
+		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'onboarding_profile',
 			'type'       => 'object',
-			'properties' => array(
-				'account_type'    => array(
-					'type'        => 'string',
-					'description' => __( 'Account type used for JetPack.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'store_address_1' => array(
-					'type'        => 'string',
-					'description' => __( 'Store address line 1.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'store_address_2' => array(
-					'type'        => 'string',
-					'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'store_zip'       => array(
-					'type'        => 'string',
-					'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'store_city'      => array(
-					'type'        => 'string',
-					'description' => __( 'Store city.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'store_state'     => array(
-					'type'        => 'string',
-					'description' => __( 'Store state.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'store_country'   => array(
-					'type'        => 'string',
-					'description' => __( 'Store country.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'industry'        => array(
-					'type'        => 'string',
-					'description' => __( 'Industry.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'product_types'   => array(
-					'type'        => 'array',
-					'description' => __( 'Types of products sold.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'product_count'   => array(
-					'type'        => 'array',
-					'description' => __( 'Number of products to be added.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'selling_venues'  => array(
-					'type'        => 'array',
-					'description' => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'other_platform'  => array(
-					'type'        => 'array',
-					'description' => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'theme'           => array(
-					'type'        => 'array',
-					'description' => __( 'Selected store theme.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-				'purchase'        => array(
-					'type'        => 'bool',
-					'description' => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
-					'context'     => array( 'view' ),
-					'readonly'    => true,
-				),
-			),
+			'properties' => $properties,
 		);
 
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		// Unset properties used for item schema.
+		$params = self::get_profile_properties();
+		foreach ( $params as $key => $param ) {
+			unset( $params[ $key ]['context'] );
+			unset( $params[ $key ]['readonly'] );
+		}
+
+		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
+
+		return apply_filters( 'rest_onboarding_profile_collection_params', $params );
 	}
 }

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * REST API Onboarding Profile Controller
+ *
+ * Handles requests to /onboarding/profile
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Onboarding Profile controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'onboarding/profile';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check whether a given request has permission to read onboarding profile data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return all onboarding profile data.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
+		$item_schema     = $this->get_item_schema();
+
+		$items = array();
+		foreach ( $item_schema['properties'] as $key => $property_schema ) {
+			$items[ $key ] = isset( $onboarding_data[ $key ] ) ? $onboarding_data[ $key ] : null;
+		}
+
+		$item = $this->prepare_item_for_response( $items, $request );
+		$data = $this->prepare_response_for_collection( $item );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @param object          $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		/**
+		 * Filter the list returned from the API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     The original item.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_onboarding_profile', $response, $item, $request );
+	}
+
+	/**
+	 * Get the schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'onboarding_profile',
+			'type'       => 'object',
+			'properties' => array(
+				'account_type'    => array(
+					'type'        => 'string',
+					'description' => __( 'Account type used for JetPack.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'store_address_1' => array(
+					'type'        => 'string',
+					'description' => __( 'Store address line 1.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'store_address_2' => array(
+					'type'        => 'string',
+					'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'store_zip'       => array(
+					'type'        => 'string',
+					'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'store_city'      => array(
+					'type'        => 'string',
+					'description' => __( 'Store city.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'store_state'     => array(
+					'type'        => 'string',
+					'description' => __( 'Store state.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'store_country'   => array(
+					'type'        => 'string',
+					'description' => __( 'Store country.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'industry'        => array(
+					'type'        => 'string',
+					'description' => __( 'Industry.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'product_types'   => array(
+					'type'        => 'array',
+					'description' => __( 'Types of products sold.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'product_count'   => array(
+					'type'        => 'array',
+					'description' => __( 'Number of products to be added.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'selling_venues'  => array(
+					'type'        => 'array',
+					'description' => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'other_platform'  => array(
+					'type'        => 'array',
+					'description' => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'theme'           => array(
+					'type'        => 'array',
+					'description' => __( 'Selected store theme.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'purchase'        => array(
+					'type'        => 'bool',
+					'description' => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -199,55 +199,19 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
-			'account_type'    => array(
+			'account_type'   => array(
 				'type'        => 'string',
 				'description' => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
 			),
-			'store_address_1' => array(
-				'type'        => 'string',
-				'description' => __( 'Store address line 1.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-			),
-			'store_address_2' => array(
-				'type'        => 'string',
-				'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-			),
-			'store_zip'       => array(
-				'type'        => 'string',
-				'description' => __( 'Store address line 2.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-			),
-			'store_city'      => array(
-				'type'        => 'string',
-				'description' => __( 'Store city.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-			),
-			'store_state'     => array(
-				'type'        => 'string',
-				'description' => __( 'Store state.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-			),
-			'store_country'   => array(
-				'type'        => 'string',
-				'description' => __( 'Store country.', 'woocommerce-admin' ),
-				'context'     => array( 'view' ),
-				'readonly'    => true,
-			),
-			'industry'        => array(
+			'industry'       => array(
 				'type'        => 'string',
 				'description' => __( 'Industry.', 'woocommerce-admin' ),
 				'context'     => array( 'view' ),
 				'readonly'    => true,
 			),
-			'product_types'   => array(
+			'product_types'  => array(
 				'type'        => 'array',
 				'description' => __( 'Types of products sold.', 'woocommerce-admin' ),
 				'context'     => array( 'view' ),
@@ -262,7 +226,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'context'     => array( 'view' ),
 				'readonly'    => true,
 			),
-			'selling_venues'  => array(
+			'selling_venues' => array(
 				'type'        => 'array',
 				'description' => __( 'Other places the store is selling products.', 'woocommerce-admin' ),
 				'context'     => array( 'view' ),
@@ -283,7 +247,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'context'     => array( 'view' ),
 				'readonly'    => true,
 			),
-			'purchase'        => array(
+			'purchase'       => array(
 				'type'        => 'bool',
 				'description' => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
 				'context'     => array( 'view' ),

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -21,7 +21,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v4';
+	protected $namespace = 'wc-internal/v1';
 
 	/**
 	 * Route base.

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -109,6 +109,7 @@ class WC_Admin_Api_Init {
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-data-download-ips-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-leaderboards-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-onboarding-levels-controller.php';
+		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-onboarding-profile-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-orders-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-products-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-product-categories-controller.php';
@@ -151,6 +152,7 @@ class WC_Admin_Api_Init {
 				'WC_Admin_REST_Data_Download_Ips_Controller',
 				'WC_Admin_REST_Leaderboards_Controller',
 				'WC_Admin_REST_Onboarding_Levels_Controller',
+				'WC_Admin_REST_Onboarding_Profile_Controller',
 				'WC_Admin_REST_Orders_Controller',
 				'WC_Admin_REST_Products_Controller',
 				'WC_Admin_REST_Product_Categories_Controller',

--- a/tests/api/onboarding-levels.php
+++ b/tests/api/onboarding-levels.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Onboarding_Levels extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v4/onboarding/levels';
+	protected $endpoint = '/wc-internal/v1/onboarding/levels';
 
 	/**
 	 * Setup test data. Called before every test.

--- a/tests/api/onboarding-levels.php
+++ b/tests/api/onboarding-levels.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Onboarding_Levels extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc-internal/v1/onboarding/levels';
+	protected $endpoint = '/wc-admin/v1/onboarding/levels';
 
 	/**
 	 * Setup test data. Called before every test.

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc-internal/v1/onboarding/profile';
+	protected $endpoint = '/wc-admin/v1/onboarding/profile';
 
 	/**
 	 * Setup test data. Called before every test.

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -95,7 +95,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 8, $properties );
+		$this->assertCount( 9, $properties );
+		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
 		$this->assertArrayHasKey( 'product_types', $properties );
@@ -103,7 +104,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'selling_venues', $properties );
 		$this->assertArrayHasKey( 'other_platform', $properties );
 		$this->assertArrayHasKey( 'theme', $properties );
-		$this->assertArrayHasKey( 'purchase', $properties );
+		$this->assertArrayHasKey( 'items_purchased', $properties );
 	}
 
 	/**

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc/v4/onboarding/profile';
+	protected $endpoint = '/wc-internal/v1/onboarding/profile';
 
 	/**
 	 * Setup test data. Called before every test.
@@ -56,7 +56,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		// Test updating 2 fields separately.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
-		$request->set_param( 'store_city', 'Atlanta' );
+		$request->set_param( 'industry', 'Clothing' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -65,7 +65,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		// Test that the update works.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
-		$request->set_param( 'store_state', 'Georgia' );
+		$request->set_param( 'theme', 'Storefront' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -78,8 +78,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'Atlanta', $data['store_city'] );
-		$this->assertEquals( 'Georgia', $data['store_state'] );
+		$this->assertEquals( 'Clothing', $data['industry'] );
+		$this->assertEquals( 'Storefront', $data['theme'] );
 	}
 
 	/**
@@ -95,14 +95,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 14, $properties );
+		$this->assertCount( 8, $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
-		$this->assertArrayHasKey( 'store_address_1', $properties );
-		$this->assertArrayHasKey( 'store_address_2', $properties );
-		$this->assertArrayHasKey( 'store_zip', $properties );
-		$this->assertArrayHasKey( 'store_city', $properties );
-		$this->assertArrayHasKey( 'store_state', $properties );
-		$this->assertArrayHasKey( 'store_country', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
 		$this->assertArrayHasKey( 'product_types', $properties );
 		$this->assertArrayHasKey( 'product_count', $properties );

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -56,7 +56,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		// Test updating 2 fields separately.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
-		$request->set_param( 'industry', 'Clothing' );
+		$request->set_param( 'industry', 'health-beauty' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -78,8 +78,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'Clothing', $data['industry'] );
-		$this->assertEquals( 'Storefront', $data['theme'] );
+		$this->assertEquals( 'health-beauty', $data['industry'][0] );
+		$this->assertEquals( 'storefront', $data['theme'] );
 	}
 
 	/**

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Onboarding Profile REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+/**
+ * WC Tests API Onboarding Profile
+ */
+class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v4/onboarding/profile';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that profile data is returned by the endpoint.
+	 */
+	public function test_get_profile_items() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$properties = WC_Admin_REST_Onboarding_Profile_Controller::get_profile_properties();
+		foreach ( $properties as $key => $property ) {
+			$this->assertArrayHasKey( $key, $properties );
+		}
+	}
+
+	/**
+	 * Test that profile date is updated by the endpoint.
+	 */
+	public function test_update_profile_items() {
+		wp_set_current_user( $this->user );
+
+		// Test updating 2 fields separately.
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_param( 'store_city', 'Atlanta' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $data['status'] );
+
+		// Test that the update works.
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_param( 'store_state', 'Georgia' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $data['status'] );
+
+		// Make sure the original field value wasn't overwritten.
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Atlanta', $data['store_city'] );
+		$this->assertEquals( 'Georgia', $data['store_state'] );
+	}
+
+	/**
+	 * Test schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertCount( 14, $properties );
+		$this->assertArrayHasKey( 'account_type', $properties );
+		$this->assertArrayHasKey( 'store_address_1', $properties );
+		$this->assertArrayHasKey( 'store_address_2', $properties );
+		$this->assertArrayHasKey( 'store_zip', $properties );
+		$this->assertArrayHasKey( 'store_city', $properties );
+		$this->assertArrayHasKey( 'store_state', $properties );
+		$this->assertArrayHasKey( 'store_country', $properties );
+		$this->assertArrayHasKey( 'industry', $properties );
+		$this->assertArrayHasKey( 'product_types', $properties );
+		$this->assertArrayHasKey( 'product_count', $properties );
+		$this->assertArrayHasKey( 'selling_venues', $properties );
+		$this->assertArrayHasKey( 'other_platform', $properties );
+		$this->assertArrayHasKey( 'theme', $properties );
+		$this->assertArrayHasKey( 'purchase', $properties );
+	}
+
+	/**
+	 * Test that profiles response changes based on applied filters.
+	 */
+	public function test_profile_extensibility() {
+		wp_set_current_user( $this->user );
+
+		add_filter(
+			'woocommerce_onboarding_profile_properties',
+			function( $properties ) {
+				$properties['test_profile_datum'] = array(
+					'type'        => 'array',
+					'description' => __( 'Test onboarding profile extensibility.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				);
+				return $properties;
+			}
+		);
+
+		// Test that the update works.
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_param( 'test_profile_datum', 'woo' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $data['status'] );
+
+		// Test that the new field is retrieved.
+		$request  = new WP_REST_Request( 'GET', $this->endpoint );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'woo', $data['test_profile_datum'] );
+	}
+}


### PR DESCRIPTION
Fixes #1883

Adds endpoints for getting profile data and setting it.

**Profile params**
`account_type`
`store_address_1`
`store_address_2`
`store_zip`
`store_city`
`store_state`
`store_country`
`industry`
`product_types`
`product_count`
`selling_venues`
`other_platform`
`theme`
`purchase`

### Screenshots
<img width="412" alt="Screen Shot 2019-05-13 at 2 33 20 PM" src="https://user-images.githubusercontent.com/10561050/57600318-133ac280-758c-11e9-9a7a-f52df551ec27.png">

### Detailed test instructions:

1.  Make a GET request to `/wp-json/wc/v4/onboarding/profile`.
2.  All initial values should be present but set to null.
3.  Post to `/wp-json/wc/v4/onboarding/profile` with any of the profile params.
4.  Make another GET request to `/wp-json/wc/v4/onboarding/profile`.
5.  Note the updated fields.