### PR TITLE
Update Dashboard Charts naming and order

### DIFF
--- a/client/dashboard/dashboard-charts/block.js
+++ b/client/dashboard/dashboard-charts/block.js
@@ -59,7 +59,6 @@ class ChartBlock extends Component {
 						sprintf( __( '%s Report', 'woocommerce-admin' ), charts[ 0 ].label ) }
 					</a>
 					<ReportChart
-						charts={ charts }
 						endpoint={ endpoint }
 						query={ query }
 						interactiveLegend={ false }

--- a/client/dashboard/dashboard-charts/config.js
+++ b/client/dashboard/dashboard-charts/config.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -11,33 +12,94 @@ import { applyFilters } from '@wordpress/hooks';
 import { charts as ordersCharts } from 'analytics/report/orders/config';
 import { charts as productsCharts } from 'analytics/report/products/config';
 import { charts as revenueCharts } from 'analytics/report/revenue/config';
-import { charts as categoriesCharts } from 'analytics/report/categories/config';
 import { charts as couponsCharts } from 'analytics/report/coupons/config';
 import { charts as taxesCharts } from 'analytics/report/taxes/config';
 import { charts as downloadsCharts } from 'analytics/report/downloads/config';
 
 const DASHBOARD_CHARTS_FILTER = 'woocommerce_admin_dashboard_charts_filter';
 
-const allCharts = applyFilters(
+const charts = {
+	revenue: revenueCharts,
+	orders: ordersCharts,
+	products: productsCharts,
+	coupons: couponsCharts,
+	taxes: taxesCharts,
+	downloads: downloadsCharts,
+};
+
+const defaultCharts = [
+	{
+		label: __( 'Gross Revenue', 'woocommerce-admin' ),
+		report: 'revenue',
+		key: 'gross_revenue',
+	},
+	{
+		label: __( 'Net Revenue', 'woocommerce-admin' ),
+		report: 'revenue',
+		key: 'net_revenue',
+	},
+	{
+		label: __( 'Orders', 'woocommerce-admin' ),
+		report: 'orders',
+		key: 'orders_count',
+	},
+	{
+		label: __( 'Average Order Value', 'woocommerce-admin' ),
+		report: 'orders',
+		key: 'avg_order_value',
+	},
+	{
+		label: __( 'Items Sold', 'woocommerce-admin' ),
+		report: 'products',
+		key: 'items_sold',
+	},
+	{
+		label: __( 'Refunds', 'woocommerce-admin' ),
+		report: 'revenue',
+		key: 'refunds',
+	},
+	{
+		label: __( 'Discounted Orders', 'woocommerce-admin' ),
+		report: 'coupons',
+		key: 'orders_count',
+	},
+	{
+		label: __( 'Gross discounted', 'woocommerce-admin' ),
+		report: 'coupons',
+		key: 'amount',
+	},
+	{
+		label: __( 'Total Tax', 'woocommerce-admin' ),
+		report: 'taxes',
+		key: 'total_tax',
+	},
+	{
+		label: __( 'Order Tax', 'woocommerce-admin' ),
+		report: 'taxes',
+		key: 'order_tax',
+	},
+	{
+		label: __( 'Shipping Tax', 'woocommerce-admin' ),
+		report: 'taxes',
+		key: 'shipping_tax',
+	},
+	{
+		label: __( 'Shipping', 'woocommerce-admin' ),
+		report: 'revenue',
+		key: 'shipping',
+	},
+	{
+		label: __( 'Downloads', 'woocommerce-admin' ),
+		report: 'downloads',
+		key: 'download_count',
+	},
+];
+
+export const uniqCharts = applyFilters(
 	DASHBOARD_CHARTS_FILTER,
-	revenueCharts
-		.map( d => ( { ...d, endpoint: 'revenue' } ) )
-		.concat(
-			ordersCharts.map( d => ( { ...d, endpoint: 'orders' } ) ),
-			productsCharts.map( d => ( { ...d, endpoint: 'products' } ) ),
-			categoriesCharts.map( d => ( { ...d, endpoint: 'categories' } ) ),
-			couponsCharts.map( d => ( { ...d, endpoint: 'orders' } ) ),
-			taxesCharts.map( d => ( { ...d, endpoint: 'taxes' } ) ),
-			downloadsCharts.map( d => ( { ...d, endpoint: 'downloads' } ) )
-		)
+	defaultCharts.map( chartDef => ( {
+		...charts[ chartDef.report ].find( chart => chart.key === chartDef.key ),
+		label: chartDef.label,
+		endpoint: chartDef.report,
+	} ) )
 );
-
-// Need to remove duplicate charts, by key, from the configs
-export const uniqCharts = allCharts.reduce( ( a, b ) => {
-	if ( a.findIndex( d => d.key === b.key ) < 0 ) {
-		a.push( b );
-	}
-	return a;
-}, [] );
-
-export const getChartFromKey = key => allCharts.filter( d => d.key === key );

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -21,7 +21,7 @@ import { getAllowedIntervalsForQuery } from '@woocommerce/date';
  * Internal dependencies
  */
 import ChartBlock from './block';
-import { getChartFromKey, uniqCharts } from './config';
+import { uniqCharts } from './config';
 import withSelect from 'wc-api/with-select';
 import './style.scss';
 
@@ -68,11 +68,11 @@ class DashboardCharts extends Component {
 						{ uniqCharts.map( chart => {
 							return (
 								<MenuItem
-									checked={ ! hiddenBlocks.includes( chart.key ) }
+									checked={ ! hiddenBlocks.includes( chart.endpoint + '_' + chart.key ) }
 									isCheckbox
 									isClickable
-									key={ chart.key }
-									onInvoke={ () => onToggleHiddenBlock( chart.key )() }
+									key={ chart.endpoint + '_' + chart.key }
+									onInvoke={ () => onToggleHiddenBlock( chart.endpoint + '_' + chart.key )() }
 								>
 									{ __( `${ chart.label }`, 'woocommerce-admin' ) }
 								</MenuItem>
@@ -178,11 +178,11 @@ class DashboardCharts extends Component {
 					</SectionHeader>
 					<div className="woocommerce-dashboard__columns">
 						{ uniqCharts.map( chart => {
-							return hiddenBlocks.includes( chart.key ) ? null : (
+							return hiddenBlocks.includes( chart.endpoint + '_' + chart.key ) ? null : (
 								<ChartBlock
-									charts={ getChartFromKey( chart.key ) }
+									charts={ [ chart ] }
 									endpoint={ chart.endpoint }
-									key={ chart.key }
+									key={ chart.endpoint + '_' + chart.key }
 									path={ path }
 									query={ query }
 								/>


### PR DESCRIPTION
Fixes #2266.

Specify the naming and order of Dashboard Charts directly in the Dashboard config, so they can be different from the report pages.

### Comments

Notice two charts have the same key (`orders_count`), so now it's required to use the report name as well as the key to identify them (`orders_orders_count` and `coupons_orders_count`). That implies that all chart keys are different from before, making previous settings of hidden charts to be lost.

Also, notice the designs in #2266 include stock and customers charts, but we currently don't have them, so they are not included in this PR.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/59501216-5c3baa80-8e9b-11e9-81d1-5cb4f1acd97c.png)

### Detailed test instructions:
- Go to the _Dashboard_.
- Verify the available charts match the designs #2266.
- Try enabling/disabling them and reloading the page to verify preferences persist.