### PR TITLE
Remove test menu from Orders panel

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -8,22 +8,12 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
-import { noop } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 
 /**
  * WooCommerce dependencies
  */
-import {
-	EllipsisMenu,
-	EmptyContent,
-	Flag,
-	Link,
-	MenuTitle,
-	MenuItem,
-	OrderStatus,
-	Section,
-} from '@woocommerce/components';
+import { EmptyContent, Flag, Link, OrderStatus, Section } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
 import { getAdminLink, getNewPath } from '@woocommerce/navigation';
 
@@ -226,18 +216,6 @@ class OrdersPanel extends Component {
 			);
 		}
 
-		const menu = (
-			<EllipsisMenu
-				label="Demo Menu"
-				renderContent={ () => (
-					<Fragment>
-						<MenuTitle>Test</MenuTitle>
-						<MenuItem onInvoke={ noop }>Test</MenuItem>
-					</Fragment>
-				) }
-			/>
-		);
-
 		const title =
 			isRequesting || orders.length
 				? __( 'Orders', 'woocommerce-admin' )
@@ -245,7 +223,7 @@ class OrdersPanel extends Component {
 
 		return (
 			<Fragment>
-				<ActivityHeader title={ title } menu={ menu } />
+				<ActivityHeader title={ title } />
 				<Section>
 					{ isRequesting ? (
 						<ActivityCardPlaceholder


### PR DESCRIPTION
I guess there is no reason to keep it.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/59586227-b4b0b900-90e2-11e9-8e9f-07a621092bc7.png)

### Detailed test instructions:
- Go to any WooCommerce Admin page.
- Open the `Orders` tab in the Activity Panel.
- Verify the menu is no longer there.