### PR TITLE
Remove errant import update operation from `wp-api` spec.

### DIFF
--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -46,7 +46,6 @@ function createWcApiSpec() {
 			},
 			update( resourceNames, data ) {
 				return [
-					...imports.operations.update( resourceNames, data ),
 					...items.operations.update( resourceNames, data ),
 					...notes.operations.update( resourceNames, data ),
 					...settings.operations.update( resourceNames, data ),


### PR DESCRIPTION
Fixes a JS error when notes try to update their status via action button clicks.

Introduced in: https://github.com/woocommerce/woocommerce-admin/commit/7c4f6a20a64082164b8a80071a9b13493b11c072#diff-32998debf72104db6396cd0bcbdba2d4R49

### Detailed test instructions:

- On `master`
- Open dev console
- Click "get started" on the historical data notice
- Verify this error in console: `Uncaught (in promise) TypeError: _imports__WEBPACK_IMPORTED_MODULE_3__.default.operations.update is not a function`
- Check out this branch, refresh
- Click "get started" on the historical data notice
- Verify no error in console

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
