### PR TITLE
Dashboard: Extend charts data

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -229,7 +229,28 @@ ReportChart.propTypes = {
 	/**
 	 * Properties of the selected chart.
 	 */
-	selectedChart: PropTypes.object.isRequired,
+	selectedChart: PropTypes.shape( {
+		/**
+		 * Key of the selected chart.
+		 */
+		key: PropTypes.string.isRequired,
+		/**
+		 * Chart label.
+		 */
+		label: PropTypes.string.isRequired,
+		/**
+		 * Order query argument.
+		 */
+		order: PropTypes.oneOf( [ 'asc', 'desc' ] ),
+		/**
+		 * Order by query argument.
+		 */
+		orderby: PropTypes.string,
+		/**
+		 * Number type for formatting.
+		 */
+		type: PropTypes.oneOf( [ 'average', 'number', 'currency' ] ).isRequired,
+	} ).isRequired,
 };
 
 ReportChart.defaultProps = {

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -129,6 +129,22 @@ ReportSummary.propTypes = {
 		 * Key of the selected chart.
 		 */
 		key: PropTypes.string.isRequired,
+		/**
+		 * Chart label.
+		 */
+		label: PropTypes.string.isRequired,
+		/**
+		 * Order query argument.
+		 */
+		order: PropTypes.oneOf( [ 'asc', 'desc' ] ),
+		/**
+		 * Order by query argument.
+		 */
+		orderby: PropTypes.string,
+		/**
+		 * Number type for formatting.
+		 */
+		type: PropTypes.oneOf( [ 'average', 'number', 'currency' ] ).isRequired,
 	} ).isRequired,
 	/**
 	 * Data to display in the SummaryNumbers.

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -3,13 +3,16 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import { getCategoryLabels } from 'lib/async-requests';
 
-export const charts = [
+const CATEGORY_REPORT_CHART_FILTER = 'woocommerce_admin_category_report_chart_filter';
+
+export const charts = applyFilters( CATEGORY_REPORT_CHART_FILTER, [
 	{
 		key: 'items_sold',
 		label: __( 'Items Sold', 'woocommerce-admin' ),
@@ -31,7 +34,7 @@ export const charts = [
 		orderby: 'orders_count',
 		type: 'number',
 	},
-];
+] );
 
 export const filters = [
 	{

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -68,7 +68,6 @@ export default class CategoriesReport extends Component {
 				/>
 				<ReportChart
 					filters={ filters }
-					charts={ charts }
 					mode={ mode }
 					endpoint="products"
 					limitProperties={ isSingleCategoryView ? [ 'products', 'categories' ] : [ 'categories' ] }

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -3,13 +3,16 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import { getCouponLabels } from 'lib/async-requests';
 
-export const charts = [
+const COUPON_REPORT_CHART_FILTER = 'woocommerce_admin_coupon_report_chart_filter';
+
+export const charts = applyFilters( COUPON_REPORT_CHART_FILTER, [
 	{
 		key: 'orders_count',
 		label: __( 'Discounted Orders', 'woocommerce-admin' ),
@@ -24,7 +27,7 @@ export const charts = [
 		orderby: 'amount',
 		type: 'currency',
 	},
-];
+] );
 
 export const filters = [
 	{

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -60,7 +60,6 @@ export default class CouponsReport extends Component {
 				/>
 				<ReportChart
 					filters={ filters }
-					charts={ charts }
 					mode={ mode }
 					endpoint="coupons"
 					path={ path }

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -3,19 +3,22 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import { getCustomerLabels, getProductLabels } from 'lib/async-requests';
 
-export const charts = [
+const DOWLOADS_REPORT_CHART_FILTER = 'woocommerce_admin_downloads_report_chart_filter';
+
+export const charts = applyFilters( DOWLOADS_REPORT_CHART_FILTER, [
 	{
 		key: 'download_count',
 		label: __( 'Downloads', 'woocommerce-admin' ),
 		type: 'number',
 	},
-];
+] );
 
 export const filters = [
 	{

--- a/client/analytics/report/downloads/index.js
+++ b/client/analytics/report/downloads/index.js
@@ -40,7 +40,6 @@ export default class DownloadsReport extends Component {
 					advancedFilters={ advancedFilters }
 				/>
 				<ReportChart
-					charts={ charts }
 					endpoint="downloads"
 					path={ path }
 					query={ query }

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,7 +12,9 @@ import { getCouponLabels, getProductLabels } from 'lib/async-requests';
 
 const { orderStatuses } = wcSettings;
 
-export const charts = [
+const ORDERS_REPORT_CHART_FILTER = 'woocommerce_admin_orders_report_chart_filter';
+
+export const charts = applyFilters( ORDERS_REPORT_CHART_FILTER, [
 	{
 		key: 'orders_count',
 		label: __( 'Orders Count', 'woocommerce-admin' ),
@@ -36,7 +39,7 @@ export const charts = [
 		orderby: 'num_items_sold',
 		type: 'average',
 	},
-];
+] );
 
 export const filters = [
 	{

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -40,7 +40,6 @@ export default class OrdersReport extends Component {
 					advancedFilters={ advancedFilters }
 				/>
 				<ReportChart
-					charts={ charts }
 					endpoint="orders"
 					path={ path }
 					query={ query }

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -3,13 +3,16 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
 import { getProductLabels, getVariationLabels } from 'lib/async-requests';
 
-export const charts = [
+const PRODUCTS_REPORT_CHART_FILTER = 'woocommerce_admin_products_report_chart_filter';
+
+export const charts = applyFilters( PRODUCTS_REPORT_CHART_FILTER, [
 	{
 		key: 'items_sold',
 		label: __( 'Items Sold', 'woocommerce-admin' ),
@@ -31,7 +34,7 @@ export const charts = [
 		orderby: 'orders_count',
 		type: 'number',
 	},
-];
+] );
 
 const filterConfig = {
 	label: __( 'Show', 'woocommerce-admin' ),

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -81,7 +81,6 @@ class ProductsReport extends Component {
 				<ReportChart
 					mode={ mode }
 					filters={ filters }
-					charts={ charts }
 					endpoint="products"
 					isRequesting={ isRequesting }
 					itemsLabel={ itemsLabel }

--- a/client/analytics/report/revenue/config.js
+++ b/client/analytics/report/revenue/config.js
@@ -3,8 +3,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
-export const charts = [
+const REVENUE_REPORT_CHART_FILTER = 'woocommerce_admin_revenue_report_chart_filter';
+
+export const charts = applyFilters( REVENUE_REPORT_CHART_FILTER, [
 	{
 		key: 'gross_revenue',
 		label: __( 'Gross Revenue', 'woocommerce-admin' ),
@@ -45,4 +48,4 @@ export const charts = [
 		orderby: 'net_revenue',
 		type: 'currency',
 	},
-];
+] );

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -33,7 +33,6 @@ export default class RevenueReport extends Component {
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 				/>
 				<ReportChart
-					charts={ charts }
 					endpoint="revenue"
 					path={ path }
 					query={ query }

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,7 +12,9 @@ import { getRequestByIdString } from 'lib/async-requests';
 import { getTaxCode } from './utils';
 import { NAMESPACE } from 'wc-api/constants';
 
-export const charts = [
+const TAXES_REPORT_CHART_FILTER = 'woocommerce_admin_taxes_report_chart_filter';
+
+export const charts = applyFilters( TAXES_REPORT_CHART_FILTER, [
 	{
 		key: 'total_tax',
 		label: __( 'Total Tax', 'woocommerce-admin' ),
@@ -40,7 +43,7 @@ export const charts = [
 		orderby: 'orders_count',
 		type: 'number',
 	},
-];
+] );
 
 export const filters = [
 	{

--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -57,7 +57,6 @@ export default class TaxesReport extends Component {
 				/>
 				<ReportChart
 					filters={ filters }
-					charts={ charts }
 					mode={ mode }
 					endpoint="taxes"
 					query={ chartQuery }

--- a/client/dashboard/dashboard-charts/config.js
+++ b/client/dashboard/dashboard-charts/config.js
@@ -1,5 +1,10 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 
@@ -9,16 +14,23 @@ import { charts as revenueCharts } from 'analytics/report/revenue/config';
 import { charts as categoriesCharts } from 'analytics/report/categories/config';
 import { charts as couponsCharts } from 'analytics/report/coupons/config';
 import { charts as taxesCharts } from 'analytics/report/taxes/config';
+import { charts as downloadsCharts } from 'analytics/report/downloads/config';
 
-const allCharts = ordersCharts
-	.map( d => ( { ...d, endpoint: 'orders' } ) )
-	.concat(
-		productsCharts.map( d => ( { ...d, endpoint: 'products' } ) ),
-		revenueCharts.map( d => ( { ...d, endpoint: 'revenue' } ) ),
-		categoriesCharts.map( d => ( { ...d, endpoint: 'categories' } ) ),
-		couponsCharts.map( d => ( { ...d, endpoint: 'orders' } ) ),
-		taxesCharts.map( d => ( { ...d, endpoint: 'taxes' } ) )
-	);
+const DASHBOARD_CHARTS_FILTER = 'woocommerce_admin_dashboard_charts_filter';
+
+const allCharts = applyFilters(
+	DASHBOARD_CHARTS_FILTER,
+	revenueCharts
+		.map( d => ( { ...d, endpoint: 'orders' } ) )
+		.concat(
+			ordersCharts.map( d => ( { ...d, endpoint: 'revenue' } ) ),
+			productsCharts.map( d => ( { ...d, endpoint: 'products' } ) ),
+			categoriesCharts.map( d => ( { ...d, endpoint: 'categories' } ) ),
+			couponsCharts.map( d => ( { ...d, endpoint: 'orders' } ) ),
+			taxesCharts.map( d => ( { ...d, endpoint: 'taxes' } ) ),
+			downloadsCharts.map( d => ( { ...d, endpoint: 'downloads' } ) )
+		)
+);
 
 // Need to remove duplicate charts, by key, from the configs
 export const uniqCharts = allCharts.reduce( ( a, b ) => {

--- a/client/dashboard/default-sections.js
+++ b/client/dashboard/default-sections.js
@@ -50,6 +50,7 @@ export default applyFilters( DEFAULT_SECTIONS_FILTER, [
 			'total_tax',
 			'order_tax',
 			'shipping_tax',
+			'download_count',
 		],
 	},
 	{

--- a/includes/features/analytics-dashboard/class-wc-admin-analytics-dashboard.php
+++ b/includes/features/analytics-dashboard/class-wc-admin-analytics-dashboard.php
@@ -44,7 +44,7 @@ class WC_Admin_Analytics_Dashboard {
 	}
 
 	/**
-	 * Preload data from the performance indicators endpoint.
+	 * Preload data from API endpoints.
 	 *
 	 * @param array $endpoints Array of preloaded endpoints.
 	 * @return array


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2244

This PR adds filters for adding charts/summaryNumbers to existing reports as well as dashboard charts from reports added by extensions.

#2244 calls for a REST API driven approach similar to leaderboards and store performance indicators. I think a js approach is more suitable in this case because existing infrastructure is already responsible for making api calls and the dashboard simply designates which charts to display. In other words, a chart config is supplied and `<ReportChart />` handles the rest.

This logic makes the assumption that dashboard charts are only made up of charts currently found on existing reports or reports introduced via extensions. In either case, the current dashboard settings, which are persisted, can determine which are hidden and which are visible.

In a follow up PR, I can go through the process of adding a chart via extension and possibly expose any holes in this logic.

I also made a few changes while here:

1. Improved the `selectedChart` propType declaration
2. Remove the unused `charts` prop from `<ReportChart />`
3. Added the `downloads` chart to the dashboard and hid it by default. You'll need to delete the following user meta if you want to confirm its hidden by default:

```
DELETE FROM `wp_usermeta` WHERE meta_key = 'wc_admin_dashboard_sections'
```

### Detailed test instructions:

Make sure the Dashboard and Reports load and function correctly. There should be no visible changes other than the added downloads chart on the dashboard.




