### PR TITLE
Add missing space in Orders Activity Panel card

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -211,7 +211,7 @@
 
 	.woocommerce-activity-card__subtitle {
 		span + span::before {
-			content: ' \2022 ';
+			content: ' \2022\ ';
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2305.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/58330658-aea71f80-7e37-11e9-8d9a-361f8a7e5771.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/58330788-f332bb00-7e37-11e9-92d4-9a3cf09bec57.png)

### Detailed test instructions:

- Open the _Orders_ tab of the Activity Panel.
- Verify there is a space between the bullet point and the amount.