### PR TITLE
Tag Version 0.13.2 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "homepage": "https://woocommerce.github.io/woocommerce-admin/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,15 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Changelog ==
 
-= 0.13.0 2019-06-12 =
+= 0.13.2 2019-06-13 = 
+
+- Fix: Bump plugin version for database update.
+
+= 0.13.1 2019-06-12 = 
+
+- Fix: Exit deactivate early if WooCommerce not active. #2410
+
+= 0.13.0 2019-06-12
 
 - Fix: Notes: update sales record link #2397
 - Enhancement: Settings: Add default date settings #2292 (Components, Dashboard, Packages)

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,10 +7,10 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 0.13.0
+ * Version: 0.13.2
  *
  * WC requires at least: 3.6.0
- * WC tested up to: 3.6.2
+ * WC tested up to: 3.6.4
  *
  * @package WC_Admin
  */
@@ -122,7 +122,7 @@ class WC_Admin_Feature_Plugin {
 		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'dist/' );
 		$this->define( 'WC_ADMIN_FEATURES_PATH', WC_ADMIN_ABSPATH . 'includes/features/' );
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', __FILE__ );
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.12.0' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.13.2' );
 	}
 
 	/**


### PR DESCRIPTION
Bump version so database migrations are run.

Fixes https://wordpress.org/support/topic/database-error-289/
