### PR TITLE
Fix conflicts with WordPress.com toolbar

### DIFF
--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -12,7 +12,7 @@
 	position: fixed;
 	width: 100%;
 	top: $adminbar-height;
-	z-index: 99991; /* higher than component-popover (99990), lower than notification dropdown at 99999 */
+	z-index: 2; /* on top of components-popover */
 
 	&.is-scrolled {
 		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -20,7 +20,9 @@
 
 	@include breakpoint( '<782px' ) {
 		// WP breakpoint for mobile menu
+		.wp-responsive-open #woocommerce-embedded-root,
 		.wp-responsive-open #wpbody {
+			position: relative;
 			right: -14.5em;
 		}
 
@@ -64,95 +66,42 @@
 	display: none;
 }
 
-.wp-responsive-open {
-	.woocommerce-layout__header {
-		margin-left: 2px;
-	}
-
-	@include breakpoint( '<782px' ) {
-		.woocommerce-layout__activity-panel-wrapper.is-open,
-		.woocommerce-layout__activity-panel-tabs {
-			width: calc(100vw - 190px);
+.woocommerce_page_wc-admin {
+	.wp-responsive-open {
+		.woocommerce-layout__header {
+			margin-left: 2px;
 		}
 	}
 }
 
 @include breakpoint( '<600px' ) {
-	#wpadminbar,
-	.jetpack-masterbar #wpadminbar {
+	#wpadminbar {
 		position: fixed;
 	}
 }
 
-#adminmenuwrap {
-	z-index: 99992;
+.auto-fold #adminmenu,
+.auto-fold #adminmenuback,
+.auto-fold #adminmenuwrap {
+	z-index: 99992; /* higher than woocommerce-layout__header (99991) */
 }
 
 // Temporary fix for compability with the Jetpack masterbar
 // See https://github.com/Automattic/jetpack/issues/9608
-// !important rules overwrite some existing !important rules
-.jetpack-masterbar {
-	@include breakpoint( '<782px' ) {
-		&.wp-admin .wrap h1 {
+@include breakpoint( '<782px' ) {
+	.jetpack-masterbar {
+		#wpadminbar #wp-admin-bar-menu-toggle > .ab-item {
+			margin-top: -10px;
+		}
+
+		// #wpwrap id added for specificity
+		#wpwrap .woocommerce-layout__header-breadcrumbs {
+			padding-left: 60px;
+		}
+
+		&.wp-admin .wrap h1,
+		&.wp-admin .wrap h2 {
 			padding-left: 0;
 		}
-
-		#wpadminbar li.menupop.my-sites {
-			margin-left: 55px;
-		}
-
-		#wpadminbar #wp-admin-bar-menu-toggle {
-			top: -5px;
-			left: -5px;
-			width: 60px;
-
-			.ab-icon::before {
-				color: $white;
-			}
-
-			a {
-				padding: 0 8px 4px 8px !important;
-			}
-
-			a:hover {
-				background: #333;
-			}
-		}
-
-		.wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle {
-			left: -5px;
-			width: 60px;
-
-			.ab-icon::before {
-				color: $white !important;
-			}
-
-			a {
-				background: #333;
-			}
-		}
-	}
-}
-
-/* Hide wp-admin and WooCommerce elements when loading the WooCommerce Admin App */
-.woocommerce-admin-is-loading {
-	#adminmenumain,
-	#wpadminbar,
-	.woocommerce-layout__header,
-	.update-nag,
-	.woocommerce-store-alerts,
-	.woocommerce-message,
-	.notice,
-	.error,
-	.updated {
-		display: none;
-	}
-
-	#wpcontent {
-		margin-left: 0;
-	}
-
-	#wpbody {
-		padding-top: 0;
 	}
 }

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -72,18 +72,16 @@
 			margin-left: 2px;
 		}
 	}
+
+	.components-popover:not(.is-mobile) {
+		z-index: 1 !important; /* below of woocommerce-layout__header */
+	}
 }
 
 @include breakpoint( '<600px' ) {
 	#wpadminbar {
 		position: fixed;
 	}
-}
-
-.auto-fold #adminmenu,
-.auto-fold #adminmenuback,
-.auto-fold #adminmenuwrap {
-	z-index: 99992; /* higher than woocommerce-layout__header (99991) */
 }
 
 // Temporary fix for compability with the Jetpack masterbar

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -74,7 +74,7 @@
 	}
 
 	.components-popover:not(.is-mobile) {
-		z-index: 1 !important; /* below of woocommerce-layout__header */
+		z-index: 1; /* below of woocommerce-layout__header */
 	}
 }
 

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -90,7 +90,7 @@
 // See https://github.com/Automattic/jetpack/issues/9608
 @include breakpoint( '<782px' ) {
 	.jetpack-masterbar {
-		#wpadminbar #wp-admin-bar-menu-toggle > .ab-item {
+		#wpadminbar #wp-admin-bar-menu-toggle {
 			margin-top: -10px;
 		}
 


### PR DESCRIPTION
Fixes #1991.

### Screenshots
WordPress.com toolbar<br>Before | WordPress.com toolbar<br>After
:--------:|:--------:
![Screen Shot 2019-06-14 at 15 59 53](https://user-images.githubusercontent.com/3616980/59514605-7f775180-8ebd-11e9-84a9-c1d541880a14.png) | ![Screen Shot 2019-06-14 at 16 00 00](https://user-images.githubusercontent.com/3616980/59514614-81d9ab80-8ebd-11e9-9e6f-12ff481da4b9.png)

### Detailed test instructions:
- Go to _Jetpack_ > _Settings_ > _Writting_ and click on _Enable the WordPress.com toolbar_.
- Navigate your site with a narrow viewport: WooCommerce pages, WooCommerce Admin pages and non-WooCommerce pages.
- Verify the WordPress.com toolbar looks good in all of them and there are no overflowing elements in the page.