### PR TITLE
Add a filter to allow other extensions to register new WC-Admin-powered pages

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -23,7 +23,9 @@ import DevDocs from 'devdocs';
 
 const TIME_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
 
-const getPages = () => {
+export const PAGES_FILTER = 'woocommerce_admin_pages_list';
+
+export const getPages = () => {
 	const pages = [];
 
 	if ( window.wcAdminFeatures.devdocs ) {
@@ -65,10 +67,10 @@ const getPages = () => {
 		} );
 	}
 
-	return pages;
+	return applyFilters( PAGES_FILTER, pages );
 };
 
-class Controller extends Component {
+export class Controller extends Component {
 	componentDidMount() {
 		window.document.documentElement.scrollTop = 0;
 	}
@@ -206,5 +208,3 @@ window.wpNavMenuClassChange = function( page ) {
 	const wpWrap = document.querySelector( '#wpwrap' );
 	wpWrap.classList.remove( 'wp-responsive-open' );
 };
-
-export { Controller, getPages };

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
+import { useFilters } from '@woocommerce/components';
 import { Router, Route, Switch } from 'react-router-dom';
 import { Slot } from 'react-slot-fill';
 import PropTypes from 'prop-types';
@@ -17,7 +18,7 @@ import { getHistory } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import './style.scss';
-import { Controller, getPages } from './controller';
+import { Controller, getPages, PAGES_FILTER } from './controller';
 import Header from 'header';
 import Notices from './notices';
 import { recordPageView } from 'lib/tracks';
@@ -95,7 +96,7 @@ Layout.propTypes = {
 	isEmbedded: PropTypes.bool,
 };
 
-export class PageLayout extends Component {
+class _PageLayout extends Component {
 	render() {
 		return (
 			<Router history={ getHistory() }>
@@ -109,6 +110,8 @@ export class PageLayout extends Component {
 		);
 	}
 }
+// Use the useFilters HoC so PageLayout is re-rendered when the filter is used to add new pages
+export const PageLayout = useFilters( PAGES_FILTER )( _PageLayout );
 
 export class EmbedLayout extends Component {
 	render() {


### PR DESCRIPTION
I've linked the relevant issue on the other extension from here, see it for more context.

This PR adds a filter so that other extensions can "plug into" the WC-Admin client-side router and add new pages.

Since it's a filter that receives the existing list of pages, an extension could remove existing WC-Admin pages. Is that something we want to allow? Or should we only make it possible to *add* new pages?