### PR TITLE
Add support for “primary” admin notice actions.

### DIFF
--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -73,6 +73,7 @@ class StoreAlerts extends Component {
 				<Button
 					key={ action.name }
 					isDefault
+					isPrimary={ action.primary }
 					href={ action.url }
 					onClick={ '' === action.status ? noop : markStatus }
 				>

--- a/includes/class-wc-admin-install.php
+++ b/includes/class-wc-admin-install.php
@@ -170,6 +170,7 @@ class WC_Admin_Install {
 			label varchar(255) NOT NULL,
 			query longtext NOT NULL,
 			status varchar(255) NOT NULL,
+			is_primary boolean DEFAULT 0 NOT NULL,
 			PRIMARY KEY (action_id),
 			KEY note_id (note_id)
 		) $collate;

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -200,13 +200,13 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 
 		$actions = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT name, label, query, status FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id = %d",
+				"SELECT name, label, query, status, is_primary FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id = %d",
 				$note->get_id()
 			)
 		);
 		if ( $actions ) {
 			foreach ( $actions as $action ) {
-				$note->add_action( $action->name, $action->label, $action->query, $action->status );
+				$note->add_action( $action->name, $action->label, $action->query, $action->status, $action->is_primary );
 			}
 		}
 	}
@@ -231,11 +231,12 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 			$wpdb->insert(
 				$wpdb->prefix . 'wc_admin_note_actions',
 				array(
-					'note_id' => $note->get_id(),
-					'name'    => $action->name,
-					'label'   => $action->label,
-					'query'   => $action->query,
-					'status'  => $action->status,
+					'note_id'    => $note->get_id(),
+					'name'       => $action->name,
+					'label'      => $action->label,
+					'query'      => $action->query,
+					'status'     => $action->status,
+					'is_primary' => $action->primary,
 				)
 			);
 		}

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -466,16 +466,18 @@ class WC_Admin_Note extends WC_Data {
 	/**
 	 * Add an action to the note
 	 *
-	 * @param string $name Label name (not presented to user).
-	 * @param string $label Note label (e.g. presented as button label).
-	 * @param string $query Note query (for redirect).
-	 * @param string $status The status to set for the action should on click.
+	 * @param string  $name    Label name (not presented to user).
+	 * @param string  $label   Note label (e.g. presented as button label).
+	 * @param string  $query   Note query (for redirect).
+	 * @param string  $status  The status to set for the action should on click.
+	 * @param boolean $primary Whether or not this is the primary action. Defaults to false.
 	 */
-	public function add_action( $name, $label, $query, $status = '' ) {
-		$name   = wc_clean( $name );
-		$label  = wc_clean( $label );
-		$query  = wc_clean( $query );
-		$status = wc_clean( $status );
+	public function add_action( $name, $label, $query, $status = '', $primary = false ) {
+		$name    = wc_clean( $name );
+		$label   = wc_clean( $label );
+		$query   = wc_clean( $query );
+		$status  = wc_clean( $status );
+		$primary = (bool) $primary;
 
 		if ( empty( $name ) ) {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note action name prop cannot be empty.', 'woocommerce-admin' ) );
@@ -485,15 +487,17 @@ class WC_Admin_Note extends WC_Data {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note action label prop cannot be empty.', 'woocommerce-admin' ) );
 		}
 
+		// @todo - maybe allow empty queries? for dismissals that don't need navigation.
 		if ( empty( $query ) ) {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note action query prop cannot be empty.', 'woocommerce-admin' ) );
 		}
 
 		$action = array(
-			'name'   => $name,
-			'label'  => $label,
-			'query'  => $query,
-			'status' => $status,
+			'name'    => $name,
+			'label'   => $label,
+			'query'   => $query,
+			'status'  => $status,
+			'primary' => $primary,
 		);
 
 		$note_actions   = $this->get_prop( 'actions', 'edit' );

--- a/includes/notes/class-wc-admin-notes-historical-data.php
+++ b/includes/notes/class-wc-admin-notes-historical-data.php
@@ -49,7 +49,8 @@ class WC_Admin_Notes_Historical_Data {
 			'get-started',
 			__( 'Get Started', 'woocommerce-admin' ),
 			'?page=wc-admin#/analytics/settings',
-			'actioned'
+			'actioned',
+			true
 		);
 
 		$note->save();


### PR DESCRIPTION
In support of https://github.com/woocommerce/woocommerce-admin/issues/2268

This PR introduces the ability to treat admin notice actions as "primary".

### Screenshots

![Screen Shot 2019-05-21 at 1 04 58 PM](https://user-images.githubusercontent.com/63922/58123520-3affdb00-7bc9-11e9-8e58-377ccc7dcf12.png)

### Detailed test instructions:

- Delete your `wc_admin_version` option to trigger a DB delta
- Trigger the historical data notice (either set back to `unactioned` in the DB, or call `WC_Admin_Notes_Historical_Data::add_note()` somewhere)
- Verify that the action button has the primary treatment

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
