### PR TITLE
Remove hover on Card component

### DIFF
--- a/packages/components/src/card/style.scss
+++ b/packages/components/src/card/style.scss
@@ -12,10 +12,6 @@
 		width: auto;
 	}
 
-	&:hover {
-		box-shadow: $muriel-box-shadow-8dp;
-	}
-
 	&.is-inactive {
 		background-color: $muriel-gray-0;
 		box-shadow: none;


### PR DESCRIPTION
This PR removes the hover effect on `Card` components.

See p1561568187019900-slack-wc-onboarding

### Detailed test instructions:

* Open up the onboarding wizard and hover over a card. See no hover style.

### Changelog Note:

Card component: updated default Muriel design.
