### PR TITLE
Fix Core Build Process

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -203,22 +203,29 @@ window.wpNavMenuClassChange = function( page ) {
 
 	if ( page.wpOpenMenu ) {
 		const currentMenu = document.querySelector( '#' + page.wpOpenMenu );
-		currentMenu.classList.remove( 'wp-not-current-submenu' );
-		currentMenu.classList.add( 'wp-has-current-submenu' );
-		currentMenu.classList.add( 'wp-menu-open' );
-		currentMenu.classList.add( 'current' );
+		if ( currentMenu && currentMenu.classList ) {
+			currentMenu.classList.remove( 'wp-not-current-submenu' );
+			currentMenu.classList.add( 'wp-has-current-submenu' );
+			currentMenu.classList.add( 'wp-menu-open' );
+			currentMenu.classList.add( 'current' );
+		}
 	}
 
 	// Sometimes navigating from the subMenu to Dashboard does not close subMenu
 	if ( page.wpClosedMenu ) {
 		const closedMenu = document.querySelector( '#' + page.wpClosedMenu );
-		closedMenu.classList.remove( 'wp-has-current-submenu' );
-		closedMenu.classList.remove( 'wp-menu-open' );
-		closedMenu.classList.add( 'wp-not-current-submenu' );
+
+		if ( closedMenu && closedMenu.classList ) {
+			closedMenu.classList.remove( 'wp-has-current-submenu' );
+			closedMenu.classList.remove( 'wp-menu-open' );
+			closedMenu.classList.add( 'wp-not-current-submenu' );
+		}
 	}
 
 	const wpWrap = document.querySelector( '#wpwrap' );
-	wpWrap.classList.remove( 'wp-responsive-open' );
+	if ( wpWrap && wpWrap.classList ) {
+		wpWrap.classList.remove( 'wp-responsive-open' );
+	}
 };
 
 export { Controller, getPages };

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -127,8 +127,8 @@ class WC_Admin_Loader {
 	 * Class loader for enabled WooCommerce Admin features/sections.
 	 */
 	public static function load_features() {
-		require_once WC_ADMIN_ABSPATH . 'includes/page-controller/class-wc-admin-page-controller.php';
-		require_once WC_ADMIN_ABSPATH . 'includes/page-controller/page-controller-functions.php';
+		require_once 'page-controller/class-wc-admin-page-controller.php';
+		require_once 'page-controller/page-controller-functions.php';
 
 		$features = self::get_features();
 		foreach ( $features as $feature ) {
@@ -160,7 +160,7 @@ class WC_Admin_Loader {
 		);
 
 		// Connect existing WooCommerce pages.
-		require_once WC_ADMIN_ABSPATH . 'includes/page-controller/connect-existing-pages.php';
+		require_once 'page-controller/connect-existing-pages.php';
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dist/**/*.js",
     "dist/feature-config-core.php",
     "includes/class-wc-admin-loader.php",
+    "includes/page-controller/*.php",
     "includes/features/**/*.php",
     "languages/**/*.json",
     "license.txt"


### PR DESCRIPTION
This PR makes sure the page handler functions are included in the core build so that https://github.com/woocommerce/woocommerce/pull/23658 works again. It also adds some defense checks against the classList DOM logic. When I was enabling just some select features in core, I was getting JS errors.

### To Test:

* Test the development build normally. Make sure things load.
* Test this branch with https://github.com/woocommerce/woocommerce/pull/23658, following the directions there.