### PR TITLE
Improve hidden tab suppression/fix rapid requests

### DIFF
--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -36,6 +36,11 @@ function createWcApiSpec() {
 		},
 		operations: {
 			read( resourceNames ) {
+				if ( document.hidden ) {
+					// Don't do any read updates while the tab isn't active.
+					return [];
+				}
+
 				return [
 					...imports.operations.read( resourceNames ),
 					...items.operations.read( resourceNames ),

--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -19,6 +19,12 @@ function createStore( name ) {
 function createDataHandlers( store ) {
 	return {
 		dataRequested: resourceNames => {
+			// This is a temporary fix until it can be resolved upstream in fresh-data.
+			// See: https://github.com/woocommerce/woocommerce-admin/pull/2387/files#r292355276
+			if ( document.hidden ) {
+				return;
+			}
+
 			store.dispatch( {
 				type: 'FRESH_DATA_REQUESTED',
 				resourceNames,

--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -19,11 +19,6 @@ function createStore( name ) {
 function createDataHandlers( store ) {
 	return {
 		dataRequested: resourceNames => {
-			const { resources } = store.getState();
-			const newResources = resourceNames.some( resourceName => ! resources[ resourceName ] );
-			if ( ! newResources && document.hidden ) {
-				return;
-			}
 			store.dispatch( {
 				type: 'FRESH_DATA_REQUESTED',
 				resourceNames,


### PR DESCRIPTION
Fixes #2365 

This replaces the code from #1732 and later additions to it. I am also proposing this fix instead of #2377.

This fixes the rapid request problem that was happening when switching
tabs while having timed out requests. It changes the approach from
suppressing the actions sent out to preventing the read function from
being called at all.

I think the original problem has occurred because the original approach
was relying on an internal implementation of `apiFetch` from `wp.data`. This
new approach does not have such a dependency. It prevents apiFetch from
even being called. However, in the process, it will also prevent any
newly required resources from being fetched if the user manages to
switch tabs before it is requested. (e.g. refresh, then switch tabs
quickly).

_Replace this with a good description of your changes & reasoning._

### Detailed test instructions:

- Follow instructions on #2365 to test.
- Monitor requests in console. Switch tabs and observe requests rapid firing
- Check out this branch
- Follow instructions on #2365 and above to switch tabs and observe that no requests are sent when tab is not active.

### Changelog Note:

Fix rapid request issue when tab is not active.
