### PR TITLE
remove double slash from image urls, use string for download ID

### DIFF
--- a/tests/api/data.php
+++ b/tests/api/data.php
@@ -54,7 +54,7 @@ class WC_Tests_API_Data extends WC_REST_Unit_Test_Case {
 
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_id( '1' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );

--- a/tests/api/data.php
+++ b/tests/api/data.php
@@ -53,7 +53,7 @@ class WC_Tests_API_Data extends WC_REST_Unit_Test_Case {
 		WC_Helper_Reports::reset_stats_dbs();
 
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
 		$prod_download->set_id( 1 );
 
 		$product = new WC_Product_Simple();

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -50,7 +50,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		// Populate all of the data.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_id( '1' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
@@ -137,7 +137,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		// First set of data.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_id( '2' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
@@ -230,7 +230,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		// Populate all of the data.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_id( '3' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -49,7 +49,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 
 		// Populate all of the data.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
 		$prod_download->set_id( 1 );
 
 		$product = new WC_Product_Simple();
@@ -136,7 +136,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 
 		// First set of data.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
 		$prod_download->set_id( 1 );
 
 		$product = new WC_Product_Simple();
@@ -229,7 +229,7 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 
 		// Populate all of the data.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
 		$prod_download->set_id( 1 );
 
 		$product = new WC_Product_Simple();

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -49,8 +49,8 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 
 		// Populate all of the data.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
+		$prod_download->set_id( '1' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
@@ -92,7 +92,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $this->user, $download_report['user_id'] );
 		$this->assertEquals( '1.2.3.4', $download_report['ip_address'] );
 		$this->assertEquals( 'help.png', $download_report['file_name'] );
-		$this->assertEquals( plugin_dir_url( __FILE__ ) . '/assets/images/help.png', $download_report['file_path'] );
+		$this->assertEquals( plugin_dir_url( __FILE__ ) . 'assets/images/help.png', $download_report['file_path'] );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 
 		// First set of data.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
 		$prod_download->set_id( 1 );
 
 		$product = new WC_Product_Simple();
@@ -138,7 +138,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 
 		// Second set of data.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/test.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/test.png' );
 		$prod_download->set_id( 2 );
 
 		$product = new WC_Product_Simple();

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -107,7 +107,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		// First set of data.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_id( '2' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
@@ -139,7 +139,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		// Second set of data.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/test.png' );
-		$prod_download->set_id( 2 );
+		$prod_download->set_id( '3' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product 2' );

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -51,7 +51,7 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		// Populate all of the data. We'll create an order and a download.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
-		$prod_download->set_id( 1 );
+		$prod_download->set_id( '1' );
 
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -50,7 +50,7 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 
 		// Populate all of the data. We'll create an order and a download.
 		$prod_download = new WC_Product_Download();
-		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
+		$prod_download->set_file( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' );
 		$prod_download->set_id( 1 );
 
 		$product = new WC_Product_Simple();


### PR DESCRIPTION
Fixes #2495

This PR does some downloads unit tests housekeeping.

### Detailed test instructions:

This should be fine with a clean pass on unit tests.

### Changelog Note:

No changelog entry needed.