### PR TITLE
Remove updated stock products from Activity Panel

### DIFF
--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -310,6 +310,12 @@
 }
 
 .woocommerce-stock-activity-card {
+	transition: opacity 0.3s;
+
+	&.is-dimmed {
+		opacity: 0.7;
+	}
+
 	.woocommerce-stock-activity-card__stock-quantity {
 		background: $core-grey-light-300;
 		color: $core-grey-dark-500;

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -310,7 +310,9 @@
 }
 
 .woocommerce-stock-activity-card {
-	transition: opacity 0.3s;
+	@media screen and (prefers-reduced-motion: no-preference) {
+		transition: opacity 0.3s;
+	}
 
 	&.is-dimmed {
 		opacity: 0.7;

--- a/client/header/activity-panel/panels/stock/card.js
+++ b/client/header/activity-panel/panels/stock/card.js
@@ -37,12 +37,10 @@ class ProductStockCard extends Component {
 		this.updateStock = this.updateStock.bind( this );
 	}
 
-	componentDidUpdate() {
-		this.quantityInput && this.quantityInput.focus();
-	}
-
 	beginEdit() {
-		this.setState( { editing: true } );
+		this.setState( { editing: true }, () => {
+			this.quantityInput && this.quantityInput.focus();
+		} );
 	}
 
 	cancelEdit() {

--- a/client/header/activity-panel/panels/stock/card.js
+++ b/client/header/activity-panel/panels/stock/card.js
@@ -149,6 +149,9 @@ class ProductStockCard extends Component {
 			: notifyLowStockAmount;
 		const isLowStock = product.stock_quantity <= lowStockAmount;
 
+		// Hide cards that are not in low stock and have not been edited.
+		// This allows clearing cards which are no longer in low stock after
+		// closing & opening the panel without having to make another request.
 		if ( ! isLowStock && ! edited && ! editing ) {
 			return null;
 		}

--- a/client/header/activity-panel/panels/stock/card.js
+++ b/client/header/activity-panel/panels/stock/card.js
@@ -140,7 +140,7 @@ class ProductStockCard extends Component {
 		const lowStockAmount = Number.isFinite( product.low_stock_amount )
 			? product.low_stock_amount
 			: notifyLowStockAmount;
-		const isLowStock = product.stock_quantity < lowStockAmount;
+		const isLowStock = product.stock_quantity <= lowStockAmount;
 
 		if ( ! isLowStock && ! edited && ! editing ) {
 			return null;

--- a/client/wc-api/items/mutations.js
+++ b/client/wc-api/items/mutations.js
@@ -1,20 +1,47 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getResourceName } from '../utils';
 
-const updateItem = operations => async ( type, id, itemData, callback ) => {
-	const resourceName = getResourceName( `items-query-${ type }-item`, id );
-	const result = await operations.update( [ resourceName ], {
-		[ resourceName ]: { id, ...itemData },
+const updateProductStock = operations => async ( product, newStock ) => {
+	const { addNotice } = dispatch( 'wc-admin' );
+	const oldStockQuantity = product.stock_quantity;
+	const resourceName = getResourceName( 'items-query-products-item', product.id );
+
+	// Optimistically update product stock
+	operations.updateLocally( [ resourceName ], {
+		[ resourceName ]: { ...product, stock_quantity: newStock },
 	} );
-	if ( typeof callback === 'function' ) {
-		callback( result[ 0 ][ resourceName ] );
+
+	const result = await operations.update( [ resourceName ], {
+		[ resourceName ]: { id: product.id, stock_quantity: newStock },
+	} );
+	const response = result[ 0 ][ resourceName ];
+	if ( response && response.data ) {
+		addNotice( {
+			status: 'success',
+			message: sprintf( __( '%s stock updated.', 'woocommerce-admin' ), product.name ),
+		} );
+	}
+	if ( response && response.error ) {
+		addNotice( {
+			status: 'error',
+			message: sprintf( __( '%s stock could not be updated.', 'woocommerce-admin' ), product.name ),
+		} );
+		// Revert local changes if the operation failed in the server
+		operations.updateLocally( [ resourceName ], {
+			[ resourceName ]: { ...product, stock_quantity: oldStockQuantity },
+		} );
 	}
 };
 
 export default {
-	updateItem,
+	updateProductStock,
 };

--- a/client/wc-api/items/mutations.js
+++ b/client/wc-api/items/mutations.js
@@ -21,7 +21,12 @@ const updateProductStock = operations => async ( product, newStock ) => {
 	} );
 
 	const result = await operations.update( [ resourceName ], {
-		[ resourceName ]: { id: product.id, stock_quantity: newStock },
+		[ resourceName ]: {
+			id: product.id,
+			type: product.type,
+			parent_id: product.parent_id,
+			stock_quantity: newStock,
+		},
 	} );
 	const response = result[ 0 ][ resourceName ];
 	if ( response && response.data ) {

--- a/client/wc-api/items/mutations.js
+++ b/client/wc-api/items/mutations.js
@@ -5,9 +5,14 @@
  */
 import { getResourceName } from '../utils';
 
-const updateItem = operations => ( type, id, itemData ) => {
+const updateItem = operations => async ( type, id, itemData, callback ) => {
 	const resourceName = getResourceName( `items-query-${ type }-item`, id );
-	operations.update( [ resourceName ], { [ resourceName ]: { id, ...itemData } } );
+	const result = await operations.update( [ resourceName ], {
+		[ resourceName ]: { id, ...itemData },
+	} );
+	if ( typeof callback === 'function' ) {
+		callback( result[ 0 ][ resourceName ] );
+	}
 };
 
 export default {

--- a/client/wc-api/items/operations.js
+++ b/client/wc-api/items/operations.js
@@ -115,7 +115,19 @@ function update( resourceNames, data, fetch = apiFetch ) {
 	} );
 }
 
+function updateLocally( resourceNames, data ) {
+	const updateableTypes = [ 'items-query-products-item' ];
+	const filteredNames = resourceNames.filter( name => {
+		return updateableTypes.includes( getResourcePrefix( name ) );
+	} );
+
+	return filteredNames.map( async resourceName => {
+		return { [ resourceName ]: { data: data[ resourceName ] } };
+	} );
+}
+
 export default {
 	read,
 	update,
+	updateLocally,
 };

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -62,6 +62,9 @@ function createWcApiSpec() {
 					...user.operations.update( resourceNames, data ),
 				];
 			},
+			updateLocally( resourceNames, data ) {
+				return [ ...items.operations.updateLocally( resourceNames, data ) ];
+			},
 		},
 	};
 }

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -518,12 +518,13 @@ class WC_Admin_Loader {
 			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true ) );
 		}
 
-		$settings['orderStatuses']     = self::get_order_statuses( wc_get_order_statuses() );
-		$settings['currentUserData']   = $current_user_data;
-		$settings['currency']          = self::get_currency_settings();
-		$settings['reviewsEnabled']    = get_option( 'woocommerce_enable_reviews' );
-		$settings['manageStock']       = get_option( 'woocommerce_manage_stock' );
-		$settings['commentModeration'] = get_option( 'comment_moderation' );
+		$settings['orderStatuses']        = self::get_order_statuses( wc_get_order_statuses() );
+		$settings['currentUserData']      = $current_user_data;
+		$settings['currency']             = self::get_currency_settings();
+		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );
+		$settings['manageStock']          = get_option( 'woocommerce_manage_stock' );
+		$settings['commentModeration']    = get_option( 'comment_moderation' );
+		$settings['notifyLowStockAmount'] = get_option( 'woocommerce_notify_low_stock_amount' );
 		// @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired,
 		// and `wcAssetUrl` can be used in its place throughout the codebase.
 		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', plugin_dir_path( dirname( __FILE__ ) ) . 'woocommerce-admin.php' );


### PR DESCRIPTION
Fixes #2175.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Screenshot_2019-06-17 Stock ‹ Analytics ‹ WooCommerce — WooCommerce](https://user-images.githubusercontent.com/3616980/59616028-f150d480-9123-11e9-8e4d-131ba2d07422.png)

### Detailed test instructions:
- Make sure you have some products in 'low stock'.
- Open the _Stock_ tab of the Activity Panel.
- Modify the stock of one of the products so it's no longer in 'low stock'.
- Verify the opacity of the product card is reduced but the card is still visible.
- Close the panel and open it again.
- Verify the card disappeared.