### PR TITLE
Fix wrong average numbers in chart legends

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -103,7 +103,16 @@ export class ReportChart extends Component {
 		return chartData;
 	}
 
-	renderChart( mode, isRequesting, chartData ) {
+	getTimeChartTotals() {
+		const { primaryData, secondaryData, selectedChart } = this.props;
+
+		return {
+			primary: get( primaryData, [ 'data', 'totals', selectedChart.key ], null ),
+			secondary: get( secondaryData, [ 'data', 'totals', selectedChart.key ], null ),
+		};
+	}
+
+	renderChart( mode, isRequesting, chartData, chartTotals ) {
 		const {
 			emptySearchResults,
 			filterParam,
@@ -140,6 +149,7 @@ export class ReportChart extends Component {
 				screenReaderFormat={ formats.screenReaderFormat }
 				showHeaderControls={ showHeaderControls }
 				title={ selectedChart.label }
+				totals={ chartTotals }
 				tooltipLabelFormat={ formats.tooltipLabelFormat }
 				tooltipTitle={ ( 'time-comparison' === mode && selectedChart.label ) || null }
 				tooltipValueFormat={ getTooltipValueFormat( selectedChart.type ) }
@@ -174,8 +184,9 @@ export class ReportChart extends Component {
 		const isChartRequesting =
 			isRequesting || primaryData.isRequesting || secondaryData.isRequesting;
 		const chartData = this.getTimeChartData();
+		const chartTotals = this.getTimeChartTotals();
 
-		return this.renderChart( 'time-comparison', isChartRequesting, chartData );
+		return this.renderChart( 'time-comparison', isChartRequesting, chartData, chartTotals );
 	}
 
 	render() {

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -112,7 +112,7 @@ export class ReportChart extends Component {
 		};
 	}
 
-	renderChart( mode, isRequesting, chartData, chartTotals ) {
+	renderChart( mode, isRequesting, chartData, legendTotals ) {
 		const {
 			emptySearchResults,
 			filterParam,
@@ -143,13 +143,13 @@ export class ReportChart extends Component {
 				isRequesting={ isRequesting }
 				itemsLabel={ itemsLabel }
 				legendPosition={ legendPosition }
+				legendTotals={ legendTotals }
 				mode={ mode }
 				path={ path }
 				query={ query }
 				screenReaderFormat={ formats.screenReaderFormat }
 				showHeaderControls={ showHeaderControls }
 				title={ selectedChart.label }
-				totals={ chartTotals }
 				tooltipLabelFormat={ formats.tooltipLabelFormat }
 				tooltipTitle={ ( 'time-comparison' === mode && selectedChart.label ) || null }
 				tooltipValueFormat={ getTooltipValueFormat( selectedChart.type ) }
@@ -184,9 +184,9 @@ export class ReportChart extends Component {
 		const isChartRequesting =
 			isRequesting || primaryData.isRequesting || secondaryData.isRequesting;
 		const chartData = this.getTimeChartData();
-		const chartTotals = this.getTimeChartTotals();
+		const legendTotals = this.getTimeChartTotals();
 
-		return this.renderChart( 'time-comparison', isChartRequesting, chartData, chartTotals );
+		return this.renderChart( 'time-comparison', isChartRequesting, chartData, legendTotals );
 	}
 
 	render() {

--- a/docs/examples/extensions/dashboard-section/js/global-prices.js
+++ b/docs/examples/extensions/dashboard-section/js/global-prices.js
@@ -33,10 +33,10 @@ const GlobalPrices = () => {
 				interval="day"
 				data={ data.reverse() }
 				dateParser="%Y-%m-%dT%H:%M:%S"
+				legendTotals={ { primary: average } }
 				showHeaderControls={ false }
 				valueType={ 'currency' }
 				tooltipValueFormat={ formatCurrency }
-				totals={ { primary: average } }
 			/>
 		</Card>
 	);

--- a/docs/examples/extensions/dashboard-section/js/global-prices.js
+++ b/docs/examples/extensions/dashboard-section/js/global-prices.js
@@ -25,6 +25,7 @@ for ( let i = 1; i <= 20; i++ ) {
 }
 
 const GlobalPrices = () => {
+	const average = data.reduce( ( total, item ) => total + item.primary.value, 0 ) / data.length;
 	return (
 		<Card className="woocommerce-dashboard__chart-block woocommerce-analytics__card" title="Global Apple Prices">
 			<Chart
@@ -35,6 +36,7 @@ const GlobalPrices = () => {
 				showHeaderControls={ false }
 				valueType={ 'currency' }
 				tooltipValueFormat={ formatCurrency }
+				totals={ { primary: average } }
 			/>
 		</Card>
 	);

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
 - EllipsisMenu component (breaking change): Remove `children` prop in favor of a render prop `renderContent` so that function arguments `isOpen`, `onToggle`, and `onClose` can be passed down.
 - Chart has a new prop named `yBelow1Format` which overrides the `yFormat` for values between -1 and 1 (not included).
+- Add a `totals` prop to Chart component that allows overwriting the total values shown in the legend.
 - Add new component `<Stepper />` for showing a list of steps and progress.
 - Add new `<Spinner />` component.
 - Card component: updated default Muriel design.

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -131,7 +131,8 @@ class Chart extends Component {
 				focus: focusedKeys.length === 0 || focusedKeys.includes( key ),
 				key,
 				label,
-				total: legendTotals ? legendTotals[ key ] : data.reduce( ( a, c ) => a + c[ key ].value, 0 ),
+				total: legendTotals && 'undefined' !== typeof legendTotals[ key ]
+					? legendTotals[ key ] : data.reduce( ( a, c ) => a + c[ key ].value, 0 ),
 				visible: visibleKeys.includes( key ),
 			};
 		} );

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -112,7 +112,7 @@ class Chart extends Component {
 	}
 
 	getOrderedKeys( focusedKeys, visibleKeys, selectedIds = [] ) {
-		const { data, mode, totals } = this.props;
+		const { data, legendTotals, mode } = this.props;
 		if ( ! data || data.length === 0 ) {
 			return [];
 		}
@@ -131,7 +131,7 @@ class Chart extends Component {
 				focus: focusedKeys.length === 0 || focusedKeys.includes( key ),
 				key,
 				label,
-				total: totals ? totals[ key ] : data.reduce( ( a, c ) => a + c[ key ].value, 0 ),
+				total: legendTotals ? legendTotals[ key ] : data.reduce( ( a, c ) => a + c[ key ].value, 0 ),
 				visible: visibleKeys.includes( key ),
 			};
 		} );
@@ -497,6 +497,10 @@ Chart.propTypes = {
 	 */
 	legendPosition: PropTypes.oneOf( [ 'bottom', 'side', 'top' ] ),
 	/**
+	 * Values to overwrite the legend totals. If not defined, the sum of all line values will be used.
+	 */
+	legendTotals: PropTypes.object,
+	/**
 	 * A datetime formatting string or overriding function to format the screen reader labels.
 	 */
 	screenReaderFormat: PropTypes.oneOfType( [ PropTypes.string, PropTypes.func ] ),
@@ -508,10 +512,6 @@ Chart.propTypes = {
 	 * A title describing this chart.
 	 */
 	title: PropTypes.string,
-	/**
-	 * Values to overwrite the legend totals. If not defined, the sum of all line values will be used.
-	 */
-	totals: PropTypes.object,
 	/**
 	 * A datetime formatting string or overriding function to format the tooltip label.
 	 */

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -79,7 +79,7 @@ class Chart extends Component {
 		const { data, filterParam, mode, query } = this.props;
 		if ( 'item-comparison' === mode ) {
 			const selectedIds = filterParam ? getIdsFromQuery( query[ filterParam ] ) : [];
-			return this.getOrderedKeys( data, mode, [], [], selectedIds ).map( orderedItem => orderedItem.key );
+			return this.getOrderedKeys( [], [], selectedIds ).map( orderedItem => orderedItem.key );
 		}
 		return getUniqueKeys( data );
 	}
@@ -111,7 +111,8 @@ class Chart extends Component {
 		window.removeEventListener( 'resize', this.updateDimensions );
 	}
 
-	getOrderedKeys( data, mode, focusedKeys, visibleKeys, selectedIds = [] ) {
+	getOrderedKeys( focusedKeys, visibleKeys, selectedIds = [] ) {
+		const { data, mode, totals } = this.props;
 		if ( ! data || data.length === 0 ) {
 			return [];
 		}
@@ -130,7 +131,7 @@ class Chart extends Component {
 				focus: focusedKeys.length === 0 || focusedKeys.includes( key ),
 				key,
 				label,
-				total: data.reduce( ( a, c ) => a + c[ key ].value, 0 ),
+				total: totals ? totals[ key ] : data.reduce( ( a, c ) => a + c[ key ].value, 0 ),
 				visible: visibleKeys.includes( key ),
 			};
 		} );
@@ -290,7 +291,7 @@ class Chart extends Component {
 			yFormat,
 		} = this.props;
 		const selectedIds = filterParam ? getIdsFromQuery( query[ filterParam ] ) : [];
-		const orderedKeys = this.getOrderedKeys( data, mode, focusedKeys, visibleKeys, selectedIds );
+		const orderedKeys = this.getOrderedKeys( focusedKeys, visibleKeys, selectedIds );
 		const visibleData = isRequesting ? null : this.getVisibleData( data, orderedKeys );
 
 		const legendPosition = this.getLegendPosition();
@@ -507,6 +508,10 @@ Chart.propTypes = {
 	 * A title describing this chart.
 	 */
 	title: PropTypes.string,
+	/**
+	 * Values to overwrite the legend totals. If not defined, the sum of all line values will be used.
+	 */
+	totals: PropTypes.object,
 	/**
 	 * A datetime formatting string or overriding function to format the tooltip label.
 	 */


### PR DESCRIPTION
Fixes #2279.

Adds a `totals` prop to `<Chart>` component that allows overwriting the numbers shown in the legend. This way, we can directly pass down the averages already returned by the API call.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/58715361-f7764f80-83c6-11e9-83c2-7397229a4ddb.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/58715327-e594ac80-83c6-11e9-932e-59c7627614f9.png)

### Detailed test instructions:
- Go to a report that shows an average number, for example _Analytics_ > _Orders_ and _Average Order Value_.
- Verify the number shown in the Summary Numbers is the same as in the Chart legend.