### PR TITLE
Fix `box-shadow-8dp` error.

### DIFF
--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -13,7 +13,7 @@
 	}
 
 	&:hover {
-		box-shadow: $box-shadow-8dp;
+		box-shadow: $muriel-box-shadow-8dp;
 	}
 
 	&.is-inactive {


### PR DESCRIPTION
This PR updates an incorrect usage of `$box-shadow-8dp` which should have been `$muriel-box-shadow-8dp`.

### Detailed test instructions:

* `npm start` and notice no error
* Optionally: Visit the `<Card />` on the `devdocs`, and hover over the card. See styles are intact.