### PR TITLE
Update Profile Wizard Header to Display Stepper

### DIFF
--- a/client/dashboard/profile-wizard/header.js
+++ b/client/dashboard/profile-wizard/header.js
@@ -3,17 +3,26 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
+import { filter } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
+import { Stepper } from '@woocommerce/components';
 import HeaderLogo from './header-logo';
+
 export default class ProfileWizardHeader extends Component {
+	renderStepper() {
+		const steps = filter( this.props.steps, step => !! step.label );
+		return <Stepper steps={ steps } currentStep={ this.props.currentStep } />;
+	}
 	render() {
-		return (
-			<div className="woocommerce-profile-wizard__header">
-				<HeaderLogo />
-			</div>
-		);
+		const currentStep = this.props.steps.find( s => s.key === this.props.currentStep );
+		const showStepper = ! currentStep || ! currentStep.label ? false : true;
+		const classes = classnames( 'woocommerce-profile-wizard__header', {
+			'is-stepper': showStepper,
+		} );
+		return <div className={ classes }>{ showStepper ? this.renderStepper() : <HeaderLogo /> }</div>;
 	}
 }

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -2,18 +2,20 @@
 /**
  * External dependencies
  */
-import { Component, createElement } from '@wordpress/element';
+import { Component, createElement, Fragment } from '@wordpress/element';
+import { pick } from 'lodash';
 
 /**
  * Internal depdencies
  */
+import ProfileWizardHeader from './header';
 import Plugins from './steps/plugins';
-import Start from './steps/start/';
+import Start from './steps/start';
 import './style.scss';
+import { __ } from '@wordpress/i18n';
 
 const getSteps = () => {
 	const steps = [];
-
 	steps.push( {
 		key: 'start',
 		container: Start,
@@ -22,7 +24,31 @@ const getSteps = () => {
 		key: 'plugins',
 		container: Plugins,
 	} );
-
+	steps.push( {
+		key: 'store-details',
+		container: Fragment,
+		label: __( 'Store Details', 'woocommerce-admin' ),
+	} );
+	steps.push( {
+		key: 'industry',
+		container: Fragment,
+		label: __( 'Industry', 'woocommerce-admin' ),
+	} );
+	steps.push( {
+		key: 'product-types',
+		container: Fragment,
+		label: __( 'Product Types', 'woocommerce-admin' ),
+	} );
+	steps.push( {
+		key: 'business-details',
+		container: Fragment,
+		label: __( 'Business Details', 'woocommerce-admin' ),
+	} );
+	steps.push( {
+		key: 'theme',
+		container: Fragment,
+		label: __( 'Theme', 'woocommerce-admin' ),
+	} );
 	return steps;
 };
 
@@ -52,6 +78,14 @@ export default class ProfileWizard extends Component {
 		const { query } = this.props;
 		const step = this.getStep();
 
-		return createElement( step.container, { query } );
+		const container = createElement( step.container, { query } );
+		const steps = getSteps().map( _step => pick( _step, [ 'key', 'label' ] ) );
+
+		return (
+			<Fragment>
+				<ProfileWizardHeader currentStep={ step.key } steps={ steps } />
+				<div className="woocommerce-profile-wizard__container">{ container }</div>
+			</Fragment>
+		);
 	}
 }

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -14,7 +14,6 @@ import { withDispatch } from '@wordpress/data';
  * Internal depdencies
  */
 import { H, Stepper, Card } from '@woocommerce/components';
-import ProfileWizardHeader from '../header';
 
 const plugins = [ 'jetpack', 'woocommerce-services' ];
 
@@ -162,45 +161,42 @@ class Plugins extends Component {
 		const { step, isPending, isError } = this.state;
 		return (
 			<Fragment>
-				<ProfileWizardHeader />
-				<div className="woocommerce-profile-wizard__container">
-					<H className="woocommerce-profile-wizard__header-title">
-						{ __( 'Install plugins', 'woocommerce-admin' ) }
-					</H>
+				<H className="woocommerce-profile-wizard__header-title">
+					{ __( 'Install plugins', 'woocommerce-admin' ) }
+				</H>
 
-					<Card className="woocommerce-profile-wizard__plugins-card">
-						<Stepper
-							direction="vertical"
-							currentStep={ step }
-							isPending={ isPending }
-							steps={ [
-								{
-									label: __( 'Install Jetpack and WooCommerce Services', 'woocommerce-admin' ),
-									key: 'install',
-								},
-								{
-									label: __( 'Activate Jetpack and WooCommerce Services', 'woocommerce-admin' ),
-									key: 'activate',
-								},
-							] }
-						/>
+				<Card className="woocommerce-profile-wizard__plugins-card">
+					<Stepper
+						direction="vertical"
+						currentStep={ step }
+						isPending={ isPending }
+						steps={ [
+							{
+								label: __( 'Install Jetpack and WooCommerce Services', 'woocommerce-admin' ),
+								key: 'install',
+							},
+							{
+								label: __( 'Activate Jetpack and WooCommerce Services', 'woocommerce-admin' ),
+								key: 'activate',
+							},
+						] }
+					/>
 
-						<div className="woocommerce-profile-wizard__plugins-actions">
-							{ isError && (
-								<Button isPrimary onClick={ () => location.reload() }>
-									{ __( 'Retry', 'woocommerce-admin' ) }
+					<div className="woocommerce-profile-wizard__plugins-actions">
+						{ isError && (
+							<Button isPrimary onClick={ () => location.reload() }>
+								{ __( 'Retry', 'woocommerce-admin' ) }
+							</Button>
+						) }
+
+						{ ! isError &&
+							'activate' === step && (
+								<Button isPrimary isBusy={ isPending } onClick={ this.activatePlugins }>
+									{ __( 'Activate & continue', 'woocommerce-admin' ) }
 								</Button>
 							) }
-
-							{ ! isError &&
-								'activate' === step && (
-									<Button isPrimary isBusy={ isPending } onClick={ this.activatePlugins }>
-										{ __( 'Activate & continue', 'woocommerce-admin' ) }
-									</Button>
-								) }
-						</div>
-					</Card>
-				</div>
+					</div>
+				</Card>
 			</Fragment>
 		);
 	}

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -11,7 +11,6 @@ import interpolateComponents from 'interpolate-components';
  * Internal depdencies
  */
 import { Card, H, Link } from '@woocommerce/components';
-import ProfileWizardHeader from '../../header';
 import SecurityIcon from './images/security';
 import SalesTaxIcon from './images/local_atm';
 import SpeedIcon from './images/flash_on';
@@ -109,58 +108,55 @@ export default class Start extends Component {
 
 		return (
 			<Fragment>
-				<ProfileWizardHeader />
-				<div className="woocommerce-profile-wizard__container">
-					<H className="woocommerce-profile-wizard__header-title">
-						{ __( 'Start setting up your WooCommerce store', 'woocommerce-admin' ) }
-					</H>
+				<H className="woocommerce-profile-wizard__header-title">
+					{ __( 'Start setting up your WooCommerce store', 'woocommerce-admin' ) }
+				</H>
 
-					<p>
-						{ interpolateComponents( {
-							mixedString: __(
-								'Simplify and enhance the setup of your store with features and benefits offered by ' +
-									'{{strong}}Jetpack & WooCommerce Services{{/strong}}.',
-								'woocommerce-admin'
-							),
-							components: {
-								strong: <strong />,
-							},
-						} ) }
-					</p>
+				<p>
+					{ interpolateComponents( {
+						mixedString: __(
+							'Simplify and enhance the setup of your store with features and benefits offered by ' +
+								'{{strong}}Jetpack & WooCommerce Services{{/strong}}.',
+							'woocommerce-admin'
+						),
+						components: {
+							strong: <strong />,
+						},
+					} ) }
+				</p>
 
-					<div className="woocommerce-profile-wizard__tracking">
-						<CheckboxControl
-							className="woocommerce-profile-wizard__tracking-checkbox"
-							checked={ trackingChecked }
-							label={ __( trackingLabel, 'woocommerce-admin' ) }
-							onChange={ this.onTrackingChange }
-						/>
+				<div className="woocommerce-profile-wizard__tracking">
+					<CheckboxControl
+						className="woocommerce-profile-wizard__tracking-checkbox"
+						checked={ trackingChecked }
+						label={ __( trackingLabel, 'woocommerce-admin' ) }
+						onChange={ this.onTrackingChange }
+					/>
 
-						<FormToggle
-							aria-hidden="true"
-							checked={ trackingChecked }
-							onChange={ this.onTrackingChange }
-							onClick={ e => e.stopPropagation() }
-							tabIndex="-1"
-						/>
+					<FormToggle
+						aria-hidden="true"
+						checked={ trackingChecked }
+						onChange={ this.onTrackingChange }
+						onClick={ e => e.stopPropagation() }
+						tabIndex="-1"
+					/>
+				</div>
+
+				<Card>
+					<div className="woocommerce-profile-wizard__benefits">
+						{ benefits.map( benefit => this.renderBenefit( benefit ) ) }
 					</div>
 
-					<Card>
-						<div className="woocommerce-profile-wizard__benefits">
-							{ benefits.map( benefit => this.renderBenefit( benefit ) ) }
-						</div>
+					<Button isPrimary onClick={ this.startWizard }>
+						{ __( 'Get started', 'woocommerce-admin' ) }
+					</Button>
+				</Card>
 
-						<Button isPrimary onClick={ this.startWizard }>
-							{ __( 'Get started', 'woocommerce-admin' ) }
-						</Button>
-					</Card>
-
-					<p>
-						<Link href="#" onClick={ this.skipWizard }>
-							{ __( 'Proceed without Jetpack or WooCommerce Services', 'woocommerce-admin' ) }
-						</Link>
-					</p>
-				</div>
+				<p>
+					<Link href="#" onClick={ this.skipWizard }>
+						{ __( 'Proceed without Jetpack or WooCommerce Services', 'woocommerce-admin' ) }
+					</Link>
+				</p>
 			</Fragment>
 		);
 	}

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -6,6 +6,10 @@
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
 
+	#wpbody-content {
+		min-height: 100vh;
+	}
+
 	.woocommerce-profile-wizard__container a {
 		color: $muriel-gray-600;
 	}
@@ -143,8 +147,6 @@
 }
 
 .woocommerce-profile-wizard__header.is-stepper {
-	display: block;
-
 	svg > g {
 		transform: initial;
 	}
@@ -162,5 +164,6 @@
 		background: transparent;
 		box-shadow: none;
 		margin-bottom: 0;
+		width: 100%;
 	}
 }

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -53,6 +53,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+		background: $muriel-white;
 
 		svg > g {
 			transform: translateX(25%);
@@ -138,5 +139,28 @@
 		button {
 			display: initial;
 		}
+	}
+}
+
+.woocommerce-profile-wizard__header.is-stepper {
+	display: block;
+
+	svg > g {
+		transform: initial;
+	}
+
+	@include breakpoint( '<782px' ) {
+		position: absolute;
+		width: 100%;
+		bottom: 0;
+		border-top: 1px solid $muriel-gray-50;
+		border-bottom: none;
+	}
+
+	.woocommerce-stepper {
+		margin: 0 $gap 0 $gap;
+		background: transparent;
+		box-shadow: none;
+		margin-bottom: 0;
 	}
 }

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -17,9 +17,12 @@
 		.wp-responsive-open #wpbody {
 			right: -14.5em;
 		}
-		#wpcontent,
-		#wpbody-content {
+		#wpcontent {
 			min-height: calc(100vh - #{$adminbar-height-mobile});
+		}
+
+		#wpbody-content {
+			min-height: 100vh;
 		}
 	}
 

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -17,12 +17,9 @@
 		.wp-responsive-open #wpbody {
 			right: -14.5em;
 		}
-		#wpcontent {
-			min-height: calc(100vh - #{$adminbar-height-mobile});
-		}
-
+		#wpcontent,
 		#wpbody-content {
-			min-height: 100vh;
+			min-height: calc(100vh - #{$adminbar-height-mobile});
 		}
 	}
 


### PR DESCRIPTION
This PR does a bit of refactoring to the main profile wizard controller and header component. It allows us to easily define labels for the steps, and display the correct step in the wizard header. To also updates the background header color to white to match the Figma designs.

To Test:
* Go to the `start` or `plugins` step and see that the header area is white, and contains the Jetpack & Plugins logos.
* Go to a page like `/?step=business-details` and note the stepper.
* Shrink your browser to mobile size. The stepper / header should display at the bottom per the designs.
* Spot check analytics on mobile, since I made a CSS adjustment. Things should still look the same.

Desktop:

<img width="1120" alt="Screen Shot 2019-05-23 at 10 13 24 AM" src="https://user-images.githubusercontent.com/689165/58259899-7aeacd80-7d43-11e9-9c48-97df87419efb.png">

Mobile:

<img width="655" alt="Screen Shot 2019-05-23 at 10 13 45 AM" src="https://user-images.githubusercontent.com/689165/58259897-7a523700-7d43-11e9-8861-b3047070d93f.png">