### PR TITLE
wc-api: Remove reference to import update functions

### DIFF
--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -46,7 +46,6 @@ function createWcApiSpec() {
 			},
 			update( resourceNames, data ) {
 				return [
-					...imports.operations.update( resourceNames, data ),
 					...items.operations.update( resourceNames, data ),
 					...notes.operations.update( resourceNames, data ),
 					...settings.operations.update( resourceNames, data ),


### PR DESCRIPTION
`wc-api` included a reference to an import operations function `update`, which does not exist, resulting in the following error:

![Screen Shot 2019-05-22 at 2 21 18 PM](https://user-images.githubusercontent.com/1922453/58143175-f7c36c00-7c9d-11e9-804e-d04ba2d489af.png)

### Detailed test instructions:

1. Apply any update function. For example, move or change a dashboard item.
2. Ensure the change persists and no errors in the console.
