### PR TITLE
Activity Panels: Add track event when panels are opened.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -25,6 +25,7 @@ import {
 import InboxPanel from './panels/inbox';
 import OrdersPanel from './panels/orders';
 import StockPanel from './panels/stock';
+import { recordEvent } from 'lib/tracks';
 import ReviewsPanel from './panels/reviews';
 import withSelect from 'wc-api/with-select';
 import WordPressNotices from './wordpress-notices';
@@ -45,6 +46,13 @@ class ActivityPanel extends Component {
 	}
 
 	togglePanel( tabName ) {
+		const { isPanelOpen, currentTab } = this.state;
+
+		// If no panel is open, or if a new panel is opening, record a track.
+		if ( ! isPanelOpen || tabName !== currentTab ) {
+			recordEvent( 'wcadmin_activity_panel_open', { tab: tabName } );
+		}
+
 		// The WordPress Notices tab is handled differently, since they are displayed inline, so the panel should be closed,
 		// Close behavior of the expanded notices is based on current tab.
 		if ( 'wpnotices' === tabName ) {

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -48,7 +48,7 @@ class ActivityPanel extends Component {
 	togglePanel( tabName ) {
 		const { isPanelOpen, currentTab } = this.state;
 
-		// If no panel is open, or if a new panel is opening, record a track.
+		// If a panel is being opened, or if an existing panel is already open and a different one is being opened, record a track.
 		if ( ! isPanelOpen || tabName !== currentTab ) {
 			recordEvent( 'wcadmin_activity_panel_open', { tab: tabName } );
 		}

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -1,4 +1,13 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import debug from 'debug';
+
+/**
+ * Module variables
+ */
+const tracksDebug = debug( 'wc-admin:tracks' );
 
 /**
  * Record an event to Tracks
@@ -8,6 +17,8 @@
  */
 
 export function recordEvent( eventName, eventProperties ) {
+	tracksDebug( 'recordevent %s %o', eventName, eventProperties );
+
 	if (
 		! window.wcTracks ||
 		'function' !== typeof window.wcTracks.recordEvent ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -8962,8 +8962,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8981,13 +8980,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9000,18 +8997,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9114,8 +9108,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9125,7 +9118,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9138,20 +9130,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9168,7 +9157,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9241,8 +9229,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9252,7 +9239,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9328,8 +9314,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9359,7 +9344,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9377,7 +9361,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9416,13 +9399,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "d3-selection": "1.4.0",
     "d3-shape": "1.3.5",
     "d3-time-format": "2.1.3",
+    "debug": "3.2.6",
     "dompurify": "1.0.11",
     "emoji-flags": "1.2.0",
     "gfm-code-blocks": "1.0.0",


### PR DESCRIPTION
For #2474

This branch adds a tracks event when an Activity Panel is opened. For the ease of debug-ability, this PR also adds in `debug` as a dependency, and creates a new debug log for `wc-admin:tracks`. `freshdata` also uses debug, so figured it might be nice to add it in here too so it makes testing PRs like these tracks ones much easier.

### Detailed test instructions:

- In your console `localStorage.setItem( 'debug', 'wc-admin:*' );`
- Open up any Woo page that has activity panels
- Toggle each panel on/off and verify the proper call to `recordEvent()` is happening. Note when running in development mode, you shouldn't see an actual call to `t.gif` happening in your network tab.
