### PR TITLE
Fix mobile onboarding stepper positioning

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -103,6 +103,8 @@
 		@include breakpoint( '<782px' ) {
 			padding-left: $gap;
 			padding-right: $gap;
+			margin-bottom: 56 + $gap; /* 56px is height of footer */
+			margin-top: 0;
 		}
 
 		p,
@@ -311,7 +313,8 @@
 	}
 
 	@include breakpoint( '<782px' ) {
-		position: absolute;
+		position: fixed;
+		z-index: 999;
 		width: 100%;
 		bottom: 0;
 		border-top: 1px solid $muriel-gray-50;


### PR DESCRIPTION
There was some slight usability/display issues with how the footer was fixed to the bottom. Since we are keeping the footer fixed (per p1560263322005100-slack-wc-onboarding), this fixes the issues.

Before:

<img width="549" alt="Screen Shot 2019-06-20 at 12 55 28 PM" src="https://user-images.githubusercontent.com/689165/59868628-60fed380-935f-11e9-9c1a-b0c09c253223.png">

After:

<img width="412" alt="Screen Shot 2019-06-20 at 1 31 20 PM" src="https://user-images.githubusercontent.com/689165/59868781-b9ce6c00-935f-11e9-91ec-4d4557378777.png">

<img width="415" alt="Screen Shot 2019-06-20 at 1 31 11 PM" src="https://user-images.githubusercontent.com/689165/59868792-c05ce380-935f-11e9-8153-47576c155f5f.png">

### Detailed test instructions:

* Open up one of the profiler steps (a short one and a long one like product types is good).
* View using mobile inspector.
* Scroll, and make sure you can use the continue button.