### PR TITLE
Add onboarding step 4

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Component, createElement, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -21,8 +22,8 @@ import ProfileWizardHeader from './header';
 import Plugins from './steps/plugins';
 import Start from './steps/start';
 import Industry from './steps/industry';
+import StoreDetails from './steps/store-details';
 import './style.scss';
-import { __ } from '@wordpress/i18n';
 
 const getSteps = () => {
 	const steps = [];
@@ -36,7 +37,7 @@ const getSteps = () => {
 	} );
 	steps.push( {
 		key: 'store-details',
-		container: Fragment,
+		container: StoreDetails,
 		label: __( 'Store Details', 'woocommerce-admin' ),
 	} );
 	steps.push( {

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -22,6 +22,7 @@ class StoreDetails extends Component {
 		this.state = {
 			addressLine1: '',
 			addressLine2: '',
+			city: '',
 			countryState: '',
 			postCode: '',
 		};
@@ -30,9 +31,9 @@ class StoreDetails extends Component {
 	}
 
 	isValidForm() {
-		const { addressLine1, countryState, postCode } = this.state;
+		const { addressLine1, city, countryState, postCode } = this.state;
 
-		if ( addressLine1.length && countryState && postCode.length ) {
+		if ( addressLine1.length && city.length && countryState.length && postCode.length ) {
 			return true;
 		}
 
@@ -44,13 +45,14 @@ class StoreDetails extends Component {
 			return;
 		}
 
-		const { addressLine1, addressLine2, countryState, postCode } = this.state;
+		const { addressLine1, addressLine2, city, countryState, postCode } = this.state;
 
 		this.props.updateSettings( {
 			general: {
 				woocommerce_store_address: addressLine1,
 				woocommerce_store_address_2: addressLine2,
 				woocommerce_default_country: countryState,
+				woocommerce_store_city: city,
 				woocommerce_store_postcode: postCode,
 			},
 		} );
@@ -89,7 +91,7 @@ class StoreDetails extends Component {
 	}
 
 	render() {
-		const { addressLine1, addressLine2, countryState, postCode } = this.state;
+		const { addressLine1, addressLine2, city, countryState, postCode } = this.state;
 
 		return (
 			<Fragment>
@@ -121,6 +123,13 @@ class StoreDetails extends Component {
 						options={ this.getCountryStateOptions() }
 						value={ countryState }
 						required
+					/>
+
+					<TextControl
+						label={ __( 'City', 'woocommerce-admin' ) }
+						onChange={ value => this.setState( { city: value } ) }
+						required
+						value={ city }
 					/>
 
 					<TextControl

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -3,8 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, SelectControl, TextControl } from '@wordpress/components';
-import classNames from 'classnames';
+import { Button, SelectControl, TextControl } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -24,39 +23,20 @@ class StoreDetails extends Component {
 			addressLine1: '',
 			addressLine2: '',
 			countryState: '',
-			email: '',
-			emailError: '',
 			postCode: '',
 		};
 
 		this.submitForm = this.submitForm.bind( this );
-		this.validateEmail = this.validateEmail.bind( this );
 	}
 
 	isValidForm() {
-		const { addressLine1, countryState, email, emailError, postCode } = this.state;
+		const { addressLine1, countryState, postCode } = this.state;
 
-		if (
-			addressLine1.length &&
-			countryState &&
-			email.length &&
-			! emailError.length &&
-			postCode.length
-		) {
+		if ( addressLine1.length && countryState && postCode.length ) {
 			return true;
 		}
 
 		return false;
-	}
-
-	validateEmail() {
-		let emailError = '';
-
-		if ( ! /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test( this.state.email ) ) {
-			emailError = __( 'Must be a valid email address', 'woocommerce-admin' );
-		}
-
-		this.setState( { emailError } );
 	}
 
 	submitForm() {
@@ -74,8 +54,6 @@ class StoreDetails extends Component {
 				woocommerce_store_postcode: postCode,
 			},
 		} );
-
-		// @todo The email address is currently not saved.  Where should this be saved to?
 
 		// @todo Go to next step once https://github.com/woocommerce/woocommerce-admin/pull/2283 is merged.
 	}
@@ -111,7 +89,7 @@ class StoreDetails extends Component {
 	}
 
 	render() {
-		const { addressLine1, addressLine2, countryState, email, emailError, postCode } = this.state;
+		const { addressLine1, addressLine2, countryState, postCode } = this.state;
 
 		return (
 			<Fragment>
@@ -151,24 +129,6 @@ class StoreDetails extends Component {
 						required
 						value={ postCode }
 					/>
-
-					<TextControl
-						label={ __( 'Email', 'woocommerce-admin' ) }
-						onBlur={ this.validateEmail }
-						onChange={ value => this.setState( { email: value } ) }
-						required
-						type="email"
-						value={ email }
-					/>
-					<span
-						className={ classNames( 'woocommerce-profile-wizard__input-help', {
-							'is-error': emailError.length,
-						} ) }
-					>
-						{ emailError.length
-							? emailError
-							: __( 'Order notifications will be sent here', 'woocommerce-admin' ) }
-					</span>
 
 					<Button isPrimary onClick={ this.submitForm } disabled={ ! this.isValidForm() }>
 						{ __( 'Continue', 'woocommerce-admin' ) }

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -1,0 +1,163 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, SelectControl, TextControl } from '@wordpress/components';
+import classNames from 'classnames';
+import { Component, Fragment } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal depdencies
+ */
+import { H, Card } from '@woocommerce/components';
+
+export default class StoreDetails extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			addressLine1: '',
+			addressLine2: '',
+			countryState: '',
+			email: '',
+			emailError: '',
+			postCode: '',
+		};
+
+		this.validateEmail = this.validateEmail.bind( this );
+	}
+
+	isValidForm() {
+		const { addressLine1, countryState, email, emailError, postCode } = this.state;
+
+		if (
+			addressLine1.length &&
+			countryState &&
+			email.length &&
+			! emailError.length &&
+			postCode.length
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	validateEmail() {
+		let emailError = '';
+
+		if ( ! /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test( this.state.email ) ) {
+			emailError = __( 'Must be a valid email address', 'woocommerce-admin' );
+		}
+
+		this.setState( { emailError } );
+	}
+
+	submitForm() {
+		if ( ! this.isValidForm() ) {
+			return;
+		}
+		// @todo Submit data to WC Settings.
+		// @todo Go to next step once https://github.com/woocommerce/woocommerce-admin/pull/2283 is merged.
+	}
+
+	getCountryStateOptions() {
+		const countries = ( wcSettings.dataEndpoints && wcSettings.dataEndpoints.countries ) || [];
+
+		const countryStateOptions = countries.reduce( ( acc, country ) => {
+			if ( ! country.states.length ) {
+				acc.push( {
+					value: country.code,
+					label: decodeEntities( country.name ),
+				} );
+
+				return acc;
+			}
+
+			const countryStates = country.states.map( state => {
+				return {
+					value: country.code + ':' + state.code,
+					label: decodeEntities( country.name ) + ' -- ' + decodeEntities( state.name ),
+				};
+			} );
+
+			acc.push( ...countryStates );
+
+			return acc;
+		}, [] );
+
+		countryStateOptions.unshift( { value: '', label: '' } );
+
+		return countryStateOptions;
+	}
+
+	render() {
+		const { addressLine1, addressLine2, countryState, email, emailError, postCode } = this.state;
+
+		return (
+			<Fragment>
+				<H className="woocommerce-profile-wizard__header-title">
+					{ __( 'Store Details', 'woocommerce-admin' ) }
+				</H>
+				<H className="woocommerce-profile-wizard__header-subtitle">
+					{ __( 'Tell us about your store', 'woocommerce-admin' ) }
+				</H>
+
+				<Card>
+					<TextControl
+						label={ __( 'Address line 1', 'woocommerce-admin' ) }
+						onChange={ value => this.setState( { addressLine1: value } ) }
+						required
+						value={ addressLine1 }
+					/>
+
+					<TextControl
+						label={ __( 'Address line 2', 'woocommerce-admin' ) }
+						onChange={ value => this.setState( { addressLine2: value } ) }
+						required
+						value={ addressLine2 }
+					/>
+
+					<SelectControl
+						label={ __( 'Country / State', 'woocommerce-admin' ) }
+						onChange={ value => this.setState( { countryState: value } ) }
+						options={ this.getCountryStateOptions() }
+						value={ countryState }
+						required
+					/>
+
+					<TextControl
+						label={ __( 'Post code', 'woocommerce-admin' ) }
+						onChange={ value => this.setState( { postCode: value } ) }
+						required
+						value={ postCode }
+					/>
+
+					<TextControl
+						label={ __( 'Email', 'woocommerce-admin' ) }
+						onBlur={ this.validateEmail }
+						onChange={ value => this.setState( { email: value } ) }
+						required
+						type="email"
+						value={ email }
+					/>
+					<span
+						className={ classNames( 'woocommerce-profile-wizard__input-help', {
+							'is-error': emailError.length,
+						} ) }
+					>
+						{ emailError.length
+							? emailError
+							: __( 'Order notifications will be sent here', 'woocommerce-admin' ) }
+					</span>
+
+					<Button isPrimary onClick={ this.submitForm } disabled={ ! this.isValidForm() }>
+						{ __( 'Continue', 'woocommerce-admin' ) }
+					</Button>
+				</Card>
+			</Fragment>
+		);
+	}
+}

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -24,10 +24,16 @@ class StoreDetails extends Component {
 			addressLine2: '',
 			city: '',
 			countryState: '',
+			countryStateOptions: [],
 			postCode: '',
 		};
 
 		this.submitForm = this.submitForm.bind( this );
+	}
+
+	componentWillMount() {
+		const countryStateOptions = this.getCountryStateOptions();
+		this.setState( { countryStateOptions } );
 	}
 
 	isValidForm() {
@@ -91,7 +97,14 @@ class StoreDetails extends Component {
 	}
 
 	render() {
-		const { addressLine1, addressLine2, city, countryState, postCode } = this.state;
+		const {
+			addressLine1,
+			addressLine2,
+			city,
+			countryState,
+			countryStateOptions,
+			postCode,
+		} = this.state;
 
 		return (
 			<Fragment>
@@ -120,7 +133,7 @@ class StoreDetails extends Component {
 					<SelectControl
 						label={ __( 'Country / State', 'woocommerce-admin' ) }
 						onChange={ value => this.setState( { countryState: value } ) }
-						options={ this.getCountryStateOptions() }
+						options={ countryStateOptions }
 						value={ countryState }
 						required
 					/>

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -28,7 +28,7 @@ class StoreDetails extends Component {
 			postCode: '',
 		};
 
-		this.submitForm = this.submitForm.bind( this );
+		this.onContinue = this.onContinue.bind( this );
 	}
 
 	componentWillMount() {
@@ -46,14 +46,15 @@ class StoreDetails extends Component {
 		return false;
 	}
 
-	submitForm() {
+	async onContinue() {
 		if ( ! this.isValidForm() ) {
 			return;
 		}
 
+		const { addNotice, goToNextStep, isError, updateSettings } = this.props;
 		const { addressLine1, addressLine2, city, countryState, postCode } = this.state;
 
-		this.props.updateSettings( {
+		await updateSettings( {
 			general: {
 				woocommerce_store_address: addressLine1,
 				woocommerce_store_address_2: addressLine2,
@@ -63,7 +64,14 @@ class StoreDetails extends Component {
 			},
 		} );
 
-		// @todo Go to next step once https://github.com/woocommerce/woocommerce-admin/pull/2283 is merged.
+		if ( ! isError ) {
+			goToNextStep();
+		} else {
+			addNotice( {
+				status: 'error',
+				message: __( 'There was a problem saving your store details.', 'woocommerce-admin' ),
+			} );
+		}
 	}
 
 	getCountryStateOptions() {
@@ -152,7 +160,7 @@ class StoreDetails extends Component {
 						value={ postCode }
 					/>
 
-					<Button isPrimary onClick={ this.submitForm } disabled={ ! this.isValidForm() }>
+					<Button isPrimary onClick={ this.onContinue } disabled={ ! this.isValidForm() }>
 						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
 				</Card>

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -15,6 +15,8 @@
 	}
 
 	.woocommerce-card {
+		margin-top: $gap;
+
 		h1,
 		h2,
 		h3 {
@@ -73,6 +75,16 @@
 		font-size: 24px;
 		line-height: 32px;
 		font-weight: 400;
+		margin-bottom: $gap-smaller;
+	}
+
+	.woocommerce-profile-wizard__header-subtitle {
+		color: $muriel-gray-600;
+		font-size: 16px;
+		line-height: 24px;
+		font-weight: 400;
+		margin-top: $gap-smaller;
+		margin-bottom: $gap;
 	}
 
 	.woocommerce-profile-wizard__container {
@@ -190,6 +202,16 @@
 
 	#wpbody {
 		padding-top: 0;
+	}
+
+	.woocommerce-profile-wizard__input-help {
+		color: $muriel-gray-600;
+		font-size: 12px;
+		padding-left: $gap-smaller;
+
+		&.is-error {
+			color: $muriel-red-500;
+		}
 	}
 }
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -207,16 +207,6 @@
 	#wpbody {
 		padding-top: 0;
 	}
-
-	.woocommerce-profile-wizard__input-help {
-		color: $muriel-gray-600;
-		font-size: 12px;
-		padding-left: $gap-smaller;
-
-		&.is-error {
-			color: $muriel-red-500;
-		}
-	}
 }
 
 .woocommerce-profile-wizard__plugins-card {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -28,6 +28,9 @@
 		button {
 			display: flex;
 			margin: 0 auto;
+			min-width: 310px;
+			max-width: 100%;
+			justify-content: center;
 
 			&:disabled {
 				display: none;
@@ -43,7 +46,7 @@
 		&.is-active,
 		&.is-complete {
 			.woocommerce-stepper__step-icon {
-				background: $muriel-gray-900;
+				background: $muriel-hot-purple-600;
 				color: $muriel-white;
 			}
 
@@ -53,7 +56,7 @@
 		}
 
 		.woocommerce-spinner__circle {
-			stroke: $muriel-gray-900;
+			stroke: $muriel-hot-purple-600;
 		}
 	}
 
@@ -132,7 +135,7 @@
 			}
 
 			input {
-				top: 15px;
+				top: 14px;
 			}
 		}
 
@@ -162,14 +165,25 @@
 		margin-top: -$gap-smallest;
 	}
 
+	.muriel-input-text,
+	.muriel-select {
+		&.with-value,
+		&.active {
+			label {
+				top: 8px;
+			}
+
+			input,
+			select {
+				top: 24px;
+			}
+		}
+	}
+
 	.muriel-input-text.active,
 	.muriel-select.active {
-		border: 2px solid $muriel-hot-purple-600;
-
-		input,
-		select {
-			top: 25px;
-		}
+		box-shadow: 0 0 0 2px $muriel-hot-purple-600;
+		border-color: transparent;
 	}
 
 	.muriel-checkbox input[type='checkbox'] {
@@ -220,6 +234,8 @@
 		min-height: 28px;
 
 		button {
+			height: 40px;
+			min-width: none;
 			display: initial;
 		}
 	}

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -28,6 +28,10 @@
 		button {
 			display: flex;
 			margin: 0 auto;
+
+			&:disabled {
+				display: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #1888 

Adds the onboarding step 4.  Design review of this is blocked until rebased from #2296.

### Questions
* There doesn't appear to be a default admin email.  Should the email here overwrite the WordPress `admin_email` (seems risky), set to `woocommerce_stock_email_recipient` which is used for notifications, or save separately under profiler data?
* I've added "Address Line 2" but I believe a city will need to be added as well to have a complete address.  Should we add that as well or remove the 2nd line address?
* Took a bit of liberty on adding an error message to the email field for invalid emails.  This probably needs design review.

### Screenshots
<img width="1453" alt="Screen Shot 2019-05-29 at 11 50 58 AM" src="https://user-images.githubusercontent.com/10561050/58528187-2e523700-8208-11e9-8a93-958211c63117.png">

### Detailed test instructions:

1. Make sure the profile wizard is visible (with flag or `profileWizardComplete` var).
2. Go to `wp-admin/admin.php?page=wc-admin#/?step=store-details`
3. Fill in form data.
4. Submit the form.
5.  Note that fields were in WC settings.
6.  Note the "Continue" button doesn't show until required fields are filled in.