### PR TITLE
Remove customizable dashboard heading

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -183,7 +183,6 @@ class CustomizableDashboard extends Component {
 
 		return (
 			<Fragment>
-				<H>{ __( 'Customizable Dashboard', 'woocommerce-admin' ) }</H>
 				<ReportFilters query={ query } path={ path } />
 				{ sections.map( ( section, index ) => {
 					if ( section.isVisible ) {


### PR DESCRIPTION
I originally added a heading that read `Customizable Dashboard` when I created the base page (https://github.com/woocommerce/woocommerce-admin/commit/3cf96e886a07e5578f57c6bcaa193d4d2b320ac8#diff-7e78b545fb7e8e978068d6402c22ede7R23). This was not part of the designs and was meant to be a temporary visual indicator until the customization features were built out. We already have the breadcrumbs as a page `<h1>`.

To Test:
* Visit the dashboard, and verify the date range picker is the first element, and no header is present.