### PR TITLE
Add vertical and spinner options to the Stepper Component

### DIFF
--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -8,7 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 /**
  * Internal depdencies
  */
-import { H } from '@woocommerce/components';
+import { H, Stepper } from '@woocommerce/components';
 import ProfileWizardHeader from '../header';
 
 export default class Start extends Component {
@@ -28,6 +28,22 @@ export default class Start extends Component {
 							'woocommerce-admin'
 						) }
 					</p>
+
+					<Stepper
+						direction="vertical"
+						currentStep="install"
+						isPending
+						steps={ [
+							{
+								label: __( 'Install Jetpack and WooCommerce Services', 'woocommerce-admin' ),
+								key: 'install',
+							},
+							{
+								label: __( 'Activate Jetpack and WooCommerce Services', 'woocommerce-admin' ),
+								key: 'activate',
+							},
+						] }
+					/>
 				</div>
 			</Fragment>
 		);

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -61,3 +61,6 @@ $button-border: darken($button, 20%);
 // Muriel
 $muriel-gray-dark-300: #969ca1;
 $muriel-active: #bb4f10;
+
+$muriel-gray-50: #e1e2e2;
+$muriel-gray-900: #1a1a1a;

--- a/packages/components/src/stepper/example.md
+++ b/packages/components/src/stepper/example.md
@@ -62,6 +62,12 @@ const MyStepper = withState( {
 				steps={ steps }
 				currentStep={ currentStep }
 			/>
+
+			<Stepper
+				direction="vertical"
+				steps={ steps }
+				currentStep={ currentStep }
+			/>
 		</div>
 	);
 } );

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -5,6 +5,7 @@
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,28 +17,36 @@ import CheckIcon from './check-icon';
  */
 class Stepper extends Component {
 	render() {
-        const { className, currentStep, steps } = this.props;
+		const { className, currentStep, steps, direction, isPending } = this.props;
 		const currentIndex = steps.findIndex( s => currentStep === s.key );
-		const stepperClassName = classnames( 'woocommerce-stepper', className );
+		const stepperClassName = classnames( 'woocommerce-stepper', className, {
+			'is-vertical': 'vertical' === direction,
+		} );
 
 		return (
 			<div className={ stepperClassName }>
-                { steps.map( ( step, i ) => {
+				{ steps.map( ( step, i ) => {
 					const { key, label, isComplete } = step;
-                    const stepClassName = classnames( 'woocommerce-stepper__step', {
-                        'is-active': key === currentStep,
-                        'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
-                    } );
+					const stepClassName = classnames( 'woocommerce-stepper__step', {
+						'is-active': key === currentStep,
+						'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
+					} );
 
-                    return (
+					// @todo Update Spinner Styles
+					// https://material.io/design/components/progress-indicators.html
+					const icon = currentStep === key && isPending ? <Spinner /> : (
+						<div className="woocommerce-stepper__step-icon">
+							<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
+							<CheckIcon />
+						</div>
+					);
+
+					return (
 						<Fragment key={ key } >
 							<div
 								className={ stepClassName }
 							>
-								<div className="woocommerce-stepper__step-icon">
-									<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
-									<CheckIcon />
-								</div>
+								{ icon }
 								<span className="woocommerce-stepper_step-label">
 									{ label }
 								</span>
@@ -79,6 +88,21 @@ Stepper.propTypes = {
             isComplete: PropTypes.bool,
 		} )
 	).isRequired,
+
+	/**
+	 * Direction of the stepper.
+	 */
+	direction: PropTypes.oneOf( [ 'horizontal', 'vertical' ] ),
+
+	/**
+	 * Optional mark the current step as in pending to show a spinner treatment.
+	 */
+	isPending: PropTypes.bool,
+};
+
+Stepper.defaultProps = {
+	direction: 'horizontal',
+	isPending: false,
 };
 
 export default Stepper;

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -95,7 +95,7 @@ Stepper.propTypes = {
 	direction: PropTypes.oneOf( [ 'horizontal', 'vertical' ] ),
 
 	/**
-	 * Optional mark the current step as in pending to show a spinner treatment.
+	 * Optionally mark the current step as pending to show a spinner.
 	 */
 	isPending: PropTypes.bool,
 };

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -22,13 +22,14 @@
 			display: none;
 		}
 
-		&:not( .is-vertical ).woocommerce-stepper_step-label {
+		&:not(.is-vertical).woocommerce-stepper_step-label {
 			margin: 0 4px 0 4px;
 		}
 
 		&.is-active,
 		&.is-complete {
-			.woocommerce-stepper__step-icon, .components-spinner {
+			.woocommerce-stepper__step-icon,
+			.components-spinner {
 				background: $muriel-active;
 			}
 		}
@@ -50,7 +51,8 @@
 		}
 	}
 
-	.woocommerce-stepper__step-icon, .components-spinner {
+	.woocommerce-stepper__step-icon,
+	.components-spinner {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -22,6 +22,10 @@
 			display: none;
 		}
 
+		&:not( .is-vertical ).woocommerce-stepper_step-label {
+			margin: 0 4px 0 4px;
+		}
+
 		&.is-active,
 		&.is-complete {
 			.woocommerce-stepper__step-icon, .components-spinner {
@@ -31,6 +35,9 @@
 
 		&.is-active {
 			font-weight: 600;
+			.woocommerce-stepper_step-label {
+				margin: 0;
+			}
 		}
 
 		&.is-complete {

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -15,7 +15,8 @@
 		display: inline-flex;
 		align-items: center;
 		padding: $gap-small;
-		font-weight: 600;
+		font-weight: 400;
+		color: $muriel-gray-900;
 
 		svg {
 			display: none;
@@ -23,11 +24,13 @@
 
 		&.is-active,
 		&.is-complete {
-			color: $muriel-active;
-
-			.woocommerce-stepper__step-icon {
+			.woocommerce-stepper__step-icon, .components-spinner {
 				background: $muriel-active;
 			}
+		}
+
+		&.is-active {
+			font-weight: 600;
 		}
 
 		&.is-complete {
@@ -40,7 +43,7 @@
 		}
 	}
 
-	.woocommerce-stepper__step-icon {
+	.woocommerce-stepper__step-icon, .components-spinner {
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -52,9 +55,13 @@
 		border-radius: 50%;
 	}
 
+	.components-spinner {
+		margin-left: 0;
+	}
+
 	.woocommerce-stepper__step-divider {
 		flex-grow: 1;
-		border-bottom: 1px solid $muriel-gray-dark-300;
+		border-bottom: 1px solid $muriel-gray-50;
 
 		&:last-child {
 			display: none;
@@ -67,6 +74,18 @@
 		}
 		.woocommerce-stepper__step-icon {
 			margin-right: 0;
+		}
+	}
+
+	&.is-vertical {
+		align-items: initial;
+		flex-direction: column;
+
+		.woocommerce-stepper__step-divider {
+			border-bottom: 0;
+			border-left: 1px solid $muriel-gray-50;
+			height: 50px;
+			margin-left: 24px;
 		}
 	}
 }


### PR DESCRIPTION
This PR cleans up a few stepper styles (the active step is meant to be bolder than the rest), and adds some additional properties to the `Stepper` component.

Specifically it adds a `direction` prop, allowing us to show the stepper as a vertical component. It also adds a prop that allows us to show a spinner for the current step. This is useful for steps that may be executing automatically, like installing plugins.

Please note, that this spinner should use Muriel/Material patterns, but currently uses core WP styles. See https://material.io/design/components/progress-indicators.html#circular-progress-indicators. This will be handled in a follow-up (See https://github.com/woocommerce/woocommerce-admin/issues/2254).

<img width="848" alt="Screen Shot 2019-05-17 at 12 57 12 PM" src="https://user-images.githubusercontent.com/689165/57944057-c284db80-78a3-11e9-9af1-cac3f5188f4f.png">

To Test:
* Set `profileWizardComplete` to `false` in `client/dashboard/index.js`
* Visit `/wp-admin/admin.php?page=wc-admin#/?step=plugins`
* Note that you see a vertical stepper component, with a spinner step.
* Visit the devdocs and test the horizontal stepper