### PR TITLE
Return a success message when updating in profiler controller

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -119,19 +119,12 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	public function update_items( $request ) {
 		$query_args      = $this->prepare_objects_query( $request );
 		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
-		$update          = update_option( 'wc_onboarding_profile', array_merge( $onboarding_data, $query_args ) );
+		update_option( 'wc_onboarding_profile', array_merge( $onboarding_data, $query_args ) );
 
-		if ( $update ) {
-			$result = array(
-				'status'  => 'success',
-				'message' => __( 'Onboarding profile data has been updated.', 'woocommerce-admin' ),
-			);
-		} else {
-			$result = array(
-				'status'  => 'error',
-				'message' => __( 'There was an error updating the onboarding profile data.', 'woocommerce-admin' ),
-			);
-		}
+		$result = array(
+			'status'  => 'success',
+			'message' => __( 'Onboarding profile data has been updated.', 'woocommerce-admin' ),
+		);
 
 		$response = $this->prepare_item_for_response( $result, $request );
 		$data     = $this->prepare_response_for_collection( $response );


### PR DESCRIPTION
Fixes #2284

Fixes an issue where an error is returned when updating params with identical values.

### Screenshots
<img width="491" alt="Screen Shot 2019-05-22 at 4 57 08 PM" src="https://user-images.githubusercontent.com/10561050/58161331-a70a3e00-7cb2-11e9-9540-13bc3e830195.png">

### Detailed test instructions:

1.  POST to `/wp-json/wc-admin/v1/onboarding/profile` with a valid param `skipped=1`.
2.  Note the success message.
3. POST the same request again.
4. Note the same success message. 🎉🤦‍♂ 