### PR TITLE
Allow links in admin notice content.

### DIFF
--- a/client/lib/sanitize-html/index.js
+++ b/client/lib/sanitize-html/index.js
@@ -5,7 +5,7 @@
 import { sanitize } from 'dompurify';
 
 export const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong' ];
-export const ALLOWED_ATTR = [ 'target', 'href' ];
+export const ALLOWED_ATTR = [ 'target', 'href', 'rel', 'name', 'download' ];
 
 export default html => {
 	return {

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -347,6 +347,15 @@ class WC_Admin_Note extends WC_Data {
 			'br'     => array(),
 			'em'     => array(),
 			'strong' => array(),
+			'a'      => array(
+				'href'     => true,
+				'rel'      => true,
+				'name'     => true,
+				'target'   => true,
+				'download' => array(
+					'valueless' => 'y',
+				),
+			),
 		);
 
 		$content = wp_kses( $content, $allowed_html );


### PR DESCRIPTION
In support of https://github.com/woocommerce/woocommerce-admin/issues/2268

Allow `<a>` tags in notice content with the following attributes: `href`, `rel`, `name`, `target`.

### Detailed test instructions:

```php
$note = new WC_Admin_Note();
$note->set_title( 'Test Link' );
$note->set_content( 'Has a <a href="https://example.com">link</a>.' );
$note->save();
```

- Create a new test note with a link in the content
- Verify note is displayed with the link rendered properly

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
