### PR TITLE
Advanced Filters: Add Tracks events

### DIFF
--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -1,0 +1,97 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import { omitBy, isUndefined } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ReportFilters as Filters } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
+export default class ReportFilters extends Component {
+	constructor() {
+		super();
+		this.trackDateSelect = this.trackDateSelect.bind( this );
+		this.trackFilterSelect = this.trackFilterSelect.bind( this );
+		this.trackAdvancedFilterAction = this.trackAdvancedFilterAction.bind( this );
+	}
+
+	trackDateSelect( data ) {
+		const { report } = this.props;
+		recordEvent( 'datepicker_update', { report, ...omitBy( data, isUndefined ) } );
+	}
+
+	trackFilterSelect( data ) {
+		const { report } = this.props;
+		recordEvent( 'analytics_filter', { report, filter: data.filter || 'all' } );
+	}
+
+	trackAdvancedFilterAction( action, data ) {
+		const { report } = this.props;
+
+		switch ( action ) {
+			case 'add':
+				recordEvent( 'analytics_filters_add', { report, filter: data.key } );
+				break;
+			case 'remove':
+				recordEvent( 'analytics_filters_remove', { report, filter: data.key } );
+				break;
+			case 'filter':
+				recordEvent( 'analytics_filters_filter', { report, ...data } );
+				break;
+			case 'clear_all':
+				recordEvent( 'analytics_filters_clear_all', { report } );
+				break;
+		}
+	}
+
+	render() {
+		const { query, path, filters, advancedFilters } = this.props;
+		return (
+			<Filters
+				query={ query }
+				path={ path }
+				filters={ filters }
+				advancedFilters={ advancedFilters }
+				onDateSelect={ this.trackDateSelect }
+				onFilterSelect={ this.trackFilterSelect }
+				onAdvancedFilterAction={ this.trackAdvancedFilterAction }
+			/>
+		);
+	}
+}
+
+ReportFilters.propTypes = {
+	/**
+	 * Config option passed through to `AdvancedFilters`
+	 */
+	advancedFilters: PropTypes.object,
+	/**
+	 * Config option passed through to `FilterPicker` - if not used, `FilterPicker` is not displayed.
+	 */
+	filters: PropTypes.array,
+	/**
+	 * The `path` parameter supplied by React-Router
+	 */
+	path: PropTypes.string.isRequired,
+	/**
+	 * The query string represented in object form
+	 */
+	query: PropTypes.object,
+	/**
+	 * Whether the date picker must be shown..
+	 */
+	showDatePicker: PropTypes.bool,
+	/**
+	 * The report where filter are placed.
+	 */
+	report: PropTypes.string.isRequired,
+};

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -7,11 +7,6 @@ import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { charts, filters } from './config';
@@ -20,6 +15,7 @@ import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 import ProductsReportTable from '../products/table';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class CategoriesReport extends Component {
 	getChartMeta() {
@@ -56,7 +52,7 @@ export default class CategoriesReport extends Component {
 
 		return (
 			<Fragment>
-				<ReportFilters query={ query } path={ path } filters={ filters } />
+				<ReportFilters query={ query } path={ path } filters={ filters } report="categories" />
 				<ReportSummary
 					charts={ charts }
 					endpoint="products"

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -7,11 +7,6 @@ import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { charts, filters } from './config';
@@ -19,6 +14,7 @@ import CouponsReportTable from './table';
 import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class CouponsReport extends Component {
 	getChartMeta() {
@@ -49,7 +45,7 @@ export default class CouponsReport extends Component {
 
 		return (
 			<Fragment>
-				<ReportFilters query={ query } path={ path } filters={ filters } />
+				<ReportFilters query={ query } path={ path } filters={ filters } report="coupons" />
 				<ReportSummary
 					charts={ charts }
 					endpoint="coupons"

--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -6,15 +6,11 @@ import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { filters, advancedFilters } from './config';
 import CustomersReportTable from './table';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class CustomersReport extends Component {
 	render() {
@@ -33,6 +29,7 @@ export default class CustomersReport extends Component {
 					filters={ filters }
 					showDatePicker={ false }
 					advancedFilters={ advancedFilters }
+					report="customers"
 				/>
 				<CustomersReportTable
 					isRequesting={ isRequesting }

--- a/client/analytics/report/downloads/index.js
+++ b/client/analytics/report/downloads/index.js
@@ -6,11 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { charts, filters, advancedFilters } from './config';
@@ -18,6 +13,7 @@ import DownloadsReportTable from './table';
 import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class DownloadsReport extends Component {
 	render() {
@@ -30,6 +26,7 @@ export default class DownloadsReport extends Component {
 					path={ path }
 					filters={ filters }
 					advancedFilters={ advancedFilters }
+					report="downloads"
 				/>
 				<ReportSummary
 					charts={ charts }

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -6,11 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { advancedFilters, charts, filters } from './config';
@@ -18,6 +13,7 @@ import getSelectedChart from 'lib/get-selected-chart';
 import OrdersReportTable from './table';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class OrdersReport extends Component {
 	render() {
@@ -30,6 +26,7 @@ export default class OrdersReport extends Component {
 					path={ path }
 					filters={ filters }
 					advancedFilters={ advancedFilters }
+					report="orders"
 				/>
 				<ReportSummary
 					charts={ charts }

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -8,11 +8,6 @@ import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { charts, filters } from './config';
@@ -23,6 +18,7 @@ import ReportError from 'analytics/components/report-error';
 import ReportSummary from 'analytics/components/report-summary';
 import VariationsReportTable from './table-variations';
 import withSelect from 'wc-api/with-select';
+import ReportFilters from 'analytics/components/report-filters';
 
 class ProductsReport extends Component {
 	getChartMeta() {
@@ -68,7 +64,7 @@ class ProductsReport extends Component {
 
 		return (
 			<Fragment>
-				<ReportFilters query={ query } path={ path } filters={ filters } />
+				<ReportFilters query={ query } path={ path } filters={ filters } report="products" />
 				<ReportSummary
 					mode={ mode }
 					charts={ charts }

--- a/client/analytics/report/revenue/index.js
+++ b/client/analytics/report/revenue/index.js
@@ -6,11 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { charts } from './config';
@@ -18,6 +13,7 @@ import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 import RevenueReportTable from './table';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class RevenueReport extends Component {
 	render() {
@@ -25,7 +21,7 @@ export default class RevenueReport extends Component {
 
 		return (
 			<Fragment>
-				<ReportFilters query={ query } path={ path } />
+				<ReportFilters query={ query } path={ path } report="revenue" />
 				<ReportSummary
 					charts={ charts }
 					endpoint="revenue"

--- a/client/analytics/report/stock/index.js
+++ b/client/analytics/report/stock/index.js
@@ -6,15 +6,11 @@ import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { showDatePicker, filters } from './config';
 import StockReportTable from './table';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class StockReport extends Component {
 	render() {
@@ -27,6 +23,7 @@ export default class StockReport extends Component {
 					path={ path }
 					showDatePicker={ showDatePicker }
 					filters={ filters }
+					report="stock"
 				/>
 				<StockReportTable query={ query } filters={ filters } />
 			</Fragment>

--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -7,11 +7,6 @@ import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 
 /**
- * WooCommerce dependencies
- */
-import { ReportFilters } from '@woocommerce/components';
-
-/**
  * Internal dependencies
  */
 import { charts, filters } from './config';
@@ -19,6 +14,7 @@ import getSelectedChart from 'lib/get-selected-chart';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 import TaxesReportTable from './table';
+import ReportFilters from 'analytics/components/report-filters';
 
 export default class TaxesReport extends Component {
 	getChartMeta() {
@@ -46,7 +42,7 @@ export default class TaxesReport extends Component {
 		}
 		return (
 			<Fragment>
-				<ReportFilters query={ query } path={ path } filters={ filters } />
+				<ReportFilters query={ query } path={ path } filters={ filters } report="taxes" />
 				<ReportSummary
 					charts={ charts }
 					endpoint="taxes"

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -12,12 +12,12 @@ const tracksDebug = debug( 'wc-admin:tracks' );
 /**
  * Record an event to Tracks
  *
- * @param {String} eventName The name of the event to record, always prefixed with wc_admin_
+ * @param {String} eventName The name of the event to record, don't include the wcadmin_ prefix
  * @param {Object} eventProperties event properties to include in the event
  */
 
 export function recordEvent( eventName, eventProperties ) {
-	tracksDebug( 'recordevent %s %o', 'wc_admin_' + eventName, eventProperties );
+	tracksDebug( 'recordevent %s %o', 'wcadmin_' + eventName, eventProperties );
 
 	if (
 		! window.wcTracks ||

--- a/packages/components/src/filters/filter/index.js
+++ b/packages/components/src/filters/filter/index.js
@@ -106,7 +106,7 @@ class FilterPicker extends Component {
 	}
 
 	update( value, additionalQueries = {} ) {
-		const { path, query, config } = this.props;
+		const { path, query, config, onFilterSelect } = this.props;
 		// Keep only time related queries when updating to a new filter
 		const persistedQuery = getPersistedQuery( query );
 		const update = {
@@ -118,6 +118,7 @@ class FilterPicker extends Component {
 			update[ param ] = query[ param ];
 		} );
 		updateQueryString( update, path, persistedQuery );
+		onFilterSelect( update );
 	}
 
 	onTagChange( filter, onClose, config, tags ) {
@@ -308,10 +309,15 @@ FilterPicker.propTypes = {
 	 * The query string represented in object form.
 	 */
 	query: PropTypes.object,
+	/**
+	 * Function to be called after filter selection.
+	 */
+	onFilterSelect: PropTypes.func,
 };
 
 FilterPicker.defaultProps = {
 	query: {},
+	onFilterSelect: () => {},
 };
 
 export default FilterPicker;

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -35,7 +35,7 @@ class ReportFilters extends Component {
 	}
 
 	renderCard( config ) {
-		const { advancedFilters, query, path } = this.props;
+		const { advancedFilters, query, path, onAdvancedFilterAction } = this.props;
 		const { filters, param } = config;
 		if ( ! query[ param ] ) {
 			return null;
@@ -56,19 +56,25 @@ class ReportFilters extends Component {
 		if ( 'advanced' === query[ param ] ) {
 			return (
 				<div key={ param } className="woocommerce-filters__advanced-filters">
-					<AdvancedFilters config={ advancedFilters } path={ path } query={ query } />
+					<AdvancedFilters
+						config={ advancedFilters }
+						path={ path }
+						query={ query }
+						onAdvancedFilterAction={ onAdvancedFilterAction }
+					/>
 				</div>
 			);
 		}
 	}
 
 	onRangeSelect( data ) {
-		const { query, path } = this.props;
+		const { query, path, onDateSelect } = this.props;
 		updateQueryString( data, path, query );
+		onDateSelect( data );
 	}
 
 	render() {
-		const { filters, query, path, showDatePicker } = this.props;
+		const { filters, query, path, showDatePicker, onFilterSelect } = this.props;
 		return (
 			<Fragment>
 				<H className="screen-reader-text">{ __( 'Filters', 'woocommerce-admin' ) }</H>
@@ -89,6 +95,7 @@ class ReportFilters extends Component {
 										config={ config }
 										query={ query }
 										path={ path }
+										onFilterSelect={ onFilterSelect }
 									/>
 								);
 							}
@@ -119,9 +126,21 @@ ReportFilters.propTypes = {
 	 */
 	query: PropTypes.object,
 	/**
-	 * Whether the date picker must be shown..
+	 * Whether the date picker must be shown.
 	 */
 	showDatePicker: PropTypes.bool,
+	/**
+	 * Function to be called after date selection.
+	 */
+	onDateSelect: PropTypes.func,
+	/**
+	 * Function to be called after filter selection.
+	 */
+	onFilterSelect: PropTypes.func,
+	/**
+	 * Function to be called after an advanced filter action has been taken.
+	 */
+	onAdvancedFilterAction: PropTypes.func,
 };
 
 ReportFilters.defaultProps = {
@@ -129,6 +148,7 @@ ReportFilters.defaultProps = {
 	filters: [],
 	query: {},
 	showDatePicker: true,
+	onDateSelect: () => {},
 };
 
 export default ReportFilters;


### PR DESCRIPTION
Partially addresses https://github.com/woocommerce/woocommerce-admin/issues/2474

Adds the following Tracks events by wrapping filters in a `<ReportFilters />` component that handles methods for recording events.

* wcadmin_analytics_filters_add
* wcadmin_analytics_filters_remove
* wcadmin_analytics_filters_clear_all
* wcadmin_analytics_filters_filter
* wcadmin_analytics_filter
* wcadmin_datepicker_update

### Detailed test instructions

1. In your console `localStorage.setItem( 'debug', 'wc-admin:*' );`
2. Check several reports by seeing events logged when manipulating filters.
3. Include date picker, simple filters ("All orders", "Single Product"), and advanced filters.
4. Ensure the payload matches properties outlined in https://github.com/woocommerce/woocommerce-admin/issues/2474 and make sense.

### Notes
* When running in development mode, you shouldn't see an actual call to `t.gif` happening in your network tab.
* Woo Tracks plumbing adds the `wcadmin_` prefix, so we don't need to include it in the eventname. 