### PR TITLE
Table queries: remove befor/after from no interval endpoints

### DIFF
--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -342,11 +342,13 @@ export function getReportTableQuery( options ) {
 	const filterQuery = getFilterQuery( options );
 	const datesFromQuery = getCurrentDates( query );
 
+	const noIntervals = includes( noIntervalEndpoints, options.endpoint );
+
 	return {
 		orderby: query.orderby || 'date',
 		order: query.order || 'desc',
-		after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
-		before: appendTimestamp( datesFromQuery.primary.before, 'end' ),
+		after: noIntervals ? undefined : appendTimestamp( datesFromQuery.primary.after, 'start' ),
+		before: noIntervals ? undefined : appendTimestamp( datesFromQuery.primary.before, 'end' ),
 		page: query.page || 1,
 		per_page: query.per_page || QUERY_DEFAULTS.pageSize,
 		...filterQuery,


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2421

Default query arguments `before` and `after` were added to table queries in the Customer and Stock Reports. This PR removes those arguments for those tables by using the same logic that was already being applied to the `/stats` endpoints.

### Detailed test instructions:

1. Go to Analytics > Customers
4. Verify that all customers are displayed
5. In the Network tab verify that endpoints `reports/customers` and `reports/customers/stats` do not have `before` or `after` query arguments.
5. Add an advanced filter for registration date
6. Select before or after any date
7. Use Network tab to verify that endpoints `reports/customers` and `reports/customers/stats` do not have `before` or `after` query arguments, only `registered_before` or `registered_after`.