### PR TITLE
Add wp-api-fetch script to dependencies

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -245,6 +245,7 @@ class WC_Admin_Loader {
 			'wc-components',
 			self::get_url( 'components/index.js' ),
 			array(
+				'wp-api-fetch',
 				'wp-components',
 				'wp-data',
 				'wp-element',


### PR DESCRIPTION
The last version of Gutenberg is not enqueueing Gutenberg scripts in non-editor pages, that was making WooCommerce Admin to show this JS error: `TypeError: fetch is not a function` in all pages because it was missing `wp-api-fetch`.

This PR adds `wp-api-fetch` to our list of script dependencies.

### Detailed test instructions:
- Install the last version of Gutenberg plugin and enable it.
- Go to any WooCommerce Admin page.
- Verify there is no error `TypeError: fetch is not a function` and data is loaded correctly.