### PR TITLE
Allow note action URLs to be empty.

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -60,7 +60,7 @@ class InboxPanel extends Component {
 				return [];
 			}
 			return actions.map( action => (
-				<Button isDefault href={ action.url }>
+				<Button isDefault href={ action.url || undefined }>
 					{ action.label }
 				</Button>
 			) );

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -74,7 +74,7 @@ class StoreAlerts extends Component {
 					key={ action.name }
 					isDefault
 					isPrimary={ action.primary }
-					href={ action.url }
+					href={ action.url || undefined }
 					onClick={ '' === action.status ? noop : markStatus }
 				>
 					{ action.label }

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -242,6 +242,9 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 	 * @return string A fully formed URL.
 	 */
 	public function prepare_query_for_response( $query ) {
+		if ( empty( $query ) ) {
+			return $query;
+		}
 		if ( 'https://' === substr( $query, 0, 8 ) ) {
 			return $query;
 		}

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -475,16 +475,16 @@ class WC_Admin_Note extends WC_Data {
 	/**
 	 * Add an action to the note
 	 *
-	 * @param string  $name    Label name (not presented to user).
-	 * @param string  $label   Note label (e.g. presented as button label).
-	 * @param string  $query   Note query (for redirect).
-	 * @param string  $status  The status to set for the action should on click.
+	 * @param string  $name    Action name (not presented to user).
+	 * @param string  $label   Action label (presented as button label).
+	 * @param string  $url     Action URL, if navigation needed. Optional.
+	 * @param string  $status  Status to transition parent Note to upon click. Defaults to 'actioned'.
 	 * @param boolean $primary Whether or not this is the primary action. Defaults to false.
 	 */
-	public function add_action( $name, $label, $query, $status = '', $primary = false ) {
+	public function add_action( $name, $label, $url = '', $status = self::E_WC_ADMIN_NOTE_ACTIONED, $primary = false ) {
 		$name    = wc_clean( $name );
 		$label   = wc_clean( $label );
-		$query   = wc_clean( $query );
+		$query   = esc_url( $url );
 		$status  = wc_clean( $status );
 		$primary = (bool) $primary;
 
@@ -494,11 +494,6 @@ class WC_Admin_Note extends WC_Data {
 
 		if ( empty( $label ) ) {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note action label prop cannot be empty.', 'woocommerce-admin' ) );
-		}
-
-		// @todo - maybe allow empty queries? for dismissals that don't need navigation.
-		if ( empty( $query ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note action query prop cannot be empty.', 'woocommerce-admin' ) );
 		}
 
 		$action = array(


### PR DESCRIPTION
In support of #2268.

This PR removes the requirement that admin notice actions have `query` values. Not all actions will require navigation.

### Detailed test instructions:

- Add an action to an admin note with an empty string for the `query` parameter
- Verify the action is added without triggering a `WP_Error`