### PR TITLE
Remove style that causes incorrect margins for certain notices

### DIFF
--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -55,7 +55,6 @@
 	}
 
 	.notice {
-		margin: 5px 15px 2px;
 		padding: 1px 12px;
 	}
 


### PR DESCRIPTION
The declaration in question causes notices that are not collapsed (not hidden in the custom Notices section) and do not have the `updated` class to have incorrect left and right margins.

### Detailed test instructions:

- Open an order
- Click **Update**
- Open your developer tools and inspect the "Order updated." notice
- Remove the `updated` class
- Note the incorrect left and right margins
- This is just an example of a notice that is excluded from being collapsed, the `updated` class should of course not be required for correct styling (there are other exclusions [here](https://github.com/woocommerce/woocommerce-admin/blob/9526e0ba84d8e1f592f48ff1dc3870c7e52b1b0f/client/header/activity-panel/wordpress-notices.js#L120-L125) that won't always have that class)

### Changelog Note:

Fix: margins on non-update notices. 👏🏻 @benignant