### PR TITLE
Notes: update sales record link

### DIFF
--- a/includes/class-wc-admin-events.php
+++ b/includes/class-wc-admin-events.php
@@ -50,7 +50,7 @@ class WC_Admin_Events {
 	 *
 	 * Note: WC_Admin_Notes_Order_Milestones::other_milestones is hooked to this as well.
 	 */
-	protected function do_wc_admin_daily() {
+	public function do_wc_admin_daily() {
 		WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();
 		WC_Admin_Notes_Giving_Feedback_Notes::add_notes_for_admin_giving_feedback();
 		WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();

--- a/includes/notes/class-wc-admin-notes-new-sales-record.php
+++ b/includes/notes/class-wc-admin-notes-new-sales-record.php
@@ -99,6 +99,8 @@ class WC_Admin_Notes_New_Sales_Record {
 			// We only want one sales record note at any time in the inbox, so we delete any other first.
 			WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
 
+			$report_url = '?page=wc-admin#/analytics/revenue?period=custom&compare=previous_year&after=' . $yesterday . '&before=' . $yesterday;
+
 			// And now, create our new note.
 			$note = new WC_Admin_Note();
 			$note->set_title( __( 'New sales record!', 'woocommerce-admin' ) );
@@ -108,7 +110,7 @@ class WC_Admin_Notes_New_Sales_Record {
 			$note->set_icon( 'trophy' );
 			$note->set_name( self::NOTE_NAME );
 			$note->set_source( 'woocommerce-admin' );
-			$note->add_action( 'view-report', __( 'View report', 'woocommerce-admin' ), '?page=wc-admin#/analytics' );
+			$note->add_action( 'view-report', __( 'View report', 'woocommerce-admin' ), $report_url );
 			$note->save();
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2319

Sales record note had a link to a blank screen. This PR changes the link to the Revenue Report with a custom date range of the day on which the record happened.

### Screenshots

### Detailed test instructions:

1. Make sure you have orders for yesterday.
1. update_option `woocommerce_sales_record_amount` with a low value (e.g. less than yesterday's total).
2. Download https://wordpress.org/plugins/wp-crontrol.
3. wp-admin > Tools > Cron Events. Look for the `wc_admin_daily` event and click Run Now.
4. See a new Sales record note.
5. Make sure the link is working and takes you to the Revenue Report looking at the day in question.