### PR TITLE
Hook up onboarding step 1 actions

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -96,9 +96,10 @@ class ProfileWizard extends Component {
 		const currentStepIndex = getSteps().findIndex( s => s.key === currentStep.key );
 		const nextStep = getSteps()[ currentStepIndex + 1 ];
 
-		if ( 'undefined' === nextStep ) {
-			await updateProfileItems( { complete: true } );
-			if ( ! isError ) {
+		if ( 'undefined' === typeof nextStep ) {
+			await updateProfileItems( { completed: true } );
+
+			if ( isError ) {
 				addNotice( {
 					status: 'error',
 					message: __( 'There was a problem completing the profiler.', 'woocommerce-admin' ),
@@ -139,7 +140,7 @@ export default compose(
 		return { isError };
 	} ),
 	withDispatch( dispatch => {
-		const { addNotice, updateProfileItems } = dispatch( 'wc-admin' );
+		const { addNotice, updateProfileItems } = dispatch( 'wc-api' );
 
 		return {
 			addNotice,

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { Component, createElement, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { pick } from 'lodash';
@@ -17,13 +16,13 @@ import { updateQueryString } from '@woocommerce/navigation';
 /**
  * Internal depdencies
  */
-import { NAMESPACE } from 'wc-api/onboarding/constants';
 import ProfileWizardHeader from './header';
 import Plugins from './steps/plugins';
 import Start from './steps/start';
 import Industry from './steps/industry';
 import StoreDetails from './steps/store-details';
 import ProductTypes from './steps/product-types';
+import withSelect from 'wc-api/with-select';
 import './style.scss';
 
 const getSteps = () => {
@@ -68,7 +67,6 @@ class ProfileWizard extends Component {
 	constructor() {
 		super( ...arguments );
 		this.goToNextStep = this.goToNextStep.bind( this );
-		this.updateProfile = this.updateProfile.bind( this );
 	}
 
 	componentDidMount() {
@@ -92,30 +90,24 @@ class ProfileWizard extends Component {
 		return currentStep;
 	}
 
-	goToNextStep() {
+	async goToNextStep() {
+		const { addNotice, isError, updateProfileItems } = this.props;
 		const currentStep = this.getCurrentStep();
 		const currentStepIndex = getSteps().findIndex( s => s.key === currentStep.key );
 		const nextStep = getSteps()[ currentStepIndex + 1 ];
 
 		if ( 'undefined' === nextStep ) {
-			this.updateProfile( { complete: true } );
+			await updateProfileItems( { complete: true } );
+			if ( ! isError ) {
+				addNotice( {
+					status: 'error',
+					message: __( 'There was a problem completing the profiler.', 'woocommerce-admin' ),
+				} );
+			}
+			return;
 		}
 
 		return updateQueryString( { step: nextStep.key } );
-	}
-
-	updateProfile( params ) {
-		const { addNotice } = this.props;
-
-		return apiFetch( {
-			path: `${ NAMESPACE }/onboarding/profile`,
-			method: 'POST',
-			data: params,
-		} ).catch( error => {
-			if ( error && error.message ) {
-				addNotice( { status: 'error', message: error.message } );
-			}
-		} );
 	}
 
 	render() {
@@ -126,7 +118,6 @@ class ProfileWizard extends Component {
 			query,
 			step,
 			goToNextStep: this.goToNextStep,
-			updateProfile: this.updateProfile,
 		} );
 		const steps = getSteps().map( _step => pick( _step, [ 'key', 'label' ] ) );
 
@@ -140,11 +131,19 @@ class ProfileWizard extends Component {
 }
 
 export default compose(
+	withSelect( select => {
+		const { getProfileItemsError } = select( 'wc-api' );
+
+		const isError = Boolean( getProfileItemsError() );
+
+		return { isError };
+	} ),
 	withDispatch( dispatch => {
-		const { addNotice } = dispatch( 'wc-admin' );
+		const { addNotice, updateProfileItems } = dispatch( 'wc-admin' );
 
 		return {
 			addNotice,
+			updateProfileItems,
 		};
 	} )
 )( ProfileWizard );


### PR DESCRIPTION
Fixes #2294 

Saves the profile data (skipped) and settings data (wc tracking) for the first step of the onboarding profiler.

### Screenshots
<img width="549" alt="Screen Shot 2019-05-29 at 12 30 39 PM" src="https://user-images.githubusercontent.com/10561050/58529491-97887900-820d-11e9-9ed7-4fae2600fac3.png">

### Detailed test instructions:

1.  Make sure `skipped` and `completed` are set to false in your onboarding profile data.
2. Visit the first step - `wp-admin/admin.php?page=wc-admin#/#`
3. Toggle the tracking checkbox on/off and click "Get Started."
4. Check that the WC tracking is enabled/disabled under WC advanced settings based on the toggle.
5. Click "Proceed without Jetpack or WooCommerce Services" and make sure `skipped` is set to true and the wizard is closed.