### PR TITLE
Call the installer in `register_activation_hook`

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -172,7 +172,7 @@ function wc_admin_activate_wc_admin_plugin() {
 
 	// Run the installer on activation.
 	require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
-	WC_Admin_Install::install();
+	WC_Admin_Install::create_tables();
 }
 register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'wc_admin_activate_wc_admin_plugin' );
 

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -169,6 +169,10 @@ function wc_admin_activate_wc_admin_plugin() {
 	if ( ! wp_next_scheduled( 'wc_admin_daily' ) ) {
 		wp_schedule_event( time(), 'daily', 'wc_admin_daily' );
 	}
+
+	// Run the installer on activation.
+	require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-install.php';
+	WC_Admin_Install::install();
 }
 register_activation_hook( WC_ADMIN_PLUGIN_FILE, 'wc_admin_activate_wc_admin_plugin' );
 


### PR DESCRIPTION
When testing out PRs I found my reports were broken due to a missing column in my DB (introduced [here](https://github.com/woocommerce/woocommerce-admin/blame/af6a19c7016901cc647a77e83d8a8276a1e52590/includes/class-wc-admin-install.php#L95)).

It seems that the installer only runs if the plugin version changes, so simply de/re-activating the plugin had no effect.

To prevent this, we need only call the installer on activation. This mirrors how WooCommerce call installs - once on activation, and then again if the version changes (upgrades). This will ensure the DB is always current.

### Detailed test instructions:

- Deactivate
- Reactivate
- Ensure there are no errors on activation.