### PR TITLE
Feature flags: Enable customizable dash on plugin

### DIFF
--- a/config/plugin.json
+++ b/config/plugin.json
@@ -3,7 +3,7 @@
 		"activity-panels": true,
 		"analytics": true,
 		"analytics-dashboard": true,
-		"analytics-dashboard/customizable": false,
+		"analytics-dashboard/customizable": true,
 		"devdocs": false,
 		"onboarding": false,
 		"store-alerts": true


### PR DESCRIPTION
Turn on customizable dashboard for the plugin.

On a side note, a false flag breaks the app. Issue here https://github.com/woocommerce/woocommerce-admin/issues/2230.