### PR TITLE
Add Report CSV Export Endpoint

### DIFF
--- a/docs/examples/extensions/table-column/woocommerce-admin-table-column.php
+++ b/docs/examples/extensions/table-column/woocommerce-admin-table-column.php
@@ -32,6 +32,27 @@ function table_column_register_script() {
 add_action( 'admin_enqueue_scripts', 'table_column_register_script' );
 
 /**
+ * When adding fields to a REST API response, we need to update the schema
+ * to reflect these changes. Not only does this let API consumers know of
+ * the new fields, it also adds them to Report Exports.
+ *
+ * @param array $properties The endpoint item schema properties.
+ * @return array Filtered schema.
+ */
+function add_product_extended_attributes_schema( $properties ) {
+	$properties['extended_info']['average_rating'] = array(
+		'type'        => 'number',
+		'readonly'    => true,
+		'context'     => array( 'view', 'edit' ),
+		'description' => 'Average product rating.',
+	);
+
+	return $properties;
+}
+
+add_filter( 'woocommerce_rest_report_products_schema', 'add_product_extended_attributes_schema' );
+
+/**
  * Extended attributes can be used to obtain any attribute from a WC_Product instance that is
  * available by a `get_*` class method. In other words, we can add `average_rating` because
  * `get_average_rating` is an available method on a WC_Product instance.

--- a/includes/api/class-wc-admin-rest-reports-export-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-export-controller.php
@@ -160,10 +160,9 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 	public function export_items( $request ) {
 		$report_type = $request['type'];
 		$report_args = empty( $request['report_args'] ) ? array() : $request['report_args'];
-		$user_id     = get_current_user_id();
 		$export_id   = str_replace( '.', '', microtime( true ) );
 
-		$total_rows = WC_Admin_Report_Exporter::queue_report_export( $user_id, $export_id, $report_type, $report_args );
+		$total_rows = WC_Admin_Report_Exporter::queue_report_export( $export_id, $report_type, $report_args );
 
 		if ( 0 === $total_rows ) {
 			$response = rest_ensure_response(
@@ -190,7 +189,7 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 				)
 			);
 
-			WC_Admin_Report_Exporter::update_export_percentage_complete( $user_id, $report_type, $export_id, 0 );
+			WC_Admin_Report_Exporter::update_export_percentage_complete( $report_type, $export_id, 0 );
 		}
 
 		$data = $this->prepare_response_for_collection( $response );
@@ -207,8 +206,7 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 	public function export_status( $request ) {
 		$report_type = $request['type'];
 		$export_id   = $request['export_id'];
-		$user_id     = get_current_user_id();
-		$percentage  = WC_Admin_Report_Exporter::get_export_percentage_complete( $user_id, $report_type, $export_id );
+		$percentage  = WC_Admin_Report_Exporter::get_export_percentage_complete( $report_type, $export_id );
 
 		if ( false === $percentage ) {
 			return new WP_Error(

--- a/includes/api/class-wc-admin-rest-reports-export-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-export-controller.php
@@ -43,7 +43,7 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'export_items' ),
-					'permission_callback' => array( $this, 'export_permissions_check' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => $this->get_export_collection_params(),
 				),
 				'schema' => array( $this, 'get_export_public_schema' ),
@@ -57,25 +57,11 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'export_status' ),
-					'permission_callback' => array( $this, 'export_permissions_check' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_export_status_public_schema' ),
 			)
 		);
-	}
-
-	/**
-	 * Makes sure the current user has access to WRITE the settings APIs.
-	 *
-	 * @param WP_REST_Request $request Full data about the request.
-	 * @return WP_Error|bool
-	 */
-	public function export_permissions_check( $request ) {
-		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
-			// @todo: better message?
-			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
-		}
-		return true;
 	}
 
 	/**

--- a/includes/api/class-wc-admin-rest-reports-export-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-export-controller.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * REST API Reports Export Controller
+ *
+ * Handles requests to:
+ * - /reports/[report]/export
+ * - /reports/[report]/export/[id]/status
+ *
+ * @package WooCommerce Admin/API
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Reports Export controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'reports/(?P<type>[a-z]+)/export';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'export_items' ),
+					'permission_callback' => array( $this, 'export_permissions_check' ),
+					'args'                => $this->get_export_collection_params(),
+				),
+				'schema' => array( $this, 'get_export_public_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Makes sure the current user has access to WRITE the settings APIs.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|bool
+	 */
+	public function export_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			// @todo: better message?
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_export_collection_params() {
+		$params                = array();
+		$params['report_args'] = array(
+			'description'       => __( 'Parameters to pass on to the exported report.', 'woocommerce-admin' ),
+			'type'              => 'object',
+			'validate_callback' => 'rest_validate_request_arg', // @todo: use each controller's schema?
+		);
+		return $params;
+	}
+
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_export_public_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'report_export',
+			'type'       => 'object',
+			'properties' => array(
+				'status'  => array(
+					'description' => __( 'Regeneration status.', 'woocommerce-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'message' => array(
+					'description' => __( 'Regenerate data message.', 'woocommerce-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Export data based on user request params.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function export_items( $request ) {
+		$report_type = $request['type'];
+		$report_args = empty( $request['report_args'] ) ? array() : $request['report_args'];
+		$user_id     = get_current_user_id();
+		$export_id   = str_replace( '.', '', microtime( true ) );
+
+		WC_Admin_Report_Exporter::queue_report_export( $user_id, $export_id, $report_type, $report_args );
+
+		// @todo: handle error case?
+		$result = array(
+			'status'  => 'success',
+			'message' => __( 'Your report file is being generated.', 'woocommerce-admin' ),
+		);
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $result );
+		// Include a link to the export status endpoint.
+		$response->add_links(
+			array(
+				'status' => array(
+					'href' => rest_url( sprintf( '%s/reports/%s/export/%s/status', $this->namespace, $report_type, $export_id ) ),
+				),
+			)
+		);
+
+		$data = $this->prepare_response_for_collection( $response );
+
+		return rest_ensure_response( $data );
+	}
+}

--- a/includes/api/class-wc-admin-rest-reports-export-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-export-controller.php
@@ -222,7 +222,12 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 
 		// @todo - add thing in the links below instead?
 		if ( 100 === $percentage ) {
-			$result['download_url'] = rest_url( sprintf( '%s/reports/%s/export/%s/download', $this->namespace, $report_type, $export_id ) );
+			$query_args = array(
+				'action'   => WC_Admin_Report_Exporter::DOWNLOAD_EXPORT_ACTION,
+				'filename' => "wc-{$report_type}-report-export-{$export_id}",
+			);
+
+			$result['download_url'] = add_query_arg( $query_args, admin_url() );
 		}
 
 		// Wrap the data in a response object.

--- a/includes/api/class-wc-admin-rest-reports-export-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-export-controller.php
@@ -164,7 +164,7 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 		$export_id   = str_replace( '.', '', microtime( true ) );
 
 		WC_Admin_Report_Exporter::queue_report_export( $user_id, $export_id, $report_type, $report_args );
-		WC_Admin_Report_Exporter::update_export_percentage_complete( $report_type, $export_id, 0 );
+		WC_Admin_Report_Exporter::update_export_percentage_complete( $user_id, $report_type, $export_id, 0 );
 
 		// @todo: handle error case?
 		$result = array(
@@ -197,7 +197,8 @@ class WC_Admin_REST_Reports_Export_Controller extends WC_Admin_REST_Reports_Cont
 	public function export_status( $request ) {
 		$report_type = $request['type'];
 		$export_id   = $request['export_id'];
-		$percentage  = WC_Admin_Report_Exporter::get_export_percentage_complete( $report_type, $export_id );
+		$user_id     = get_current_user_id();
+		$percentage  = WC_Admin_Report_Exporter::get_export_percentage_complete( $user_id, $report_type, $export_id );
 
 		if ( false === $percentage ) {
 			return new WP_Error(

--- a/includes/class-wc-admin-api-init.php
+++ b/includes/class-wc-admin-api-init.php
@@ -132,6 +132,7 @@ class WC_Admin_Api_Init {
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-reports-stock-stats-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-taxes-controller.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-customers-controller.php';
+		require_once WC_ADMIN_ABSPATH . 'includes/api/class-wc-admin-rest-reports-export-controller.php';
 
 		$controllers = array(
 			'WC_Admin_REST_Admin_Notes_Controller',
@@ -151,6 +152,7 @@ class WC_Admin_Api_Init {
 			'WC_Admin_REST_Reports_Controller',
 			'WC_Admin_REST_Setting_Options_Controller',
 			'WC_Admin_REST_Reports_Import_Controller',
+			'WC_Admin_REST_Reports_Export_Controller',
 			'WC_Admin_REST_Reports_Products_Controller',
 			'WC_Admin_REST_Reports_Variations_Controller',
 			'WC_Admin_REST_Reports_Products_Stats_Controller',

--- a/includes/export/class-wc-admin-report-csv-exporter.php
+++ b/includes/export/class-wc-admin-report-csv-exporter.php
@@ -47,12 +47,17 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * @param string $type Report type. E.g. 'customers'.
 	 * @param array  $args Report parameters.
 	 */
-	public function __construct( $type, $args ) {
+	public function __construct( $type = false, $args = array() ) {
 		parent::__construct();
 
-		$this->set_report_type( $type );
-		$this->set_report_args( $args );
-		$this->set_column_names( $this->get_report_columns() );
+		if ( ! empty( $type ) ) {
+			$this->set_report_type( $type );
+			$this->set_column_names( $this->get_report_columns() );
+		}
+
+		if ( ! empty( $args ) ) {
+			$this->set_report_args( $args );
+		}
 	}
 
 	/**

--- a/includes/export/class-wc-admin-report-csv-exporter.php
+++ b/includes/export/class-wc-admin-report-csv-exporter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles reports CSV export.
+ * Handles reports CSV export batches.
  *
  * @package WooCommerce/Export
  */
@@ -50,7 +50,6 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	public function __construct( $type, $args ) {
 		parent::__construct();
 
-		$this->set_limit( 10 );
 		$this->set_report_type( $type );
 		$this->set_report_args( $args );
 		$this->set_column_names( $this->get_report_columns() );
@@ -64,7 +63,7 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	public function set_report_type( $type ) {
 		$this->report_type = $type;
 		$this->export_type = "admin_{$type}_report";
-		$this->filename    = "wc-{$type}-report-export.csv";
+		$this->filename    = "wc-{$type}-report-export";
 		$this->controller  = $this->map_report_controller();
 	}
 
@@ -110,7 +109,11 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		);
 
 		if ( isset( $controller_map[ $this->report_type ] ) ) {
-			// @todo: load the controllers if accessing outside a context where the REST API is loaded?
+			// Load the controllers if accessing outside the REST API.
+			if ( ! did_action( 'rest_api_init' ) ) {
+				do_action( 'rest_api_init' );
+			}
+
 			return new $controller_map[ $this->report_type ]();
 		}
 
@@ -152,6 +155,15 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 */
 	public function get_percent_complete() {
 		return intval( parent::get_percent_complete() );
+	}
+
+	/**
+	 * Get total number of rows in export.
+	 *
+	 * @return int Number of rows to export.
+	 */
+	public function get_total_rows() {
+		return $this->total_rows;
 	}
 
 	/**

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -78,6 +78,7 @@ class WC_Admin_Report_Exporter {
 		$num_batches = (int) ceil( $total_rows / $batch_size );
 		$start_time  = time() + 5;
 
+		// @todo - batch these batches, like initial import.
 		for ( $batch = 1; $batch <= $num_batches; $batch++ ) {
 			$report_batch_args = array_merge(
 				$report_args,

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -172,7 +172,8 @@ class WC_Admin_Report_Exporter {
 		if (
 			isset( $_GET['action'] ) &&
 			! empty( $_GET['filename'] ) &&
-			self::DOWNLOAD_EXPORT_ACTION === wp_unslash( $_GET['action'] ) // WPCS: input var ok, sanitization ok.
+			self::DOWNLOAD_EXPORT_ACTION === wp_unslash( $_GET['action'] ) && // WPCS: input var ok, sanitization ok.
+			current_user_can( 'view_woocommerce_reports' )
 		) {
 			$exporter = new WC_Admin_Report_CSV_Exporter();
 			$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // WPCS: input var ok, sanitization ok.

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -72,7 +72,7 @@ class WC_Admin_Report_Exporter {
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param array  $report_args Report parameters, passed to data query.
-	 * @return void
+	 * @return int Number of items to export.
 	 */
 	public static function queue_report_export( $user_id, $export_id, $report_type, $report_args = array() ) {
 		$exporter = new WC_Admin_Report_CSV_Exporter( $report_type, $report_args );
@@ -99,6 +99,8 @@ class WC_Admin_Report_Exporter {
 				self::QUEUE_GROUP
 			);
 		}
+
+		return $total_rows;
 	}
 
 	/**

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -29,6 +29,11 @@ class WC_Admin_Report_Exporter {
 	const EXPORT_STATUS_OPTION = 'wc_admin_report_export_status';
 
 	/**
+	 * Export file download action.
+	 */
+	const DOWNLOAD_EXPORT_ACTION = 'woocommerce_admin_download_report_csv';
+
+	/**
 	 * Queue instance.
 	 *
 	 * @var WC_Queue_Interface
@@ -63,6 +68,8 @@ class WC_Admin_Report_Exporter {
 	public static function init() {
 		// Initialize scheduled action handlers.
 		add_action( self::REPORT_EXPORT_ACTION, array( __CLASS__, 'report_export_action' ), 10, 4 );
+		// Report download handler.
+		add_action( 'admin_init', array( __CLASS__, 'download_export_file' ) );
 	}
 
 	/**
@@ -155,6 +162,22 @@ class WC_Admin_Report_Exporter {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Serve the export file.
+	 */
+	public static function download_export_file() {
+		// @todo - add nonce? (nonces are good for 24 hours)
+		if (
+			isset( $_GET['action'] ) &&
+			! empty( $_GET['filename'] ) &&
+			self::DOWNLOAD_EXPORT_ACTION === wp_unslash( $_GET['action'] ) // WPCS: input var ok, sanitization ok.
+		) {
+			$exporter = new WC_Admin_Report_CSV_Exporter();
+			$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // WPCS: input var ok, sanitization ok.
+			$exporter->export();
+		}
 	}
 }
 

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -24,6 +24,11 @@ class WC_Admin_Report_Exporter {
 	const QUEUE_GROUP = 'wc-admin-data';
 
 	/**
+	 * Export status option name.
+	 */
+	const EXPORT_STATUS_OPTION = 'wc_admin_report_export_status';
+
+	/**
 	 * Queue instance.
 	 *
 	 * @var WC_Queue_Interface
@@ -109,6 +114,48 @@ class WC_Admin_Report_Exporter {
 		$exporter = new WC_Admin_Report_CSV_Exporter( $report_type, $report_args );
 		$exporter->set_filename( "wc-{$report_type}-report-export-{$user_id}-{$export_id}" );
 		$exporter->generate_file();
+
+		self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
+	}
+
+	/**
+	 * Update the completion percentage of a report export.
+	 *
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @param int    $percentage Completion percentage.
+	 * @return void
+	 */
+	public static function update_export_percentage_complete( $report_type, $export_id, $percentage ) {
+		$exports_status = get_option( self::EXPORT_STATUS_OPTION, array() );
+
+		if ( ! isset( $exports_status[ $report_type ] ) ) {
+			$exports_status[ $report_type ] = array();
+		}
+
+		$exports_status[ $report_type ][ $export_id ] = $percentage;
+
+		update_option( self::EXPORT_STATUS_OPTION, $exports_status );
+	}
+
+	/**
+	 * Get the completion percentage of a report export.
+	 *
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @return bool|int Completion percentage, or false if export not found.
+	 */
+	public static function get_export_percentage_complete( $report_type, $export_id ) {
+		$exports_status = get_option( self::EXPORT_STATUS_OPTION, array() );
+
+		if (
+			isset( $exports_status[ $report_type ] ) &&
+			isset( $exports_status[ $report_type ][ $export_id ] )
+		) {
+			return $exports_status[ $report_type ][ $export_id ];
+		}
+
+		return false;
 	}
 }
 

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -62,19 +62,18 @@ class WC_Admin_Report_Exporter {
 	 */
 	public static function init() {
 		// Initialize scheduled action handlers.
-		add_action( self::REPORT_EXPORT_ACTION, array( __CLASS__, 'report_export_action' ), 10, 5 );
+		add_action( self::REPORT_EXPORT_ACTION, array( __CLASS__, 'report_export_action' ), 10, 4 );
 	}
 
 	/**
 	 * Queue up actions for a full report export.
 	 *
-	 * @param int    $user_id User requesting export.
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param array  $report_args Report parameters, passed to data query.
 	 * @return int Number of items to export.
 	 */
-	public static function queue_report_export( $user_id, $export_id, $report_type, $report_args = array() ) {
+	public static function queue_report_export( $export_id, $report_type, $report_args = array() ) {
 		$exporter = new WC_Admin_Report_CSV_Exporter( $report_type, $report_args );
 		$exporter->prepare_data_to_export();
 
@@ -84,7 +83,7 @@ class WC_Admin_Report_Exporter {
 		$start_time  = time() + 5;
 
 		// Create batches, like initial import.
-		$report_batch_args = array( $user_id, $export_id, $report_type, $report_args );
+		$report_batch_args = array( $export_id, $report_type, $report_args );
 
 		if ( 0 < $num_batches ) {
 			WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, self::REPORT_EXPORT_ACTION, $report_batch_args );
@@ -97,46 +96,43 @@ class WC_Admin_Report_Exporter {
 	 * Process a report export action.
 	 *
 	 * @param int    $page_number Page number for this action.
-	 * @param int    $user_id User requesting export.
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param array  $report_args Report parameters, passed to data query.
 	 * @return void
 	 */
-	public static function report_export_action( $page_number, $user_id, $export_id, $report_type, $report_args ) {
+	public static function report_export_action( $page_number, $export_id, $report_type, $report_args ) {
 		$report_args['page'] = $page_number;
 
 		$exporter = new WC_Admin_Report_CSV_Exporter( $report_type, $report_args );
-		$exporter->set_filename( "wc-{$report_type}-report-export-{$user_id}-{$export_id}" );
+		$exporter->set_filename( "wc-{$report_type}-report-export-{$export_id}" );
 		$exporter->generate_file();
 
-		self::update_export_percentage_complete( $user_id, $report_type, $export_id, $exporter->get_percent_complete() );
+		self::update_export_percentage_complete( $report_type, $export_id, $exporter->get_percent_complete() );
 	}
 
 	/**
 	 * Generate a key to reference an export status.
 	 *
-	 * @param int    $user_id User ID who requested the export.
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @return string Status key.
 	 */
-	protected static function get_status_key( $user_id, $report_type, $export_id ) {
-		return implode( ':', array( $user_id, $report_type, $export_id ) );
+	protected static function get_status_key( $report_type, $export_id ) {
+		return $report_type . ':' . $export_id;
 	}
 
 	/**
 	 * Update the completion percentage of a report export.
 	 *
-	 * @param int    $user_id User ID who requested the export.
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @param int    $percentage Completion percentage.
 	 * @return void
 	 */
-	public static function update_export_percentage_complete( $user_id, $report_type, $export_id, $percentage ) {
+	public static function update_export_percentage_complete( $report_type, $export_id, $percentage ) {
 		$exports_status = get_option( self::EXPORT_STATUS_OPTION, array() );
-		$status_key     = self::get_status_key( $user_id, $report_type, $export_id );
+		$status_key     = self::get_status_key( $report_type, $export_id );
 
 		$exports_status[ $status_key ] = $percentage;
 
@@ -146,14 +142,13 @@ class WC_Admin_Report_Exporter {
 	/**
 	 * Get the completion percentage of a report export.
 	 *
-	 * @param int    $user_id User ID who requested the export.
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @return bool|int Completion percentage, or false if export not found.
 	 */
-	public static function get_export_percentage_complete( $user_id, $report_type, $export_id ) {
+	public static function get_export_percentage_complete( $report_type, $export_id ) {
 		$exports_status = get_option( self::EXPORT_STATUS_OPTION, array() );
-		$status_key     = self::get_status_key( $user_id, $report_type, $export_id );
+		$status_key     = self::get_status_key( $report_type, $export_id );
 
 		if ( isset( $exports_status[ $status_key ] ) ) {
 			return $exports_status[ $status_key ];

--- a/includes/export/class-wc-admin-report-exporter.php
+++ b/includes/export/class-wc-admin-report-exporter.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Handles reports CSV export.
+ *
+ * @package WooCommerce/Export
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Admin_Report_Exporter Class.
+ */
+class WC_Admin_Report_Exporter {
+	/**
+	 * Action hook for generating a report export.
+	 */
+	const REPORT_EXPORT_ACTION = 'wc-admin_report_export';
+
+	/**
+	 * Action scheduler group.
+	 */
+	const QUEUE_GROUP = 'wc-admin-data';
+
+	/**
+	 * Queue instance.
+	 *
+	 * @var WC_Queue_Interface
+	 */
+	protected static $queue = null;
+
+	/**
+	 * Get queue instance.
+	 *
+	 * @return WC_Queue_Interface
+	 */
+	public static function queue() {
+		if ( is_null( self::$queue ) ) {
+			self::$queue = WC()->queue();
+		}
+
+		return self::$queue;
+	}
+
+	/**
+	 * Set queue instance.
+	 *
+	 * @param WC_Queue_Interface $queue Queue instance.
+	 */
+	public static function set_queue( $queue ) {
+		self::$queue = $queue;
+	}
+
+	/**
+	 * Hook in action methods.
+	 */
+	public static function init() {
+		// Initialize scheduled action handlers.
+		add_action( self::REPORT_EXPORT_ACTION, array( __CLASS__, 'report_export_action' ), 10, 4 );
+	}
+
+	/**
+	 * Queue up actions for a full report export.
+	 *
+	 * @param int    $user_id User requesting export.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param array  $report_args Report parameters, passed to data query.
+	 * @return void
+	 */
+	public static function queue_report_export( $user_id, $export_id, $report_type, $report_args = array() ) {
+		$exporter = new WC_Admin_Report_CSV_Exporter( $report_type, $report_args );
+		$exporter->prepare_data_to_export();
+
+		$total_rows  = $exporter->get_total_rows();
+		$batch_size  = $exporter->get_limit();
+		$num_batches = (int) ceil( $total_rows / $batch_size );
+		$start_time  = time() + 5;
+
+		for ( $batch = 1; $batch <= $num_batches; $batch++ ) {
+			$report_batch_args = array_merge(
+				$report_args,
+				array(
+					'page' => $batch,
+				)
+			);
+
+			self::queue()->schedule_single(
+				$action_timestamp,
+				self::REPORT_EXPORT_ACTION,
+				array( $user_id, $export_id, $report_type, $report_batch_args ),
+				self::QUEUE_GROUP
+			);
+		}
+	}
+
+	/**
+	 * Process a report export action.
+	 *
+	 * @param int    $user_id User requesting export.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @param array  $report_args Report parameters, passed to data query.
+	 * @return void
+	 */
+	public static function report_export_action( $user_id, $export_id, $report_type, $report_args ) {
+		$exporter = new WC_Admin_Report_CSV_Exporter( $report_type, $report_args );
+		$exporter->set_filename( "wc-{$report_type}-report-export-{$user_id}-{$export_id}" );
+		$exporter->generate_file();
+	}
+}
+
+WC_Admin_Report_Exporter::init();

--- a/tests/api/reports-export.php
+++ b/tests/api/reports-export.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Reports Export REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+
+/**
+ * Class WC_Tests_API_Reports_Export
+ */
+class WC_Tests_API_Reports_Export extends WC_REST_Unit_Test_Case {
+	/**
+	 * Export route.
+	 *
+	 * @var string
+	 */
+	protected $export_route = '/wc/v4/reports/(?P<type>[a-z]+)/export';
+
+	/**
+	 * Export status route.
+	 *
+	 * @var string
+	 */
+	protected $status_route = '/wc/v4/reports/(?P<type>[a-z]+)/export/(?P<export_id>[a-z0-9]+)/status';
+
+	/**
+	 * Setup test reports categories data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->export_route, $routes );
+		$this->assertArrayHasKey( $this->status_route, $routes );
+	}
+
+	/**
+	 * Test the export of a taxes report.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_taxes_report_export() {
+		global $wpdb;
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		// Add a GA tax rate.
+		$ga_rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate'          => '7',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'GA',
+				'tax_rate_name'     => 'GA Tax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		// Add a FL tax rate.
+		$fl_rate_id = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate'          => '6',
+				'tax_rate_country'  => 'US',
+				'tax_rate_state'    => 'FL',
+				'tax_rate_name'     => 'FL Tax',
+				'tax_rate_priority' => 1,
+				'tax_rate_order'    => 1,
+			)
+		);
+
+		// Create a GA order.
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_billing_city( 'Savannah' );
+		$order->set_billing_state( 'GA' );
+		$order->set_billing_postcode( '31401' );
+		$order->set_status( 'completed' );
+		$order->calculate_totals();
+		$order->save();
+
+		// Create a FL order.
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_billing_city( 'Orlando' );
+		$order->set_billing_state( 'FL' );
+		$order->set_billing_postcode( '32801' );
+		$order->set_status( 'completed' );
+		$order->calculate_totals();
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Initiate an export of the taxes report.
+		$response   = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v4/reports/taxes/export' ) );
+		$export     = $response->get_data();
+		$status_url = $export['_links']['status'][0]['href'];
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $export['status'] );
+		$this->assertEquals( 'Your report file is being generated.', $export['message'] );
+		$this->assertStringMatchesFormat( '%s/wc/v4/reports/taxes/export/%d/status', $status_url );
+
+		// Check the initial status of the export.
+		$status_url_query = array();
+		parse_str( parse_url( $status_url, PHP_URL_QUERY ), $status_url_query );
+		$status_route = $status_url_query['rest_route'];
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $status_route ) );
+		$status   = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, $status['percent_complete'] );
+		$this->assertStringMatchesFormat( '%s/wc/v4/reports/taxes/export/%d/status', $status['_links']['self'][0]['href'] );
+
+		// Run the pending export jobs.
+		WC_Helper_Queue::run_all_pending();
+
+		// Check that the status shows 100% and includes a download url.
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $status_route ) );
+		$status   = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 100, $status['percent_complete'] );
+		$this->assertStringMatchesFormat( '%s/wp-admin/?action=woocommerce_admin_download_report_csv&filename=wc-taxes-report-export-%d', $status['download_url'] );
+		$this->assertStringMatchesFormat( '%s/wc/v4/reports/taxes/export/%d/status', $status['_links']['self'][0]['href'] );
+	}
+}

--- a/tests/api/reports-export.php
+++ b/tests/api/reports-export.php
@@ -52,6 +52,15 @@ class WC_Tests_API_Reports_Export extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test requesting export without valid permissions.
+	 */
+	public function test_request_export_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v4/reports/taxes/export' ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * Test the export of a taxes report.
 	 *
 	 * @since 3.5.0

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -90,6 +90,8 @@ function _manually_load_plugin() {
 	define( 'WC_TAX_ROUNDING_MODE', 'auto' );
 	define( 'WC_USE_TRANSACTIONS', false );
 	update_option( 'woocommerce_enable_coupons', 'yes' );
+	update_option( 'woocommerce_calc_taxes', 'yes' );
+
 	require_once wc_dir() . '/woocommerce.php';
 
 	wc_admin_install();

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -146,6 +146,7 @@ class WC_Admin_Feature_Plugin {
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-events.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/class-wc-admin-api-init.php';
 		require_once WC_ADMIN_ABSPATH . 'includes/export/class-wc-admin-report-csv-exporter.php';
+		require_once WC_ADMIN_ABSPATH . 'includes/export/class-wc-admin-report-exporter.php';
 
 		// Data triggers.
 		require_once WC_ADMIN_ABSPATH . 'includes/data-stores/class-wc-admin-notes-data-store.php';


### PR DESCRIPTION
Addresses #311 partially.

This PR adds:

- 2 new endpoints: `/reports/[type]/export` and `/reports/[type]/export[id]/status`
- Export file download capability (on `admin_init`, like core's product export)
- Queued batch creation of report export files
- Example filter for modifying schema when adding fields to report API responses

### Detailed test instructions:

- `POST /wc/v4/reports/products/export`
- `GET /wc/v4/reports/products/export/<id here>/status` (get URL from `POST` response)
- When 100%, `download_url` should be in status response
- Open download URL in browser
- Verify CSV contents
