### PR TITLE
Add progress bars to Historical Data Import screen

### DIFF
--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -7,13 +7,11 @@ import { Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 function HistoricalDataActions( {
-	activeImport,
-	customersProgress,
+	importDate,
 	onDeletePreviousData,
 	onReimportData,
 	onStartImport,
 	onStopImport,
-	ordersProgress,
 	status,
 } ) {
 	const getActions = () => {
@@ -46,8 +44,7 @@ function HistoricalDataActions( {
 		}
 
 		if ( [ 'ready', 'nothing' ].includes( status ) ) {
-			// An import was stopped before finishing
-			if ( activeImport && ( customersProgress > 0 || ordersProgress > 0 ) ) {
+			if ( importDate ) {
 				return (
 					<Fragment>
 						<Button isPrimary onClick={ onStartImport } disabled={ importDisabled }>
@@ -60,7 +57,6 @@ function HistoricalDataActions( {
 				);
 			}
 
-			// Has no imported data or user clicked on 'reimport data'
 			return (
 				<Fragment>
 					<Button isPrimary onClick={ onStartImport } disabled={ importDisabled }>

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -7,9 +7,9 @@ import { Button } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 function HistoricalDataActions( {
+	activeImport,
 	customersProgress,
 	onDeletePreviousData,
-	ongoingImport,
 	onReimportData,
 	onStartImport,
 	onStopImport,
@@ -47,7 +47,7 @@ function HistoricalDataActions( {
 
 		if ( [ 'ready', 'nothing' ].includes( status ) ) {
 			// An import was stopped before finishing
-			if ( ongoingImport && ( customersProgress > 0 || ordersProgress > 0 ) ) {
+			if ( activeImport && ( customersProgress > 0 || ordersProgress > 0 ) ) {
 				return (
 					<Fragment>
 						<Button isPrimary onClick={ onStartImport } disabled={ importDisabled }>

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -20,7 +20,7 @@ function HistoricalDataActions( {
 		const importDisabled = status !== 'ready';
 
 		// An import is currently in progress
-		if ( [ 'customers', 'orders', 'finalizing' ].includes( status ) ) {
+		if ( [ 'initializing', 'customers', 'orders', 'finalizing' ].includes( status ) ) {
 			return (
 				<Fragment>
 					<Button

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -8,18 +8,19 @@ import { Fragment } from '@wordpress/element';
 
 function HistoricalDataActions( {
 	customersProgress,
-	customersTotal,
-	hasImportedData,
-	inProgress,
 	onDeletePreviousData,
+	onReimportData,
 	onStartImport,
 	onStopImport,
+	ongoingImport,
 	ordersProgress,
-	ordersTotal,
+	status,
 } ) {
 	const getActions = () => {
+		const importDisabled = status !== 'ready';
+
 		// An import is currently in progress
-		if ( inProgress ) {
+		if ( [ 'customers', 'orders', 'finalizing' ].includes( status ) ) {
 			return (
 				<Fragment>
 					<Button
@@ -44,42 +45,36 @@ function HistoricalDataActions( {
 			);
 		}
 
-		// Has no imported data
-		if ( ! hasImportedData ) {
-			// @todo When the import status endpoint is hooked up,
-			// the 'Delete Previously Imported Data' button should be
-			// removed from this section.
+		if ( [ 'ready', 'nothing' ].includes( status ) ) {
+			if ( ongoingImport && ( customersProgress > 0 || ordersProgress > 0 ) ) {
+				// An import was stopped before finishing
+				return (
+					<Fragment>
+						<Button isPrimary onClick={ onStartImport } disabled={ importDisabled }>
+							{ __( 'Start', 'woocommerce-admin' ) }
+						</Button>
+						<Button isDefault onClick={ onDeletePreviousData }>
+							{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }
+						</Button>
+					</Fragment>
+				);
+			}
+
+			// Has no imported data or user clicked on 'reimport data'
 			return (
 				<Fragment>
-					<Button isPrimary onClick={ onStartImport }>
+					<Button isPrimary onClick={ onStartImport } disabled={ importDisabled }>
 						{ __( 'Start', 'woocommerce-admin' ) }
-					</Button>
-					<Button isDefault onClick={ onDeletePreviousData }>
-						{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }
 					</Button>
 				</Fragment>
 			);
 		}
 
 		// Has imported all possible data
-		if ( customersProgress === customersTotal && ordersProgress === ordersTotal ) {
-			return (
-				<Fragment>
-					<Button isDefault onClick={ () => null }>
-						{ __( 'Re-import Data', 'woocommerce-admin' ) }
-					</Button>
-					<Button isDefault onClick={ onDeletePreviousData }>
-						{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }
-					</Button>
-				</Fragment>
-			);
-		}
-
-		// It's not in progress and has some imported data
 		return (
 			<Fragment>
-				<Button isPrimary onClick={ onStartImport }>
-					{ __( 'Start', 'woocommerce-admin' ) }
+				<Button isDefault onClick={ onReimportData }>
+					{ __( 'Re-import Data', 'woocommerce-admin' ) }
 				</Button>
 				<Button isDefault onClick={ onDeletePreviousData }>
 					{ __( 'Delete Previously Imported Data', 'woocommerce-admin' ) }

--- a/client/analytics/settings/historical-data/actions.js
+++ b/client/analytics/settings/historical-data/actions.js
@@ -9,10 +9,10 @@ import { Fragment } from '@wordpress/element';
 function HistoricalDataActions( {
 	customersProgress,
 	onDeletePreviousData,
+	ongoingImport,
 	onReimportData,
 	onStartImport,
 	onStopImport,
-	ongoingImport,
 	ordersProgress,
 	status,
 } ) {
@@ -46,8 +46,8 @@ function HistoricalDataActions( {
 		}
 
 		if ( [ 'ready', 'nothing' ].includes( status ) ) {
+			// An import was stopped before finishing
 			if ( ongoingImport && ( customersProgress > 0 || ordersProgress > 0 ) ) {
-				// An import was stopped before finishing
 				return (
 					<Fragment>
 						<Button isPrimary onClick={ onStartImport } disabled={ importDisabled }>

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
 import moment from 'moment';
+import { withSpokenMessages } from '@wordpress/components';
 
 /**
  * WooCommerce dependencies
@@ -25,7 +26,7 @@ class HistoricalData extends Component {
 		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
 
 		this.state = {
-			// Whether there is an ongoing import which is not paused
+			// Whether there is an import that is running
 			inProgress: false,
 			period: {
 				date: moment().format( this.dateFormat ),
@@ -39,6 +40,7 @@ class HistoricalData extends Component {
 		};
 
 		this.makeQuery = this.makeQuery.bind( this );
+		this.onImportFinish = this.onImportFinish.bind( this );
 		this.onDeletePreviousData = this.onDeletePreviousData.bind( this );
 		this.onReimportData = this.onReimportData.bind( this );
 		this.onStartImport = this.onStartImport.bind( this );
@@ -78,6 +80,14 @@ class HistoricalData extends Component {
 		} );
 	}
 
+	onImportFinish() {
+		const { debouncedSpeak } = this.props;
+		debouncedSpeak( 'Import complete' );
+		this.setState( {
+			inProgress: false,
+		} );
+	}
+
 	onReimportData() {
 		this.setState( {
 			inProgress: false,
@@ -105,7 +115,6 @@ class HistoricalData extends Component {
 	onStopImport() {
 		this.setState( {
 			inProgress: false,
-			reimportingData: false,
 		} );
 		const path = '/wc/v4/reports/import/cancel';
 		const errorMessage = __(
@@ -151,6 +160,7 @@ class HistoricalData extends Component {
 		return (
 			<HistoricalDataLayout
 				dateFormat={ this.dateFormat }
+				onImportFinish={ this.onImportFinish }
 				inProgress={ inProgress }
 				ongoingImport={ ongoingImport }
 				onPeriodChange={ this.onPeriodChange }
@@ -168,4 +178,4 @@ class HistoricalData extends Component {
 	}
 }
 
-export default HistoricalData;
+export default withSpokenMessages( HistoricalData );

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -26,15 +26,16 @@ class HistoricalData extends Component {
 		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
 
 		this.state = {
-			// Whether there is an import that is running
+			// Whether there is an active import (which might have already finished)
+			// which matches the period and skipChecked settings
+			activeImport: false,
+			// Whether the active import is currently running
 			inProgress: false,
 			period: {
 				date: moment().format( this.dateFormat ),
 				label: 'all',
 			},
-			// Whether there is an ongoing import (that might be paused) which matches the period and skipChecked settings
-			ongoingImport: false,
-			// Whether there is an ongoingImport but the user click on 'reimport data'
+			// Whether there is an active import but the user click on 'reimport data'
 			reimportingData: false,
 			skipChecked: true,
 		};
@@ -75,8 +76,8 @@ class HistoricalData extends Component {
 		);
 		this.makeQuery( path, errorMessage );
 		this.setState( {
+			activeImport: false,
 			inProgress: false,
-			ongoingImport: false,
 		} );
 	}
 
@@ -98,8 +99,8 @@ class HistoricalData extends Component {
 	onStartImport() {
 		const { period, skipChecked } = this.state;
 		this.setState( {
+			activeImport: true,
 			inProgress: true,
-			ongoingImport: true,
 			reimportingData: false,
 		} );
 		const path =
@@ -126,43 +127,43 @@ class HistoricalData extends Component {
 
 	onPeriodChange( val ) {
 		this.setState( {
+			activeImport: false,
 			inProgress: false,
 			period: {
 				...this.state.period,
 				label: val,
 			},
-			ongoingImport: false,
 		} );
 	}
 
 	onDateChange( val ) {
 		this.setState( {
+			activeImport: false,
 			inProgress: false,
 			period: {
 				date: val,
 				label: 'custom',
 			},
-			ongoingImport: false,
 		} );
 	}
 
 	onSkipChange( val ) {
 		this.setState( {
+			activeImport: false,
 			inProgress: false,
-			ongoingImport: false,
 			skipChecked: val,
 		} );
 	}
 
 	render() {
-		const { inProgress, ongoingImport, period, reimportingData, skipChecked } = this.state;
+		const { activeImport, inProgress, period, reimportingData, skipChecked } = this.state;
 
 		return (
 			<HistoricalDataLayout
+				activeImport={ activeImport }
 				dateFormat={ this.dateFormat }
 				onImportFinish={ this.onImportFinish }
 				inProgress={ inProgress }
-				ongoingImport={ ongoingImport }
 				onPeriodChange={ this.onPeriodChange }
 				onDateChange={ this.onDateChange }
 				onSkipChange={ this.onSkipChange }

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -26,17 +26,18 @@ class HistoricalData extends Component {
 		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
 
 		this.state = {
-			// Whether there is an active import (which might have already finished)
-			// which matches the period and skipChecked settings
-			activeImport: false,
+			// Whether there is an active import (which might have been stopped)
+			// that matches the period and skipChecked settings
+			activeImport: null,
 			// Whether the active import is currently running
-			inProgress: false,
+			inProgress: null,
+			lastImportTimestamp: 0,
 			period: {
 				date: moment().format( this.dateFormat ),
 				label: 'all',
 			},
 			// Whether there is an active import but the user click on 'reimport data'
-			reimportingData: false,
+			reimportingData: null,
 			skipChecked: true,
 		};
 
@@ -59,11 +60,19 @@ class HistoricalData extends Component {
 					addNotice( { status: 'success', message: response.message } );
 				} else {
 					addNotice( { status: 'error', message: errorMessage } );
+					this.setState( {
+						activeImport: false,
+						inProgress: null,
+					} );
 				}
 			} )
 			.catch( error => {
 				if ( error && error.message ) {
 					addNotice( { status: 'error', message: error.message } );
+					this.setState( {
+						activeImport: false,
+						inProgress: null,
+					} );
 				}
 			} );
 	}
@@ -77,7 +86,7 @@ class HistoricalData extends Component {
 		this.makeQuery( path, errorMessage );
 		this.setState( {
 			activeImport: false,
-			inProgress: false,
+			inProgress: null,
 		} );
 	}
 
@@ -91,7 +100,8 @@ class HistoricalData extends Component {
 
 	onReimportData() {
 		this.setState( {
-			inProgress: false,
+			activeImport: false,
+			inProgress: null,
 			reimportingData: true,
 		} );
 	}
@@ -101,6 +111,7 @@ class HistoricalData extends Component {
 		this.setState( {
 			activeImport: true,
 			inProgress: true,
+			lastImportTimestamp: Date.now(),
 			reimportingData: false,
 		} );
 		const path =
@@ -128,7 +139,7 @@ class HistoricalData extends Component {
 	onPeriodChange( val ) {
 		this.setState( {
 			activeImport: false,
-			inProgress: false,
+			inProgress: null,
 			period: {
 				...this.state.period,
 				label: val,
@@ -139,7 +150,7 @@ class HistoricalData extends Component {
 	onDateChange( val ) {
 		this.setState( {
 			activeImport: false,
-			inProgress: false,
+			inProgress: null,
 			period: {
 				date: val,
 				label: 'custom',
@@ -150,13 +161,20 @@ class HistoricalData extends Component {
 	onSkipChange( val ) {
 		this.setState( {
 			activeImport: false,
-			inProgress: false,
+			inProgress: null,
 			skipChecked: val,
 		} );
 	}
 
 	render() {
-		const { activeImport, inProgress, period, reimportingData, skipChecked } = this.state;
+		const {
+			activeImport,
+			inProgress,
+			lastImportTimestamp,
+			period,
+			reimportingData,
+			skipChecked,
+		} = this.state;
 
 		return (
 			<HistoricalDataLayout
@@ -164,6 +182,7 @@ class HistoricalData extends Component {
 				dateFormat={ this.dateFormat }
 				onImportFinish={ this.onImportFinish }
 				inProgress={ inProgress }
+				lastImportTimestamp={ lastImportTimestamp }
 				onPeriodChange={ this.onPeriodChange }
 				onDateChange={ this.onDateChange }
 				onSkipChange={ this.onSkipChange }

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -25,8 +25,6 @@ class HistoricalData extends Component {
 		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
 
 		this.state = {
-			// Whether there is an ongoing import and it's not paused
-			inProgress: false,
 			period: {
 				date: moment().format( this.dateFormat ),
 				label: 'all',
@@ -80,7 +78,6 @@ class HistoricalData extends Component {
 	onStartImport() {
 		const { period, skipChecked } = this.state;
 		this.setState( {
-			inProgress: true,
 			ongoingImport: true,
 			reimportingData: false,
 		} );
@@ -96,7 +93,6 @@ class HistoricalData extends Component {
 
 	onStopImport() {
 		this.setState( {
-			inProgress: false,
 			reimportingData: false,
 		} );
 		const path = '/wc/v4/reports/import/cancel';
@@ -141,12 +137,11 @@ class HistoricalData extends Component {
 	}
 
 	render() {
-		const { inProgress, ongoingImport, period, reimportingData, skipChecked } = this.state;
+		const { ongoingImport, period, reimportingData, skipChecked } = this.state;
 
 		return (
 			<HistoricalDataLayout
 				dateFormat={ this.dateFormat }
-				inProgress={ inProgress }
 				ongoingImport={ ongoingImport }
 				onPeriodChange={ this.onPeriodChange }
 				onDateChange={ this.onDateChange }

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -60,6 +60,7 @@ class HistoricalData extends Component {
 					addNotice( { status: 'error', message: errorMessage } );
 					this.setState( {
 						activeImport: false,
+						lastImportStopTimestamp: Date.now(),
 					} );
 				}
 			} )
@@ -68,6 +69,7 @@ class HistoricalData extends Component {
 					addNotice( { status: 'error', message: error.message } );
 					this.setState( {
 						activeImport: false,
+						lastImportStopTimestamp: Date.now(),
 					} );
 				}
 			} );

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -25,6 +25,8 @@ class HistoricalData extends Component {
 		this.dateFormat = __( 'MM/DD/YYYY', 'woocommerce-admin' );
 
 		this.state = {
+			// Whether there is an ongoing import which is not paused
+			inProgress: false,
 			period: {
 				date: moment().format( this.dateFormat ),
 				label: 'all',
@@ -71,13 +73,22 @@ class HistoricalData extends Component {
 		);
 		this.makeQuery( path, errorMessage );
 		this.setState( {
+			inProgress: false,
 			ongoingImport: false,
+		} );
+	}
+
+	onReimportData() {
+		this.setState( {
+			inProgress: false,
+			reimportingData: true,
 		} );
 	}
 
 	onStartImport() {
 		const { period, skipChecked } = this.state;
 		this.setState( {
+			inProgress: true,
 			ongoingImport: true,
 			reimportingData: false,
 		} );
@@ -93,6 +104,7 @@ class HistoricalData extends Component {
 
 	onStopImport() {
 		this.setState( {
+			inProgress: false,
 			reimportingData: false,
 		} );
 		const path = '/wc/v4/reports/import/cancel';
@@ -103,14 +115,9 @@ class HistoricalData extends Component {
 		this.makeQuery( path, errorMessage );
 	}
 
-	onReimportData() {
-		this.setState( {
-			reimportingData: true,
-		} );
-	}
-
 	onPeriodChange( val ) {
 		this.setState( {
+			inProgress: false,
 			period: {
 				...this.state.period,
 				label: val,
@@ -121,6 +128,7 @@ class HistoricalData extends Component {
 
 	onDateChange( val ) {
 		this.setState( {
+			inProgress: false,
 			period: {
 				date: val,
 				label: 'custom',
@@ -131,17 +139,19 @@ class HistoricalData extends Component {
 
 	onSkipChange( val ) {
 		this.setState( {
+			inProgress: false,
 			ongoingImport: false,
 			skipChecked: val,
 		} );
 	}
 
 	render() {
-		const { ongoingImport, period, reimportingData, skipChecked } = this.state;
+		const { inProgress, ongoingImport, period, reimportingData, skipChecked } = this.state;
 
 		return (
 			<HistoricalDataLayout
 				dateFormat={ this.dateFormat }
+				inProgress={ inProgress }
 				ongoingImport={ ongoingImport }
 				onPeriodChange={ this.onPeriodChange }
 				onDateChange={ this.onDateChange }

--- a/client/analytics/settings/historical-data/layout.js
+++ b/client/analytics/settings/historical-data/layout.js
@@ -22,12 +22,12 @@ import './style.scss';
 class HistoricalDataLayout extends Component {
 	render() {
 		const {
+			activeImport,
 			customersProgress,
 			customersTotal,
 			dateFormat,
 			importDate,
 			inProgress,
-			ongoingImport,
 			onPeriodChange,
 			onDateChange,
 			onSkipChange,
@@ -94,9 +94,9 @@ class HistoricalDataLayout extends Component {
 					</div>
 				</div>
 				<HistoricalDataActions
+					activeImport={ activeImport }
 					customersProgress={ customersProgress }
 					onDeletePreviousData={ onDeletePreviousData }
-					ongoingImport={ ongoingImport }
 					onReimportData={ onReimportData }
 					onStartImport={ onStartImport }
 					onStopImport={ onStopImport }
@@ -110,11 +110,11 @@ class HistoricalDataLayout extends Component {
 
 export default withSelect( ( select, props ) => {
 	const { getImportStatus, getImportTotals } = select( 'wc-api' );
-	const { dateFormat, inProgress, ongoingImport, period, skipChecked } = props;
+	const { activeImport, dateFormat, inProgress, period, skipChecked } = props;
 
 	const { customers, orders } = getImportTotals( formatParams( dateFormat, period, skipChecked ) );
 
-	if ( ! ongoingImport ) {
+	if ( ! activeImport ) {
 		return {
 			customersTotal: customers,
 			ordersTotal: orders,

--- a/client/analytics/settings/historical-data/layout.js
+++ b/client/analytics/settings/historical-data/layout.js
@@ -23,7 +23,6 @@ import './style.scss';
 class HistoricalDataLayout extends Component {
 	render() {
 		const {
-			activeImport,
 			customersProgress,
 			customersTotal,
 			dateFormat,
@@ -93,13 +92,11 @@ class HistoricalDataLayout extends Component {
 					</div>
 				</div>
 				<HistoricalDataActions
-					activeImport={ activeImport }
-					customersProgress={ customersProgress }
+					importDate={ importDate }
 					onDeletePreviousData={ onDeletePreviousData }
 					onReimportData={ onReimportData }
 					onStartImport={ onStartImport }
 					onStopImport={ onStopImport }
-					ordersProgress={ ordersProgress }
 					status={ status }
 				/>
 			</Fragment>
@@ -166,12 +163,12 @@ export default withSelect( ( select, props ) => {
 	if ( ! activeImport ) {
 		return {
 			customersTotal: customers,
+			importDate,
 			ordersTotal: orders,
 		};
 	}
 
 	return {
-		activeImport,
 		customersProgress,
 		customersTotal: isNil( customersTotal ) ? customers : customersTotal,
 		importDate,

--- a/client/analytics/settings/historical-data/layout.js
+++ b/client/analytics/settings/historical-data/layout.js
@@ -20,37 +20,6 @@ import withSelect from 'wc-api/with-select';
 import './style.scss';
 
 class HistoricalDataLayout extends Component {
-	constructor() {
-		super();
-
-		this.state = {
-			inProgress: false,
-		};
-
-		this.onStartImport = this.onStartImport.bind( this );
-		this.onStopImport = this.onStopImport.bind( this );
-	}
-
-	onStartImport() {
-		const { onStartImport } = this.props;
-
-		this.setState( {
-			inProgress: true,
-		} );
-
-		onStartImport();
-	}
-
-	onStopImport() {
-		const { onStopImport } = this.props;
-
-		this.setState( {
-			inProgress: false,
-		} );
-
-		onStopImport();
-	}
-
 	render() {
 		const {
 			customersProgress,
@@ -58,6 +27,7 @@ class HistoricalDataLayout extends Component {
 			dateFormat,
 			debouncedSpeak,
 			importDate,
+			inProgress,
 			isImporting,
 			ongoingImport,
 			onPeriodChange,
@@ -65,20 +35,22 @@ class HistoricalDataLayout extends Component {
 			onSkipChange,
 			onDeletePreviousData,
 			onReimportData,
+			onStartImport,
+			onStopImport,
 			ordersProgress,
 			ordersTotal,
 			period,
 			reimportingData,
 			skipChecked,
 		} = this.props;
-		const inProgress = this.state.inProgress && isImporting !== false;
-		if ( inProgress ) {
+		const importInProgress = inProgress && isImporting !== false;
+		if ( inProgress && isImporting === false ) {
 			debouncedSpeak( 'Import complete' );
 		}
 		const status = getStatus( {
 			customersProgress,
 			customersTotal,
-			inProgress,
+			inProgress: importInProgress,
 			ordersProgress,
 			ordersTotal,
 			reimportingData,
@@ -102,13 +74,13 @@ class HistoricalDataLayout extends Component {
 							<Fragment>
 								<HistoricalDataPeriodSelector
 									dateFormat={ dateFormat }
-									disabled={ inProgress }
+									disabled={ importInProgress }
 									onPeriodChange={ onPeriodChange }
 									onDateChange={ onDateChange }
 									value={ period }
 								/>
 								<HistoricalDataSkipCheckbox
-									disabled={ inProgress }
+									disabled={ importInProgress }
 									checked={ skipChecked }
 									onChange={ onSkipChange }
 								/>
@@ -128,12 +100,12 @@ class HistoricalDataLayout extends Component {
 					</div>
 				</div>
 				<HistoricalDataActions
+					customersProgress={ customersProgress }
 					onDeletePreviousData={ onDeletePreviousData }
 					onReimportData={ onReimportData }
-					onStartImport={ this.onStartImport }
-					onStopImport={ this.onStopImport }
+					onStartImport={ onStartImport }
+					onStopImport={ onStopImport }
 					ongoingImport={ ongoingImport }
-					customersProgress={ customersProgress }
 					ordersProgress={ ordersProgress }
 					status={ status }
 				/>

--- a/client/analytics/settings/historical-data/progress.js
+++ b/client/analytics/settings/historical-data/progress.js
@@ -5,18 +5,17 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { isNil } from 'lodash';
 
-function HistoricalDataProgress( { label, progress, total } ) {
+function HistoricalDataProgress( { label, progress = 0, total } ) {
 	const labelText = sprintf( __( 'Imported %(label)s', 'woocommerce-admin' ), {
 		label,
 	} );
 
-	const labelCounters =
-		! isNil( progress ) && ! isNil( total )
-			? sprintf( __( '%(progress)s of %(total)s', 'woocommerce-admin' ), {
-					progress,
-					total,
-				} )
-			: null;
+	const labelCounters = ! isNil( total )
+		? sprintf( __( '%(progress)s of %(total)s', 'woocommerce-admin' ), {
+				progress,
+				total,
+			} )
+		: null;
 
 	return (
 		<div className="woocommerce-settings-historical-data__progress">

--- a/client/analytics/settings/historical-data/progress.js
+++ b/client/analytics/settings/historical-data/progress.js
@@ -5,7 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { isNil } from 'lodash';
 
-function HistoricalDataProgress( { label, progress = 0, total } ) {
+function HistoricalDataProgress( { label, progress, total } ) {
 	const labelText = sprintf( __( 'Imported %(label)s', 'woocommerce-admin' ), {
 		label,
 	} );

--- a/client/analytics/settings/historical-data/progress.js
+++ b/client/analytics/settings/historical-data/progress.js
@@ -12,7 +12,7 @@ function HistoricalDataProgress( { label, progress = 0, total } ) {
 
 	const labelCounters = ! isNil( total )
 		? sprintf( __( '%(progress)s of %(total)s', 'woocommerce-admin' ), {
-				progress,
+				progress: progress || 0,
 				total,
 			} )
 		: null;
@@ -28,7 +28,7 @@ function HistoricalDataProgress( { label, progress = 0, total } ) {
 			<progress
 				className="woocommerce-settings-historical-data__progress-bar"
 				max={ total }
-				value={ progress }
+				value={ progress || 0 }
 			/>
 		</div>
 	);

--- a/client/analytics/settings/historical-data/status.js
+++ b/client/analytics/settings/historical-data/status.js
@@ -18,6 +18,7 @@ function HistoricalDataStatus( { importDate, status } ) {
 	const statusLabels = applyFilters( HISTORICAL_DATA_STATUS_FILTER, {
 		nothing: __( 'Nothing To Import', 'woocommerce-admin' ),
 		ready: __( 'Ready To Import', 'woocommerce-admin' ),
+		initializing: [ __( 'Initializing', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		customers: [ __( 'Importing Customers', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		orders: [ __( 'Importing Orders', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		finalizing: [ __( 'Finalizing', 'woocommerce-admin' ), <Spinner key="spinner" /> ],

--- a/client/analytics/settings/historical-data/status.js
+++ b/client/analytics/settings/historical-data/status.js
@@ -16,13 +16,14 @@ const HISTORICAL_DATA_STATUS_FILTER = 'woocommerce_admin_import_status';
 
 function HistoricalDataStatus( { importDate, status } ) {
 	const statusLabels = applyFilters( HISTORICAL_DATA_STATUS_FILTER, {
+		nothing: __( 'Nothing To Import', 'woocommerce-admin' ),
 		ready: __( 'Ready To Import', 'woocommerce-admin' ),
 		customers: [ __( 'Importing Customers', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		orders: [ __( 'Importing Orders', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		finalizing: [ __( 'Finalizing', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		finished: sprintf(
 			__( 'Historical data from %s onward imported', 'woocommerce-admin' ),
-			moment( importDate ).format( 'll' )
+			importDate !== '-1' ? moment( importDate ).format( 'll' ) : ''
 		),
 	} );
 

--- a/client/analytics/settings/historical-data/style.scss
+++ b/client/analytics/settings/historical-data/style.scss
@@ -4,10 +4,10 @@
 	display: grid;
 	grid-column-gap: $gap-large;
 	grid-template-columns: calc(50% - #{$gap-large/2}) calc(50% - #{$gap-large/2});
-	margin-top: $gap-small;
 
 	.woocommerce-settings-historical-data__column {
 		align-self: end;
+		margin-top: $gap-small;
 		// Auto-position fix for IE11.
 		@include set-grid-item-position( 2, 2 );
 	}

--- a/client/analytics/settings/historical-data/test/utils.js
+++ b/client/analytics/settings/historical-data/test/utils.js
@@ -87,19 +87,6 @@ describe( 'getStatus', () => {
 		).toEqual( 'finished' );
 	} );
 
-	it( 'returns `ready` when customers and orders are not already imported but `reimportingData` is true', () => {
-		expect(
-			getStatus( {
-				customersProgress: 1,
-				customersTotal: 1,
-				inProgress: false,
-				ordersProgress: 0,
-				ordersTotal: 1,
-				reimportingData: true,
-			} )
-		).toEqual( 'ready' );
-	} );
-
 	it( 'returns `ready` when there are customers or orders to import', () => {
 		expect(
 			getStatus( {

--- a/client/analytics/settings/historical-data/test/utils.js
+++ b/client/analytics/settings/historical-data/test/utils.js
@@ -1,0 +1,126 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { formatParams, getStatus } from '../utils';
+
+describe( 'formatParams', () => {
+	it( 'returns empty string when skipChecked is false and period is all', () => {
+		expect( formatParams( 'YYYY-MM-DD', { label: 'all' }, false ) ).toEqual( {} );
+	} );
+
+	it( 'returns skip_checked param', () => {
+		expect( formatParams( 'YYYY-MM-DD', { label: 'all' }, true ) ).toEqual( {
+			skip_existing: true,
+		} );
+	} );
+
+	it( 'returns correct days param based on period label', () => {
+		expect( formatParams( 'YYYY-MM-DD', { label: '30' }, false ) ).toEqual( { days: 30 } );
+	} );
+
+	it( 'returns correct days param based on period label', () => {
+		const date = '2018-01-01';
+		const days = Math.ceil( moment().diff( moment( date, 'YYYY-MM-DD' ), 'days', true ) );
+		expect( formatParams( 'YYYY-MM-DD', { label: 'custom', date }, false ) ).toEqual( { days } );
+	} );
+
+	it( 'returns both params when required', () => {
+		expect( formatParams( 'YYYY-MM-DD', { label: '30' }, true ) ).toEqual( {
+			skip_existing: true,
+			days: 30,
+		} );
+	} );
+} );
+
+describe( 'getStatus', () => {
+	it( 'returns `customers` when importing customers', () => {
+		expect(
+			getStatus( {
+				customersProgress: 0,
+				customersTotal: 1,
+				inProgress: true,
+				ordersProgress: 0,
+				ordersTotal: 1,
+			} )
+		).toEqual( 'customers' );
+	} );
+
+	it( 'returns `customers` when importing orders', () => {
+		expect(
+			getStatus( {
+				customersProgress: 1,
+				customersTotal: 1,
+				inProgress: true,
+				ordersProgress: 0,
+				ordersTotal: 1,
+			} )
+		).toEqual( 'orders' );
+	} );
+
+	it( 'returns `finalizing` when customers and orders are already imported', () => {
+		expect(
+			getStatus( {
+				customersProgress: 1,
+				customersTotal: 1,
+				inProgress: true,
+				ordersProgress: 1,
+				ordersTotal: 1,
+			} )
+		).toEqual( 'finalizing' );
+	} );
+
+	it( 'returns `finished` when customers and orders are already imported and inProgress is false', () => {
+		expect(
+			getStatus( {
+				customersProgress: 1,
+				customersTotal: 1,
+				inProgress: false,
+				ordersProgress: 1,
+				ordersTotal: 1,
+			} )
+		).toEqual( 'finished' );
+	} );
+
+	it( 'returns `ready` when customers and orders are not already imported but `reimportingData` is true', () => {
+		expect(
+			getStatus( {
+				customersProgress: 1,
+				customersTotal: 1,
+				inProgress: false,
+				ordersProgress: 0,
+				ordersTotal: 1,
+				reimportingData: true,
+			} )
+		).toEqual( 'ready' );
+	} );
+
+	it( 'returns `ready` when there are customers or orders to import', () => {
+		expect(
+			getStatus( {
+				customersProgress: 0,
+				customersTotal: 1,
+				inProgress: false,
+				ordersProgress: 0,
+				ordersTotal: 1,
+			} )
+		).toEqual( 'ready' );
+	} );
+
+	it( 'returns `nothing` when there are no customers or orders to import', () => {
+		expect(
+			getStatus( {
+				customersProgress: 0,
+				customersTotal: 0,
+				inProgress: false,
+				ordersProgress: 0,
+				ordersTotal: 0,
+			} )
+		).toEqual( 'nothing' );
+	} );
+} );

--- a/client/analytics/settings/historical-data/test/utils.js
+++ b/client/analytics/settings/historical-data/test/utils.js
@@ -10,11 +10,11 @@ import moment from 'moment';
 import { formatParams, getStatus } from '../utils';
 
 describe( 'formatParams', () => {
-	it( 'returns empty string when skipChecked is false and period is all', () => {
+	it( 'returns empty object when skipChecked is false and period is all', () => {
 		expect( formatParams( 'YYYY-MM-DD', { label: 'all' }, false ) ).toEqual( {} );
 	} );
 
-	it( 'returns skip_checked param', () => {
+	it( 'returns skip_existing param', () => {
 		expect( formatParams( 'YYYY-MM-DD', { label: 'all' }, true ) ).toEqual( {
 			skip_existing: true,
 		} );
@@ -24,13 +24,13 @@ describe( 'formatParams', () => {
 		expect( formatParams( 'YYYY-MM-DD', { label: '30' }, false ) ).toEqual( { days: 30 } );
 	} );
 
-	it( 'returns correct days param based on period label', () => {
+	it( 'returns correct days param based on period date', () => {
 		const date = '2018-01-01';
 		const days = Math.ceil( moment().diff( moment( date, 'YYYY-MM-DD' ), 'days', true ) );
 		expect( formatParams( 'YYYY-MM-DD', { label: 'custom', date }, false ) ).toEqual( { days } );
 	} );
 
-	it( 'returns both params when required', () => {
+	it( 'returns both params', () => {
 		expect( formatParams( 'YYYY-MM-DD', { label: '30' }, true ) ).toEqual( {
 			skip_existing: true,
 			days: 30,
@@ -51,7 +51,7 @@ describe( 'getStatus', () => {
 		).toEqual( 'customers' );
 	} );
 
-	it( 'returns `customers` when importing orders', () => {
+	it( 'returns `orders` when importing orders', () => {
 		expect(
 			getStatus( {
 				customersProgress: 1,

--- a/client/analytics/settings/historical-data/test/utils.js
+++ b/client/analytics/settings/historical-data/test/utils.js
@@ -39,6 +39,16 @@ describe( 'formatParams', () => {
 } );
 
 describe( 'getStatus', () => {
+	it( 'returns `initializing` when no progress numbers are defined', () => {
+		expect(
+			getStatus( {
+				customersTotal: 1,
+				inProgress: true,
+				ordersTotal: 1,
+			} )
+		).toEqual( 'initializing' );
+	} );
+
 	it( 'returns `customers` when importing customers', () => {
 		expect(
 			getStatus( {

--- a/client/analytics/settings/historical-data/test/utils.js
+++ b/client/analytics/settings/historical-data/test/utils.js
@@ -26,7 +26,7 @@ describe( 'formatParams', () => {
 
 	it( 'returns correct days param based on period date', () => {
 		const date = '2018-01-01';
-		const days = Math.ceil( moment().diff( moment( date, 'YYYY-MM-DD' ), 'days', true ) );
+		const days = Math.floor( moment().diff( moment( date, 'YYYY-MM-DD' ), 'days', true ) );
 		expect( formatParams( 'YYYY-MM-DD', { label: 'custom', date }, false ) ).toEqual( { days } );
 	} );
 

--- a/client/analytics/settings/historical-data/utils.js
+++ b/client/analytics/settings/historical-data/utils.js
@@ -28,7 +28,6 @@ export const getStatus = ( {
 	inProgress,
 	ordersProgress,
 	ordersTotal,
-	reimportingData,
 } ) => {
 	if ( inProgress ) {
 		if ( customersProgress < customersTotal ) {
@@ -47,11 +46,7 @@ export const getStatus = ( {
 		}
 	}
 	if ( customersTotal > 0 || ordersTotal > 0 ) {
-		if (
-			! reimportingData &&
-			customersProgress === customersTotal &&
-			ordersProgress === ordersTotal
-		) {
+		if ( customersProgress === customersTotal && ordersProgress === ordersTotal ) {
 			return 'finished';
 		}
 		return 'ready';

--- a/client/analytics/settings/historical-data/utils.js
+++ b/client/analytics/settings/historical-data/utils.js
@@ -13,7 +13,7 @@ export const formatParams = ( dateFormat, period, skipChecked ) => {
 	if ( period.label !== 'all' ) {
 		if ( period.label === 'custom' ) {
 			const daysDifference = moment().diff( moment( period.date, dateFormat ), 'days', true );
-			params.days = Math.ceil( daysDifference );
+			params.days = Math.floor( daysDifference );
 		} else {
 			params.days = parseInt( period.label, 10 );
 		}

--- a/client/analytics/settings/historical-data/utils.js
+++ b/client/analytics/settings/historical-data/utils.js
@@ -44,6 +44,7 @@ export const getStatus = ( {
 		) {
 			return 'finalizing';
 		}
+		return 'initializing';
 	}
 	if ( customersTotal > 0 || ordersTotal > 0 ) {
 		if ( customersProgress === customersTotal && ordersProgress === ordersTotal ) {

--- a/client/analytics/settings/historical-data/utils.js
+++ b/client/analytics/settings/historical-data/utils.js
@@ -2,16 +2,17 @@
 /**
  * External dependencies
  */
+import { isNil } from 'lodash';
 import moment from 'moment';
 
-export const formatParams = ( period, skipChecked ) => {
+export const formatParams = ( dateFormat, period, skipChecked ) => {
 	const params = {};
 	if ( skipChecked ) {
 		params.skip_existing = true;
 	}
 	if ( period.label !== 'all' ) {
 		if ( period.label === 'custom' ) {
-			const daysDifference = moment().diff( moment( period.date, this.dateFormat ), 'days', true );
+			const daysDifference = moment().diff( moment( period.date, dateFormat ), 'days', true );
 			params.days = Math.ceil( daysDifference );
 		} else {
 			params.days = parseInt( period.label, 10 );
@@ -19,4 +20,42 @@ export const formatParams = ( period, skipChecked ) => {
 	}
 
 	return params;
+};
+
+export const getStatus = ( {
+	customersProgress,
+	customersTotal,
+	inProgress,
+	ordersProgress,
+	ordersTotal,
+	reimportingData,
+} ) => {
+	if ( inProgress ) {
+		if ( customersProgress < customersTotal ) {
+			return 'customers';
+		}
+		if ( ordersProgress < ordersTotal ) {
+			return 'orders';
+		}
+		if (
+			! isNil( customersTotal ) &&
+			! isNil( ordersTotal ) &&
+			customersProgress === customersTotal &&
+			ordersProgress === ordersTotal
+		) {
+			return 'finalizing';
+		}
+	}
+	if (
+		! reimportingData &&
+		( customersTotal > 0 || ordersTotal > 0 ) &&
+		customersProgress === customersTotal &&
+		ordersProgress === ordersTotal
+	) {
+		return 'finished';
+	}
+	if ( customersTotal > 0 || ordersTotal > 0 ) {
+		return 'ready';
+	}
+	return 'nothing';
 };

--- a/client/analytics/settings/historical-data/utils.js
+++ b/client/analytics/settings/historical-data/utils.js
@@ -46,15 +46,14 @@ export const getStatus = ( {
 			return 'finalizing';
 		}
 	}
-	if (
-		! reimportingData &&
-		( customersTotal > 0 || ordersTotal > 0 ) &&
-		customersProgress === customersTotal &&
-		ordersProgress === ordersTotal
-	) {
-		return 'finished';
-	}
 	if ( customersTotal > 0 || ordersTotal > 0 ) {
+		if (
+			! reimportingData &&
+			customersProgress === customersTotal &&
+			ordersProgress === ordersTotal
+		) {
+			return 'finished';
+		}
 		return 'ready';
 	}
 	return 'nothing';

--- a/client/analytics/settings/historical-data/utils.js
+++ b/client/analytics/settings/historical-data/utils.js
@@ -30,21 +30,21 @@ export const getStatus = ( {
 	ordersTotal,
 } ) => {
 	if ( inProgress ) {
+		if (
+			isNil( customersProgress ) ||
+			isNil( ordersProgress ) ||
+			isNil( customersTotal ) ||
+			isNil( ordersTotal )
+		) {
+			return 'initializing';
+		}
 		if ( customersProgress < customersTotal ) {
 			return 'customers';
 		}
 		if ( ordersProgress < ordersTotal ) {
 			return 'orders';
 		}
-		if (
-			! isNil( customersTotal ) &&
-			! isNil( ordersTotal ) &&
-			customersProgress === customersTotal &&
-			ordersProgress === ordersTotal
-		) {
-			return 'finalizing';
-		}
-		return 'initializing';
+		return 'finalizing';
 	}
 	if ( customersTotal > 0 || ordersTotal > 0 ) {
 		if ( customersProgress === customersTotal && ordersProgress === ordersTotal ) {

--- a/client/wc-api/imports/operations.js
+++ b/client/wc-api/imports/operations.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { omit } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -32,15 +33,15 @@ function read( resourceNames, fetch = apiFetch ) {
 		const query = getResourceIdentifier( resourceName );
 		const fetchArgs = {
 			parse: false,
-			path: NAMESPACE + `/${ endpoint }${ stringifyQuery( query ) }`,
+			path: NAMESPACE + `/${ endpoint }${ stringifyQuery( omit( query, [ 'timestamp' ] ) ) }`,
 		};
 
 		try {
 			const response = await fetch( fetchArgs );
-			const totals = await response.json();
+			const data = await response.json();
 
 			return {
-				[ resourceName ]: totals,
+				[ resourceName ]: { data },
 			};
 		} catch ( error ) {
 			return { [ resourceName ]: { error } };

--- a/client/wc-api/imports/operations.js
+++ b/client/wc-api/imports/operations.js
@@ -12,17 +12,27 @@ import { stringifyQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { isResourcePrefix, getResourceIdentifier } from '../utils';
+import { getResourcePrefix, getResourceIdentifier } from '../utils';
 import { NAMESPACE } from '../constants';
 
+const typeEndpointMap = {
+	'import-status': 'reports/import/status',
+	'import-totals': 'reports/import/totals',
+};
+
 function read( resourceNames, fetch = apiFetch ) {
-	const filteredNames = resourceNames.filter( name => isResourcePrefix( name, 'import-totals' ) );
+	const filteredNames = resourceNames.filter( name => {
+		const prefix = getResourcePrefix( name );
+		return Boolean( typeEndpointMap[ prefix ] );
+	} );
 
 	return filteredNames.map( async resourceName => {
+		const prefix = getResourcePrefix( resourceName );
+		const endpoint = typeEndpointMap[ prefix ];
 		const query = getResourceIdentifier( resourceName );
 		const fetchArgs = {
 			parse: false,
-			path: NAMESPACE + '/reports/import/totals' + stringifyQuery( query ),
+			path: NAMESPACE + `/${ endpoint }${ stringifyQuery( query ) }`,
 		};
 
 		try {

--- a/client/wc-api/imports/selectors.js
+++ b/client/wc-api/imports/selectors.js
@@ -1,4 +1,8 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
 
 /**
  * Internal dependencies
@@ -7,12 +11,12 @@ import { getResourceName } from '../utils';
 import { DEFAULT_REQUIREMENT } from '../constants';
 
 const getImportStatus = ( getResource, requireResource ) => (
-	query = {},
+	timestamp,
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const resourceName = getResourceName( 'import-status', query );
+	const resourceName = getResourceName( 'import-status', timestamp );
 	return (
-		requireResource( requirement, resourceName ) || {
+		requireResource( requirement, resourceName ).data || {
 			customers_total: null,
 			customers_count: null,
 			imported_from: null,
@@ -23,15 +27,29 @@ const getImportStatus = ( getResource, requireResource ) => (
 	);
 };
 
+const isGetImportStatusRequesting = getResource => timestamp => {
+	const resourceName = getResourceName( 'import-status', timestamp );
+	const { lastRequested, lastReceived } = getResource( resourceName );
+
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
 const getImportTotals = ( getResource, requireResource ) => (
 	query = {},
+	timestamp,
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const resourceName = getResourceName( 'import-totals', query );
-	return requireResource( requirement, resourceName ) || { customers: null, orders: null };
+	const identifier = { ...query, timestamp };
+	const resourceName = getResourceName( 'import-totals', identifier );
+	return requireResource( requirement, resourceName ).data || { customers: null, orders: null };
 };
 
 export default {
 	getImportStatus,
+	isGetImportStatusRequesting,
 	getImportTotals,
 };

--- a/client/wc-api/imports/selectors.js
+++ b/client/wc-api/imports/selectors.js
@@ -6,6 +6,23 @@
 import { getResourceName } from '../utils';
 import { DEFAULT_REQUIREMENT } from '../constants';
 
+const getImportStatus = ( getResource, requireResource ) => (
+	query = {},
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'import-status', query );
+	return (
+		requireResource( requirement, resourceName ) || {
+			customers_total: null,
+			customers_count: null,
+			orders_total: null,
+			orders_count: null,
+			imported_from: null,
+			is_importing: null,
+		}
+	);
+};
+
 const getImportTotals = ( getResource, requireResource ) => (
 	query = {},
 	requirement = DEFAULT_REQUIREMENT
@@ -15,5 +32,6 @@ const getImportTotals = ( getResource, requireResource ) => (
 };
 
 export default {
+	getImportStatus,
 	getImportTotals,
 };

--- a/client/wc-api/imports/selectors.js
+++ b/client/wc-api/imports/selectors.js
@@ -15,16 +15,7 @@ const getImportStatus = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
 	const resourceName = getResourceName( 'import-status', timestamp );
-	return (
-		requireResource( requirement, resourceName ).data || {
-			customers_total: null,
-			customers_count: null,
-			imported_from: null,
-			is_importing: null,
-			orders_total: null,
-			orders_count: null,
-		}
-	);
+	return requireResource( requirement, resourceName ).data || {};
 };
 
 const isGetImportStatusRequesting = getResource => timestamp => {
@@ -45,7 +36,7 @@ const getImportTotals = ( getResource, requireResource ) => (
 ) => {
 	const identifier = { ...query, timestamp };
 	const resourceName = getResourceName( 'import-totals', identifier );
-	return requireResource( requirement, resourceName ).data || { customers: null, orders: null };
+	return requireResource( requirement, resourceName ).data || {};
 };
 
 export default {

--- a/client/wc-api/imports/selectors.js
+++ b/client/wc-api/imports/selectors.js
@@ -15,10 +15,10 @@ const getImportStatus = ( getResource, requireResource ) => (
 		requireResource( requirement, resourceName ) || {
 			customers_total: null,
 			customers_count: null,
-			orders_total: null,
-			orders_count: null,
 			imported_from: null,
 			is_importing: null,
+			orders_total: null,
+			orders_count: null,
 		}
 	);
 };

--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -187,7 +187,7 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
-			'minimum'           => 1,
+			'minimum'           => 0,
 		);
 		$params['skip_existing'] = array(
 			'description'       => __( 'Skip importing existing order data.', 'woocommerce-admin' ),

--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -284,10 +284,10 @@ class WC_Admin_REST_Reports_Import_Controller extends WC_Admin_REST_Reports_Cont
 	public function get_import_status( $request ) {
 		$result = array(
 			'is_importing'    => WC_Admin_Reports_Sync::is_importing(),
-			'customers_total' => get_option( 'wc_admin_import_customers_total', 0 ),
-			'customers_count' => get_option( 'wc_admin_import_customers_count', 0 ),
-			'orders_total'    => get_option( 'wc_admin_import_orders_total', 0 ),
-			'orders_count'    => get_option( 'wc_admin_import_orders_count', 0 ),
+			'customers_total' => (int) get_option( 'wc_admin_import_customers_total', 0 ),
+			'customers_count' => (int) get_option( 'wc_admin_import_customers_count', 0 ),
+			'orders_total'    => (int) get_option( 'wc_admin_import_orders_total', 0 ),
+			'orders_count'    => (int) get_option( 'wc_admin_import_orders_count', 0 ),
 			'imported_from'   => get_option( 'wc_admin_imported_from_date', false ),
 		);
 

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -597,7 +597,7 @@ class WC_Admin_Reports_Sync {
 	 * Init customer lookup table update (in batches).
 	 *
 	 * @param int|bool $days Number of days to process.
-	 * @param bool     $skip_existing Skip exisiting records.
+	 * @param bool     $skip_existing Skip existing records.
 	 */
 	public static function customer_lookup_import_batch_init( $days, $skip_existing ) {
 		$batch_size      = self::get_batch_size( self::CUSTOMERS_IMPORT_BATCH_ACTION );

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -161,12 +161,14 @@ class WC_Admin_Reports_Sync {
 	 */
 	public static function get_import_totals( $days, $skip_existing ) {
 		$orders         = self::get_orders( 1, 1, $days, $skip_existing );
+		$customer_roles = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
 		$customer_query = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
 			array(
-				'fields' => 'ID',
-				'number' => 1,
+				'fields'   => 'ID',
+				'number'   => 1,
+				'role__in' => $customer_roles,
 			)
 		);
 
@@ -187,6 +189,7 @@ class WC_Admin_Reports_Sync {
 				'status'   => 'pending',
 				'per_page' => 1,
 				'claimed'  => false,
+				'search'   => 'import',
 				'group'    => self::QUEUE_GROUP,
 			)
 		);
@@ -334,7 +337,7 @@ class WC_Admin_Reports_Sync {
 	public static function get_orders( $limit = 10, $page = 1, $days = false, $skip_existing = false ) {
 		global $wpdb;
 		$where_clause = '';
-		$offset       = $page > 1 ? $page * $limit : 0;
+		$offset       = $page > 1 ? ( $page - 1 ) * $limit : 0;
 
 		if ( $days ) {
 			$days_ago      = date( 'Y-m-d 00:00:00', time() - ( DAY_IN_SECONDS * $days ) );

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -238,7 +238,7 @@ class WC_Admin_Reports_Sync {
 		// Delete customers after order data is deleted.
 		self::queue_dependent_action( self::CUSTOMERS_DELETE_BATCH_INIT, array(), self::ORDERS_DELETE_BATCH_INIT );
 
-		// Delete options about deleted imports.
+		// Delete import options.
 		delete_option( 'wc_admin_import_customers_count' );
 		delete_option( 'wc_admin_import_orders_count' );
 		delete_option( 'wc_admin_import_customers_total' );

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -346,7 +346,7 @@ class WC_Admin_Reports_Sync {
 		$where_clause = '';
 		$offset       = $page > 1 ? ( $page - 1 ) * $limit : 0;
 
-		if ( $days ) {
+		if ( is_int( $days ) ) {
 			$days_ago      = date( 'Y-m-d 00:00:00', time() - ( DAY_IN_SECONDS * $days ) );
 			$where_clause .= " AND post_date >= '{$days_ago}'";
 		}
@@ -574,7 +574,7 @@ class WC_Admin_Reports_Sync {
 			$query_args = array();
 		}
 
-		if ( $days ) {
+		if ( is_int( $days ) ) {
 			$query_args['date_query'] = array(
 				'after' => date( 'Y-m-d 00:00:00', time() - ( DAY_IN_SECONDS * $days ) ),
 			);

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -238,6 +238,13 @@ class WC_Admin_Reports_Sync {
 		// Delete customers after order data is deleted.
 		self::queue_dependent_action( self::CUSTOMERS_DELETE_BATCH_INIT, array(), self::ORDERS_DELETE_BATCH_INIT );
 
+		// Delete options about deleted imports.
+		delete_option( 'wc_admin_import_customers_count' );
+		delete_option( 'wc_admin_import_orders_count' );
+		delete_option( 'wc_admin_import_customers_total' );
+		delete_option( 'wc_admin_import_orders_total' );
+		delete_option( 'wc_admin_imported_from_date' );
+
 		return __( 'Report table data is being deleted.', 'woocommerce-admin' );
 	}
 

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -330,8 +330,9 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$report     = $response->get_data();
 		$user_query = new WP_User_Query(
 			array(
-				'fields' => 'ID',
-				'number' => 1,
+				'fields'   => 'ID',
+				'number'   => 1,
+				'role__in' => array( 'customer' ),
 			)
 		);
 
@@ -363,7 +364,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( true, $report['is_importing'] );
 		$this->assertEquals( 0, $report['customers_count'] );
-		$this->assertEquals( 3, $report['customers_total'] );
+		$this->assertEquals( 1, $report['customers_total'] );
 		$this->assertEquals( 0, $report['orders_count'] );
 		$this->assertEquals( 4, $report['orders_total'] );
 
@@ -380,7 +381,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( false, $report['is_importing'] );
 		$this->assertEquals( 1, $report['customers_count'] );
-		$this->assertEquals( 3, $report['customers_total'] );
+		$this->assertEquals( 1, $report['customers_total'] );
 		$this->assertEquals( 4, $report['orders_count'] );
 		$this->assertEquals( 4, $report['orders_total'] );
 
@@ -390,8 +391,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$report   = $response->get_data();
 
-		// @todo The following line should be uncommented when https://github.com/woocommerce/woocommerce-admin/issues/2195 is resolved.
-		// $this->assertEquals( 0, $report['customers'] );
+		$this->assertEquals( 0, $report['customers'] );
 		$this->assertEquals( 0, $report['orders'] );
 	}
 }


### PR DESCRIPTION
Fixes #1851.

This PR hooks up `import/status` endpoint to _Historical Data Import_ screen.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/58426966-78b7a480-809e-11e9-912f-155c4bea8f79.png)

### Detailed test instructions:
- Go to _Settings_ and _Import Historical Data_.
- Start an import.
- Verify progress bars update and reflect the progress status.
- Try pausing an import, deleting previous data, changing the period, reloading the page while an import is running, etc. Verify no errors are shown and page behavior matches the designs here:
https://www.figma.com/proto/G1xF07y9TuuhfirzYtqmIvTO/Analytics-Settings