### PR TITLE
Add Onboarding Step 5 - Industry

### DIFF
--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -2,52 +2,85 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { SelectControl, TextControl, Button } from 'newspack-components';
+import { Button, CheckboxControl } from 'newspack-components';
+import { includes, filter } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { H, Card } from '@woocommerce/components';
 
 class Industry extends Component {
 	constructor() {
 		super();
 		this.state = {
-			textInput: '',
-			selectValue1: '1st',
-			selectValue2: '',
+			selected: [],
 		};
+		this.onContinue = this.onContinue.bind( this );
+		this.onChange = this.onChange.bind( this );
 	}
+
+	async onContinue() {
+		const updateProfile = await this.props.updateProfile( { industry: this.state.selected } );
+		if ( updateProfile && 'success' === updateProfile.status ) {
+			this.props.goToNextStep();
+		}
+	}
+
+	onChange( slug ) {
+		this.setState( state => {
+			if ( includes( state.selected, slug ) ) {
+				return {
+					selected:
+						filter( state.selected, value => {
+							return value !== slug;
+						} ) || [],
+				};
+			}
+			const newSelected = state.selected;
+			newSelected.push( slug );
+			return {
+				selected: newSelected,
+			};
+		} );
+	}
+
 	render() {
+		const { industries } = wcSettings.onboarding;
+		const { selected } = this.state;
 		return (
 			<Fragment>
-				<TextControl
-					label={ 'Text Input' }
-					value={ this.state.textInput }
-					onChange={ value => {
-						this.setState( { textInput: value } );
-					} }
-				/>
+				<H className="woocommerce-profile-wizard__header-title">
+					{ __( 'In which industry does the store operate?', 'woocommerce-admin' ) }
+				</H>
+				<p>{ __( 'Choose any that apply' ) }</p>
+				<Card className="woocommerce-profile-wizard__industry-card">
+					<div className="woocommerce-profile-wizard__checkbox-group">
+						{ Object.keys( industries ).map( slug => {
+							return (
+								<CheckboxControl
+									key={ slug }
+									label={ __( industries[ slug ], 'woocommerce-admin' ) }
+									onChange={ () => this.onChange( slug ) }
+								/>
+							);
+						} ) }
+					</div>
 
-				<SelectControl
-					label="Select with value"
-					value={ this.state.selectValue1 }
-					options={ [
-						{ value: '1st', label: 'First' },
-						{ value: '2nd', label: 'Second' },
-						{ value: '3rd', label: 'Third' },
-					] }
-					onChange={ value => this.setState( { selectValue1: value } ) }
-				/>
-
-				<SelectControl
-					label="Select empty"
-					value={ this.state.selectValue2 }
-					options={ [
-						{ value: '1st', label: 'First' },
-						{ value: '2nd', label: 'Second' },
-						{ value: '3rd', label: 'Third' },
-					] }
-					onChange={ value => this.setState( { selectValue2: value } ) }
-				/>
-
-				<Button isPrimary>Button</Button>
+					<div className="woocommerce-profile-wizard__industry-actions">
+						{ selected.length > 0 && (
+							<Button
+								isPrimary
+								className="woocommerce-profile-wizard__continue"
+								onClick={ this.onContinue }
+							>
+								{ __( 'Continue', 'woocommerce-admin' ) }
+							</Button>
+						) }
+					</div>
+				</Card>
 			</Fragment>
 		);
 	}

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { forEach } from 'lodash';

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -154,7 +154,7 @@ export default class Start extends Component {
 					<Button
 						isPrimary
 						onClick={ this.startWizard }
-						className="woocommerce-profile-wizard__start"
+						className="woocommerce-profile-wizard__continue"
 					>
 						{ __( 'Get started', 'woocommerce-admin' ) }
 					</Button>

--- a/client/dashboard/profile-wizard/steps/start/style.scss
+++ b/client/dashboard/profile-wizard/steps/start/style.scss
@@ -24,11 +24,6 @@
 			margin-left: $gap-large;
 		}
 
-		.muriel-checkbox input {
-			background-color: $muriel-hot-purple-600;
-			border-color: $muriel-hot-purple-600;
-		}
-
 		.components-form-toggle__track {
 			background-color: $muriel-hot-purple-600;
 		}
@@ -85,10 +80,5 @@
 		&:last-child p {
 			border-bottom: 0;
 		}
-	}
-
-	.woocommerce-profile-wizard__start {
-		padding-left: $gap-larger * 2;
-		padding-right: $gap-larger * 2;
 	}
 }

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -208,11 +208,6 @@
 		}
 	}
 
-	.woocommerce-profile-wizard__continue {
-		padding-left: $gap-larger * 2;
-		padding-right: $gap-larger * 2;
-	}
-
 	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard */
 	#adminmenumain,
 	#wpadminbar,

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -171,6 +171,48 @@
 		height: 48px;
 	}
 
+	.muriel-checkbox input:checked {
+		background-color: $muriel-hot-purple-600;
+		border-color: $muriel-hot-purple-600;
+	}
+
+	.woocommerce-profile-wizard__checkbox-group {
+		.muriel-checkbox {
+			margin-top: 0;
+			margin-bottom: 0;
+			height: 56px;
+
+			label.components-checkbox-control__label {
+				border-bottom: 1px solid $muriel-gray-50;
+				position: absolute;
+				left: $gap-small;
+				width: calc(100% - #{$gap-large});
+				padding-bottom: $gap;
+			}
+
+			&:last-of-type {
+				label.components-checkbox-control__label {
+					border-bottom: 0;
+				}
+			}
+		}
+	}
+
+	.woocommerce-profile-wizard__industry-card {
+		.woocommerce-card__body {
+			padding-bottom: 0;
+		}
+
+		.woocommerce-profile-wizard__industry-actions {
+			padding-bottom: $gap;
+		}
+	}
+
+	.woocommerce-profile-wizard__continue {
+		padding-left: $gap-larger * 2;
+		padding-right: $gap-larger * 2;
+	}
+
 	/* Hide wp-admin and WooCommerce elements when viewing the profile wizard */
 	#adminmenumain,
 	#wpadminbar,

--- a/client/wc-api/onboarding/selectors.js
+++ b/client/wc-api/onboarding/selectors.js
@@ -18,7 +18,7 @@ const getProfileItems = ( getResource, requireResource ) => (
 	const ids = requireResource( requirement, resourceName ).data || [];
 
 	if ( ! ids.length ) {
-		return wcSettings.onboardingProfile;
+		return wcSettings.onboarding.profile;
 	}
 
 	const items = {};

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -227,14 +227,7 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'sanitize_callback' => 'wp_parse_slug_list',
 				'validate_callback' => 'rest_validate_request_arg',
 				'items'             => array(
-					'enum' => array(
-						'fashion-apparel-accessories',
-						'health-beauty',
-						'art-music-photography',
-						'food-drink',
-						'home-furniture-garden',
-						'other',
-					),
+					'enum' => array_keys( WC_Admin_Onboarding::get_allowed_industries() ),
 					'type' => 'string',
 				),
 			),

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -52,12 +52,35 @@ class WC_Admin_Onboarding {
 	}
 
 	/**
+	 * Get a list of allowed industries for the onboarding wizard.
+	 *
+	 * @return array
+	 */
+	public static function get_allowed_industries() {
+		return apply_filters(
+			'woocommerce_admin_onboarding_industries',
+			array(
+				'fashion-apparel-accessories' => __( 'Fashion, apparel & accessories', 'woocommerce-admin' ),
+				'health-beauty'               => __( 'Health & beauty', 'woocommerce-admin' ),
+				'art-music-photography'       => __( 'Art, music, & photography', 'woocommerce-admin' ),
+				'electronics-computers'       => __( 'Electronics & computers', 'woocommerce-admin' ),
+				'food-drink'                  => __( 'Food & drink', 'woocommerce-admin' ),
+				'home-furniture-garden'       => __( 'Home, furniture & garden', 'woocommerce-admin' ),
+				'other'                       => __( 'Other', 'woocommerce-admin' ),
+			)
+		);
+	}
+
+	/**
 	 * Add profiler items to component settings.
 	 *
 	 * @param array $settings Component settings.
 	 */
 	public function component_settings( $settings ) {
-		$settings['onboardingProfile'] = get_option( 'wc_onboarding_profile', array() );
+		$settings['onboarding'] = array(
+			'profile'    => get_option( 'wc_onboarding_profile', array() ),
+			'industries' => self::get_allowed_industries(),
+		);
 		return $settings;
 	}
 


### PR DESCRIPTION
Closes #1885.

This PR adds the industry step to the profile wizard.

<img width="1181" alt="Screen Shot 2019-05-28 at 12 57 51 PM" src="https://user-images.githubusercontent.com/689165/58499360-f7b7e600-814d-11e9-8a98-3be7220a10da.png">

<img width="1182" alt="Screen Shot 2019-05-28 at 1 03 56 PM" src="https://user-images.githubusercontent.com/689165/58499370-fd153080-814d-11e9-95a4-25bf37d93999.png">

To Test:
* Go to `/wp-admin/admin.php?page=wc-admin#/?step=industry` and confirm that you see the industries listed.
* Try selecting a couple, and hit save. You should be directed to the next page.
* Make a GET request to the profiler endpoint, and see that your industries are set.

