### PR TITLE
Onboarding - Add shared step actions and step 1 actions

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -11,7 +11,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { stringifyQuery, updateQueryString } from '@woocommerce/navigation';
+import { updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal depdencies
@@ -102,11 +102,11 @@ class ProfileWizard extends Component {
 
 	updateProfile( params ) {
 		const { addNotice } = this.props;
-		const payload = stringifyQuery( params );
 
 		return apiFetch( {
-			path: `/wc-admin/v1/onboarding/profile${ payload }`,
+			path: '/wc-admin/v1/onboarding/profile',
 			method: 'POST',
+			data: params,
 		} ).catch( error => {
 			if ( error && error.message ) {
 				addNotice( { status: 'error', message: error.message } );

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -61,14 +61,17 @@ export default class Start extends Component {
 		};
 
 		this.onTrackingChange = this.onTrackingChange.bind( this );
+		this.startWizard = this.startWizard.bind( this );
+		this.skipWizard = this.skipWizard.bind( this );
 	}
 
 	skipWizard() {
-		// @todo This should close the wizard and set the `skipped` property to true via the API.
+		this.props.updateProfile( { skipped: true } );
 	}
 
 	startWizard() {
-		// @todo This should go to the next step.
+		// @todo This should update the settings with the tracking selection. See #2281.
+		this.props.goToNextStep();
 	}
 
 	onTrackingChange() {

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -117,7 +117,8 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_items( $request ) {
-		$query_args      = $this->prepare_objects_query( $request );
+		$params          = $request->get_json_params();
+		$query_args      = $this->prepare_objects_query( $params );
 		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
 		update_option( 'wc_onboarding_profile', array_merge( $onboarding_data, $query_args ) );
 
@@ -135,16 +136,16 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	/**
 	 * Prepare objects query.
 	 *
-	 * @param  WP_REST_Request $request Full details about the request.
+	 * @param  array $params The params sent in the request.
 	 * @return array
 	 */
-	protected function prepare_objects_query( $request ) {
+	protected function prepare_objects_query( $params ) {
 		$args       = array();
 		$properties = self::get_profile_properties();
 
 		foreach ( $properties as $key => $property ) {
-			if ( isset( $request[ $key ] ) ) {
-				$args[ $key ] = $request[ $key ];
+			if ( isset( $params[ $key ] ) ) {
+				$args[ $key ] = $params[ $key ];
 			}
 		}
 
@@ -154,10 +155,10 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 		 * Enables adding extra arguments or setting defaults for a post
 		 * collection request.
 		 *
-		 * @param array           $args    Key value array of query var to query value.
-		 * @param WP_REST_Request $request The request used.
+		 * @param array $args    Key value array of query var to query value.
+		 * @param array $params The params sent in the request.
 		 */
-		$args = apply_filters( 'woocommerce_rest_onboarding_profile_object_query', $args, $request );
+		$args = apply_filters( 'woocommerce_rest_onboarding_profile_object_query', $args, $params );
 
 		return $args;
 	}

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -56,7 +56,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		// Test updating 2 fields separately.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
-		$request->set_param( 'industry', 'health-beauty' );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'industry' => 'health-beauty' ) ) );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -65,7 +66,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		// Test that the update works.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
-		$request->set_param( 'theme', 'Storefront' );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'theme' => 'Storefront' ) ) );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -128,7 +130,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 
 		// Test that the update works.
 		$request = new WP_REST_Request( 'POST', $this->endpoint );
-		$request->set_param( 'test_profile_datum', 'woo' );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'test_profile_datum' => 'woo' ) ) );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION
Fixes #2282

Passes reusable shared actions as props to step components. `goToNextStep()` and `updateProfile()` are made available as props inside steps.

Note that updating the WC settings (not the profiler settings - https://github.com/woocommerce/woocommerce-admin/issues/2281) and closing the wizard will be handled in follow-up PRs.

### Screenshots
<img width="550" alt="Screen Shot 2019-05-22 at 4 32 39 PM" src="https://user-images.githubusercontent.com/10561050/58159777-c81d5f80-7caf-11e9-993b-de45acc4202d.png">

### Detailed test instructions:

1.  Change to `const profileWizardComplete = false;` in `dashboard/index.js`
2.  Go to the dashboard `/wp-admin/admin.php?page=wc-admin#`
3.  Click on "Get Started" and make sure this takes you to the next step.
4.  Go back and click on "Proceed without Jetpack or WooCommerce Services" and make sure this updates the profiler setting `skipped` to `true` by sending a GET request to `wp-json/wc-admin/v1/onboarding/profile`.