### PR TITLE
Notes: Add filters to disable milestone and sales record notes.

### DIFF
--- a/includes/notes/class-wc-admin-notes-new-sales-record.php
+++ b/includes/notes/class-wc-admin-notes-new-sales-record.php
@@ -39,6 +39,19 @@ class WC_Admin_Notes_New_Sales_Record {
 	 * Possibly add a sales record note.
 	 */
 	public static function possibly_add_sales_record_note() {
+		/**
+		 * Filter to allow for disabling sales record milestones.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param boolean default true
+		 */
+		$sales_record_notes_enabled = apply_filters( 'woocommerce_admin_sales_record_milestone_enabled', true );
+
+		if ( ! $sales_record_notes_enabled ) {
+			return;
+		}
+
 		$yesterday = date( 'Y-m-d', current_time( 'timestamp', 0 ) - DAY_IN_SECONDS );
 		$total     = self::sum_sales_for_date( $yesterday );
 

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -124,6 +124,11 @@ class WC_Admin_Notes_Order_Milestones {
 	 * Used to avoid celebrating milestones that were reached before plugin activation.
 	 */
 	public function backfill_last_milestone() {
+		// If the milestone notes have been disabled via filter, bail.
+		if ( ! $this->are_milestones_enabled() ) {
+			return;
+		}
+
 		$this->set_last_milestone( $this->get_current_milestone() );
 	}
 
@@ -263,9 +268,30 @@ class WC_Admin_Notes_Order_Milestones {
 	}
 
 	/**
+	 * Convenience method to see if the milestone notes are enabled.
+	 */
+	public function are_milestones_enabled() {
+		/**
+		 * Filter to allow for disabling order milestones.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param boolean default true
+		 */
+		$milestone_notes_enabled = apply_filters( 'woocommerce_admin_order_milestone_enabled', true );
+
+		return $milestone_notes_enabled;
+	}
+
+	/**
 	 * Add milestone notes for other significant thresholds.
 	 */
 	public function other_milestones() {
+		// If the milestone notes have been disabled via filter, bail.
+		if ( ! $this->are_milestones_enabled() ) {
+			return;
+		}
+
 		$last_milestone    = $this->get_last_milestone();
 		$current_milestone = $this->get_current_milestone();
 

--- a/includes/notes/class-wc-admin-notes-order-milestones.php
+++ b/includes/notes/class-wc-admin-notes-order-milestones.php
@@ -269,6 +269,8 @@ class WC_Admin_Notes_Order_Milestones {
 
 	/**
 	 * Convenience method to see if the milestone notes are enabled.
+	 *
+	 * @return boolean True if milestone notifications are enabled.
 	 */
 	public function are_milestones_enabled() {
 		/**
@@ -278,7 +280,7 @@ class WC_Admin_Notes_Order_Milestones {
 		 *
 		 * @param boolean default true
 		 */
-		$milestone_notes_enabled = apply_filters( 'woocommerce_admin_order_milestone_enabled', true );
+		$milestone_notes_enabled = apply_filters( 'woocommerce_admin_order_milestones_enabled', true );
 
 		return $milestone_notes_enabled;
 	}


### PR DESCRIPTION
The idea for this filter was brought up after we experienced some performance issues on woocommerce.com. While we are exploring a better fix for that in #2222 - it also feels like adding in some filters to disable the order milestone and sales record notes seems like a good thing to have. So here we are!

I originally put the filters for the order milestone in the `init()` method, but figured having the checks at the areas that actually create the notifs would capture any direct calls to those public methods too. But keen for feedback on that placement @jeffstieler 

### Detailed test instructions:

- Verify that all boots up still, you can add some filters to your theme or elsewhere to test out if you please.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
