### PR TITLE
add match=any support for advanced orders table filter

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-controller.php
@@ -54,6 +54,8 @@ class WC_Admin_REST_Reports_Orders_Controller extends WC_Admin_REST_Reports_Cont
 		$args['customer_type']    = $request['customer_type'];
 		$args['extended_info']    = $request['extended_info'];
 		$args['refunds']          = $request['refunds'];
+		$args['match']            = $request['match'];
+
 		return $args;
 	}
 

--- a/includes/class-wc-admin-reports-orders-query.php
+++ b/includes/class-wc-admin-reports-orders-query.php
@@ -32,8 +32,7 @@ class WC_Admin_Reports_Orders_Query extends WC_Admin_Reports_Query {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_orders_query_args', $this->get_query_vars() );
-
+		$args       = apply_filters( 'woocommerce_reports_orders_query_args', $this->get_query_vars() );
 		$data_store = WC_Data_Store::load( 'report-orders' );
 		$results    = $data_store->get_data( $args );
 		return apply_filters( 'woocommerce_reports_orders_select_query', $results, $args );

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -79,7 +79,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 		$status_subquery = $this->get_status_subquery( $query_args );
 		if ( $status_subquery ) {
-			$where_subquery[] = $status_subquery;
+			$sql_query_params['where_clause'] .= " AND {$status_subquery}";
 		}
 
 		if ( $query_args['customer_type'] ) {
@@ -120,7 +120,7 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 		}
 
 		if ( 0 < count( $where_subquery ) ) {
-			$sql_query_params['where_clause'] = ' AND (' . implode( " {$operator} ", $where_subquery ) . ')';
+			$sql_query_params['where_clause'] .= ' AND (' . implode( " {$operator} ", $where_subquery ) . ')';
 		}
 
 		return $sql_query_params;

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -79,7 +79,11 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 		$status_subquery = $this->get_status_subquery( $query_args );
 		if ( $status_subquery ) {
-			$sql_query_params['where_clause'] .= " AND {$status_subquery}";
+			if ( empty( $query_args['status_is'] ) && empty( $query_args['status_is_not'] ) ) {
+				$sql_query_params['where_clause'] .= " AND {$status_subquery}";
+			} else {
+				$where_subquery[] = $status_subquery;
+			}
 		}
 
 		if ( $query_args['customer_type'] ) {

--- a/includes/data-stores/class-wc-admin-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-data-store.php
@@ -70,6 +70,8 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 	protected function get_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_stats_lookup_table = $wpdb->prefix . self::TABLE_NAME;
+		$operator                 = $this->get_match_operator( $query_args );
+		$where_subquery           = array();
 
 		$sql_query_params = $this->get_time_period_sql_params( $query_args, $order_stats_lookup_table );
 		$sql_query_params = array_merge( $sql_query_params, $this->get_limit_sql_params( $query_args ) );
@@ -77,17 +79,19 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 		$status_subquery = $this->get_status_subquery( $query_args );
 		if ( $status_subquery ) {
-			$sql_query_params['where_clause'] .= " AND {$status_subquery}";
+			$where_subquery[] = $status_subquery;
 		}
 
 		if ( $query_args['customer_type'] ) {
-			$returning_customer                = 'returning' === $query_args['customer_type'] ? 1 : 0;
-			$sql_query_params['where_clause'] .= " AND {$order_stats_lookup_table}.returning_customer = ${returning_customer}";
+			$returning_customer = 'returning' === $query_args['customer_type'] ? 1 : 0;
+			$where_subquery[]   = "{$order_stats_lookup_table}.returning_customer = ${returning_customer}";
 		}
 
-		$refund_subquery                   = $this->get_refund_subquery( $query_args );
-		$sql_query_params['from_clause']  .= $refund_subquery['from_clause'] ? $refund_subquery['from_clause'] : '';
-		$sql_query_params['where_clause'] .= $refund_subquery['where_clause'] ? ' AND ' . $refund_subquery['where_clause'] : '';
+		$refund_subquery                  = $this->get_refund_subquery( $query_args );
+		$sql_query_params['from_clause'] .= $refund_subquery['from_clause'] ? $refund_subquery['from_clause'] : '';
+		if ( $refund_subquery['where_clause'] ) {
+			$where_subquery[] = $refund_subquery['where_clause'];
+		}
 
 		$included_coupons          = $this->get_included_coupons( $query_args );
 		$excluded_coupons          = $this->get_excluded_coupons( $query_args );
@@ -96,10 +100,10 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			$sql_query_params['from_clause'] .= " JOIN {$order_coupon_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_coupon_lookup_table}.order_id";
 		}
 		if ( $included_coupons ) {
-			$sql_query_params['where_clause'] .= " AND {$order_coupon_lookup_table}.coupon_id IN ({$included_coupons})";
+			$where_subquery[] = "{$order_coupon_lookup_table}.coupon_id IN ({$included_coupons})";
 		}
 		if ( $excluded_coupons ) {
-			$sql_query_params['where_clause'] .= " AND {$order_coupon_lookup_table}.coupon_id NOT IN ({$excluded_coupons})";
+			$where_subquery[] = "{$order_coupon_lookup_table}.coupon_id NOT IN ({$excluded_coupons})";
 		}
 
 		$included_products          = $this->get_included_products( $query_args );
@@ -109,10 +113,14 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 			$sql_query_params['from_clause'] .= " JOIN {$order_product_lookup_table} ON {$order_stats_lookup_table}.order_id = {$order_product_lookup_table}.order_id";
 		}
 		if ( $included_products ) {
-			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id IN ({$included_products})";
+			$where_subquery[] = "{$order_product_lookup_table}.product_id IN ({$included_products})";
 		}
 		if ( $excluded_products ) {
-			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id NOT IN ({$excluded_products})";
+			$where_subquery[] = "{$order_product_lookup_table}.product_id NOT IN ({$excluded_products})";
+		}
+
+		if ( 0 < count( $where_subquery ) ) {
+			$sql_query_params['where_clause'] = ' AND (' . implode( " {$operator} ", $where_subquery ) . ')';
 		}
 
 		return $sql_query_params;
@@ -163,7 +171,6 @@ class WC_Admin_Reports_Orders_Data_Store extends WC_Admin_Reports_Data_Store imp
 
 			$selections       = $this->selected_columns( $query_args );
 			$sql_query_params = $this->get_sql_query_params( $query_args );
-
 			$db_records_count = (int) $wpdb->get_var(
 				"SELECT COUNT(*) FROM (
 							SELECT


### PR DESCRIPTION
Fixes #2188

This PR add the match query parameter for the order stats table and implements the operator processing used for calculating the table summary.

### Detailed test instructions:

- Go to Analytics -> Orders
- Choose Advanced filters
- Change Order Match to `Any`
- Add 2 or more filters
- Check that table contains row matching any of the filters
- Check that table summary matches the detail data in the table rows
