### PR TITLE
Check for good WC_Orders before using instance methods.

### DIFF
--- a/includes/class-wc-admin-order-refund.php
+++ b/includes/class-wc-admin-order-refund.php
@@ -45,13 +45,13 @@ class WC_Admin_Order_Refund extends WC_Order_Refund {
 	/**
 	 * Get the customer ID of the parent order used for reports in the customer lookup table.
 	 *
-	 * @return int
+	 * @return int|bool Customer ID of parent order, or false if parent order not found.
 	 */
 	public function get_report_customer_id() {
 		$parent_order = wc_get_order( $this->get_parent_id() );
 
 		if ( ! $parent_order ) {
-			return null;
+			return false;
 		}
 
 		return WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $parent_order );

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -438,11 +438,12 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 	 * @return int|bool
 	 */
 	public static function get_existing_customer_id_from_order( $order ) {
-		if ( ! $order ) {
+		global $wpdb;
+
+		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return false;
 		}
 
-		global $wpdb;
 		$user_id = $order->get_customer_id();
 
 		if ( 0 === $user_id ) {
@@ -481,6 +482,11 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		}
 
 		global $wpdb;
+
+		if ( ! is_a( $order, 'WC_Order' ) ) {
+			return false;
+		}
+
 		$returning_customer_id = self::get_existing_customer_id_from_order( $order );
 
 		if ( $returning_customer_id ) {

--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -436,9 +436,11 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 		);
 
 		if ( 'shop_order_refund' === $order->get_type() ) {
-			$parent_order      = wc_get_order( $order->get_parent_id() );
-			$data['parent_id'] = $parent_order->get_id();
-			$format[]          = '%d';
+			$parent_order = wc_get_order( $order->get_parent_id() );
+			if ( $parent_order ) {
+				$data['parent_id'] = $parent_order->get_id();
+				$format[]          = '%d';
+			}
 		} else {
 			$data['returning_customer'] = self::is_returning_customer( $order );
 		}

--- a/tests/api/orders.php
+++ b/tests/api/orders.php
@@ -56,4 +56,30 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $order->get_id(), $orders[0]['id'] );
 	}
+
+	/**
+	 * Verify that deleted refund parent orders don't cause
+	 */
+	public function test_refund_parent_order_deleted() {
+		global $wpdb;
+
+		wp_set_current_user( $this->user );
+
+		// Create an order.
+		$order = WC_Helper_Order::create_order( $this->user );
+
+		// Create a refund order.
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+			)
+		);
+
+		// Forcibly delete the original order.
+		$wpdb->delete( $wpdb->prefix . 'posts', array( 'ID' => $order->get_id() ), array( '%d' ) );
+		clean_post_cache( $order->get_id() );
+
+		// Trigger an order sync on the refund which should handle the missing parent order.
+		$this->assertTrue( WC_Admin_Reports_Orders_Stats_Data_Store::sync_order( $refund->get_id() ) );
+	}
 }

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -418,4 +418,12 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		$this->assertCount( 1, $reports );
 		$this->assertEquals( 'Daenerys Targaryen', $reports[0]['name'] );
 	}
+
+	/**
+	 * Test that bad order params don't cause PHP errors when retrieving customers.
+	 */
+	public function test_customer_retrieval_from_order_bad_order() {
+		$this->assertFalse( WC_Admin_Reports_Customers_Data_Store::get_existing_customer_id_from_order( false ) );
+		$this->assertFalse( WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( false ) );
+	}
 }


### PR DESCRIPTION
## Prevent potential get_customer_id() & other functions running into a fatal error when $order is a bool (false)

Reworking of https://github.com/woocommerce/woocommerce-admin/pull/2326 - props to @KZeni.

Fixes #1985.

Check for good `WC_Order` objects before using instance methods during sync.

### Detailed test instructions:

1. Use a dataset with Refunds where the parent Order has been deleted from the DB (like WCCOM)
1. Import All of the past data into WooCommerce Admin.
1. Verify the import doesn't have failed scheduled actions citing "PHP Fatal error Uncaught Error: Call to a member function get_customer_id() on boolean"

### Changelog Note:

Fix: PHP errors on missing refund orders during import.