### PR TITLE
Remove unnecessary WP style dependencies.

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -266,7 +266,7 @@ class WC_Admin_Loader {
 		wp_register_style(
 			'wc-components',
 			self::get_url( 'components/style.css' ),
-			array( 'wp-edit-blocks' ),
+			array( 'wp-components' ),
 			self::get_file_version( 'components/style.css' )
 		);
 		wp_style_add_data( 'wc-components', 'rtl', 'replace' );
@@ -274,7 +274,7 @@ class WC_Admin_Loader {
 		wp_register_style(
 			'wc-components-ie',
 			self::get_url( 'components/ie.css' ),
-			array( 'wp-edit-blocks' ),
+			array( 'wp-components' ),
 			self::get_file_version( 'components/ie.css' )
 		);
 		wp_style_add_data( 'wc-components-ie', 'rtl', 'replace' );


### PR DESCRIPTION
Use `wp-component` styles instead of full `wp-edit-blocks` styles.

Fixes https://wordpress.org/support/topic/legal-issues-with-google-fonts-gdpr/.

This PR seeks to pare down the style dependencies on WP core and also eliminate the side effect of including unused Google Fonts.

### Detailed test instructions:

- Spot check every UI component in WooCommerce Admin
- Make sure everything looks/functions as expected

### Changelog Note:

Tweak: Reduce style dependencies on WP core, avoid errantly including WP core's Google Fonts.