### PR TITLE
Fix onboarding profiler layout and notices

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -30,6 +30,10 @@
 		}
 	}
 
+	.woocommerce-layout .woocommerce-layout__main {
+		padding-right: 0;
+	}
+
 	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard*/
 	#adminmenumain,
 	#wpadminbar,

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -33,7 +33,13 @@
 	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard*/
 	#adminmenumain,
 	#wpadminbar,
-	.woocommerce-layout__header {
+	.woocommerce-layout__header,
+	.update-nag,
+	.woocommerce-store-alerts,
+	.woocommerce-message,
+	.notice,
+	.error,
+	.updated {
 		display: none;
 	}
 


### PR DESCRIPTION
Fixes #1937

Remove notices in layout and center layout content.

### Before
<img width="1659" alt="Screen Shot 2019-05-13 at 3 29 42 PM" src="https://user-images.githubusercontent.com/10561050/57603341-05893b00-7594-11e9-8c0d-eabc9e871852.png">

### After
<img width="1182" alt="Screen Shot 2019-05-13 at 3 28 51 PM" src="https://user-images.githubusercontent.com/10561050/57603338-04580e00-7594-11e9-9930-c9989a3f01ce.png">

### Detailed test instructions:

1.  Make sure you have notices, nags, and/or other items showing.
2.  Enable the profiler by setting `const profileWizardComplete = true;`.
3.  Note that notices and nags are gone.
4.  Note that content is centered horizontally.