### PR TITLE
Update Amount of Orders to Number of Orders throughout

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-categories-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-categories-controller.php
@@ -180,7 +180,7 @@ class WC_Admin_REST_Reports_Categories_Controller extends WC_Admin_REST_Reports_
 					'readonly'    => true,
 				),
 				'orders_count'   => array(
-					'description' => __( 'Amount of orders.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders.', 'woocommerce-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/includes/api/class-wc-admin-rest-reports-coupons-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-coupons-controller.php
@@ -162,7 +162,7 @@ class WC_Admin_REST_Reports_Coupons_Controller extends WC_REST_Reports_Controlle
 					'readonly'    => true,
 				),
 				'orders_count'  => array(
-					'description' => __( 'Amount of orders.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders.', 'woocommerce-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/includes/api/class-wc-admin-rest-reports-coupons-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-coupons-stats-controller.php
@@ -147,13 +147,13 @@ class WC_Admin_REST_Reports_Coupons_Stats_Controller extends WC_REST_Reports_Con
 				'format'      => 'currency',
 			),
 			'coupons_count' => array(
-				'description' => __( 'Amount of coupons.', 'woocommerce-admin' ),
+				'description' => __( 'Number of coupons.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 			),
 			'orders_count'  => array(
-				'description' => __( 'Amount of discounted orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of discounted orders.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-orders-stats-controller.php
@@ -155,7 +155,7 @@ class WC_Admin_REST_Reports_Orders_Stats_Controller extends WC_Admin_REST_Report
 				'format'      => 'currency',
 			),
 			'orders_count'            => array(
-				'description' => __( 'Amount of orders', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/includes/api/class-wc-admin-rest-reports-revenue-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-revenue-stats-controller.php
@@ -189,7 +189,7 @@ class WC_Admin_REST_Reports_Revenue_Stats_Controller extends WC_REST_Reports_Con
 				'format'      => 'currency',
 			),
 			'orders_count'   => array(
-				'description' => __( 'Amount of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/includes/api/class-wc-admin-rest-reports-taxes-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-controller.php
@@ -202,7 +202,7 @@ class WC_Admin_REST_Reports_Taxes_Controller extends WC_REST_Reports_Controller 
 					'readonly'    => true,
 				),
 				'orders_count' => array(
-					'description' => __( 'Amount of orders.', 'woocommerce-admin' ),
+					'description' => __( 'Number of orders.', 'woocommerce-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-taxes-stats-controller.php
@@ -188,7 +188,7 @@ class WC_Admin_REST_Reports_Taxes_Stats_Controller extends WC_REST_Reports_Contr
 				'format'      => 'currency',
 			),
 			'orders_count' => array(
-				'description' => __( 'Amount of orders.', 'woocommerce-admin' ),
+				'description' => __( 'Number of orders.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -102,7 +102,7 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		$this->assertEquals( 2, count( $reports ) );
 
 		$this->assertEquals( 'orders/orders_count', $reports[0]['stat'] );
-		$this->assertEquals( 'Amount of orders', $reports[0]['label'] );
+		$this->assertEquals( 'Number of orders', $reports[0]['label'] );
 		$this->assertEquals( 1, $reports[0]['value'] );
 		$this->assertEquals( 'orders_count', $reports[0]['chart'] );
 		$this->assertEquals( '/analytics/orders', $response->data[0]['_links']['report'][0]['href'] );


### PR DESCRIPTION
Fixes #2354

Replace all instances of `Number of Orders` string with `Amount of Orders`.


### Detailed test instructions:

- Screens where the string appeared
- Categories
- Coupons
- Orders
- Revenue
- Taxes
- Leaderboard


### Changelog Note:

Tweak: Replace all instances of `Number of Orders` string with `Amount of Orders`.