### PR TITLE
use summary query to total coupons per order

### DIFF
--- a/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-orders-stats-data-store.php
@@ -330,7 +330,7 @@ class WC_Admin_Reports_Orders_Stats_Data_Store extends WC_Admin_Reports_Data_Sto
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
 			}
 
-			if ( isset( $intervals[0] ) && isset( $intervals[0]['coupons_count'] ) ) {
+			if ( isset( $intervals[0] ) ) {
 				$unique_coupons                = $this->get_unique_coupon_count( $intervals_query['from_clause'], $intervals_query['where_time_clause'], $intervals_query['where_clause'], true );
 				$intervals[0]['coupons_count'] = $unique_coupons;
 			}


### PR DESCRIPTION
Fixes #2400 

This PR implements a coupon summary query grouped by `order_id` to total the coupons per order when retrieving the order stats.


### Detailed test instructions:

- Create these orders in the dashboard
  - One product with quantity of 2 or more, 0 coupons
  - One product with quantity of 2 or more, 1 coupons
  - One product with quantity of 2 or more, 2 coupons
  - Repeat the above 3 with two products
- Pay for all the orders
- Compare both the revenue and orders analytics to the totals (total, net, coupons, & taxes) for the orders
 
### Changelog Note:

Fix: Only calculate one order row when the order has multiple coupons.