### PR TITLE
Remove the "wpClosedMenu" page setting

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -31,13 +31,11 @@ const getPages = () => {
 			container: DevDocs,
 			path: '/devdocs',
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			wpClosedMenu: 'toplevel_page_wc-admin--analytics-revenue',
 		} );
 		pages.push( {
 			container: DevDocs,
 			path: '/devdocs/:component',
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			wpClosedMenu: 'toplevel_page_wc-admin--analytics-revenue',
 		} );
 	}
 
@@ -46,7 +44,6 @@ const getPages = () => {
 			container: Dashboard,
 			path: '/',
 			wpOpenMenu: 'toplevel_page_woocommerce',
-			wpClosedMenu: 'toplevel_page_wc-admin--analytics-revenue',
 		} );
 	}
 
@@ -55,19 +52,16 @@ const getPages = () => {
 			container: Analytics,
 			path: '/analytics',
 			wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
-			wpClosedMenu: 'toplevel_page_woocommerce',
 		} );
 		pages.push( {
 			container: AnalyticsSettings,
 			path: '/analytics/settings',
 			wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
-			wpClosedMenu: 'toplevel_page_woocommerce',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
 			path: '/analytics/:report',
 			wpOpenMenu: 'toplevel_page_wc-admin--analytics-revenue',
-			wpClosedMenu: 'toplevel_page_woocommerce',
 		} );
 	}
 
@@ -170,9 +164,9 @@ window.wpNavMenuUrlUpdate = function( page, query ) {
 	] );
 	const nextQuery = stringifyQuery( getPersistedQuery( query ) );
 
-	Array.from(
-		document.querySelectorAll( `#${ page.wpOpenMenu } a, #${ page.wpClosedMenu } a` )
-	).forEach( item => updateLinkHref( item, nextQuery, excludedScreens ) );
+	Array.from( document.querySelectorAll( '#adminmenu a' ) ).forEach( item =>
+		updateLinkHref( item, nextQuery, excludedScreens )
+	);
 };
 
 // When the route changes, we need to update wp-admin's menu with the correct section & current link
@@ -207,14 +201,6 @@ window.wpNavMenuClassChange = function( page ) {
 		currentMenu.classList.add( 'wp-has-current-submenu' );
 		currentMenu.classList.add( 'wp-menu-open' );
 		currentMenu.classList.add( 'current' );
-	}
-
-	// Sometimes navigating from the subMenu to Dashboard does not close subMenu
-	if ( page.wpClosedMenu ) {
-		const closedMenu = document.querySelector( '#' + page.wpClosedMenu );
-		closedMenu.classList.remove( 'wp-has-current-submenu' );
-		closedMenu.classList.remove( 'wp-menu-open' );
-		closedMenu.classList.add( 'wp-not-current-submenu' );
 	}
 
 	const wpWrap = document.querySelector( '#wpwrap' );


### PR DESCRIPTION
Conceptually, it doesn't make a lot of sense for a page to specify the menu section it's *not* on. That won't scale past 2 sections, and we're already at that point (`WooCommerce`, `Analytics`, and now a new one).

I'm trying to understand the WC-Admin client-side controller, but this seems redundant: https://github.com/woocommerce/woocommerce-admin/blob/172bb3e2074eee4012dcc0c1672fcd61b865aeaa/client/layout/controller.js#L237-L243
All the opened submenus get closed already a few lines above: https://github.com/woocommerce/woocommerce-admin/blob/172bb3e2074eee4012dcc0c1672fcd61b865aeaa/client/layout/controller.js#L209-L216 

I don't see any adverse effects when I removed those lines, so I did. I had to change the logic that updates menu links to iterate on *all* the menu items, not only the open and closed one.

To test: Navigate through the different WC-Admin pages. Navigate thgough those pages with a date filter set, see that it's preserved. I'm not sure what else to test for, I didn't find anything unusual but I could have missed stuff.

Note: This PR branches off `update/route-handling` so I can work locally wothout going crazy. I can rebase it onto `master` if this PR is accepted before `update/route-handling` lands.