### PR TITLE
Add test to catch missing version updates.

### DIFF
--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -14,8 +14,8 @@ foreach ( $plugin_file as $line ) {
 	if ( stripos( $line, ' * Version: ' ) !== false ) {
 		$line = " * Version: {$package->version}\n";
 	}
-	if ( stripos( $line, "\tdefine( 'WC_ADMIN_VERSION_NUMBER'," ) !== false ) {
-		$line = "\tdefine( 'WC_ADMIN_VERSION_NUMBER', '{$package->version}' );\n";
+	if ( stripos( $line, ">define( 'WC_ADMIN_VERSION_NUMBER'," ) !== false ) {
+		$line = "\t\t\$this->define( 'WC_ADMIN_VERSION_NUMBER', '{$package->version}' );\n";
 	}
 	$lines[] = $line;
 }

--- a/tests/plugin-version.php
+++ b/tests/plugin-version.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Plugin Version Tests
+ *
+ * @package WooCommerce\Tests\Reports
+ * @since 3.6.4
+ */
+
+/**
+ * Plugin Version Tests Class
+ *
+ * @package WooCommerce\Tests\Reports
+ * @since 3.6.4
+ */
+class WC_Admin_Tests_Plugin_Version extends WP_UnitTestCase {
+	/**
+	 * Ensure that all version numbers match.
+	 */
+	public function test_version_numbers() {
+		// Get package.json version.
+		$package_json = file_get_contents( 'package.json' );
+		$package      = json_decode( $package_json );
+
+		// Get main plugin file header version.
+		$plugin = get_file_data( 'woocommerce-admin.php', array( 'Version' => 'Version' ) );
+
+		// Get plugin DB version.
+		$db_version = defined( 'WC_ADMIN_VERSION_NUMBER' ) ? constant( 'WC_ADMIN_VERSION_NUMBER' ) : false;
+
+		// Compare all versions to the package.json value.
+		$this->assertEquals( $package->version, $plugin['Version'], 'Plugin header version does not match package.json' );
+		$this->assertEquals( $package->version, $db_version, 'DB version constant does not match package.json' );
+	}
+}

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -122,6 +122,8 @@ class WC_Admin_Feature_Plugin {
 		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'dist/' );
 		$this->define( 'WC_ADMIN_FEATURES_PATH', WC_ADMIN_ABSPATH . 'includes/features/' );
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', __FILE__ );
+		// WARNING: Do not directly edit this version number constant.
+		// It is updated as part of the prebuild process from the package.json value.
 		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.13.2' );
 	}
 


### PR DESCRIPTION
This PR seeks to add a test to catch missing version number bumps. The intent is to catch missing version number changes when the `release/x` PR is opened.

### Detailed test instructions:

- Verify tests pass
- Change either the version in `package.json`, `woocommerce-admin.php`, or the `WC_ADMIN_VERSION_NUMBER` constant.
- Verify test fails
