### PR TITLE
Test that REST controllers work with their default parameters.

### DIFF
--- a/includes/api/class-wc-admin-rest-orders-controller.php
+++ b/includes/api/class-wc-admin-rest-orders-controller.php
@@ -36,6 +36,8 @@ class WC_Admin_REST_Orders_Controller extends WC_REST_Orders_Controller {
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
+		// Fix the default 'status' value until it can be patched in core.
+		$params['status']['default'] = array( 'any' );
 		return $params;
 	}
 

--- a/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-performance-indicators-controller.php
@@ -501,7 +501,9 @@ class WC_Admin_REST_Reports_Performance_Indicators_Controller extends WC_REST_Re
 			'validate_callback' => 'rest_validate_request_arg',
 			'items'             => array(
 				'type' => 'string',
+				'enum' => $this->allowed_stats,
 			),
+			'default'           => $this->allowed_stats,
 		);
 		$params['after']   = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),

--- a/tests/api/report-controllers.php
+++ b/tests/api/report-controllers.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * REST Controller Tests
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.6.4
+ */
+
+/**
+ * REST Controller Tests Class
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.6.4
+ */
+class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
+	/**
+	 * Ensure that every REST controller works with their defaults.
+	 */
+	public function test_default_params() {
+		$controller_classes = array(
+			'WC_Admin_REST_Admin_Notes_Controller',
+			'WC_Admin_REST_Admin_Note_Action_Controller',
+			'WC_Admin_REST_Coupons_Controller',
+			'WC_Admin_REST_Customers_Controller',
+			'WC_Admin_REST_Data_Controller',
+			'WC_Admin_REST_Data_Countries_Controller',
+			'WC_Admin_REST_Data_Download_Ips_Controller',
+			'WC_Admin_REST_Leaderboards_Controller',
+			'WC_Admin_REST_Orders_Controller',
+			'WC_Admin_REST_Products_Controller',
+			'WC_Admin_REST_Product_Categories_Controller',
+			'WC_Admin_REST_Product_Variations_Controller',
+			'WC_Admin_REST_Product_Reviews_Controller',
+			'WC_Admin_REST_Product_Variations_Controller',
+			'WC_Admin_REST_Reports_Controller',
+			'WC_Admin_REST_Setting_Options_Controller',
+			'WC_Admin_REST_Reports_Import_Controller',
+			'WC_Admin_REST_Reports_Products_Controller',
+			'WC_Admin_REST_Reports_Variations_Controller',
+			'WC_Admin_REST_Reports_Products_Stats_Controller',
+			'WC_Admin_REST_Reports_Revenue_Stats_Controller',
+			'WC_Admin_REST_Reports_Orders_Controller',
+			'WC_Admin_REST_Reports_Orders_Stats_Controller',
+			'WC_Admin_REST_Reports_Categories_Controller',
+			'WC_Admin_REST_Reports_Taxes_Controller',
+			'WC_Admin_REST_Reports_Taxes_Stats_Controller',
+			'WC_Admin_REST_Reports_Coupons_Controller',
+			'WC_Admin_REST_Reports_Coupons_Stats_Controller',
+			'WC_Admin_REST_Reports_Stock_Controller',
+			'WC_Admin_REST_Reports_Stock_Stats_Controller',
+			'WC_Admin_REST_Reports_Downloads_Controller',
+			'WC_Admin_REST_Reports_Downloads_Stats_Controller',
+			'WC_Admin_REST_Reports_Customers_Controller',
+			'WC_Admin_REST_Reports_Customers_Stats_Controller',
+			'WC_Admin_REST_Taxes_Controller',
+			'WC_Admin_REST_Onboarding_Levels_Controller',
+			'WC_Admin_REST_Onboarding_Profile_Controller',
+			'WC_Admin_REST_Onboarding_Plugins_Controller',
+			'WC_Admin_REST_Reports_Performance_Indicators_Controller',
+		);
+
+		// Force REST controllers to load.
+		do_action( 'rest_api_init' );
+
+		foreach ( $controller_classes as $controller_class ) {
+			$controller = new $controller_class();
+			$response   = $controller->get_items( new WP_REST_Request() );
+
+			$this->assertTrue( is_array( $response ) );
+		}
+	}
+}

--- a/tests/api/report-controllers.php
+++ b/tests/api/report-controllers.php
@@ -34,8 +34,10 @@ class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
 	 * Ensure that every REST controller works with their defaults.
 	 */
 	public function test_default_params() {
-		// This list intentionall missing `WC_Admin_REST_Setting_Options_Controller`
-		// because it's just a version override.
+		// These controllers intentionally missing:
+		// - `WC_Admin_REST_Setting_Options_Controller`
+		// - `WC_Admin_REST_Data_Download_Ips_Controller`
+		// because they don't have defaults for required params.
 		$controller_classes = array(
 			'WC_Admin_REST_Admin_Notes_Controller',
 			'WC_Admin_REST_Admin_Note_Action_Controller',
@@ -43,7 +45,6 @@ class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
 			'WC_Admin_REST_Customers_Controller',
 			'WC_Admin_REST_Data_Controller',
 			'WC_Admin_REST_Data_Countries_Controller',
-			'WC_Admin_REST_Data_Download_Ips_Controller',
 			'WC_Admin_REST_Leaderboards_Controller',
 			'WC_Admin_REST_Orders_Controller',
 			'WC_Admin_REST_Products_Controller',

--- a/tests/api/report-controllers.php
+++ b/tests/api/report-controllers.php
@@ -14,9 +14,28 @@
  */
 class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
 	/**
+	 * Setup test admin notes data. Called before every test.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		wp_set_current_user( $this->user );
+	}
+
+	/**
 	 * Ensure that every REST controller works with their defaults.
 	 */
 	public function test_default_params() {
+		// This list intentionall missing `WC_Admin_REST_Setting_Options_Controller`
+		// because it's just a version override.
 		$controller_classes = array(
 			'WC_Admin_REST_Admin_Notes_Controller',
 			'WC_Admin_REST_Admin_Note_Action_Controller',
@@ -33,7 +52,6 @@ class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
 			'WC_Admin_REST_Product_Reviews_Controller',
 			'WC_Admin_REST_Product_Variations_Controller',
 			'WC_Admin_REST_Reports_Controller',
-			'WC_Admin_REST_Setting_Options_Controller',
 			'WC_Admin_REST_Reports_Import_Controller',
 			'WC_Admin_REST_Reports_Products_Controller',
 			'WC_Admin_REST_Reports_Variations_Controller',
@@ -64,9 +82,25 @@ class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
 
 		foreach ( $controller_classes as $controller_class ) {
 			$controller = new $controller_class();
-			$response   = $controller->get_items( new WP_REST_Request() );
+			$params     = $controller->get_collection_params();
+			$defaults   = array();
 
-			$this->assertTrue( is_array( $response ) );
+			foreach ( $params as $arg => $options ) {
+				if ( isset( $options['default'] ) ) {
+					$defaults[ $arg ] = $options['default'];
+				}
+			}
+
+			$request = new WP_REST_Request();
+			$request->set_default_params( $defaults );
+			$response = $controller->get_items( $request );
+
+			// Surface any errors for easier debugging.
+			if ( is_wp_error( $response ) ) {
+				$this->fail( $response->get_error_message() );
+			}
+
+			$this->assertTrue( is_array( $response->get_data() ) );
 		}
 	}
 }

--- a/tests/api/report-controllers.php
+++ b/tests/api/report-controllers.php
@@ -12,7 +12,7 @@
  * @package WooCommerce\Tests\API
  * @since 3.6.4
  */
-class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
+class WC_Tests_API_Report_Controllers extends WC_REST_Unit_Test_Case {
 	/**
 	 * Setup test admin notes data. Called before every test.
 	 *
@@ -35,66 +35,50 @@ class WC_Tests_API_Report_Controllers extends WP_UnitTestCase {
 	 */
 	public function test_default_params() {
 		// These controllers intentionally missing:
+		// - `WC_Admin_REST_Admin_Note_Action_Controller`
 		// - `WC_Admin_REST_Setting_Options_Controller`
 		// - `WC_Admin_REST_Data_Download_Ips_Controller`
-		// because they don't have defaults for required params.
-		$controller_classes = array(
-			'WC_Admin_REST_Admin_Notes_Controller',
-			'WC_Admin_REST_Admin_Note_Action_Controller',
-			'WC_Admin_REST_Coupons_Controller',
-			'WC_Admin_REST_Customers_Controller',
-			'WC_Admin_REST_Data_Controller',
-			'WC_Admin_REST_Data_Countries_Controller',
-			'WC_Admin_REST_Leaderboards_Controller',
-			'WC_Admin_REST_Orders_Controller',
-			'WC_Admin_REST_Products_Controller',
-			'WC_Admin_REST_Product_Categories_Controller',
-			'WC_Admin_REST_Product_Variations_Controller',
-			'WC_Admin_REST_Product_Reviews_Controller',
-			'WC_Admin_REST_Product_Variations_Controller',
-			'WC_Admin_REST_Reports_Controller',
-			'WC_Admin_REST_Reports_Import_Controller',
-			'WC_Admin_REST_Reports_Products_Controller',
-			'WC_Admin_REST_Reports_Variations_Controller',
-			'WC_Admin_REST_Reports_Products_Stats_Controller',
-			'WC_Admin_REST_Reports_Revenue_Stats_Controller',
-			'WC_Admin_REST_Reports_Orders_Controller',
-			'WC_Admin_REST_Reports_Orders_Stats_Controller',
-			'WC_Admin_REST_Reports_Categories_Controller',
-			'WC_Admin_REST_Reports_Taxes_Controller',
-			'WC_Admin_REST_Reports_Taxes_Stats_Controller',
-			'WC_Admin_REST_Reports_Coupons_Controller',
-			'WC_Admin_REST_Reports_Coupons_Stats_Controller',
-			'WC_Admin_REST_Reports_Stock_Controller',
-			'WC_Admin_REST_Reports_Stock_Stats_Controller',
-			'WC_Admin_REST_Reports_Downloads_Controller',
-			'WC_Admin_REST_Reports_Downloads_Stats_Controller',
-			'WC_Admin_REST_Reports_Customers_Controller',
-			'WC_Admin_REST_Reports_Customers_Stats_Controller',
-			'WC_Admin_REST_Taxes_Controller',
-			'WC_Admin_REST_Onboarding_Levels_Controller',
-			'WC_Admin_REST_Onboarding_Profile_Controller',
-			'WC_Admin_REST_Onboarding_Plugins_Controller',
-			'WC_Admin_REST_Reports_Performance_Indicators_Controller',
+		// - `WC_Admin_REST_Product_Variations_Controller`
+		// - `WC_Admin_REST_Reports_Import_Controller`
+		// because they don't have defaults for required params or a get_items() method.
+		$endpoints = array(
+			'/wc/v4/admin/notes',
+			'/wc/v4/coupons',
+			'/wc/v4/customers',
+			'/wc/v4/data',
+			'/wc/v4/data/countries',
+			'/wc/v4/leaderboards',
+			'/wc/v4/orders',
+			'/wc/v4/products',
+			'/wc/v4/products/categories',
+			'/wc/v4/reports',
+			'/wc/v4/reports/products',
+			'/wc/v4/reports/variations',
+			'/wc/v4/reports/products/stats',
+			'/wc/v4/reports/revenue/stats',
+			'/wc/v4/reports/orders',
+			'/wc/v4/reports/orders/stats',
+			'/wc/v4/reports/categories',
+			'/wc/v4/reports/taxes',
+			'/wc/v4/reports/taxes/stats',
+			'/wc/v4/reports/coupons',
+			'/wc/v4/reports/coupons/stats',
+			'/wc/v4/reports/stock',
+			'/wc/v4/reports/stock/stats',
+			'/wc/v4/reports/downloads',
+			'/wc/v4/reports/downloads/stats',
+			'/wc/v4/reports/customers',
+			'/wc/v4/reports/customers/stats',
+			'/wc/v4/taxes',
+			'/wc/v4/reports/performance-indicators',
+			'/wc-admin/v1/onboarding/levels',
+			'/wc-admin/v1/onboarding/profile',
+			'/wc-admin/v1/onboarding/plugins',
 		);
 
-		// Force REST controllers to load.
-		do_action( 'rest_api_init' );
-
-		foreach ( $controller_classes as $controller_class ) {
-			$controller = new $controller_class();
-			$params     = $controller->get_collection_params();
-			$defaults   = array();
-
-			foreach ( $params as $arg => $options ) {
-				if ( isset( $options['default'] ) ) {
-					$defaults[ $arg ] = $options['default'];
-				}
-			}
-
-			$request = new WP_REST_Request();
-			$request->set_default_params( $defaults );
-			$response = $controller->get_items( $request );
+		foreach ( $endpoints as $endpoint ) {
+			$request  = new WP_REST_Request( 'GET', $endpoint );
+			$response = $this->server->dispatch( $request );
 
 			// Surface any errors for easier debugging.
 			if ( is_wp_error( $response ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,6 +89,7 @@ function wc_test_includes() {
 function _manually_load_plugin() {
 	define( 'WC_TAX_ROUNDING_MODE', 'auto' );
 	define( 'WC_USE_TRANSACTIONS', false );
+	update_option( 'woocommerce_enable_coupons', 'yes' );
 	require_once wc_dir() . '/woocommerce.php';
 
 	wc_admin_install();


### PR DESCRIPTION
In testing my Reports CSV Exporter class, I noticed that some REST controllers caused SQL errors with their default values.

This PR seeks to fix the few errant/missing defaults and add a test to ensure we don't regress.

### Detailed test instructions:

- Make some REST API requests to report endpoints with no parameters
- Verify they work
- Check the new test class
- Verify all tests pass

### Changelog Note:

Tweak: fix some report endpoint default params.