### PR TITLE
Changelog script: Use PR author note, if supplied

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,4 @@ be sure to detail parts affected in Release Notes --->
 
 ### Changelog Note:
 
-<!--- Please follow the WooCommerce core format using prefixes of Enhancement, Tweak, Dev, Fix  --->
+<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -76,7 +76,22 @@ const writeEntry = async ( content_url ) => {
 					const labels = getLabels( data.labels );
 					const labelTag = labels.length ? `(${ labels })` : '';
 					const authorTag = collaborator ? '' : `👏 @${ data.user.login }`;
-					const entry = `- ${ type }: ${ data.title } #${ data.number } ${ labelTag } ${ authorTag }`;
+					let title;
+					if ( /### Changelog Note/.test( data.body ) ) {
+						const bodyParts = data.body.split( '### Changelog Note:' );
+						const note = bodyParts[ bodyParts.length - 1 ];
+						title = note
+							// Remove comment prompt
+							.replace( /<!---(.*)--->/gm, '' )
+							// Remove new lines and whitespace
+							.trim();
+						if ( ! title.length ) {
+							title = `${ type }: ${ data.title }`;
+						}
+					} else {
+						title = `${ type }: ${ data.title }`;
+					}
+					const entry = `- ${ title } #${ data.number } ${ labelTag } ${ authorTag }`;
 					console.log( entry );
 				}
 			}


### PR DESCRIPTION
Since we've been prompting PR authors to supply a changelog note, this PR checks to see if it exists and uses it instead of constructing the entry via the title.

I'm sure there will be some oddness slipping through the logic cracks, but since the output of this script is meant to be checked over anyways, this should do.

### Testing instructions

1. `npm run changelog`
2. Use the current sprint: `5586451`
3. Check for the output for https://github.com/woocommerce/woocommerce-admin/pull/2423 and see it uses Jeff's note and not the title.