### PR TITLE
Fix batch queue range bug.

### DIFF
--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -515,11 +515,15 @@ class WC_Admin_Reports_Sync {
 		if ( $range_size > $batch_size ) {
 			// If the current batch range is larger than a single batch,
 			// split the range into $queue_batch_size chunks.
-			$chunk_size = ceil( $range_size / $batch_size );
+			$chunk_size = (int) ceil( $range_size / $batch_size );
 
 			for ( $i = 0; $i < $batch_size; $i++ ) {
-				$batch_start = $range_start + ( $i * $chunk_size );
-				$batch_end   = min( $range_end, $range_start + ( $chunk_size * ( $i + 1 ) ) - 1 );
+				$batch_start = (int) ( $range_start + ( $i * $chunk_size ) );
+				$batch_end   = (int) min( $range_end, $range_start + ( $chunk_size * ( $i + 1 ) ) - 1 );
+
+				if ( $batch_start > $range_end ) {
+					return;
+				}
 
 				self::queue()->schedule_single(
 					$action_timestamp,

--- a/tests/batch-queue.php
+++ b/tests/batch-queue.php
@@ -79,15 +79,17 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_queue_batches_splits_into_batches_correctly() {
 		$num_customers = 1234; // 1234 / 5 = 247 batches
-		$num_batches   = ceil( $num_customers / $this->customers_batch_size );
+		$num_batches   = (int) ceil( $num_customers / $this->customers_batch_size );
+		$chunk_size    = (int) ceil( $num_batches / $this->queue_batch_size );
+		$num_chunks    = (int) ceil( $num_batches / $chunk_size );
 
 		WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION );
 
-		$this->assertCount( $this->queue_batch_size, $this->queue->actions );
+		$this->assertCount( $num_chunks, $this->queue->actions );
 		$this->assertArraySubset(
 			array(
 				'hook' => WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
-				'args' => array( 1, 3, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
+				'args' => array( 1, $chunk_size, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
 			),
 			$this->queue->actions[0]
 		);
@@ -96,7 +98,7 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 				'hook' => WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
 				'args' => array( 247, 247, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
 			),
-			$this->queue->actions[ $this->queue_batch_size - 1 ]
+			$this->queue->actions[ $num_chunks - 1 ]
 		);
 	}
 

--- a/tests/batch-queue.php
+++ b/tests/batch-queue.php
@@ -18,7 +18,7 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var integer
 	 */
-	public $queue_batch_size = 10;
+	public $queue_batch_size = 100;
 
 	/**
 	 * Customers batch size.
@@ -87,14 +87,14 @@ class WC_Tests_Reports_Regenerate_Batching extends WC_REST_Unit_Test_Case {
 		$this->assertArraySubset(
 			array(
 				'hook' => WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
-				'args' => array( 1, 25, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
+				'args' => array( 1, 3, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
 			),
 			$this->queue->actions[0]
 		);
 		$this->assertArraySubset(
 			array(
 				'hook' => WC_Admin_Reports_Sync::QUEUE_BATCH_ACTION,
-				'args' => array( 226, 247, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
+				'args' => array( 247, 247, WC_Admin_Reports_Sync::CUSTOMERS_IMPORT_BATCH_ACTION ),
 			),
 			$this->queue->actions[ $this->queue_batch_size - 1 ]
 		);


### PR DESCRIPTION
When splitting the queueing of many actions into chunks, the existing `queue_batches()` method always queues `QUEUE_BATCH_ACTION` number of jobs (100 as of this writing).

In cases where there will be less than 100 chunks to queue, the remaining queued actions have range starts that are greater than the end.

Example:

State: 1234 items, item batch size of 5, queue batch size of 100.

`WC_Admin_Reports_Sync::queue_batches( 1, 247, ITEM_ACTION );`

The current version of `queue_batches()` will create the following errant ranges:

- `[ 250, 247 ]`
- `[ 253, 247 ]`
- `[ 256, 247 ]`
- `[ 259, 247 ]`
- `[ 262, 247 ]`
- `[ 265, 247 ]`
- `[ 268, 247 ]`
- `[ 271, 247 ]`
- `[ 274, 247 ]`
- `[ 277, 247 ]`
- `[ 280, 247 ]`
- `[ 283, 247 ]`
- `[ 286, 247 ]`
- `[ 289, 247 ]`
- `[ 292, 247 ]`
- `[ 295, 247 ]`
- `[ 298, 247 ]`

### Detailed test instructions:

It's probably easiest to verify the behavior using the unit test. You can comment out this statement in `queue_batches()` to see the failure:

```php
if ( $batch_start > $range_end ) {
	return;
}
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
