### PR TITLE
Onboarding: Add profiler body class on initial load + respect skipped/completed flags

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -22,9 +22,8 @@ export default class Dashboard extends Component {
 	renderDashboardOutput() {
 		const { query, path } = this.props;
 
-		// @todo This should be replaced by a check from the REST API response from #1897.
-		const profileWizardComplete = true;
-		if ( window.wcAdminFeatures.onboarding && ! profileWizardComplete ) {
+		// @todo This should check a selector client side, with wcSettings.showProfiler as initial state.
+		if ( window.wcAdminFeatures.onboarding && wcSettings.showProfiler ) {
 			return <ProfileWizard query={ query } />;
 		}
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -27,6 +27,12 @@ import StoreAlerts from './store-alerts';
 class Layout extends Component {
 	componentDidMount() {
 		this.recordPageViewTrack();
+
+		const path = this.getPath();
+
+		if ( 'dashboard' !== path ) {
+			document.body.classList.remove( 'woocommerce-profile-wizard__body' );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -42,7 +48,7 @@ class Layout extends Component {
 		}
 	}
 
-	recordPageViewTrack() {
+	getPath() {
 		const pathname = get( this.props, 'location.pathname' );
 		if ( ! pathname ) {
 			return;
@@ -56,7 +62,11 @@ class Layout extends Component {
 			path = 'dashboard';
 		}
 
-		recordPageView( path );
+		return path;
+	}
+
+	recordPageViewTrack() {
+		recordPageView( this.getPath() );
 	}
 
 	render() {

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -27,12 +27,7 @@ import StoreAlerts from './store-alerts';
 class Layout extends Component {
 	componentDidMount() {
 		this.recordPageViewTrack();
-
-		const path = this.getPath();
-
-		if ( 'dashboard' !== path ) {
-			document.body.classList.remove( 'woocommerce-profile-wizard__body' );
-		}
+		document.body.classList.remove( 'woocommerce-admin-is-loading' );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -48,7 +43,7 @@ class Layout extends Component {
 		}
 	}
 
-	getPath() {
+	recordPageViewTrack() {
 		const pathname = get( this.props, 'location.pathname' );
 		if ( ! pathname ) {
 			return;
@@ -62,11 +57,7 @@ class Layout extends Component {
 			path = 'dashboard';
 		}
 
-		return path;
-	}
-
-	recordPageViewTrack() {
-		recordPageView( this.getPath() );
+		recordPageView( path );
 	}
 
 	render() {

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -126,3 +126,26 @@
 		}
 	}
 }
+
+/* Hide wp-admin and WooCommerce elements when loading the WooCommerce Admin App */
+.woocommerce-admin-is-loading {
+	#adminmenumain,
+	#wpadminbar,
+	.woocommerce-layout__header,
+	.update-nag,
+	.woocommerce-store-alerts,
+	.woocommerce-message,
+	.notice,
+	.error,
+	.updated {
+		display: none;
+	}
+
+	#wpcontent {
+		margin-left: 0;
+	}
+
+	#wpbody {
+		padding-top: 0;
+	}
+}

--- a/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
@@ -206,13 +206,14 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 			return new WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce-admin' ), 404 );
 		}
 
-		$redirect_url = esc_url_raw(
+		$next_step_slug = 'store-details';
+		$redirect_url   = esc_url_raw(
 			add_query_arg(
 				array(
 					'page' => 'wc-admin',
 				),
 				admin_url( 'admin.php' )
-			) . '#/?step=details'
+			) . '#/?step=' . $next_step_slug
 		);
 
 		$connect_url = Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );

--- a/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
@@ -206,7 +206,7 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 			return new WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce-admin' ), 404 );
 		}
 
-		$next_step_slug = 'store-details';
+		$next_step_slug = apply_filters( 'woocommerce_onboarding_after_jetpack_step', 'store-details' );
 		$redirect_url   = esc_url_raw(
 			add_query_arg(
 				array(

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -192,6 +192,13 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
+			'completed'       => array(
+				'type'              => 'bool',
+				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
 			'skipped'         => array(
 				'type'              => 'bool',
 				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce-admin' ),

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -86,7 +86,7 @@ class WC_Admin_Loader {
 	 */
 	public static function is_feature_enabled( $feature ) {
 		$features = self::get_features();
-		return in_array( $feature, $features );
+		return in_array( $feature, $features, true );
 	}
 
 	/**
@@ -404,8 +404,6 @@ class WC_Admin_Loader {
 	 * @param string $admin_body_class Body class to add.
 	 */
 	public static function add_admin_body_classes( $admin_body_class = '' ) {
-		global $hook_suffix;
-
 		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
 			return $admin_body_class;
 		}
@@ -414,6 +412,12 @@ class WC_Admin_Loader {
 		$classes[] = 'woocommerce-page';
 		if ( self::is_embed_page() ) {
 			$classes[] = 'woocommerce-embed-page';
+		}
+
+		// Some routes or features like onboarding hide the wp-admin navigation and masterbar. Setting `woocommerce_admin_is_loading` to true allows us
+		// to premeptively hide these elements while the JS app loads. This class is removed when `<Layout />` is rendered.
+		if ( self::is_admin_page() && apply_filters( 'woocommerce_admin_is_loading', false ) ) {
+			$classes[] = 'woocommerce-admin-is-loading';
 		}
 
 		$features = self::get_features();

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -95,7 +95,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 9, $properties );
+		$this->assertCount( 10, $properties );
+		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );


### PR DESCRIPTION
This PR adds the `woocommerce-profile-wizard__body` body class on initial load of the PHP app if we know that the profiler will display and if the user is on the main JS page.

This allows us to prevent the initial flash of the sidebar / masterbar (which makes for a smoother transition between Calypso and `wc-admin`).

It also adds a (temporary) PHP flag so that we can enable/disable the profiler, without editing `dashboard/index.js`. (I don't know about you Josh, but it was getting annoying to switch branches, stash the change, etc 😆). In addition to that, I've added some logic so the profiler will hide/show based on the skipped/complete flags.

To Test:
* Set `WOOCOMMERCE_ADMIN_DEV_SHOW_PROFILER` to `true` wherever you keep your development snippets / constants.
* Make sure `skipped` and `completed` are both false via `/wc-admin/v1/onboarding/profile`
* Visit `/wp-admin/admin.php?page=wc-admin#/`. Notice that the admin menus do not display, and the profiler loads in (Another good example of this is running through the plugins flow and seeing the transition between Calypso).
* Test setting `skipped` or `completed` to true, and refresh the page. Note that the profiler does not show.
* Test visiting an analytics route, and make sure the admin bar loads in correctly.