### PR TITLE
Add uninstall file to release ZIP

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -72,6 +72,7 @@ build_files=$(ls dist/*/*.{js,css})
 status "Creating archive... 🎁"
 zip -r woocommerce-admin.zip \
 	woocommerce-admin.php \
+	uninstall.php \
 	includes/ \
 	images/ \
 	$build_files \


### PR DESCRIPTION
Our build process seemed not to include the `uninstall.php` file.

### Detailed test instructions:
- Run `npm run build:release`.
- Verify the resulting zip has an `uninstall.php` file inside.