### PR TITLE
Add Stepper component

### DIFF
--- a/client/devdocs/examples.json
+++ b/client/devdocs/examples.json
@@ -22,6 +22,7 @@
   { "component": "Section" },
   { "component": "SegmentedSelection" },
   { "component": "SplitButton" },
+  { "component": "Stepper" },
   { "component": "Summary", "render": "MySummaryList" },
   { "component": "Table" },
   { "component": "Tag" },

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -65,3 +65,7 @@ $core-orange: #ca4a1f;
 
 $button: #f0f2f4;
 $button-border: darken($button, 20%);
+
+// Muriel
+$muriel-gray-dark-300: #969ca1;
+$muriel-active: #bb4f10;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
 - EllipsisMenu component (breaking change): Remove `children` prop in favor of a render prop `renderContent` so that function arguments `isOpen`, `onToggle`, and `onClose` can be passed down.
 - Chart has a new prop named `yBelow1Format` which overrides the `yFormat` for values between -1 and 1 (not included).
+- Add new component `<Stepper />` for showing a list of steps and progress.
 
 # 2.0.0
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -40,6 +40,7 @@ export { default as SearchListItem } from './search-list-control/item';
 export { default as SectionHeader } from './section-header';
 export { default as SegmentedSelection } from './segmented-selection';
 export { default as SplitButton } from './split-button';
+export { default as Stepper } from './stepper';
 export { default as SummaryList } from './summary';
 export { default as SummaryListPlaceholder } from './summary/placeholder';
 export { default as SummaryNumber } from './summary/number';

--- a/packages/components/src/stepper/check-icon.js
+++ b/packages/components/src/stepper/check-icon.js
@@ -1,0 +1,22 @@
+/** @format */
+
+export default () => (
+    <svg
+        role="img"
+        aria-hidden="true"
+        focusable="false"
+        width="18"
+        height="18"
+        viewBox="0 0 18 18"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="2" y="3" width="14" height="12">
+            <path d="M6.59631 11.9062L3.46881 8.77875L2.40381 9.83625L6.59631 14.0287L15.5963
+                5.02875L14.5388 3.97125L6.59631 11.9062Z" fill="white" />
+        </mask>
+        <g mask="url(#mask0)">
+            <rect width="18" height="18" fill="white" />
+        </g>
+    </svg>
+);

--- a/packages/components/src/stepper/example.md
+++ b/packages/components/src/stepper/example.md
@@ -29,7 +29,7 @@ const MyStepper = withState( {
         steps.forEach( s => s.isComplete = true );
     }
 
-	return (
+    return (
         <div>
             { isComplete ? (
                 <button onClick={ () => setState( { currentStep: 'first', isComplete: false } ) } >

--- a/packages/components/src/stepper/example.md
+++ b/packages/components/src/stepper/example.md
@@ -2,8 +2,9 @@
 import { Stepper } from '@woocommerce/components';
 
 const MyStepper = withState( {
-	currentStep: 'first',
-} )( ( { currentStep, setState } ) => {
+    currentStep: 'first',
+    isComplete: false,
+} )( ( { currentStep, isComplete, setState } ) => {
     const steps = [
         {
             label: 'First',
@@ -24,20 +25,39 @@ const MyStepper = withState( {
     ];
     const currentIndex = steps.findIndex( s => currentStep === s.key );
 
+    if ( isComplete ) {
+        steps.forEach( s => s.isComplete = true );
+    }
+
 	return (
-		<div>
-            <button
-                onClick={ () => setState( { currentStep: steps[ currentIndex - 1 ]['key'] } ) }
-                disabled={ currentIndex < 1 }
-            >
-                Previous step
-            </button>
-            <button
-                onClick={ () => setState( { currentStep: steps[ currentIndex + 1 ]['key'] } ) }
-                disabled={ currentIndex >= steps.length - 1 }
-            >
-                Next step
-            </button>
+        <div>
+            { isComplete ? (
+                <button onClick={ () => setState( { currentStep: 'first', isComplete: false } ) } >
+                    Reset
+                </button>
+            ) : (
+                <div>
+                    <button
+                        onClick={ () => setState( { currentStep: steps[ currentIndex - 1 ]['key'] } ) }
+                        disabled={ currentIndex < 1 }
+                    >
+                        Previous step
+                    </button>
+                    <button
+                        onClick={ () => setState( { currentStep: steps[ currentIndex + 1 ]['key'] } ) }
+                        disabled={ currentIndex >= steps.length - 1 }
+                    >
+                        Next step
+                    </button>
+                    <button
+                        onClick={ () => setState( { isComplete: true } ) }
+                        disabled={ currentIndex !== steps.length - 1 }
+                    >
+                        Complete
+                    </button>
+                </div>
+            ) }
+
 			<Stepper
 				steps={ steps }
 				currentStep={ currentStep }

--- a/packages/components/src/stepper/example.md
+++ b/packages/components/src/stepper/example.md
@@ -1,0 +1,48 @@
+```jsx
+import { Stepper } from '@woocommerce/components';
+
+const MyStepper = withState( {
+	currentStep: 'first',
+} )( ( { currentStep, setState } ) => {
+    const steps = [
+        {
+            label: 'First',
+            key: 'first',
+        },
+        {
+            label: 'Second',
+            key: 'second',
+        },
+        {
+            label: 'Third',
+            key: 'third',
+        },
+        {
+            label: 'Fourth',
+            key: 'fourth',
+        },
+    ];
+    const currentIndex = steps.findIndex( s => currentStep === s.key );
+
+	return (
+		<div>
+            <button
+                onClick={ () => setState( { currentStep: steps[ currentIndex - 1 ]['key'] } ) }
+                disabled={ currentIndex < 1 }
+            >
+                Previous step
+            </button>
+            <button
+                onClick={ () => setState( { currentStep: steps[ currentIndex + 1 ]['key'] } ) }
+                disabled={ currentIndex >= steps.length - 1 }
+            >
+                Next step
+            </button>
+			<Stepper
+				steps={ steps }
+				currentStep={ currentStep }
+			/>
+		</div>
+	);
+} );
+```

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -22,25 +22,23 @@ class Stepper extends Component {
 		return (
 			<div className="woocommerce-stepper">
                 { steps.map( ( step, i ) => {
-					const isComplete = currentIndex > i;
-					const isActive = step.key === currentStep;
+					const { key, label, isComplete } = step;
                     const className = classnames( 'woocommerce-stepper__step', {
-                        'is-active': isActive,
-                        'is-complete': isComplete,
+                        'is-active': key === currentStep,
+                        'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
                     } );
 
                     return (
-						<Fragment>
+						<Fragment key={ key } >
 							<div
 								className={ className }
-								key={ step.key }
 							>
 								<div className="woocommerce-stepper__step-icon">
-									<span class="woocommerce-stepper__step-number">{ i + 1 }</span>
+									<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
 									<CheckIcon />
 								</div>
 								<span className="woocommerce-stepper_step-label">
-									{ step.label }
+									{ label }
 								</span>
 							</div>
 							<div className="woocommerce-stepper__step-divider" />
@@ -61,17 +59,21 @@ Stepper.propTypes = {
 			/**
 			 * Key used to identify step.
 			 */
-			key: PropTypes.string,
+			key: PropTypes.string.isRequired,
 			/**
 			 * Label displayed in stepper.
 			 */
-            label: PropTypes.string,
+			label: PropTypes.string.isRequired,
+			/**
+			 * Optionally mark a step complete regardless of step index.
+			 */
+            isComplete: PropTypes.bool,
 		} )
-	),
+	).isRequired,
 	/**
 	 * The current step's key.
 	 */
-	currentStep: PropTypes.string,
+	currentStep: PropTypes.string.isRequired,
 };
 
 export default Stepper;

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -1,0 +1,66 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * A stepper component to indicate progress in a set number of steps.
+ */
+class Stepper extends Component {
+	render() {
+        const { currentStep, steps } = this.props;
+		const currentIndex = steps.findIndex( s => currentStep === s.key );
+
+		return (
+			<div className="woocommerce-stepper">
+                { steps.map( ( step, i ) => {
+                    const className = classnames( 'woocommerce-stepper__step', {
+                        'is-active': step.key === currentStep,
+                        'is-complete': currentIndex > i,
+                    } );
+
+                    return (
+                        <div
+							className={ className }
+							key={ step.key }
+                        >
+							<span className="woocommerce-stepper_step-number">
+								{ i + 1 }
+							</span>
+							<span className="woocommerce-stepper_step-label">
+								{ step.label }
+							</span>
+                        </div>
+                    );
+                } ) }
+			</div>
+		);
+	}
+}
+
+Stepper.propTypes = {
+	/**
+	 * An array of steps used.
+	 */
+	steps: PropTypes.arrayOf(
+		PropTypes.shape( {
+			/**
+			 * Key used to identify step.
+			 */
+			key: PropTypes.string,
+			/**
+			 * Label displayed in stepper.
+			 */
+            label: PropTypes.string,
+		} )
+	),
+	/**
+	 * The current step's key.
+	 */
+	currentStep: PropTypes.string,
+};
+
+export default Stepper;

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -3,8 +3,13 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import CheckIcon from './check-icon';
 
 /**
  * A stepper component to indicate progress in a set number of steps.
@@ -17,23 +22,29 @@ class Stepper extends Component {
 		return (
 			<div className="woocommerce-stepper">
                 { steps.map( ( step, i ) => {
+					const isComplete = currentIndex > i;
+					const isActive = step.key === currentStep;
                     const className = classnames( 'woocommerce-stepper__step', {
-                        'is-active': step.key === currentStep,
-                        'is-complete': currentIndex > i,
+                        'is-active': isActive,
+                        'is-complete': isComplete,
                     } );
 
                     return (
-                        <div
-							className={ className }
-							key={ step.key }
-                        >
-							<span className="woocommerce-stepper_step-number">
-								{ i + 1 }
-							</span>
-							<span className="woocommerce-stepper_step-label">
-								{ step.label }
-							</span>
-                        </div>
+						<Fragment>
+							<div
+								className={ className }
+								key={ step.key }
+							>
+								<div className="woocommerce-stepper__step-icon">
+									<span class="woocommerce-stepper__step-number">{ i + 1 }</span>
+									<CheckIcon />
+								</div>
+								<span className="woocommerce-stepper_step-label">
+									{ step.label }
+								</span>
+							</div>
+							<div className="woocommerce-stepper__step-divider" />
+						</Fragment>
                     );
                 } ) }
 			</div>

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -16,14 +16,15 @@ import CheckIcon from './check-icon';
  */
 class Stepper extends Component {
 	render() {
-        const { currentStep, steps } = this.props;
+        const { className, currentStep, steps } = this.props;
 		const currentIndex = steps.findIndex( s => currentStep === s.key );
+		const stepperClassName = classnames( 'woocommerce-stepper', className );
 
 		return (
-			<div className="woocommerce-stepper">
+			<div className={ stepperClassName }>
                 { steps.map( ( step, i ) => {
 					const { key, label, isComplete } = step;
-                    const className = classnames( 'woocommerce-stepper__step', {
+                    const stepClassName = classnames( 'woocommerce-stepper__step', {
                         'is-active': key === currentStep,
                         'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
                     } );
@@ -31,7 +32,7 @@ class Stepper extends Component {
                     return (
 						<Fragment key={ key } >
 							<div
-								className={ className }
+								className={ stepClassName }
 							>
 								<div className="woocommerce-stepper__step-icon">
 									<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
@@ -52,6 +53,14 @@ class Stepper extends Component {
 
 Stepper.propTypes = {
 	/**
+	 * Additional class name to style the component.
+	 */
+	className: PropTypes.string,
+	/**
+	 * The current step's key.
+	 */
+	currentStep: PropTypes.string.isRequired,
+	/**
 	 * An array of steps used.
 	 */
 	steps: PropTypes.arrayOf(
@@ -70,10 +79,6 @@ Stepper.propTypes = {
             isComplete: PropTypes.bool,
 		} )
 	).isRequired,
-	/**
-	 * The current step's key.
-	 */
-	currentStep: PropTypes.string.isRequired,
 };
 
 export default Stepper;

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -1,13 +1,15 @@
 .woocommerce-stepper {
-    background: #FFFFFF;
-    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.12), 0px 0px 2px rgba(0, 0, 0, 0.14);
+	background: #fff;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2),
+		0 2px 2px rgba(0, 0, 0, 0.12),
+		0 0 2px rgba(0, 0, 0, 0.14);
 	display: flex;
 	justify-content: space-around;
 	align-items: center;
 	margin-bottom: $gap-large;
 	padding-left: $gap;
 	padding-right: $gap;
-	
+
 	.woocommerce-stepper__step {
 		display: inline-flex;
 		align-items: center;
@@ -18,9 +20,10 @@
 			display: none;
 		}
 
-		&.is-active, &.is-complete {
+		&.is-active,
+		&.is-complete {
 			color: #6802f3;
-			
+
 			.woocommerce-stepper__step-icon {
 				color: #fff;
 				background: #6802f3;
@@ -51,7 +54,7 @@
 	.woocommerce-stepper__step-divider {
 		flex-grow: 1;
 		border-bottom: 1px solid #e4e1e4;
-		
+
 		&:last-child {
 			display: none;
 		}

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -9,6 +9,7 @@
 	margin-bottom: $gap-large;
 	padding-left: $gap;
 	padding-right: $gap;
+	font-size: 16px;
 
 	.woocommerce-stepper__step {
 		display: inline-flex;
@@ -22,11 +23,10 @@
 
 		&.is-active,
 		&.is-complete {
-			color: #6802f3;
+			color: $muriel-active;
 
 			.woocommerce-stepper__step-icon {
-				color: #fff;
-				background: #6802f3;
+				background: $muriel-active;
 			}
 		}
 
@@ -47,13 +47,14 @@
 		width: 24px;
 		height: 24px;
 		margin-right: $gap-small;
-		background: #e4e1e4;
+		background: $muriel-gray-dark-300;
+		color: #fff;
 		border-radius: 50%;
 	}
 
 	.woocommerce-stepper__step-divider {
 		flex-grow: 1;
-		border-bottom: 1px solid #e4e1e4;
+		border-bottom: 1px solid $muriel-gray-dark-300;
 
 		&:last-child {
 			display: none;

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -1,0 +1,59 @@
+.woocommerce-stepper {
+    background: #FFFFFF;
+    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.2), 0px 2px 2px rgba(0, 0, 0, 0.12), 0px 0px 2px rgba(0, 0, 0, 0.14);
+	display: flex;
+	justify-content: space-around;
+	align-items: center;
+	margin-bottom: $gap-large;
+	padding-left: $gap;
+	padding-right: $gap;
+	
+	.woocommerce-stepper__step {
+		display: inline-flex;
+		align-items: center;
+		padding: $gap-small;
+		font-weight: 600;
+
+		svg {
+			display: none;
+		}
+
+		&.is-active, &.is-complete {
+			color: #6802f3;
+			
+			.woocommerce-stepper__step-icon {
+				color: #fff;
+				background: #6802f3;
+			}
+		}
+
+		&.is-complete {
+			.woocommerce-stepper__step-number {
+				display: none;
+			}
+			svg {
+				display: inline;
+			}
+		}
+	}
+
+	.woocommerce-stepper__step-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		margin-right: $gap-small;
+		background: #e4e1e4;
+		border-radius: 50%;
+	}
+
+	.woocommerce-stepper__step-divider {
+		flex-grow: 1;
+		border-bottom: 1px solid #e4e1e4;
+		
+		&:last-child {
+			display: none;
+		}
+	}
+}

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -56,4 +56,13 @@
 			display: none;
 		}
 	}
+
+	@include breakpoint( '<782px' ) {
+		.woocommerce-stepper_step-label {
+			display: none;
+		}
+		.woocommerce-stepper__step-icon {
+			margin-right: 0;
+		}
+	}
 }

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -26,6 +26,7 @@
 @import 'section-header/style.scss';
 @import 'segmented-selection/style.scss';
 @import 'split-button/style.scss';
+@import 'stepper/style.scss';
 @import 'summary/style.scss';
 @import 'table/style.scss';
 @import 'tag/style.scss';


### PR DESCRIPTION
Fixes #2164 

Adds in a Muriel style stepper component to be used with the onboarding profiler.

### Thoughts
* Made steps that are prior to the `currentStep` complete by default unless a boolean is passed specifying otherwise.  Still allows the `isComplete` boolean for a step to override this and/or mark the final step complete.
* I did my best to match this design around other Muriel components, but this is not an existing component with guidelines so it's a bit mix and match.  Obviously it's contrasted quite heavily with existing wc-admin components, but I believe that's the direction we'll be headed in for most components going forward.

### Screenshots
<img width="424" alt="Screen Shot 2019-05-16 at 5 09 23 PM" src="https://user-images.githubusercontent.com/10561050/57841653-8860fe80-77fd-11e9-85d6-aab23a5f9719.png">
<img width="632" alt="Screen Shot 2019-05-16 at 5 09 12 PM" src="https://user-images.githubusercontent.com/10561050/57841655-8860fe80-77fd-11e9-8450-6fd6d808c23d.png">

### Detailed test instructions:

1.  Open the devdocs `wp-admin/admin.php?page=wc-admin#/devdocs`.
2.  Go through the steps in the stepper component.
3.  Make sure it works as expected.
4.  Make sure styling is correct.