### PR TITLE
Extensions: fix registering a page

### DIFF
--- a/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
+++ b/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
@@ -39,8 +39,9 @@ add_action( 'admin_enqueue_scripts', 'add_report_register_script' );
  */
 function add_report_add_report_menu_item( $report_pages ) {
 	$report_pages[] = array(
+		'id'     => 'example-analytics-report',
 		'title'  => __( 'Example', 'woocommerce-admin' ),
-		'parent' => '/analytics/revenue',
+		'parent' => 'woocommerce-analytics',
 		'path'   => '/analytics/example',
 	);
 

--- a/docs/page-controller.md
+++ b/docs/page-controller.md
@@ -117,14 +117,17 @@ addFilter( 'woocommerce_admin_reports_list', 'my-namespace', ( reports ) => {
 Register the report page with the controller:
 
 ```php
-wc_admin_register_page(
-	array(
-		'id'     => 'woocommerce-analytics-example',
-		'title'  => __( 'Example', 'my-textdomain' ),
+function add_report_menu_item( $report_pages ) {
+	$report_pages[] = array(
+		'id'     => 'example-analytics-report',
+		'title'  => __( 'Example', 'woocommerce-admin' ),
 		'parent' => 'woocommerce-analytics',
 		'path'   => '/analytics/example',
-	)
-);
+	);
+
+	return $report_pages;
+}
+add_filter( 'woocommerce_admin_report_menu_items', 'add_report_menu_item' );
 ```
 
 ### Further Reading

--- a/docs/page-controller.md
+++ b/docs/page-controller.md
@@ -120,7 +120,7 @@ Register the report page with the controller:
 function add_report_menu_item( $report_pages ) {
 	$report_pages[] = array(
 		'id'     => 'example-analytics-report',
-		'title'  => __( 'Example', 'woocommerce-admin' ),
+		'title'  => __( 'Example', 'my-textdomain' ),
 		'parent' => 'woocommerce-analytics',
 		'path'   => '/analytics/example',
 	);


### PR DESCRIPTION
A refactor of the pages controller(https://github.com/woocommerce/woocommerce-admin/pull/2209) required fixes in the Extension Examples to correctly add a submenu item under `Analytics`.

I also changed the docs to encourage use of the `woocommerce_admin_report_menu_items` filter instead of directly using `wc_admin_register_page`. 

### Detailed test instructions:

1. `npm run example -- --ext=add-report`
2. Activate the WooCommerce Admin Add Report Example plugin.
3. Ensure the "Example" submenu item exists in the sidebar.
