### PR TITLE
Action Scheduler: fix potential endless sync

### DIFF
--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -432,6 +432,26 @@ class WC_Admin_Reports_Sync {
 	 * @return void
 	 */
 	public static function orders_lookup_import_order( $order_id ) {
+
+		$order = wc_get_order( $order_id );
+
+		// If the order isn't found for some reason, skip the sync.
+		if ( ! $order ) {
+			return;
+		}
+
+		$type = $order->get_type();
+
+		// If the order isn't the right type, skip sync.
+		if ( 'shop_order' !== $type && 'shop_order_refund' !== $type ) {
+			return;
+		}
+
+		// If the order has no id or date created, skip sync.
+		if ( ! $order->get_id() || ! $order->get_date_created() ) {
+			return;
+		}
+
 		$result = array_sum(
 			array(
 				WC_Admin_Reports_Orders_Stats_Data_Store::sync_order( $order_id ),

--- a/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-coupons-data-store.php
@@ -358,6 +358,10 @@ class WC_Admin_Reports_Coupons_Data_Store extends WC_Admin_Reports_Data_Store im
 
 		$order = wc_get_order( $order_id );
 
+		if ( ! $order ) {
+			return -1;
+		}
+
 		// Refunds don't affect coupon stats so return successfully if one is called here.
 		if ( 'shop_order_refund' === $order->get_type() ) {
 			return true;

--- a/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-taxes-data-store.php
@@ -311,7 +311,12 @@ class WC_Admin_Reports_Taxes_Data_Store extends WC_Admin_Reports_Data_Store impl
 	 */
 	public static function sync_order_taxes( $order_id ) {
 		global $wpdb;
-		$order       = wc_get_order( $order_id );
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return -1;
+		}
+
 		$tax_items   = $order->get_items( 'tax' );
 		$num_updated = 0;
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2367
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2363

When syncing orders, attempts to write to the database result in 1 or 0 or -1 depending on success. If the sum of the results isn't right, we retry the sync by creating another action scheduler job. 

When a failure is due to something wrong with an order, such a non-existent order, a new job is created which will inevitably also fail, resulting in an endless loop of job creations.

https://github.com/woocommerce/woocommerce-admin/blob/41135fa19f94fd555f811070da10f124dbdfc7f0/includes/class-wc-admin-reports-sync.php#L454-L470

This PR moves checks in the syncing functions on the `$order` which don't involve database writes. Any failure of these checks now returns early instead of failing at the write step, causing another AS job which will also fail.

See occurrences of this issue in the wild:
https://wordpress.org/support/topic/php-fatal-error-call-to-a-member-function-get_type-on-boolean/
https://wordpress.org/support/topic/over-170-000-scheduled-action-created/

### Detailed test instructions:

1. Create an order with taxes and a coupon.
2. See the order get synced when the order is reflected on the Revenue, Taxes, and Coupons reports.
3. Create a refund.
4. See the order synced by viewing the Revenue report.