### PR TITLE
Trigger an action server side when admin note actions are clicked

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -219,6 +219,14 @@
 // Needs the double-class for specificity
 .woocommerce-activity-card.woocommerce-inbox-activity-card {
 	grid-template-columns: 72px 1fr;
+	height: 100%;
+	opacity: 1;
+	padding: $fallback-gutter;
+	padding: $gutter;
+
+	@media screen and (prefers-reduced-motion: no-preference) {
+		transition: opacity 0.3s, height 0s, padding 0s;
+	}
 
 	@include breakpoint( '<782px' ) {
 		grid-template-columns: 64px 1fr;
@@ -226,6 +234,15 @@
 
 	.woocommerce-activity-card__header {
 		margin-bottom: $gap-small;
+	}
+
+	&.actioned {
+		height: 0;
+		opacity: 0;
+		padding: 0;
+		@media screen and (prefers-reduced-motion: no-preference) {
+			transition: opacity 0.3s, height 0s 0.3s, padding 0s 0.3s;
+		}
 	}
 }
 

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -49,18 +49,23 @@ class InboxPanel extends Component {
 	}
 
 	renderNotes() {
-		const { lastRead, notes } = this.props;
+		const { lastRead, notes, triggerNoteAction } = this.props;
 
 		if ( 0 === Object.keys( notes ).length ) {
 			return this.renderEmptyCard();
 		}
 
-		const getButtonsFromActions = actions => {
-			if ( ! actions ) {
+		const getButtonsFromActions = note => {
+			if ( ! note.actions ) {
 				return [];
 			}
-			return actions.map( action => (
-				<Button isDefault href={ action.url || undefined }>
+			return note.actions.map( action => (
+				<Button
+					isDefault
+					isPrimary={ action.primary }
+					href={ action.url || undefined }
+					onClick={ () => triggerNoteAction( note.id, action.id ) }
+				>
 					{ action.label }
 				</Button>
 			) );
@@ -80,7 +85,7 @@ class InboxPanel extends Component {
 					! note.date_created_gmt ||
 					new Date( note.date_created_gmt + 'Z' ).getTime() > lastRead
 				}
-				actions={ getButtonsFromActions( note.actions ) }
+				actions={ getButtonsFromActions( note ) }
 			>
 				<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />
 			</ActivityCard>
@@ -154,10 +159,11 @@ export default compose(
 		return { notes, isError, isRequesting, lastRead: userData.activity_panel_inbox_last_read };
 	} ),
 	withDispatch( dispatch => {
-		const { updateCurrentUserData } = dispatch( 'wc-api' );
+		const { updateCurrentUserData, triggerNoteAction } = dispatch( 'wc-api' );
 
 		return {
 			updateCurrentUserData,
+			triggerNoteAction,
 		};
 	} )
 )( InboxPanel );

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -18,6 +18,7 @@ import { EmptyContent, Section } from '@woocommerce/components';
 import sanitizeHTML from 'lib/sanitize-html';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
+import classnames from 'classnames';
 
 class InboxPanel extends Component {
 	constructor( props ) {
@@ -76,7 +77,9 @@ class InboxPanel extends Component {
 		return notesArray.map( note => (
 			<ActivityCard
 				key={ note.id }
-				className="woocommerce-inbox-activity-card"
+				className={ classnames( 'woocommerce-inbox-activity-card', {
+					actioned: 'unactioned' !== note.status,
+				} ) }
 				title={ note.title }
 				date={ note.date_created_gmt }
 				icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
@@ -150,6 +153,7 @@ export default compose(
 			type: 'info,warning',
 			orderby: 'date',
 			order: 'desc',
+			status: 'unactioned',
 		};
 
 		const notes = getNotes( inboxQuery );

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -8,7 +8,6 @@ import { IconButton, Button, Dashicon, Dropdown, NavigableMenu } from '@wordpres
 import classnames from 'classnames';
 import interpolateComponents from 'interpolate-components';
 import { compose } from '@wordpress/compose';
-import { noop } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 import moment from 'moment';
 
@@ -64,18 +63,15 @@ class StoreAlerts extends Component {
 	}
 
 	renderActions( alert ) {
-		const { updateNote } = this.props;
+		const { triggerNoteAction, updateNote } = this.props;
 		const actions = alert.actions.map( action => {
-			const markStatus = () => {
-				updateNote( alert.id, { status: action.status } );
-			};
 			return (
 				<Button
 					key={ action.name }
 					isDefault
 					isPrimary={ action.primary }
 					href={ action.url || undefined }
-					onClick={ '' === action.status ? noop : markStatus }
+					onClick={ () => triggerNoteAction( alert.id, action.id ) }
 				>
 					{ action.label }
 				</Button>
@@ -257,8 +253,10 @@ export default compose(
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { updateNote } = dispatch( 'wc-api' );
+		const { triggerNoteAction, updateNote } = dispatch( 'wc-api' );
+
 		return {
+			triggerNoteAction,
 			updateNote,
 		};
 	} )

--- a/client/wc-api/notes/mutations.js
+++ b/client/wc-api/notes/mutations.js
@@ -5,6 +5,12 @@ const updateNote = operations => ( noteId, noteFields ) => {
 	operations.update( [ resourceKey ], { [ resourceKey ]: { noteId, ...noteFields } } );
 };
 
+const triggerNoteAction = operations => ( noteId, actionId ) => {
+	const resourceKey = 'note-action';
+	operations.update( [ resourceKey ], { [ resourceKey ]: { noteId, actionId } } );
+};
+
 export default {
 	updateNote,
+	triggerNoteAction,
 };

--- a/client/wc-api/notes/operations.js
+++ b/client/wc-api/notes/operations.js
@@ -20,7 +20,10 @@ function read( resourceNames, fetch = apiFetch ) {
 }
 
 function update( resourceNames, data, fetch = apiFetch ) {
-	return [ ...updateNote( resourceNames, data, fetch ) ];
+	return [
+		...updateNote( resourceNames, data, fetch ),
+		...triggerAction( resourceNames, data, fetch ),
+	];
 }
 
 function readNoteQueries( resourceNames, fetch ) {
@@ -93,7 +96,26 @@ function updateNote( resourceNames, data, fetch ) {
 	return [];
 }
 
+function triggerAction( resourceNames, data, fetch ) {
+	const resourceName = 'note-action';
+	if ( resourceNames.includes( resourceName ) ) {
+		const { noteId, actionId } = data[ resourceName ];
+		const url = `${ NAMESPACE }/admin/notes/${ noteId }/action/${ actionId }`;
+		return [
+			fetch( { path: url, method: 'POST' } )
+				.then( note => {
+					return { [ 'note:' + noteId ]: { data: note } };
+				} )
+				.catch( error => {
+					return { [ 'note:' + noteId ]: { error } };
+				} ),
+		];
+	}
+	return [];
+}
+
 export default {
 	read,
 	update,
+	triggerAction,
 };

--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -58,7 +58,7 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 		if ( ! $note ) {
 			return new WP_Error(
 				'woocommerce_admin_notes_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -77,7 +77,7 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 		if ( ! $triggered_action ) {
 			return new WP_Error(
 				'woocommerce_admin_note_action_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}

--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -85,17 +85,18 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 		/**
 		 * Fires when an admin note action is taken.
 		 *
-		 * @param string $name   The triggered action name.
-		 * @param object $action The triggered action.
+		 * @param string        $name The triggered action name.
+		 * @param WC_Admin_Note $note The corresponding Note.
 		 */
-		do_action( 'woocommerce_admin_note_action', $triggered_action->name, $triggered_action );
+		do_action( 'woocommerce_admin_note_action', $triggered_action->name, $note );
 
 		/**
 		 * Fires when an admin note action is taken.
-		 *
 		 * For more specific targeting of note actions.
+		 *
+		 * @param WC_Admin_Note $note The corresponding Note.
 		 */
-		do_action( 'woocommerce_admin_note_action_' . $triggered_action->name );
+		do_action( 'woocommerce_admin_note_action_' . $triggered_action->name, $note );
 
 		// Update the note with the status for this action.
 		$note->set_status( $triggered_action->status );

--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -99,7 +99,10 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 		do_action( 'woocommerce_admin_note_action_' . $triggered_action->name, $note );
 
 		// Update the note with the status for this action.
-		$note->set_status( $triggered_action->status );
+		if ( ! empty( $triggered_action->status ) ) {
+			$note->set_status( $triggered_action->status );
+		}
+
 		$note->save();
 
 		$data = $note->get_data();

--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * REST API Admin Note Action controller
+ *
+ * Handles requests to the admin note action endpoint.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Admin Note Action controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_CRUD_Controller
+ */
+class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Notes_Controller {
+
+	/**
+	 * Register the routes for admin notes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<note_id>[\d-]+)/action/(?P<action_id>[\d-]+)',
+			array(
+				'args'   => array(
+					'note_id'   => array(
+						'description' => __( 'Unique ID for the Note.', 'woocommerce-admin' ),
+						'type'        => 'integer',
+					),
+					'action_id' => array(
+						'description' => __( 'Unique ID for the Note Action.', 'woocommerce-admin' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'trigger_note_action' ),
+					// @todo - double check these permissions for taking note actions.
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Trigger a note action.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Request|WP_Error
+	 */
+	public function trigger_note_action( $request ) {
+		$note = WC_Admin_Notes::get_note( $request->get_param( 'note_id' ) );
+
+		if ( ! $note ) {
+			return new WP_Error(
+				'woocommerce_admin_notes_invalid_id',
+				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		// Find note action by ID.
+		$action_id        = $request->get_param( 'action_id' );
+		$actions          = $note->get_actions( 'edit' );
+		$triggered_action = false;
+
+		foreach ( $actions as $action ) {
+			if ( $action->id === $action_id ) {
+				$triggered_action = $action;
+			}
+		}
+
+		if ( ! $triggered_action ) {
+			return new WP_Error(
+				'woocommerce_admin_note_action_invalid_id',
+				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		/**
+		 * Fires when an admin note action is taken.
+		 *
+		 * @param string $name   The triggered action name.
+		 * @param object $action The triggered action.
+		 */
+		do_action( 'woocommerce_admin_note_action', $triggered_action->name, $triggered_action );
+
+		/**
+		 * Fires when an admin note action is taken.
+		 *
+		 * For more specific targeting of note actions.
+		 */
+		do_action( 'woocommerce_admin_note_action_' . $triggered_action->name );
+
+		// Update the note with the status for this action.
+		$note->set_status( $triggered_action->status );
+		$note->save();
+
+		$data = $note->get_data();
+		$data = $this->prepare_item_for_response( $data, $request );
+		$data = $this->prepare_response_for_collection( $data );
+
+		return rest_ensure_response( $data );
+	}
+}

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -86,7 +86,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new WP_Error(
 				'woocommerce_admin_notes_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -199,7 +199,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new WP_Error(
 				'woocommerce_admin_notes_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -103,6 +103,7 @@ class WC_Admin_Api_Init {
 	 */
 	public function rest_api_init() {
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-admin-notes-controller.php';
+		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-admin-note-action-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-coupons-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-data-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-data-countries-controller.php';
@@ -141,6 +142,7 @@ class WC_Admin_Api_Init {
 
 		$controllers = array(
 			'WC_Admin_REST_Admin_Notes_Controller',
+			'WC_Admin_REST_Admin_Note_Action_Controller',
 			'WC_Admin_REST_Coupons_Controller',
 			'WC_Admin_REST_Customers_Controller',
 			'WC_Admin_REST_Data_Controller',

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -485,7 +485,7 @@ class WC_Admin_Note extends WC_Data {
 	public function add_action( $name, $label, $url = '', $status = self::E_WC_ADMIN_NOTE_ACTIONED, $primary = false ) {
 		$name    = wc_clean( $name );
 		$label   = wc_clean( $label );
-		$query   = esc_url( $url );
+		$query   = esc_url_raw( $url );
 		$status  = wc_clean( $status );
 		$primary = (bool) $primary;
 

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -509,4 +509,13 @@ class WC_Admin_Note extends WC_Data {
 		$note_actions[] = (object) $action;
 		$this->set_prop( 'actions', $note_actions );
 	}
+
+	/**
+	 * Set actions on a note.
+	 *
+	 * @param array $actions Note actions.
+	 */
+	public function set_actions( $actions ) {
+		$this->set_prop( 'actions', $actions );
+	}
 }


### PR DESCRIPTION
In support of #2268.

This PR introduces a new endpoint `/notes/[id]/action/[id]` to trigger actions on the server side when an action is "taken".

The endpoint is hit when admin note actions are clicked - this supplants the current behavior where the `/notes/[id]` endpoint is used to update the `status` of the note to the one found on the taken action. The `status` is still updated, but through a new endpoint.

### Detailed test instructions:

- Add an admin note with actions if you don't already have some
- Hook into `'woocommerce_admin_note_action'` to verify that a WP hook is triggered
- Verify that an XHR request is made when clicking an action button
- Verify that the WP hook was fired
- Verify that the `status` of the parent note has changed to that of the action