### PR TITLE
open external note action links in a new tab

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -37,7 +37,7 @@ class InboxPanel extends Component {
 		const { triggerNoteAction } = this.props;
 		const href = event.target.href || '';
 
-		if ( 'http' === href.substr( 0, 4 ).toLowerCase() ) {
+		if ( href.length && href.indexOf( 'wc-admin#/' ) <= 0 ) {
 			event.preventDefault();
 			window.open( href, '_blank' );
 		}

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -33,6 +33,18 @@ class InboxPanel extends Component {
 		this.props.updateCurrentUserData( userDataFields );
 	}
 
+	handleActionClick( event, note_id, action_id ) {
+		const { triggerNoteAction } = this.props;
+		const href = event.target.href || '';
+
+		if ( 'http' === href.substr( 0, 4 ).toLowerCase() ) {
+			event.preventDefault();
+			window.open( href, '_blank' );
+		}
+
+		triggerNoteAction( note_id, action_id );
+	}
+
 	renderEmptyCard() {
 		return (
 			<ActivityCard
@@ -50,7 +62,7 @@ class InboxPanel extends Component {
 	}
 
 	renderNotes() {
-		const { lastRead, notes, triggerNoteAction } = this.props;
+		const { lastRead, notes } = this.props;
 
 		if ( 0 === Object.keys( notes ).length ) {
 			return this.renderEmptyCard();
@@ -65,7 +77,7 @@ class InboxPanel extends Component {
 					isDefault
 					isPrimary={ action.primary }
 					href={ action.url || undefined }
-					onClick={ () => triggerNoteAction( note.id, action.id ) }
+					onClick={ e => this.handleActionClick( e, note.id, action.id ) }
 				>
 					{ action.label }
 				</Button>

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -37,7 +37,7 @@ class InboxPanel extends Component {
 		const { triggerNoteAction } = this.props;
 		const href = event.target.href || '';
 
-		if ( href.length && href.indexOf( 'wc-admin#/' ) <= 0 ) {
+		if ( ! href.startsWith( wcSettings.adminUrl ) ) {
 			event.preventDefault();
 			window.open( href, '_blank' );
 		}

--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -37,7 +37,7 @@ class InboxPanel extends Component {
 		const { triggerNoteAction } = this.props;
 		const href = event.target.href || '';
 
-		if ( ! href.startsWith( wcSettings.adminUrl ) ) {
+		if ( href.length && ! href.startsWith( wcSettings.adminUrl ) ) {
 			event.preventDefault();
 			window.open( href, '_blank' );
 		}


### PR DESCRIPTION
Fixes #2403

This PR adds a handler to the note action button click. The handler opens the action link in a new tab if the URL starts with `http`.

### Detailed test instructions:

- Add a note with an internal to WC Admin link
- Add a note with an external fully qualified URL
- Add a hook to verify that the REST API is being called
```
add_action( 'woocommerce_admin_note_action', function( $note ) {
	error_log( $note );
} );
```
- Load an Analytics screen
- Open the Inbox and click both action buttons
- The external should be opened in a new tab
- Both notes should be logged in debug.log

### Changelog Note:

Tweak: Open external note action links in a new tab
