### PR TITLE
Settings: Add default date settings

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -15,8 +15,10 @@ import { Link } from '@woocommerce/components';
  * Internal dependencies
  */
 import { DEFAULT_ACTIONABLE_STATUSES } from 'wc-api/constants';
+import DefaultDate from './default-date';
 
 const SETTINGS_FILTER = 'woocommerce_admin_analytics_settings';
+const DEFAUTL_DATE_RANGE = 'period=month&compare=previous_year';
 
 const defaultOrderStatuses = [
 	'completed',
@@ -67,7 +69,8 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 				moreLink: <Link href="#" type="external" />, // @todo This needs to be replaced with a real link.
 			},
 		} ),
-		initialValue: wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses || [],
+		initialValue:
+			[ ...wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses ] || [],
 		defaultValue: [ 'pending', 'cancelled', 'failed' ],
 	},
 	{
@@ -90,7 +93,20 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 				'These orders will show up in the Orders tab under the activity panel.',
 			'woocommerce-admin'
 		),
-		initialValue: wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || [],
+		initialValue: [ ...wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses ] || [],
 		defaultValue: DEFAULT_ACTIONABLE_STATUSES,
+	},
+	{
+		name: 'woocommerce_default_date_range',
+		label: __( 'Default Date Range:', 'woocommerce-admin' ),
+		inputType: 'component',
+		component: DefaultDate,
+		helpText: __(
+			'Select a default date range. When no range is selected, reports will be viewed by ' +
+				'the default date range.',
+			'woocommerce-admin'
+		),
+		initialValue: wcSettings.wcAdminSettings.woocommerce_default_date_range || DEFAUTL_DATE_RANGE,
+		defaultValue: DEFAUTL_DATE_RANGE,
 	},
 ] );

--- a/client/analytics/settings/default-date.js
+++ b/client/analytics/settings/default-date.js
@@ -1,0 +1,24 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { parse, stringify } from 'qs';
+/**
+ * WooCommerce dependencies
+ */
+import { DateRangeFilterPicker } from '@woocommerce/components';
+
+const DefaultDate = ( { value, onChange } ) => {
+	const change = query => {
+		onChange( {
+			target: {
+				name: 'woocommerce_default_date_range',
+				value: stringify( query ),
+			},
+		} );
+	};
+	const query = parse( value.replace( /&amp;/g, '&' ) );
+	return <DateRangeFilterPicker query={ query } onRangeSelect={ change } />;
+};
+
+export default DefaultDate;

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -34,7 +34,7 @@ class Settings extends Component {
 		analyticsSettings.forEach( setting => ( settings[ setting.name ] = setting.initialValue ) );
 
 		this.state = {
-			settings: settings,
+			settings,
 			saving: false,
 		};
 
@@ -87,7 +87,23 @@ class Settings extends Component {
 		}
 	}
 
+	/**
+	 * Ensure changes are reflected to parameters on the window as well as
+	 * the config for construction of this component when re-navigating to
+	 * the settings page.
+	 *
+	 * @param {object} state - State
+	 */
+	persistChanges( state ) {
+		analyticsSettings.forEach( setting => {
+			const updatedValue = state.settings[ setting.name ];
+			wcSettings.wcAdminSettings[ setting.name ] = updatedValue;
+			setting.initialValue = updatedValue;
+		} );
+	}
+
 	saveChanges = () => {
+		this.persistChanges( this.state );
 		this.props.updateSettings( { wc_admin: this.state.settings } );
 		this.setState( { saving: true } );
 	};

--- a/client/analytics/settings/setting.js
+++ b/client/analytics/settings/setting.js
@@ -23,7 +23,7 @@ class Setting extends Component {
 	}
 
 	renderInput = () => {
-		const { handleChange, name, inputText, inputType, options, value } = this.props;
+		const { handleChange, name, inputText, inputType, options, value, component } = this.props;
 		const { disabled } = this.state;
 		const id = uniqueId( name );
 
@@ -54,6 +54,9 @@ class Setting extends Component {
 						{ inputText }
 					</Button>
 				);
+			case 'component':
+				const SettingComponent = component;
+				return <SettingComponent value={ value } onChange={ handleChange } { ...this.props } />;
 			case 'text':
 			default:
 				return (
@@ -150,7 +153,7 @@ Setting.propTypes = {
 	/**
 	 * Type of input to use; defaults to a text input.
 	 */
-	inputType: PropTypes.oneOf( [ 'button', 'checkbox', 'checkboxGroup', 'text' ] ),
+	inputType: PropTypes.oneOf( [ 'button', 'checkbox', 'checkboxGroup', 'text', 'component' ] ),
 	/**
 	 * Label used for describing the setting.
 	 */

--- a/client/analytics/settings/setting.scss
+++ b/client/analytics/settings/setting.scss
@@ -23,6 +23,10 @@
 	flex-direction: column;
 	@include breakpoint( '>1280px' ) {
 		width: 35%;
+
+		.woocommerce-filters-filter {
+			width: 100%;
+		}
 	}
 
 	label {
@@ -30,6 +34,10 @@
 		display: block;
 		margin-bottom: $gap-small;
 		color: $core-grey-dark-500;
+	}
+
+	.woocommerce-filters-filter label {
+		margin-bottom: 0;
 	}
 
 	input[type='checkbox'] {

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -598,6 +598,14 @@ class WC_Admin_Loader {
 			'type'        => 'multiselect',
 			'options'     => $statuses,
 		);
+		$settings[] = array(
+			'id'          => 'woocommerce_default_date_range',
+			'option_key'  => 'woocommerce_default_date_range',
+			'label'       => __( 'Default Date Range', 'woocommerce-admin' ),
+			'description' => __( 'Default Date Range', 'woocommerce-admin' ),
+			'default'     => 'period=month&compare=previous_year',
+			'type'        => 'text',
+		);
 		return $settings;
 	}
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Card component: updated default Muriel design.
 - Card component: new `description` prop.
 - Card component: new `isInactive` prop.
+- DateRangeFilterPicker (breaking change): Introduced `onRangeSelect` prop and remove `path` prop better control.
 
 # 2.0.0
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.

--- a/packages/components/src/filters/date/index.js
+++ b/packages/components/src/filters/date/index.js
@@ -11,7 +11,6 @@ import PropTypes from 'prop-types';
  * WooCommerce dependencies
  */
 import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from '@woocommerce/date';
-import { updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -57,7 +56,7 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	onSelect( selectedTab, onClose ) {
-		const { path, query } = this.props;
+		const { onRangeSelect } = this.props;
 		return event => {
 			const { period, compare, after, before } = this.state;
 			const data = {
@@ -71,7 +70,7 @@ class DateRangeFilterPicker extends Component {
 				data.after = undefined;
 				data.before = undefined;
 			}
-			updateQueryString( data, path, query );
+			onRangeSelect( data );
 			onClose( event );
 		};
 	}
@@ -158,9 +157,9 @@ class DateRangeFilterPicker extends Component {
 
 DateRangeFilterPicker.propTypes = {
 	/**
-	 * The `path` parameter supplied by React-Router.
+	 * Callback called when selection is made.
 	 */
-	path: PropTypes.string.isRequired,
+	onRangeSelect: PropTypes.func.isRequired,
 	/**
 	 * The query string represented in object form.
 	 */

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -8,6 +8,11 @@ import { find } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
+ * WooCommerce dependencies
+ */
+import { updateQueryString } from '@woocommerce/navigation';
+
+/**
  * Internal dependencies
  */
 import AdvancedFilters from './advanced';
@@ -26,6 +31,7 @@ class ReportFilters extends Component {
 	constructor() {
 		super();
 		this.renderCard = this.renderCard.bind( this );
+		this.onRangeSelect = this.onRangeSelect.bind( this );
 	}
 
 	renderCard( config ) {
@@ -56,6 +62,11 @@ class ReportFilters extends Component {
 		}
 	}
 
+	onRangeSelect( data ) {
+		const { query, path } = this.props;
+		updateQueryString( data, path, query );
+	}
+
 	render() {
 		const { filters, query, path, showDatePicker } = this.props;
 		return (
@@ -64,7 +75,11 @@ class ReportFilters extends Component {
 				<Section component="div" className="woocommerce-filters">
 					<div className="woocommerce-filters__basic-filters">
 						{ showDatePicker && (
-							<DateRangeFilterPicker key={ JSON.stringify( query ) } query={ query } path={ path } />
+							<DateRangeFilterPicker
+								key={ JSON.stringify( query ) }
+								query={ query }
+								onRangeSelect={ this.onRangeSelect }
+							/>
 						) }
 						{ filters.map( config => {
 							if ( config.showFilters( query ) ) {

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -5,12 +5,7 @@
 import moment from 'moment';
 import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
-
-const QUERY_DEFAULTS = {
-	pageSize: 25,
-	period: 'month',
-	compare: 'previous_year',
-};
+import { parse } from 'qs';
 
 export const isoDateFormat = 'YYYY-MM-DD';
 
@@ -73,7 +68,9 @@ export const appendTimestamp = ( date, timeOfDay ) => {
 	if ( timeOfDay === 'end' ) {
 		return date + 'T23:59:59';
 	}
-	throw new Error( 'appendTimestamp requires second parameter to be either `start`, `now` or `end`' );
+	throw new Error(
+		'appendTimestamp requires second parameter to be either `start`, `now` or `end`'
+	);
 };
 
 /**
@@ -268,11 +265,26 @@ function getDateValue( period, compare, after, before ) {
  * @return {DateParams} - date parameters derived from query parameters with added defaults
  */
 export const getDateParamsFromQuery = ( { period, compare, after, before } ) => {
+	if ( period && compare ) {
+		return {
+			period,
+			compare,
+			after: after ? moment( after ) : null,
+			before: before ? moment( before ) : null,
+		};
+	}
+
+	const defaultDateRange =
+		wcSettings.wcAdminSettings.woocommerce_default_date_range ||
+		'period=month&compare=previous_year';
+
+	const queryDefaults = parse( defaultDateRange.replace( /&amp;/g, '&' ) );
+
 	return {
-		period: period || QUERY_DEFAULTS.period,
-		compare: compare || QUERY_DEFAULTS.compare,
-		after: after ? moment( after ) : null,
-		before: before ? moment( before ) : null,
+		period: queryDefaults.period,
+		compare: queryDefaults.compare,
+		after: queryDefaults.after ? moment( queryDefaults.after ) : null,
+		before: queryDefaults.before ? moment( queryDefaults.before ) : null,
 	};
 };
 

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -62,7 +62,10 @@ global.wcSettings = {
 		userLocale: 'en_US',
 		weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
 	},
-	wcAdminSettings: {},
+	wcAdminSettings: {
+		woocommerce_actionable_order_statuses: [],
+		woocommerce_excluded_report_order_statuses: [],
+	},
 };
 
 const config = require( '../../config/development.json' );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2250

Persist a default date setting of the user's choosing. 

![Screen Shot 2019-05-24 at 11 04 24 AM](https://user-images.githubusercontent.com/1922453/58292019-d71d2280-7e13-11e9-9b68-d176df513f9a.png)

### Detailed test instructions:

1. Analytics > Settings.
2. Select a new date range > Update > Save Changes.
3. Navigate to a report and see the date range applied by default.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->