### PR TITLE
Packages: prepare for release

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -75,7 +75,7 @@ To create a new package, add a new folder to `/packages`, containing…
 - Run `npm run publish-packages:check` to see which packages will be published
 - Create a PR with a CHANGELOG for each updated package (or try to add to the CHANGELOG with any PR editing `packages/`)
 - Run `npm run publish-packages:prod` to publish the package
-- _OR_ Run `npm run publish-packages:dev` to publish "next" releases (installed as `npm i @woocommerce/package@next`). Currently packages are published this way, but we should be using prod in the future. Only use `:dev` if you have a reason to.
+- _OR_ Run `npm run publish-packages:dev` to publish "next" releases (installed as `npm i @woocommerce/package@next`). Only use `:dev` if you have a reason to.
 - Both commands will run `build:packages` before the lerna task, just to catch any last updates.
 
 It will confirm with you once more before publishing:

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.0.0 (unreleased)
+# 3.0.0
 - <DateInput> and <DatePicker> got a `disabled` prop.
 - TableCard component: new `onPageChange` prop.
 - TableCard now has a `defaultOrder` parameter to specify default sort column sort order.
@@ -13,6 +13,7 @@
 - Card component: new `description` prop.
 - Card component: new `isInactive` prop.
 - DateRangeFilterPicker (breaking change): Introduced `onRangeSelect` prop and remove `path` prop better control.
+- Update liscence to GPL-3.0-or-later.
 
 # 2.0.0
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/components",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "UI components for WooCommerce.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Update liscence to GPL-3.0-or-later
+
 # 1.1.0
 
 - Fix error in `getCSVRows` when there is a null or undefined column value.

--- a/packages/csv-export/package.json
+++ b/packages/csv-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/csv-export",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "WooCommerce utility library to convert data to CSV files.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.2
+
+- Update liscence to GPL-3.0-or-later
+
 # 1.1.1
 
 - Change text domain on i18n functions.

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/currency",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "WooCommerce currency utilities.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0
+
+- Enhancement: gather default date settings from `wcSettings.wcAdminSettings.woocommerce_default_date_range` if they exist.
+- Update liscence to GPL-3.0-or-later
+
 # 1.0.7
 
 - Change text domain on i18n functions.

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/date",
-  "version": "1.0.7",
+  "version": "1.2.0",
   "description": "WooCommerce date utilities.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -3,6 +3,10 @@
 - `getHistory` updated to reflect path parameters in url query.
 - `getNewPath` also updated to reflect path parameters in url query.
 
+# 2.1.1
+
+- Update liscence to GPL-3.0-or-later
+
 # 2.1.0
 
 - New method `getSearchWords` that extracts search words given a query object.

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/navigation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "WooCommerce navigation utilities.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3
+
+- Update liscence to GPL-3.0-or-later
+
 # 1.0.2
 
 - Bump dependency versions.

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/number",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Number formatting utilities for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Updates to release packages.

Relevant instructions: https://github.com/woocommerce/woocommerce-admin/blob/1135506317f1541fdb1df5f38591c3ca14a05a45/packages/README.md#publishing-packages

Packages to be published (via `npm run publish-packages:check`):

```
@woocommerce/components
@woocommerce/csv-export
@woocommerce/currency
@woocommerce/date
@woocommerce/navigation
@woocommerce/number
lerna success found 6 packages ready to publish
```

## Changelog

### components

```
# 3.0.0
- <DateInput> and <DatePicker> got a `disabled` prop.
- TableCard component: new `onPageChange` prop.
- TableCard now has a `defaultOrder` parameter to specify default sort column sort order.
- Pagination no longer considers `0` a valid input and triggers `onPageChange` on the input blur event.
- Tweaks to SummaryListPlaceholder height in order to better match SummaryNumber.
- EllipsisMenu component (breaking change): Remove `children` prop in favor of a render prop `renderContent` so that function arguments `isOpen`, `onToggle`, and `onClose` can be passed down.
- Chart has a new prop named `yBelow1Format` which overrides the `yFormat` for values between -1 and 1 (not included).
- Add a `totals` prop to Chart component that allows overwriting the total values shown in the legend.
- Add new component `<Stepper />` for showing a list of steps and progress.
- Add new `<Spinner />` component.
- Card component: updated default Muriel design.
- Card component: new `description` prop.
- Card component: new `isInactive` prop.
- DateRangeFilterPicker (breaking change): Introduced `onRangeSelect` prop and remove `path` prop better control.
- Update liscence to GPL-3.0-or-later.
```

### csv-export

```
# 1.1.1

- Update liscence to GPL-3.0-or-later
```

### currency

```
# 1.1.2

- Update liscence to GPL-3.0-or-later
```

### date

```
# 1.2.0

- Enhancement: gather default date settings from `wcSettings.wcAdminSettings.woocommerce_default_date_range` if they exist.
- Update liscence to GPL-3.0-or-later
```

### navigation

```
# 2.1.1

- Update liscence to GPL-3.0-or-later
```

### number

```
# 1.0.3

- Update liscence to GPL-3.0-or-later
```

@ryelle Is it possible to `npm run publish-packages:prod`, or should I stick to `:dev`? I'm not entirely sure:

>Currently packages are published this way, but we should be using prod in the future.
