### PR TITLE
Fix boolean casting in profile controller params

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -193,8 +193,15 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 */
 	public static function get_profile_properties() {
 		$properties = array(
+			'completed'       => array(
+				'type'              => 'boolean',
+				'description'       => __( 'Whether or not the profile was completed.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
 			'skipped'         => array(
-				'type'              => 'bool',
+				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
@@ -300,7 +307,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'items_purchased' => array(
-				'type'              => 'bool',
+				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the user opted to purchase items now or later.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -97,7 +97,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 9, $properties );
+		$this->assertCount( 10, $properties );
+		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );


### PR DESCRIPTION
Fixes #2299

Casts `skipped`, `completed`, and `items_purchased` param to boolean values.

### Screenshots
<img width="285" alt="Screen Shot 2019-05-28 at 3 03 12 PM" src="https://user-images.githubusercontent.com/10561050/58457630-bc231900-8159-11e9-98bf-b801843940b9.png">
<img width="266" alt="Screen Shot 2019-05-28 at 3 03 03 PM" src="https://user-images.githubusercontent.com/10561050/58457631-bcbbaf80-8159-11e9-9729-6f7677ba9ba7.png">

### Detailed test instructions:

1. Send a POST request with `application/json` in the headers and the following body to `/wp-json/wc-admin/v1/onboarding/profile`:
```json
{
	"skipped": "false"
}
```
2. Check that the profile params returned in the GET request to `/wp-json/wc-admin/v1/onboarding/profile` return as boolean values.