### PR TITLE
Add filters for customer roles

### DIFF
--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -274,7 +274,7 @@ class WC_Admin_Reports_Sync {
 				( self::SINGLE_ORDER_IMPORT_ACTION === $existing_job->get_hook() ) ||
 				(
 					self::QUEUE_DEPEDENT_ACTION === $existing_job->get_hook() &&
-					in_array( self::SINGLE_ORDER_IMPORT_ACTION, $existing_job->get_args() )
+					in_array( self::SINGLE_ORDER_IMPORT_ACTION, $existing_job->get_args(), true )
 				)
 			) {
 				return;

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -589,12 +589,14 @@ class WC_Admin_Reports_Sync {
 	 */
 	public static function customer_lookup_import_batch_init( $days, $skip_existing ) {
 		$batch_size      = self::get_batch_size( self::CUSTOMERS_IMPORT_BATCH_ACTION );
+		$customer_roles  = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
 		$customer_query  = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
 			array(
-				'fields' => 'ID',
-				'number' => 1,
+				'fields'   => 'ID',
+				'number'   => 1,
+				'role__in' => $customer_roles,
 			)
 		);
 		$total_customers = $customer_query->get_total();
@@ -618,15 +620,17 @@ class WC_Admin_Reports_Sync {
 	 */
 	public static function customer_lookup_import_batch( $batch_number, $days, $skip_existing ) {
 		$batch_size     = self::get_batch_size( self::CUSTOMERS_IMPORT_BATCH_ACTION );
+		$customer_roles = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
 		$customer_query = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
 			array(
-				'fields'  => 'ID',
-				'orderby' => 'ID',
-				'order'   => 'ASC',
-				'number'  => $batch_size,
-				'paged'   => $batch_number,
+				'fields'   => 'ID',
+				'orderby'  => 'ID',
+				'order'    => 'ASC',
+				'number'   => $batch_size,
+				'paged'    => $batch_number,
+				'role__in' => $customer_roles,
 			)
 		);
 

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -686,7 +686,8 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			return false;
 		}
 
-		if ( $customer->get_order_count() < 1 && 'customer' !== $customer->get_role() ) {
+		$customer_roles = (array) apply_filters( 'woocommerce_admin_customer_roles', array( 'customer' ) );
+		if ( $customer->get_order_count() < 1 && ! in_array( $customer->get_role(), $customer_roles, true ) ) {
 			return false;
 		}
 

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -363,7 +363,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( false, $report['is_importing'] );
-		$this->assertEquals( 3, $report['customers_count'] );
+		$this->assertEquals( 1, $report['customers_count'] );
 		$this->assertEquals( 3, $report['customers_total'] );
 		$this->assertEquals( 5, $report['orders_count'] );
 		$this->assertEquals( 5, $report['orders_total'] );


### PR DESCRIPTION
Fixes #2195

This PR limits the customer import to users with the `customer` role. It includes a `woocommerce_admin_import_customer_roles` filter to allow including other user roles.

### Detailed test instructions:

- Go to Analytics -> Settings
- Delete previously imported data
- Start an import including `All`
- Verify Import scheduled actions complete
- Check the customer lookup table and verify non-customer users without orders are not imported.

### Test data store

- Remove a customer record from `wp_wc_customer_lookup`
- Edit that customer in the dashboard and add/change the billing address
- Check to see that the customer is added to `wp_wc_customer_lookup`
- Add a filter to `woocommerce_admin_customer_roles` and add `subscriber` to the array
- Edit a subscriber user that has no orders
- Check to see that the subscriber is added to `wp_wc_customer_lookup`
