### PR TITLE
Only show unactioned notes in the Inbox panel.

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -223,7 +223,10 @@
 	opacity: 1;
 	padding: $fallback-gutter;
 	padding: $gutter;
-	transition: opacity 0.6s, height 0s, padding 0s;
+
+	@media screen and (prefers-reduced-motion: no-preference) {
+		transition: opacity 0.3s, height 0s, padding 0s;
+	}
 
 	@include breakpoint( '<782px' ) {
 		grid-template-columns: 64px 1fr;
@@ -237,7 +240,9 @@
 		height: 0;
 		opacity: 0;
 		padding: 0;
-		transition: opacity 0.6s, height 0s 0.6s, padding 0s 0.6s;
+		@media screen and (prefers-reduced-motion: no-preference) {
+			transition: opacity 0.3s, height 0s 0.3s, padding 0s 0.3s;
+		}
 	}
 }
 

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -223,7 +223,7 @@
 	opacity: 1;
 	padding: $fallback-gutter;
 	padding: $gutter;
-	transition: opacity 1s, height 0s, padding 0s;
+	transition: opacity 0.6s, height 0s, padding 0s;
 
 	@include breakpoint( '<782px' ) {
 		grid-template-columns: 64px 1fr;
@@ -237,7 +237,7 @@
 		height: 0;
 		opacity: 0;
 		padding: 0;
-		transition: opacity 1s, height 0s 1s, padding 0s 1s;
+		transition: opacity 0.6s, height 0s 0.6s, padding 0s 0.6s;
 	}
 }
 

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -219,6 +219,11 @@
 // Needs the double-class for specificity
 .woocommerce-activity-card.woocommerce-inbox-activity-card {
 	grid-template-columns: 72px 1fr;
+	height: 100%;
+	opacity: 1;
+	padding: $fallback-gutter;
+	padding: $gutter;
+	transition: opacity 1s, height 0s, padding 0s;
 
 	@include breakpoint( '<782px' ) {
 		grid-template-columns: 64px 1fr;
@@ -226,6 +231,13 @@
 
 	.woocommerce-activity-card__header {
 		margin-bottom: $gap-small;
+	}
+
+	&.actioned {
+		height: 0;
+		opacity: 0;
+		padding: 0;
+		transition: opacity 1s, height 0s 1s, padding 0s 1s;
 	}
 }
 

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -18,6 +18,7 @@ import { EmptyContent, Section } from '@woocommerce/components';
 import sanitizeHTML from 'lib/sanitize-html';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
+import classnames from 'classnames';
 
 class InboxPanel extends Component {
 	constructor( props ) {
@@ -76,7 +77,9 @@ class InboxPanel extends Component {
 		return notesArray.map( note => (
 			<ActivityCard
 				key={ note.id }
-				className="woocommerce-inbox-activity-card"
+				className={ classnames( 'woocommerce-inbox-activity-card', {
+					actioned: 'unactioned' !== note.status,
+				} ) }
 				title={ note.title }
 				date={ note.date_created_gmt }
 				icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
@@ -150,6 +153,7 @@ export default compose(
 			type: 'info,warning',
 			orderby: 'date',
 			order: 'desc',
+			status: 'unactioned',
 		};
 
 		const notes = getNotes( inboxQuery );

--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -58,7 +58,7 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 		if ( ! $note ) {
 			return new WP_Error(
 				'woocommerce_admin_notes_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -77,7 +77,7 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 		if ( ! $triggered_action ) {
 			return new WP_Error(
 				'woocommerce_admin_note_action_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -86,7 +86,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new WP_Error(
 				'woocommerce_admin_notes_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -199,7 +199,7 @@ class WC_Admin_REST_Admin_Notes_Controller extends WC_REST_CRUD_Controller {
 		if ( ! $note ) {
 			return new WP_Error(
 				'woocommerce_admin_notes_invalid_id',
-				__( 'Sorry, there is no resouce with that ID.', 'woocommerce-admin' ),
+				__( 'Sorry, there is no resource with that ID.', 'woocommerce-admin' ),
 				array( 'status' => 404 )
 			);
 		}


### PR DESCRIPTION
And hide notes once an action has been taken.

In support of #2268.

Hide notes from the Inbox that are in a `status` other than `unactioned`. Hide notes once an action has been taken.

### Accessibility

I don't believe the `prefers-reduced-motion` applies for this transition, but please correct me if I'm wrong about that!

### Screenshots

![2019-05-28 14 08 25](https://user-images.githubusercontent.com/63922/58508796-1ddf8500-8152-11e9-9ccf-a64ecbdcdf6e.gif)

### Detailed test instructions:

- Open a WooCommerce Admin page
- Open the Inbox
- Take an action on a note
- Verify the note transitions and is removed from the inbox
- Refresh page
- Verify the note isn't visible
