### PR TITLE
Fix: Exit deactivate early if WooCommerce not active.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8929,8 +8929,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8948,13 +8947,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8967,18 +8964,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9081,8 +9075,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9092,7 +9085,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9105,20 +9097,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9135,7 +9124,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9208,8 +9196,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9219,7 +9206,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9295,8 +9281,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9326,7 +9311,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9344,7 +9328,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9383,13 +9366,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -78,6 +78,12 @@ class WC_Admin_Feature_Plugin {
 	 * @return void
 	 */
 	public function on_deactivation() {
+		// Check if we are deactivating due to dependencies not being satisfied.
+		// If WooCommerce is disabled we can't include files that depend upon it.
+		if ( ! $this->check_dependencies() ) {
+			return;
+		}
+
 		$this->includes();
 		WC_Admin_Reports_Sync::clear_queued_actions();
 		WC_Admin_Notes::clear_queued_actions();


### PR DESCRIPTION
While testing out the 0.13.0 release, I was verifying the fix for the fatal that happened upon WooCommerce being deactivated and wc-admin still being active... and a fatal was happening again. 

It appears the issue was introduced in #2399, which adds in the deactivation logic to clean up all wc-admin items... but what was happening was, since WooCommerce was no longer active, wc-admin was auto-deactivating itself, which then was loading classes that extend Woo core classes, resulting in the fatal.

This branch adds in another check to see if WooCommerce is active prior to running the deactivation routines.

__To Test__
- First see the fatal in action by installing master or v0.13.0
- Deactivate WooCommerce with wc-admin still active
- note the fatal `Fatal error: Class 'WC_Data_Store_WP' not found in /srv/www/woo-nux/public_html/wp-content/plugins/woocommerce-admin1/includes/data-stores/class-wc-admin-notes-data-store.php on line 13`
- Apply this branch and repeat the steps and verify no fatal occurs