### PR TITLE
Fix Activity Panel being overlapped by editor toolbar

### DIFF
--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -12,7 +12,7 @@
 	position: fixed;
 	width: 100%;
 	top: $adminbar-height;
-	z-index: 2; /* on top of components-popover */
+	z-index: 1001; /* on top of #wp-content-editor-tools */
 
 	&.is-scrolled {
 		box-shadow: 0 8px 8px 0 rgba(85, 93, 102, 0.3);


### PR DESCRIPTION
Fixes #2439.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/59665317-f27d1280-91b2-11e9-9854-50e2bfb93ba2.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/59665295-e6915080-91b2-11e9-8edf-568bffcabdca.png)

### Detailed test instructions:
- Go to the _Edit Product_ page.
- Open any Activity Panel tab.
- Verify it appears on top of the editor toolbar.