### PR TITLE
fix warning for string shipping tax meta value

### DIFF
--- a/includes/class-wc-admin-order-trait.php
+++ b/includes/class-wc-admin-order-trait.php
@@ -60,7 +60,7 @@ trait WC_Admin_Order_Trait {
 			if ( $tax_data ) {
 				foreach ( $order_taxes as $tax_item ) {
 					$tax_item_id                = $tax_item->get_rate_id();
-					$tax_item_total             = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : 0;
+					$tax_item_total             = isset( $tax_data['total'][ $tax_item_id ] ) ? (float) $tax_data['total'][ $tax_item_id ] : 0;
 					$total_shipping_tax_amount += $tax_item_total;
 				}
 			}


### PR DESCRIPTION
I noticed a warning when running the import scheduled actions with WP CLI. My dev install is PHP 7.3:

```
Warning: A non-numeric value encountered in /wp-content/plugins/woocommerce-admin/includes/class-wc-admin-order-trait.php on line 64
```

I looked up the order being processed and the tax value was `"0"`. This PR casts the tax value to a float to ensure it is a numeric type to eliminate the warning.