### PR TITLE
Don't create Notices tab in Activity Panel if notices HTML element was removed by a plugin

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -254,11 +254,13 @@ class ActivityPanel extends Component {
 							className="woocommerce-layout__activity-panel-tabs"
 						>
 							{ tabs && tabs.map( this.renderTab ) }
-							<WordPressNotices
-								showNotices={ 'wpnotices' === currentTab }
-								togglePanel={ this.togglePanel }
-								onCountUpdate={ this.updateNoticeFlag }
-							/>
+							{ Boolean( document.getElementById( 'wp__notice-list' ) ) && (
+								<WordPressNotices
+									showNotices={ 'wpnotices' === currentTab }
+									togglePanel={ this.togglePanel }
+									onCountUpdate={ this.updateNoticeFlag }
+								/>
+							) }
 						</NavigableMenu>
 						{ this.renderPanel() }
 					</div>


### PR DESCRIPTION
Fixes #2366.

This PR prevents the creation of the component `<WordPressNotices>` when there isn't a `#wp__notice-list` element in the document.

### Detailed test instructions:
- Install and enable a plugin like `hide-plugin-updates-notifications`. It was unlisted from WP.org repo, but it can still be found in GitHub: https://github.com/wp-plugins/hide-plugin-updates-notifications.
- Browse around WooCommerce Admin.
- Verify you don't get JS errors.