### PR TITLE
Persisted Queries: Avoid adding to non time related screens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,20 @@ matrix:
   include:
   - name: "PHP 7.2 unit tests, PHP Coding standards check and JS tests"
     php: 7.2
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress NODE_RELEASE=8.x RUN_PHPCS=1 RUN_JS=1
+    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_PHPCS=1 RUN_JS=1
   - name: "PHP 7.1 unit tests"
     php: 7.1
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress NODE_RELEASE=8.x
+    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
   - name: "PHP 7.0 unit tests"
     php: 7.0
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress NODE_RELEASE=8.x
+    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
   - name: "PHP 5.6 unit tests"
     php: 5.6
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress NODE_RELEASE=8.x
+    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
 
 
-node_js:
-  - "8"
+before_install:
+  - nvm install 'lts/*'
 
 before_script:
   - phpenv config-rm xdebug.ini

--- a/client/layout/test/index.js
+++ b/client/layout/test/index.js
@@ -1,0 +1,68 @@
+/** @format */
+/**
+ * WooCommerce dependencies
+ */
+import { stringifyQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import { updateLinkHref } from '../controller';
+
+describe( 'updateLinkHref', () => {
+	const timeExcludedScreens = [ 'devdocs', 'stock', 'settings', 'customers' ];
+
+	const REPORT_URL =
+		'http://example.com/wp-admin/admin.php?page=wc-admin#/analytics/orders?period=today&compare=previous_year';
+	const DASHBOARD_URL =
+		'http://example.com/wp-admin/admin.php?page=wc-admin#/?period=week&compare=previous_year';
+	const DASHBOARD_URL_NO_HASH = 'http://example.com/wp-admin/admin.php?page=wc-admin';
+	const WOO_URL = 'http://example.com/wp-admin/edit.php?post_type=shop_coupon';
+	const WP_ADMIN_URL = 'http://example.com/wp-admin/edit-comments.php';
+
+	const nextQuery = stringifyQuery( {
+		fruit: 'apple',
+		dish: 'cobbler',
+	} );
+
+	it( 'should update report urls', () => {
+		const item = { href: REPORT_URL };
+		updateLinkHref( item, nextQuery, timeExcludedScreens );
+
+		expect( item.href ).toBe(
+			'http://example.com/wp-admin/admin.php?page=wc-admin#/analytics/orders?fruit=apple&dish=cobbler'
+		);
+	} );
+
+	it( 'should update dashboard urls', () => {
+		const item = { href: DASHBOARD_URL };
+		updateLinkHref( item, nextQuery, timeExcludedScreens );
+
+		expect( item.href ).toBe(
+			'http://example.com/wp-admin/admin.php?page=wc-admin#/?fruit=apple&dish=cobbler'
+		);
+	} );
+
+	it( 'should update dashboard urls with no hash', () => {
+		const item = { href: DASHBOARD_URL_NO_HASH };
+		updateLinkHref( item, nextQuery, timeExcludedScreens );
+
+		expect( item.href ).toBe(
+			'http://example.com/wp-admin/admin.php?page=wc-admin#/?fruit=apple&dish=cobbler'
+		);
+	} );
+
+	it( 'should not update WooCommerce urls', () => {
+		const item = { href: WOO_URL };
+		updateLinkHref( item, nextQuery, timeExcludedScreens );
+
+		expect( item.href ).toBe( WOO_URL );
+	} );
+
+	it( 'should not update wp-admin urls', () => {
+		const item = { href: WP_ADMIN_URL };
+		updateLinkHref( item, nextQuery, timeExcludedScreens );
+
+		expect( item.href ).toBe( WP_ADMIN_URL );
+	} );
+} );

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -62,6 +62,7 @@ global.wcSettings = {
 		userLocale: 'en_US',
 		weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
 	},
+	wcAdminSettings: {},
 };
 
 const config = require( '../../config/development.json' );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2214
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2176

Some screens don't have a datepicker. Navigating to those pages now don't persist time-related url params.

This PR also introduces Node at LTS for our build process. This is what [Gutenberg](https://github.com/WordPress/gutenberg/blob/master/.nvmrc) uses.

### Detailed test instructions:

1. Go to Dashboard.
2. Choose a date range.
3. Inspect wc-admin urls. With the exception of devdocs, stock, settings, and customers pages, all urls should have a time related query, eg `?period=last_week&compare=previous_year`.
4. Inspect other urls to make sure no regressions occurred.
