### PR TITLE
Fix search bar in Orders page not being tapable on mobile

### DIFF
--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -11,7 +11,7 @@
 	}
 
 	.wrap {
-		padding: 20px;
+		padding: 20px 20px 0;
 
 		@include breakpoint( '<782px' ) {
 			p.search-box {

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -12,6 +12,12 @@
 
 	.wrap {
 		padding: 20px;
+
+		@include breakpoint( '<782px' ) {
+			p.search-box {
+				width: calc(100% - 40px);
+			}
+		}
 	}
 
 	#woocommerce-embedded-root.is-embed-loading + #wpbody .wrap {

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -7,20 +7,16 @@
 
 	#wpcontent,
 	#wpbody-content {
-		padding-left: 0;
+		padding: 0;
 		overflow-x: hidden !important;
 		min-height: calc(100vh - #{$adminbar-height});
 	}
 
-	&.woocommerce_page_wc-admin {
-		#wpbody-content {
-			padding-bottom: 0;
-		}
-	}
-
-	@include breakpoint( '>782px' ) {
-		#wpbody-content {
-			padding-bottom: 0;
+	@include breakpoint( '<782px' ) {
+		&:not(.woocommerce_page_wc-admin) {
+			#wpbody-content {
+				padding-bottom: 80px;
+			}
 		}
 	}
 

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -7,9 +7,21 @@
 
 	#wpcontent,
 	#wpbody-content {
-		padding: 0;
+		padding-left: 0;
 		overflow-x: hidden !important;
 		min-height: calc(100vh - #{$adminbar-height});
+	}
+
+	&.woocommerce_page_wc-admin {
+		#wpbody-content {
+			padding-bottom: 0;
+		}
+	}
+
+	@include breakpoint( '>782px' ) {
+		#wpbody-content {
+			padding-bottom: 0;
+		}
 	}
 
 	@include breakpoint( '<782px' ) {

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -18,13 +18,12 @@
 				padding-bottom: 80px;
 			}
 		}
-	}
 
-	@include breakpoint( '<782px' ) {
 		// WP breakpoint for mobile menu
 		.wp-responsive-open #wpbody {
 			right: -14.5em;
 		}
+
 		#wpcontent,
 		#wpbody-content {
 			min-height: calc(100vh - #{$adminbar-height-mobile});

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -6,19 +6,19 @@
 	}
 
 	#wpcontent,
-	#wpbody-content {
+	&.woocommerce_page_wc-admin #wpbody-content {
 		padding: 0;
 		overflow-x: hidden !important;
 		min-height: calc(100vh - #{$adminbar-height});
 	}
 
-	@include breakpoint( '<782px' ) {
-		&:not(.woocommerce_page_wc-admin) {
-			#wpbody-content {
-				padding-bottom: 80px;
-			}
+	@include breakpoint( '>782px' ) {
+		#wpbody-content {
+			padding: 0;
 		}
+	}
 
+	@include breakpoint( '<782px' ) {
 		// WP breakpoint for mobile menu
 		.wp-responsive-open #wpbody {
 			right: -14.5em;


### PR DESCRIPTION
Fixes #2383.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/59181982-d6e98a80-8b68-11e9-8e47-b6b0feaf49cb.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/59183198-ca1a6600-8b6b-11e9-9a19-4aed5a103476.png)

### Detailed test instructions:
- Go to _WooCommerce_ > _Orders_ with a narrow viewport.
- Verify the search bar is displayed below the navigation buttons.