### PR TITLE
Fix revenue and orders charts using the wrong endpoint in the Dashboard

### DIFF
--- a/client/dashboard/dashboard-charts/config.js
+++ b/client/dashboard/dashboard-charts/config.js
@@ -21,9 +21,9 @@ const DASHBOARD_CHARTS_FILTER = 'woocommerce_admin_dashboard_charts_filter';
 const allCharts = applyFilters(
 	DASHBOARD_CHARTS_FILTER,
 	revenueCharts
-		.map( d => ( { ...d, endpoint: 'orders' } ) )
+		.map( d => ( { ...d, endpoint: 'revenue' } ) )
 		.concat(
-			ordersCharts.map( d => ( { ...d, endpoint: 'revenue' } ) ),
+			ordersCharts.map( d => ( { ...d, endpoint: 'orders' } ) ),
 			productsCharts.map( d => ( { ...d, endpoint: 'products' } ) ),
 			categoriesCharts.map( d => ( { ...d, endpoint: 'categories' } ) ),
 			couponsCharts.map( d => ( { ...d, endpoint: 'orders' } ) ),


### PR DESCRIPTION
Fixes #2388.

### Detailed test instructions:
- Go to the _Dashboard_.
- Verify all charts show the correct data (for example, _Average Order Value_ chart).