### PR TITLE
Dashboard Extension Example: Make namespace unique

### DIFF
--- a/docs/examples/extensions/dashboard-section/woocommerce-admin-dashboard-section.php
+++ b/docs/examples/extensions/dashboard-section/woocommerce-admin-dashboard-section.php
@@ -15,7 +15,7 @@ function dashboard_section_register_script() {
 	}
 
 	wp_register_script(
-		'add-report',
+		'dashboard_section',
 		plugins_url( '/dist/index.js', __FILE__ ),
 		array(
 			'wp-hooks',
@@ -27,6 +27,6 @@ function dashboard_section_register_script() {
 		true
 	);
 
-	wp_enqueue_script( 'add-report' );
+	wp_enqueue_script( 'dashboard_section' );
 }
 add_action( 'admin_enqueue_scripts', 'dashboard_section_register_script' );


### PR DESCRIPTION
@timmyc notice here https://github.com/woocommerce/woocommerce-admin/pull/2280#issuecomment-495390068 that both example extensions had a name collision and couldn't work simultaneously.

Changes here fixes this by making the namespace unique.

### Test

1. Activate Add Report and Dashboard Section plugins.
2. Make sure `/wp-admin/admin.php?page=wc-admin#/analytics/example` is available.
3. Make sure the Apple Dashboard items are shown.