### PR TITLE
Table extension: fix page error and jsDoc

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -118,7 +118,7 @@ class ReportTable extends Component {
 		 * @param {array} reportTableData.rows - table rows data.
 		 * @param {object} reportTableData.totals - total aggregates for request.
 		 * @param {array} reportTableData.summary - summary numbers data.
-		 * @param {array} reportTableData.items - response from api requerst.
+		 * @param {object} reportTableData.items - response from api requerst.
 		 */
 		const { headers, ids, rows, summary } = applyFilters( TABLE_FILTER, {
 			endpoint,

--- a/docs/examples/extensions/table-column/js/index.js
+++ b/docs/examples/extensions/table-column/js/index.js
@@ -7,7 +7,12 @@ import { addFilter } from '@wordpress/hooks';
 import { Rating } from '@woocommerce/components';
 
 addFilter( 'woocommerce_admin_report_table', 'plugin-domain', reportTableData => {
-	if ( 'products' !== reportTableData.endpoint || ! reportTableData.items.data.length ) {
+	if (
+		'products' !== reportTableData.endpoint ||
+		! reportTableData.items ||
+		! reportTableData.items.data ||
+		! reportTableData.items.data.length
+	) {
 		return reportTableData;
 	}
 
@@ -33,7 +38,9 @@ addFilter( 'woocommerce_admin_report_table', 'plugin-domain', reportTableData =>
 			},
 			// average_rating can be found on extended_info on productData.
 			{
-				display: <Rating rating={ Number( product.extended_info.average_rating ) } totalStars={ 5 } />,
+				display: (
+					<Rating rating={ Number( product.extended_info.average_rating ) } totalStars={ 5 } />
+				),
 				value: product.extended_info.average_rating,
 			},
 		];


### PR DESCRIPTION
A js error was introduced in the Table Extension example (whoops 😓 ).

![Screen Shot 2019-06-24 at 11 59 09 AM](https://user-images.githubusercontent.com/1922453/59983756-9a915080-9677-11e9-897d-2ad0a2e55040.png)

This PR addresses that issue and fixes a jsDoc issue.

### Testing

1. See that the changes make sense
2. If you'd like, run `npm run example -- --ext=table-column` to make sure the Product Report loads correctly.