### PR TITLE
Allow paragraph tags in admin notes.

### DIFF
--- a/client/lib/sanitize-html/index.js
+++ b/client/lib/sanitize-html/index.js
@@ -4,7 +4,7 @@
  */
 import { sanitize } from 'dompurify';
 
-export const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong' ];
+export const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong', 'p' ];
 export const ALLOWED_ATTR = [ 'target', 'href', 'rel', 'name', 'download' ];
 
 export default html => {

--- a/includes/notes/class-wc-admin-note.php
+++ b/includes/notes/class-wc-admin-note.php
@@ -356,6 +356,7 @@ class WC_Admin_Note extends WC_Data {
 					'valueless' => 'y',
 				),
 			),
+			'p'      => array(),
 		);
 
 		$content = wp_kses( $content, $allowed_html );


### PR DESCRIPTION
In support of #2268.

Allow `<p>` tags in admin note content.

### Detailed test instructions:

- Add an admin note that contains paragraph tags in the content
- Verify the paragraph tags are rendered properly