### PR TITLE
Add Muriel/Newspack components for use in onboarding

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -11,6 +11,7 @@ import { pick } from 'lodash';
 import ProfileWizardHeader from './header';
 import Plugins from './steps/plugins';
 import Start from './steps/start';
+import Industry from './steps/industry';
 import './style.scss';
 import { __ } from '@wordpress/i18n';
 
@@ -31,7 +32,7 @@ const getSteps = () => {
 	} );
 	steps.push( {
 		key: 'industry',
-		container: Fragment,
+		container: Industry,
 		label: __( 'Industry', 'woocommerce-admin' ),
 	} );
 	steps.push( {

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -1,0 +1,56 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component, Fragment } from '@wordpress/element';
+import { SelectControl, TextControl, Button } from 'newspack-components';
+
+class Industry extends Component {
+	constructor() {
+		super();
+		this.state = {
+			textInput: '',
+			selectValue1: '1st',
+			selectValue2: '',
+		};
+	}
+	render() {
+		return (
+			<Fragment>
+				<TextControl
+					label={ 'Text Input' }
+					value={ this.state.textInput }
+					onChange={ value => {
+						this.setState( { textInput: value } );
+					} }
+				/>
+
+				<SelectControl
+					label="Select with value"
+					value={ this.state.selectValue1 }
+					options={ [
+						{ value: '1st', label: 'First' },
+						{ value: '2nd', label: 'Second' },
+						{ value: '3rd', label: 'Third' },
+					] }
+					onChange={ value => this.setState( { selectValue1: value } ) }
+				/>
+
+				<SelectControl
+					label="Select empty"
+					value={ this.state.selectValue2 }
+					options={ [
+						{ value: '1st', label: 'First' },
+						{ value: '2nd', label: 'Second' },
+						{ value: '3rd', label: 'Third' },
+					] }
+					onChange={ value => this.setState( { selectValue2: value } ) }
+				/>
+
+				<Button isPrimary>Button</Button>
+			</Fragment>
+		);
+	}
+}
+
+export default Industry;

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -3,7 +3,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, CheckboxControl, FormToggle } from '@wordpress/components';
+import { FormToggle } from '@wordpress/components';
+import { Button, CheckboxControl } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
 
@@ -96,7 +97,7 @@ export default class Start extends Component {
 
 		const trackingLabel = interpolateComponents( {
 			mixedString: __(
-				'Help improve WooCommerce with usage tracking. {{link}}Learn More.{{/link}}',
+				'Help improve WooCommerce with {{link}}usage tracking{{/link}}',
 				'woocommerce-admin'
 			),
 			components: {
@@ -125,29 +126,33 @@ export default class Start extends Component {
 					} ) }
 				</p>
 
-				<div className="woocommerce-profile-wizard__tracking">
-					<CheckboxControl
-						className="woocommerce-profile-wizard__tracking-checkbox"
-						checked={ trackingChecked }
-						label={ __( trackingLabel, 'woocommerce-admin' ) }
-						onChange={ this.onTrackingChange }
-					/>
-
-					<FormToggle
-						aria-hidden="true"
-						checked={ trackingChecked }
-						onChange={ this.onTrackingChange }
-						onClick={ e => e.stopPropagation() }
-						tabIndex="-1"
-					/>
-				</div>
-
 				<Card>
 					<div className="woocommerce-profile-wizard__benefits">
 						{ benefits.map( benefit => this.renderBenefit( benefit ) ) }
 					</div>
 
-					<Button isPrimary onClick={ this.startWizard }>
+					<div className="woocommerce-profile-wizard__tracking">
+						<CheckboxControl
+							className="woocommerce-profile-wizard__tracking-checkbox"
+							checked={ trackingChecked }
+							label={ __( trackingLabel, 'woocommerce-admin' ) }
+							onChange={ this.onTrackingChange }
+						/>
+
+						<FormToggle
+							aria-hidden="true"
+							checked={ trackingChecked }
+							onChange={ this.onTrackingChange }
+							onClick={ e => e.stopPropagation() }
+							tabIndex="-1"
+						/>
+					</div>
+
+					<Button
+						isPrimary
+						onClick={ this.startWizard }
+						className="woocommerce-profile-wizard__start"
+					>
 						{ __( 'Get started', 'woocommerce-admin' ) }
 					</Button>
 				</Card>

--- a/client/dashboard/profile-wizard/steps/start/style.scss
+++ b/client/dashboard/profile-wizard/steps/start/style.scss
@@ -20,12 +20,41 @@
 			margin-bottom: 0;
 		}
 
+		.muriel-checkbox label.components-checkbox-control__label {
+			margin-left: $gap-large;
+		}
+
+		.muriel-checkbox input {
+			background-color: $muriel-hot-purple-600;
+			border-color: $muriel-hot-purple-600;
+		}
+
+		.components-form-toggle__track {
+			background-color: $muriel-hot-purple-600;
+		}
+
+		border-bottom: 1px solid $muriel-gray-50;
+		border-top: 1px solid $muriel-gray-50;
+		margin-left: -$gap;
+		margin-right: -$gap;
+		padding-left: $gap;
+		padding-right: $gap;
+
 		@include breakpoint( '<782px' ) {
 			.components-form-toggle {
 				display: inline-block;
 			}
 			.components-checkbox-control__input {
 				display: none;
+			}
+
+			display: flex;
+			flex-direction: row-reverse;
+			align-items: center;
+			justify-content: flex-end;
+
+			.muriel-checkbox label.components-checkbox-control__label {
+				margin-left: $gap-small;
 			}
 		}
 	}
@@ -56,5 +85,10 @@
 		&:last-child p {
 			border-bottom: 0;
 		}
+	}
+
+	.woocommerce-profile-wizard__start {
+		padding-left: $gap-larger * 2;
+		padding-right: $gap-larger * 2;
 	}
 }

--- a/client/dashboard/profile-wizard/steps/start/style.scss
+++ b/client/dashboard/profile-wizard/steps/start/style.scss
@@ -2,7 +2,7 @@
 
 .woocommerce-profile-wizard__body {
 	.woocommerce-profile-wizard__tracking {
-		margin-bottom: $gap-large;
+		margin-bottom: $gap;
 
 		label {
 			font-size: 14px;

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -108,6 +108,41 @@
 		padding-right: 0;
 	}
 
+	.muriel-input-text {
+		&.empty {
+			.components-base-control__label {
+				display: none;
+			}
+
+			input {
+				top: 15px;
+			}
+		}
+
+		input[type='text']:focus {
+			box-shadow: none;
+			border: 0;
+		}
+	}
+
+	.muriel-input-text label,
+	.muriel-select label {
+		display: initial;
+		width: auto;
+		right: auto;
+		left: $gap;
+	}
+
+	.muriel-input-text.active,
+	.muriel-select.active {
+		border: 2px solid $muriel-hot-purple-600;
+
+		input,
+		select {
+			top: 25px;
+		}
+	}
+
 	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard*/
 	#adminmenumain,
 	#wpadminbar,

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -108,6 +108,7 @@
 		padding-right: 0;
 	}
 
+	/* Muriel style overrides */
 	.muriel-input-text {
 		&.empty {
 			.components-base-control__label {
@@ -133,6 +134,18 @@
 		left: $gap;
 	}
 
+	.muriel-select select {
+		left: 15px;
+	}
+
+	.muriel-select.empty label {
+		top: 15px;
+	}
+
+	.muriel-select::after {
+		margin-top: -$gap-smallest;
+	}
+
 	.muriel-input-text.active,
 	.muriel-select.active {
 		border: 2px solid $muriel-hot-purple-600;
@@ -143,7 +156,22 @@
 		}
 	}
 
-	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard*/
+	.muriel-checkbox input[type='checkbox'] {
+		width: 18px;
+		height: 18px;
+	}
+
+	.muriel-checkbox input[type='checkbox']:checked::before {
+		font-size: 18px;
+		margin-left: -3px;
+		margin-top: -1px;
+	}
+
+	.muriel-button.is-button {
+		height: 48px;
+	}
+
+	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard */
 	#adminmenumain,
 	#wpadminbar,
 	.woocommerce-layout__header,

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "interpolate-components": "1.1.1",
     "marked": "0.6.2",
     "memoize-one": "5.0.4",
+    "newspack-components": "0.1.5",
     "prismjs": "1.16.0",
     "qs": "6.7.0",
     "react-click-outside": "3.0.1",
@@ -165,6 +166,7 @@
     "style-loader": "0.23.1",
     "stylelint": "9.10.1",
     "stylelint-config-wordpress": "13.1.0",
+    "url-loader": "1.1.2",
     "webpack": "4.31.0",
     "webpack-cli": "3.3.1",
     "webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,6 +10,13 @@ module.exports = {
 				outlines: '#007cba',
 			},
 			themes: {
+				'woocommerce-profile-wizard__body': {
+					primary: '#d52c82',
+					secondary: '#d52c82',
+					toggle: '#d52c82',
+					button: '#d52c82',
+					outlines: '#d52c82',
+				},
 				'woocommerce-page': {
 					primary: '#95588a',
 					secondary: '#95588a',

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -22,5 +22,8 @@
     "<rootDir>/.*/build/",
     "<rootDir>/.*/build-module/"
   ],
+  "transformIgnorePatterns": [
+    "node_modules/(?!(newspack-components)/)"
+  ],
   "verbose": true
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,6 +107,10 @@ const webpackConfig = {
 			},
 			{ test: /\.md$/, use: 'raw-loader' },
 			{
+				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/,
+				loader: 'url-loader',
+			},
+			{
 				test: /\.s?css$/,
 				use: [
 					MiniCssExtractPlugin.loader,


### PR DESCRIPTION
This PR pulls in the recently published Newspack components, which allows us to reuse some patterns like the form inputs. I did run into a couple things that may need changed, which I've logged here: https://github.com/Automattic/newspack-plugin/pull/72#issuecomment-496292548 -- but this is working well for us to start implementing. I also make a few slight style changes to the main start page, per recent Figma updates.

To Test:
* Visit the main onboarding page, view updated button / checkbox styles.
* Visit `/wp-admin/admin.php?page=wc-admin#/?step=industry` and test the select, input, and button styles.

<img width="1053" alt="Screen Shot 2019-05-27 at 3 30 54 PM" src="https://user-images.githubusercontent.com/689165/58437039-2ffbed80-8096-11e9-9bba-ada77dd11e4e.png">

<img width="633" alt="Screen Shot 2019-05-27 at 1 16 35 PM" src="https://user-images.githubusercontent.com/689165/58437062-40ac6380-8096-11e9-985e-a6026734347c.png">
