### PR TITLE
Transpile newspack-components package

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,6 +100,7 @@ const webpackConfig = {
 					'|acorn-jsx' +
 					'|d3-array' +
 					'|debug' +
+					'|newspack-components' +
 					'|regexpu-core' +
 					'|unicode-match-property-ecmascript' +
 					'|unicode-match-property-value-ecmascript)/'


### PR DESCRIPTION
Adds `newspack-components` to the list of packages to transpile.

### Detailed test instructions:
- Open WooCommerce Admin in IE11.
- Verify it loads.