### PR TITLE
Update Onboarding Colors

### DIFF
--- a/client/dashboard/profile-wizard/header-logo.js
+++ b/client/dashboard/profile-wizard/header-logo.js
@@ -18,7 +18,7 @@ export default () => (
 							viewBox="0 0 24 24"
 							height="72"
 							width="72"
-							fill="#bbc9d5"
+							fill="#2B2D2F"
 						>
 							<g xmlns="http://www.w3.org/2000/svg">
 								<path d="M18 11h-5V6h-2v5H6v2h5v5h2v-5h5" />
@@ -32,7 +32,7 @@ export default () => (
                                 L161.2,145.8 L118.1,121.8 L23.8,121.8 C11.2,121.8 1,111.6 1,99
                                 L1,23 C0.9,10.5 11.1,0.2 23.7,0.2 Z"
 							id="Shape"
-							fill="#BEABCE"
+							fill="#2B2D2F"
 						/>
 						<path
 							d="M13.2,20.9 C14.6,19 16.7,18 19.5,17.8 C24.6,17.4 27.5,19.8 28.2,25
@@ -46,7 +46,7 @@ export default () => (
                                 39.3,110.1 35.1,110.4 C32.4,110.6 30.1,108.3 28.1,103.5 C23,90.4 17.5,65.1
                                 11.6,27.6 C11.3,25 11.8,22.7 13.2,20.9 Z"
 							id="Shape"
-							fill="#342148"
+							fill="#F6F6F6"
 							fillRule="nonzero"
 						/>
 						<path
@@ -60,7 +60,7 @@ export default () => (
                                 198.2,47.5 C201.5,42.6 205,40.6 208.6,41.3 C211,41.8 213,43.9 214.5,47.8
                                 C215.7,50.9 216.3,54 216.3,56.9 C216.3,59.5 216,62 215.6,64.3 Z"
 							id="Shape"
-							fill="#342148"
+							fill="#F6F6F6"
 							fillRule="nonzero"
 						/>
 						<path
@@ -74,17 +74,17 @@ export default () => (
                                 135.5,47.5 C138.8,42.6 142.3,40.6 145.9,41.3 C148.3,41.8 150.3,43.9 151.8,47.8
                                 C153,50.9 153.6,54 153.6,56.9 C153.6,59.5 153.4,62 152.9,64.3 Z"
 							id="Shape"
-							fill="#342148"
+							fill="#F6F6F6"
 							fillRule="nonzero"
 						/>
 					</g>
 					<svg height="150" width="150" viewBox="0 0 32 32">
 						<path
-							fill="#BEABCE"
+							fill="#2B2D2F"
 							d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
 						/>
-						<polygon fill="#342148" points="15,19 7,19 15,3 " />
-						<polygon fill="#342148" points="17,29 17,13 25,13 " />
+						<polygon fill="#F6F6F6" points="15,19 7,19 15,3 " />
+						<polygon fill="#F6F6F6" points="17,29 17,13 25,13 " />
 					</svg>
 				</g>
 			</g>

--- a/client/dashboard/profile-wizard/header-logo.js
+++ b/client/dashboard/profile-wizard/header-logo.js
@@ -12,7 +12,7 @@ export default () => (
 		<g fill="none" fillRule="evenodd">
 			<g>
 				<g>
-					<g transform="translate(219 35.082353)">
+					<g transform="translate(219 35.082353)" className="woocommerce-profile-wizard__plus">
 						<svg
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 0 24 24"

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -1,14 +1,14 @@
 /** @format */
 
 .woocommerce-profile-wizard__body {
-	background: #342248;
-	color: #beabce;
+	background: $woocommerce-onboarding-background;
+	color: $muriel-gray-600;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
 
 	.woocommerce-profile-wizard__header {
 		height: 56px;
-		border-bottom: 1px solid #1f112e;
+		border-bottom: 1px solid $muriel-gray-50;
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -19,7 +19,7 @@
 	}
 
 	.woocommerce-profile-wizard__header-title {
-		color: #fff;
+		color: $muriel-gray-800;
 		font-size: 24px;
 		line-height: 32px;
 		font-weight: 400;

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -16,6 +16,10 @@
 		svg > g {
 			transform: translateX(25%);
 		}
+
+		.woocommerce-profile-wizard__plus {
+			stroke: $muriel-gray-800;
+		}
 	}
 
 	.woocommerce-profile-wizard__header-title {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -1,7 +1,7 @@
 /** @format */
 
 .woocommerce-profile-wizard__body {
-	background: $woocommerce-onboarding-background;
+	background: $muriel-gray-0;
 	color: $muriel-gray-600;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -1,7 +1,6 @@
 /** @format */
 
 @import 'node_modules/color-studio/dist/color-variables.scss';
-
 // @todo Replace duplicate colors below with their color-studio/Muriel counterparts.
 
 $white: rgba(255, 255, 255, 1);
@@ -61,10 +60,3 @@ $core-orange: #ca4a1f;
 
 $button: #f0f2f4;
 $button-border: darken($button, 20%);
-
-// Muriel
-$muriel-gray-dark-300: #969ca1;
-$muriel-active: #bb4f10;
-
-// Onboarding
-$woocommerce-onboarding-background: #f6f6f6;

--- a/client/stylesheets/abstracts/_colors.scss
+++ b/client/stylesheets/abstracts/_colors.scss
@@ -1,5 +1,9 @@
 /** @format */
 
+@import 'node_modules/color-studio/dist/color-variables.scss';
+
+// @todo Replace duplicate colors below with their color-studio/Muriel counterparts.
+
 $white: rgba(255, 255, 255, 1);
 
 // Greys
@@ -62,5 +66,5 @@ $button-border: darken($button, 20%);
 $muriel-gray-dark-300: #969ca1;
 $muriel-active: #bb4f10;
 
-$muriel-gray-50: #e1e2e2;
-$muriel-gray-900: #1a1a1a;
+// Onboarding
+$woocommerce-onboarding-background: #f6f6f6;

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "babel-plugin-transform-es2015-template-literals": "6.22.0",
     "chalk": "2.4.2",
     "concurrently": "4.1.0",
-    "color-studio": "github:automattic/color-studio#1.0.1",
+    "color-studio": "github:automattic/color-studio#1.0.3",
     "copy-webpack-plugin": "4.6.0",
     "cross-env": "5.2.0",
     "css-loader": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "babel-plugin-transform-es2015-template-literals": "6.22.0",
     "chalk": "2.4.2",
     "concurrently": "4.1.0",
+    "color-studio": "github:automattic/color-studio#1.0.1",
     "copy-webpack-plugin": "4.6.0",
     "cross-env": "5.2.0",
     "css-loader": "2.1.1",

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -30,7 +30,7 @@
 		&.is-complete {
 			.woocommerce-stepper__step-icon,
 			.components-spinner {
-				background: $muriel-active;
+				background: $muriel-hot-orange-700;
 			}
 		}
 
@@ -59,7 +59,7 @@
 		width: 24px;
 		height: 24px;
 		margin-right: $gap-small;
-		background: $muriel-gray-dark-300;
+		background: $muriel-gray-300;
 		color: #fff;
 		border-radius: 50%;
 	}


### PR DESCRIPTION
This PR updates the onboarding colors. After some feedback and discussion by the designers, we are using a lighter color scheme -- see iteration 15 in the Figma file.

This PR also pulls in the`color-studio` package (also consumed by Calypso), so that we can stop copy and pasting variables everywhere.

To Test:
* `npm install`
* `npm start`
* Set `profileWizardComplete` to false in `dashboard/index.js`
* Visit `/wp-admin/admin.php?page=wc-admin#/?step=plugins` and verify you see the new color(s).


<img width="930" alt="Screen Shot 2019-05-20 at 1 56 53 PM" src="https://user-images.githubusercontent.com/689165/58042028-979ac180-7b07-11e9-8e41-680e124f291d.png">
