### PR TITLE
Exclude auto-draft and trashed orders from imports.

### DIFF
--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -351,6 +351,7 @@ class WC_Admin_Reports_Sync {
 		$count = $wpdb->get_var(
 			"SELECT COUNT(*) FROM {$wpdb->posts}
 			WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
+			AND post_status NOT IN ( 'auto-draft', 'trash' )
 			{$where_clause}"
 		); // WPCS: unprepared SQL ok.
 
@@ -358,6 +359,7 @@ class WC_Admin_Reports_Sync {
 			$wpdb->prepare(
 				"SELECT ID FROM {$wpdb->posts}
 				WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
+				AND post_status NOT IN ( 'auto-draft', 'trash' )
 				{$where_clause}
 				ORDER BY post_date ASC
 				LIMIT %d


### PR DESCRIPTION
Fixes #2229.

Exclude `auto-draft` and `trash` status order from imports.

### Detailed test instructions:

_If you want to see this in the UI, you'll need to merge https://github.com/woocommerce/woocommerce-admin/pull/2208 as well._

Before testing - enable the progress bars:

> In `client/analytics/settings/historical-data/layout.js` line 70 set: `const showImportStatus = true;`, so progress bars are displayed.

1. Go to WooCommerce > Analytics > Settings
1. Select "Last 24 hours"
1. Make note of the orders count
1. Go to WooCommerce > Orders > Add New (this creates a draft)
1. Go back to WooCommerce > Analytics > Settings
1. Select "Last 24 hours" again
1. Verify that the Orders count remained the same

Alternatively, check the test code.
