### PR TITLE
Add changelog script

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+'use strict';
+
+const requestPromise = require('request-promise');
+const chalk = require( 'chalk' );
+const octokit = require( '@octokit/rest' )();
+const promptly = require('promptly');
+
+const headers = {
+	'Content-Type': 'application/json;charset=UTF-8',
+	'Authorization': `token ${process.env.GH_API_TOKEN}`,
+	'Accept': 'application/vnd.github.inertia-preview+json',
+	'User-Agent': 'request'
+};
+
+const columnIds = [];
+
+const getPullRequestType = labels => {
+	const typeLabel = labels.find( label => label.name.includes( '[Type]' ) );
+	if ( ! typeLabel ) {
+		return 'Dev';
+	}
+	return typeLabel.name.replace( '[Type] ', '' );
+};
+
+const getLabels = labels => {
+	return labels
+		.filter( label => ! /\[.*\]/.test( label.name ) )
+		.map( label => label.name )
+		.join( ', ' );
+
+};
+const isCollaborator = async ( username ) => {
+	return requestPromise( {
+		url: `https://api.github.com/orgs/woocommerce/members/${ username }`,
+		headers,
+		resolveWithFullResponse: true
+	} ).then( response => {
+		return response.statusCode === 204;
+	} )
+		.catch( err => {
+			if ( err.statusCode !== 404 ) {
+				console.log( '🤯' );
+				console.log( err.message );
+			}
+		});
+}
+
+const writeEntry = async ( content_url ) => {
+	const options = {
+		url: content_url,
+		headers,
+		json: true
+	}
+	return requestPromise( options )
+		.then( async data => {
+			if ( data.pull_request ) {
+				const collaborator = await isCollaborator( data.user.login );
+				const type = getPullRequestType( data.labels );
+				const labels = getLabels( data.labels );
+				const labelTag = labels.length ? `(${ labels })` : '';
+				const authorTag = collaborator ? '' : `👏 @${ data.user.login }`;
+				const entry = `- ${ type }: ${ data.title } #${ data.number } ${ labelTag } ${ authorTag }`;
+				console.log( entry );
+			}
+		} )
+		.catch( err => {
+			console.log( '🤯' );
+			console.log( err.message );
+		});
+};
+
+const makeChangelog = async column_id => {
+	octokit.paginate(
+		'GET /projects/columns/:column_id/cards',
+		{ headers, column_id },
+		response => response.data.forEach( async card => {
+			await writeEntry( card.content_url );
+		} )
+	).catch( err => {
+		console.log( '🤯' );
+		console.log( err.message );
+	})
+};
+
+const printProjectColumns = async () => {
+	const options = {
+		url: 'https://api.github.com/projects/1492664/columns',
+		headers,
+		json: true,
+	}
+
+	return requestPromise( options )
+		.then( data => {
+			console.log( ' ' );
+			console.log( chalk.yellow( 'The project board contains the following columns:' ) );
+			console.log( ' ' );
+			console.log( '+---------+-----------------------------' );
+			console.log( '| id      | sprint name ' );
+			console.log( '+---------+-----------------------------' );
+			data.forEach( column => {
+				columnIds.push( column.id.toString() );
+				console.log( '| ' + chalk.green( column.id ) +  ' | ' + column.name );
+			} );
+			console.log( '+---------+-----------------------------' );
+			console.log( ' ' );
+		} );
+}
+
+( async () => {
+	console.log( chalk.yellow( 'This program requires an api token. You can create one here: ' ) + 'https://github.com/settings/tokens' );
+	console.log( '' );
+	console.log( chalk.yellow( 'Token scope will require read permissions on public_repo, admin:org, and user.' ) );
+	console.log( '' );
+	console.log( chalk.yellow( 'Export the token as variable called GH_API_TOKEN from your bash profile.' ) );
+	console.log( '' );
+
+	const ready = await promptly.confirm( 'Are you ready to continue? ' );
+
+	if ( ready ) {
+		await printProjectColumns();
+		const id = await promptly.prompt( chalk.yellow( 'Enter a column id: ' ) );
+
+		if ( columnIds.includes( id ) ) {
+			console.log( '' );
+			console.log( chalk.green( 'Here is the generated changelog. Be sure to remove entries ' +
+				'not intended for a WooCommerce Admin release.' ) );
+			console.log( '' );
+			makeChangelog( id );
+		} else {
+			console.log( '' );
+			console.log( chalk.red( 'Invalid column id' ) );
+			console.log( '' );
+		}
+	} else {
+		console.log( '' );
+		console.log( chalk.yellow( 'Ok, see you soon.' ) );
+		console.log( '' );
+	}
+} )();
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -17598,6 +17598,24 @@
         "retry": "^0.10.0"
       }
     },
+    "promptly": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/promptly/-/promptly-3.0.3.tgz",
+      "integrity": "sha512-EWnzOsxVKUjqKeE6SStH1/cO4+DE44QolaoJ4ojGd9z6pcNkpgfJKr1ncwxrOFHSTIzoudo7jG8y0re30/LO1g==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0",
+        "read": "^1.0.4"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "prompts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
@@ -18747,6 +18765,18 @@
             "punycode": "^1.4.1"
           }
         }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "request-promise-core": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "test:help": "wp-scripts test-unit-js --help",
     "test:update-snapshots": "jest --updateSnapshot --config tests/js/jest.config.json",
     "test:watch": "npm run test -- --watch",
-    "example": "webpack --config docs/examples/extensions/examples.config.js --watch"
+    "example": "webpack --config docs/examples/extensions/examples.config.js --watch",
+    "changelog": "node ./bin/changelog.js "
   },
   "husky": {
     "hooks": {
@@ -112,6 +113,7 @@
     "@babel/plugin-transform-async-to-generator": "7.4.4",
     "@babel/plugin-transform-react-jsx": "7.3.0",
     "@babel/runtime-corejs2": "7.4.5",
+    "@octokit/rest": "^16.28.1",
     "@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
     "@wordpress/babel-plugin-makepot": "2.1.3",
     "@wordpress/babel-preset-default": "3.0.2",
@@ -127,8 +129,8 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-es2015-template-literals": "6.22.0",
     "chalk": "2.4.2",
-    "concurrently": "4.1.0",
     "color-studio": "github:automattic/color-studio#1.0.4",
+    "concurrently": "4.1.0",
     "copy-webpack-plugin": "5.0.3",
     "cross-env": "5.2.0",
     "css-loader": "3.0.0",
@@ -154,12 +156,14 @@
     "postcss-color-function": "4.1.0",
     "postcss-loader": "3.0.0",
     "prettier": "github:automattic/calypso-prettier#c56b4251",
+    "promptly": "^3.0.3",
     "prop-types": "15.7.2",
     "raw-loader": "1.0.0",
     "react-docgen": "2.21.0",
     "readline-sync": "1.4.9",
     "recast": "0.18.1",
     "replace": "1.1.0",
+    "request-promise": "^4.2.4",
     "rimraf": "2.6.3",
     "rtlcss": "2.4.0",
     "sass-loader": "7.1.0",


### PR DESCRIPTION
Add a script to automate creation of the changelog based on the project board.

### Features

* A type derived from the `[Type]` label (defaults to `dev`)
* Title
* Pull request number
* Additional labels
* Shoutout to PR author if they are not part of the WooCommerce org on github

### Test
1. `npm install` to get added dependencies.
1. Get a Github api token https://github.com/settings/tokens
2. export variable `GH_API_TOKEN` from bash profile
2. `npm run changelog`