### PR TITLE
Move StoreAlerts below screen meta links on embed pages.

### DIFF
--- a/client/embedded.js
+++ b/client/embedded.js
@@ -13,13 +13,17 @@ import { EmbedLayout, PrimaryLayout as NoticeArea } from './layout';
 import 'store';
 import 'wc-api/wp-data-store';
 
+const embeddedRoot = document.getElementById( 'woocommerce-embedded-root' );
+
 // Render the header.
 render(
 	<SlotFillProvider>
 		<EmbedLayout />
 	</SlotFillProvider>,
-	document.getElementById( 'woocommerce-embedded-root' )
+	embeddedRoot
 );
+
+embeddedRoot.classList.remove( 'is-embed-loading' );
 
 // Render notices just above the WP content div.
 const wpBody = document.getElementById( 'wpbody-content' );

--- a/client/embedded.js
+++ b/client/embedded.js
@@ -9,13 +9,26 @@ import { Provider as SlotFillProvider } from 'react-slot-fill';
  * Internal dependencies
  */
 import './stylesheets/_embedded.scss';
-import { EmbedLayout } from './layout';
+import { EmbedLayout, PrimaryLayout as NoticeArea } from './layout';
 import 'store';
 import 'wc-api/wp-data-store';
 
+// Render the header.
 render(
 	<SlotFillProvider>
 		<EmbedLayout />
 	</SlotFillProvider>,
 	document.getElementById( 'woocommerce-embedded-root' )
+);
+
+// Render notices just above the WP content div.
+const wpBody = document.getElementById( 'wpbody-content' );
+const wrap = wpBody.querySelector( '.wrap' );
+const noticeContainer = document.createElement( 'div' );
+
+render(
+	<div className="woocommerce-layout">
+		<NoticeArea />
+	</div>,
+	wpBody.insertBefore( noticeContainer, wrap )
 );

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -94,17 +94,6 @@ Layout.propTypes = {
 	isEmbedded: PropTypes.bool,
 };
 
-export class NoticeArea extends Component {
-	render() {
-		return (
-			<Fragment>
-				{ window.wcAdminFeatures[ 'store-alerts' ] && <StoreAlerts /> }
-				<Notices />
-			</Fragment>
-		);
-	}
-}
-
 export class PageLayout extends Component {
 	render() {
 		return (

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -24,6 +24,19 @@ import { recordPageView } from 'lib/tracks';
 import TransientNotices from './transient-notices';
 import StoreAlerts from './store-alerts';
 
+export class PrimaryLayout extends Component {
+	render() {
+		const { children } = this.props;
+		return (
+			<div className="woocommerce-layout__primary" id="woocommerce-layout__primary">
+				{ window.wcAdminFeatures[ 'store-alerts' ] && <StoreAlerts /> }
+				<Notices />
+				{ children }
+			</div>
+		);
+	}
+}
+
 class Layout extends Component {
 	componentDidMount() {
 		this.recordPageViewTrack();
@@ -60,29 +73,37 @@ class Layout extends Component {
 	}
 
 	render() {
-		const { isEmbeded, ...restProps } = this.props;
+		const { isEmbedded, ...restProps } = this.props;
 		return (
 			<div className="woocommerce-layout">
 				<Slot name="header" />
 				<TransientNotices />
-
-				<div className="woocommerce-layout__primary" id="woocommerce-layout__primary">
-					{ window.wcAdminFeatures[ 'store-alerts' ] && <StoreAlerts /> }
-					<Notices />
-					{ ! isEmbeded && (
+				{ ! isEmbedded && (
+					<PrimaryLayout>
 						<div className="woocommerce-layout__main">
 							<Controller { ...restProps } />
 						</div>
-					) }
-				</div>
+					</PrimaryLayout>
+				) }
 			</div>
 		);
 	}
 }
 
 Layout.propTypes = {
-	isEmbededLayout: PropTypes.bool,
+	isEmbedded: PropTypes.bool,
 };
+
+export class NoticeArea extends Component {
+	render() {
+		return (
+			<Fragment>
+				{ window.wcAdminFeatures[ 'store-alerts' ] && <StoreAlerts /> }
+				<Notices />
+			</Fragment>
+		);
+	}
+}
 
 export class PageLayout extends Component {
 	render() {
@@ -104,7 +125,7 @@ export class EmbedLayout extends Component {
 		return (
 			<Fragment>
 				<Header sections={ wcSettings.embedBreadcrumbs } isEmbedded />
-				<Layout isEmbeded />
+				<Layout isEmbedded />
 			</Fragment>
 		);
 	}

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -14,9 +14,26 @@
 		padding: 20px;
 	}
 
+	#screen-meta,
+	#screen-meta-links {
+		top: $large-header-height;
+
+		@include breakpoint( '782px-960px' ) {
+			top: $medium-header-height;
+		}
+
+		@include breakpoint( '<782px' ) {
+			top: $small-header-height;
+		}
+	}
+
 	#screen-meta {
 		border-right: 0;
 		margin: 0;
+	}
+
+	#screen-meta-links {
+		position: relative;
 	}
 
 	.notice {
@@ -46,10 +63,10 @@
 
 	.woocommerce-layout__primary {
 		margin: 0;
-		padding-top: 80px;
+		padding-top: $large-header-height + 20;
 
 		@include breakpoint( '782px-960px' ) {
-			padding-top: 60px;
+			padding-top: $medium-header-height + 20;
 		}
 	}
 

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -14,6 +14,18 @@
 		padding: 20px;
 	}
 
+	#woocommerce-embedded-root.is-embed-loading + #wpbody .wrap {
+		padding-top: $large-header-height + 40;
+
+		@include breakpoint( '782px-960px' ) {
+			padding-top: $medium-header-height + 40;
+		}
+
+		@include breakpoint( '<782px' ) {
+			padding-top: $small-header-height + 40;
+		}
+	}
+
 	#screen-meta,
 	#screen-meta-links {
 		top: $large-header-height;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -80,6 +80,10 @@
 		@include breakpoint( '782px-960px' ) {
 			padding-top: $medium-header-height + 20;
 		}
+
+		@include breakpoint( '<782px' ) {
+			padding-top: 10px;
+		}
 	}
 
 	@keyframes isLoaded {

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -22,7 +22,7 @@
 		}
 
 		@include breakpoint( '<782px' ) {
-			padding-top: $small-header-height + 40;
+			padding-top: 30px;
 		}
 	}
 

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -378,7 +378,7 @@ class WC_Admin_Loader {
 		$sections = self::get_embed_breadcrumbs();
 		$sections = is_array( $sections ) ? $sections : array( $sections );
 		?>
-		<div id="woocommerce-embedded-root">
+		<div id="woocommerce-embedded-root" class="is-embed-loading">
 			<div class="woocommerce-layout">
 				<div class="woocommerce-layout__header is-embed-loading">
 					<h1 class="woocommerce-layout__header-breadcrumbs">
@@ -390,9 +390,6 @@ class WC_Admin_Loader {
 						<?php endforeach; ?>
 					</h1>
 				</div>
-			</div>
-			<div class="woocommerce-layout__primary is-embed-loading" id="woocommerce-layout__primary">
-				<div id="woocommerce-layout__notice-list" class="woocommerce-layout__notice-list"></div>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
Fixes #2192.

Render the `StoreAlerts` component beneath the screen meta links (options, help) so they can be positioned underneath the nav bar.

### Screenshots

![Screen Shot 2019-05-22 at 3 10 17 PM](https://user-images.githubusercontent.com/63922/58209188-c3eb4500-7ca3-11e9-8b67-a2e6b5189aba.png)

### Detailed test instructions:

- Test both JS pages and embed pages
- Verify that the screen meta links are just underneath the nav bar (check all breakpoints)
- Verify that the notices panel works as expected

### Known issue:

It seems the screen meta links float out of place until the page is fully rendered.. any ideas?

![Screen Shot 2019-05-22 at 3 10 31 PM](https://user-images.githubusercontent.com/63922/58209231-debdb980-7ca3-11e9-8530-181ee8dea425.png)
