### PR TITLE
allow additional parameters in the page query string

### DIFF
--- a/includes/page-controller/class-wc-admin-page-controller.php
+++ b/includes/page-controller/class-wc-admin-page-controller.php
@@ -116,7 +116,7 @@ class WC_Admin_Page_Controller {
 
 				if (
 					$page_path === $current_path &&
-					$page_query === $current_query &&
+					0 === strpos( $current_query, $page_query ) &&
 					$page_fragment === $current_fragment
 				) {
 					$this->current_page = $page;


### PR DESCRIPTION
Fixes #2314 

This PR allows additional query parameters in the URL query string (eg. `?page=wc-admin&var=value#/analytics/revenue`. 


### Detailed test instructions:

- Repeat without and with PR
- Go to Analytics -> Orders (URL is `/wp-admin/admin.php?page=wc-admin#/analytics/orders`)
- Add a query parameter in the address bar `/wp-admin/admin.php?page=wc-admin&abc=123#/analytics/orders`
- Without PR is an empty page
- With PR the Orders page loads

### Changelog Note:

> Allow additional query string parameters in page URLs.