### PR TITLE
Performance indicators - bail whenever an internal API request fails.

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -117,19 +117,30 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 			return true;
 		}
 
-		$request       = new WP_REST_Request( 'GET', '/wc/v4/reports' );
-		$response      = rest_do_request( $request );
-		$endpoints     = $response->get_data();
-		$allowed_stats = array();
+		$request  = new WP_REST_Request( 'GET', '/wc/v4/reports' );
+		$response = rest_do_request( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		if ( 200 !== $response->get_status() ) {
 			return new WP_Error( 'woocommerce_reports_performance_indicators_result_failed', __( 'Sorry, fetching performance indicators failed.', 'woocommerce-admin' ) );
 		}
+
+		$endpoints     = $response->get_data();
+		$allowed_stats = array();
 
 		foreach ( $endpoints as $endpoint ) {
 			if ( '/stats' === substr( $endpoint['slug'], -6 ) ) {
 				$request  = new WP_REST_Request( 'OPTIONS', $endpoint['path'] );
 				$response = rest_do_request( $request );
-				$data     = $response->get_data();
+
+				if ( is_wp_error( $response ) ) {
+					return $response;
+				}
+
+				$data = $response->get_data();
 
 				$prefix = substr( $endpoint['slug'], 0, -6 );
 
@@ -282,6 +293,10 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 			$request->set_param( 'after', $query_args['after'] );
 
 			$response = rest_do_request( $request );
+
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
 
 			$data   = $response->get_data();
 			$format = $this->formats[ $stat ];

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -530,7 +530,12 @@ class WC_Admin_Loader {
 
 		if ( ! empty( $preload_data_endpoints ) ) {
 			foreach ( $preload_data_endpoints as $key => $endpoint ) {
-				$settings['dataEndpoints'][ $key ] = $preload_data[ $endpoint ]['body'];
+				// Handle error case: rest_do_request() doesn't guarantee success.
+				if ( empty( $preload_data[ $endpoint ] ) ) {
+					$settings['dataEndpoints'][ $key ] = array();
+				} else {
+					$settings['dataEndpoints'][ $key ] = $preload_data[ $endpoint ]['body'];
+				}
 			}
 		}
 		$settings = self::get_custom_settings( $settings );


### PR DESCRIPTION
Fixes #2288 

When using `rest_do_request()` internally, add handling for cases where a `WP_Error` is returned.

### Detailed test instructions:

Use the following snippet to force the error condition:

```php
add_filter( 'rest_pre_dispatch', function( $pre, $server, $request ) {
        if (
            'GET' === $request->get_method() &&
            '/wc/v4/reports' === $request->get_route()
        ) {
            return new WP_Error( 'bam', 'pow' );
        }

        return $pre;
}, 10, 3 );
```

- On `master`, verify the error shows up in the logs when visiting the Dashboard
- Check out this branch
- Verify the error no longer occurs in log when visiting the Dashboard (Performance Indicators section will be empty though)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: handle internal `rest_do_request()` error conditions.