### PR TITLE
Prevent inactive tabs from making requests

### DIFF
--- a/client/wc-api/imports/operations.js
+++ b/client/wc-api/imports/operations.js
@@ -26,6 +26,10 @@ function read( resourceNames, fetch = apiFetch ) {
 		};
 
 		try {
+			if ( document.hidden ) {
+				return {};
+			}
+
 			const response = await fetch( fetchArgs );
 			const totals = await response.json();
 

--- a/client/wc-api/items/operations.js
+++ b/client/wc-api/items/operations.js
@@ -40,6 +40,10 @@ function read( resourceNames, fetch = apiFetch ) {
 		const isUnboundedRequest = -1 === query.per_page;
 
 		try {
+			if ( document.hidden ) {
+				return {};
+			}
+
 			const response = await fetch( {
 				/* eslint-disable max-len */
 				/**

--- a/client/wc-api/notes/operations.js
+++ b/client/wc-api/notes/operations.js
@@ -31,6 +31,10 @@ function readNoteQueries( resourceNames, fetch ) {
 		const url = `${ NAMESPACE }/admin/notes${ stringifyQuery( query ) }`;
 
 		try {
+			if ( document.hidden ) {
+				return {};
+			}
+
 			const response = await fetch( {
 				parse: false,
 				path: url,

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -45,6 +45,10 @@ function read( resourceNames, fetch = apiFetch ) {
 		};
 
 		try {
+			if ( document.hidden ) {
+				return {};
+			}
+
 			const response = await fetch( fetchArgs );
 			const report = await response.json();
 			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -60,6 +60,10 @@ function read( resourceNames, fetch = apiFetch ) {
 		}
 
 		try {
+			if ( document.hidden ) {
+				return {};
+			}
+
 			const response = await fetch( fetchArgs );
 			const report = await response.json();
 			const totalResults = parseInt( response.headers.get( 'x-wp-total' ) );

--- a/client/wc-api/reviews/operations.js
+++ b/client/wc-api/reviews/operations.js
@@ -27,6 +27,10 @@ function readReviewQueries( resourceNames, fetch ) {
 		const url = `${ NAMESPACE }/products/reviews${ stringifyQuery( query ) }`;
 
 		try {
+			if ( document.hidden ) {
+				return {};
+			}
+
 			const response = await fetch( {
 				parse: false,
 				path: url,

--- a/client/wc-api/settings/operations.js
+++ b/client/wc-api/settings/operations.js
@@ -25,6 +25,10 @@ function readSettings( resourceNames, fetch ) {
 	} );
 
 	return filteredNames.map( async resourceName => {
+		if ( document.hidden ) {
+			return {};
+		}
+
 		const url = NAMESPACE + '/' + resourceName;
 
 		return fetch( { path: url } )
@@ -41,6 +45,10 @@ function updateSettings( resourceNames, data, fetch ) {
 	} );
 
 	return filteredNames.map( async resourceName => {
+		if ( document.hidden ) {
+			return {};
+		}
+
 		const url = NAMESPACE + '/' + resourceName + '/batch';
 		const settingsData = Object.keys( data[ resourceName ] ).map( key => {
 			return { id: key, value: data[ resourceName ][ key ] };

--- a/client/wc-api/user/operations.js
+++ b/client/wc-api/user/operations.js
@@ -15,7 +15,7 @@ function update( resourceNames, data, fetch = apiFetch ) {
 }
 
 function readCurrentUserData( resourceNames, fetch ) {
-	if ( resourceNames.includes( 'current-user-data' ) ) {
+	if ( ! document.hidden && resourceNames.includes( 'current-user-data' ) ) {
 		const url = '/wp/v2/users/me?context=edit';
 
 		return [


### PR DESCRIPTION
Part of #2365.

This PR avoids making network requests on inactive tabs.

### Detailed test instructions:
- Temporarily decrease the default freshness to something like 15 seconds (in `client/wc-api/constants.js`).
- Visit any WooCommerce Admin page.
- Verify there are no regressions and data loads correctly.
- Open the _Network_ devtools of your browser and detach them from the main browser window.
- Switch to another tab in your browser.
- Verify WooCommerce Admin doesn't make requests while the tab is inactive.
- Switch to WooCommerce Admin tab again.
- Verify requests are being made again.
- Try other things that you think could break, like opening WooCommerce Admin in an inactive tab, reloading the tab while it's inactive, etc. and verify everything works as expected.