### PR TITLE
Onboarding - Profile Wizard: Add tracks events

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -37,13 +37,9 @@ class BusinessDetails extends Component {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 		const { other_platform, product_count, selling_venues } = this.state;
 
-		const alreadySelling = [ 'other', 'brick-mortar-other', 'brick-mortar' ].includes(
-			selling_venues
-		);
-
-		recordEvent( 'storeprofiler_store_business_details', {
+		recordEvent( 'storeprofiler_store_business_details_continue', {
 			product_number: product_count,
-			already_selling: alreadySelling,
+			already_selling: 'no' !== selling_venues,
 			used_platform: other_platform,
 		} );
 

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -18,6 +18,7 @@ import { numberFormat } from '@woocommerce/number';
  */
 import { H, Card } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class BusinessDetails extends Component {
 	constructor() {
@@ -35,6 +36,16 @@ class BusinessDetails extends Component {
 	async onContinue() {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 		const { other_platform, product_count, selling_venues } = this.state;
+
+		const alreadySelling = [ 'other', 'brick-mortar-other', 'brick-mortar' ].includes(
+			selling_venues
+		);
+
+		recordEvent( 'storeprofiler_store_business_details', {
+			product_number: product_count,
+			already_selling: alreadySelling,
+			used_platform: other_platform,
+		} );
 
 		await updateProfileItems( { other_platform, product_count, selling_venues } );
 

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -29,7 +29,7 @@ class Industry extends Component {
 	async onContinue() {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 
-		recordEvent( 'storeprofiler_store_industry', { store_industry: this.state.selected } );
+		recordEvent( 'storeprofiler_store_industry_continue', { store_industry: this.state.selected } );
 		await updateProfileItems( { industry: this.state.selected } );
 
 		if ( ! isError ) {

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -14,6 +14,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { H, Card } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class Industry extends Component {
 	constructor() {
@@ -28,6 +29,7 @@ class Industry extends Component {
 	async onContinue() {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 
+		recordEvent( 'storeprofiler_store_industry', { store_industry: this.state.selected } );
 		await updateProfileItems( { industry: this.state.selected } );
 
 		if ( ! isError ) {

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -84,7 +84,7 @@ class Plugins extends Component {
 			isPending: true,
 		} );
 
-		recordEvent( 'storeprofiler_plugin_install' );
+		recordEvent( 'storeprofiler_install_plugin' );
 
 		forEach( plugins, async plugin => {
 			const response = await this.doPluginAction( 'activate', plugin );

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -15,6 +15,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { H, Stepper, Card } from '@woocommerce/components';
 import { NAMESPACE } from 'wc-api/onboarding/constants';
+import { recordEvent } from 'lib/tracks';
 
 const plugins = [ 'jetpack', 'woocommerce-services' ];
 
@@ -82,6 +83,8 @@ class Plugins extends Component {
 		this.setState( {
 			isPending: true,
 		} );
+
+		recordEvent( 'storeprofiler_plugin_install' );
 
 		forEach( plugins, async plugin => {
 			const response = await this.doPluginAction( 'activate', plugin );

--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -15,6 +15,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { H, Card, Link } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class ProductTypes extends Component {
 	constructor() {
@@ -31,6 +32,7 @@ class ProductTypes extends Component {
 	async onContinue() {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 
+		recordEvent( 'storeprofiler_store_product_type', { product_type: this.state.selected } );
 		await updateProfileItems( { product_types: this.state.selected } );
 
 		if ( ! isError ) {
@@ -61,6 +63,10 @@ class ProductTypes extends Component {
 		} );
 	}
 
+	onLearnMore( slug ) {
+		recordEvent( 'storeprofiler_store_product_type_learn_more', { product_type: slug } );
+	}
+
 	render() {
 		const { productTypes } = wcSettings.onboarding;
 		const { selected } = this.state;
@@ -80,7 +86,12 @@ class ProductTypes extends Component {
 									( productTypes[ slug ].more_url ? ' {{moreLink/}}' : '' ),
 								components: {
 									moreLink: productTypes[ slug ].more_url ? (
-										<Link href={ productTypes[ slug ].more_url } target="_blank" type="external">
+										<Link
+											href={ productTypes[ slug ].more_url }
+											target="_blank"
+											type="external"
+											onClick={ () => this.onLearnMore( slug ) }
+										>
 											{ __( 'Learn more', 'woocommerce-admin' ) }
 										</Link>
 									) : (

--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -32,7 +32,9 @@ class ProductTypes extends Component {
 	async onContinue() {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 
-		recordEvent( 'storeprofiler_store_product_type', { product_type: this.state.selected } );
+		recordEvent( 'storeprofiler_store_product_type_continue', {
+			product_type: this.state.selected,
+		} );
 		await updateProfileItems( { product_types: this.state.selected } );
 
 		if ( ! isError ) {

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -79,7 +79,7 @@ class Start extends Component {
 	async skipWizard() {
 		const { addNotice, isProfileItemsError, updateProfileItems, isSettingsError } = this.props;
 
-		recordEvent( 'storeprofiler_welcome_skip' );
+		recordEvent( 'storeprofiler_welcome_clicked', { proceed_without_install: true } );
 
 		await updateProfileItems( { skipped: true } );
 		await this.updateTracking();
@@ -95,7 +95,7 @@ class Start extends Component {
 	async startWizard() {
 		const { addNotice, isSettingsError } = this.props;
 
-		recordEvent( 'storeprofiler_welcome' );
+		recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
 
 		await this.updateTracking();
 

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -20,6 +20,7 @@ import SpeedIcon from './images/flash_on';
 import MobileAppIcon from './images/phone_android';
 import './style.scss';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 const benefits = [
 	{
@@ -78,6 +79,8 @@ class Start extends Component {
 	async skipWizard() {
 		const { addNotice, isProfileItemsError, updateProfileItems, isSettingsError } = this.props;
 
+		recordEvent( 'storeprofiler_welcome_skip' );
+
 		await updateProfileItems( { skipped: true } );
 		await this.updateTracking();
 
@@ -91,6 +94,8 @@ class Start extends Component {
 
 	async startWizard() {
 		const { addNotice, isSettingsError } = this.props;
+
+		recordEvent( 'storeprofiler_welcome' );
 
 		await this.updateTracking();
 

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -55,7 +55,9 @@ class StoreDetails extends Component {
 		const { addNotice, goToNextStep, isError, updateSettings } = this.props;
 		const { addressLine1, addressLine2, city, countryState, postCode } = this.state;
 
-		recordEvent( 'storeprofiler_store_details', { store_country: countryState.split( ':' )[ 0 ] } );
+		recordEvent( 'storeprofiler_store_details_continue', {
+			store_country: countryState.split( ':' )[ 0 ],
+		} );
 
 		await updateSettings( {
 			general: {

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -8,6 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
 import { withDispatch } from '@wordpress/data';
+import { recordEvent } from 'lib/tracks';
 
 /**
  * Internal depdencies
@@ -53,6 +54,8 @@ class StoreDetails extends Component {
 
 		const { addNotice, goToNextStep, isError, updateSettings } = this.props;
 		const { addressLine1, addressLine2, city, countryState, postCode } = this.state;
+
+		recordEvent( 'storeprofiler_store_details', { store_country: countryState.split( ':' )[ 0 ] } );
 
 		await updateSettings( {
 			general: {

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -55,7 +55,7 @@ class Theme extends Component {
 	openDemo( theme ) {
 		// @todo This should open a theme demo preview.
 
-		recordEvent( 'storeprofiler_store_theme_demo', { theme } );
+		recordEvent( 'storeprofiler_store_theme_live_demo', { theme } );
 	}
 
 	renderTheme( theme ) {

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -20,6 +20,7 @@ import { Card, H } from '@woocommerce/components';
  */
 import withSelect from 'wc-api/with-select';
 import './style.scss';
+import { recordEvent } from 'lib/tracks';
 
 class Theme extends Component {
 	constructor() {
@@ -37,6 +38,7 @@ class Theme extends Component {
 	async onChoose( theme ) {
 		const { addNotice, goToNextStep, isError, updateProfileItems } = this.props;
 
+		recordEvent( 'storeprofiler_store_theme_choose', { theme } );
 		await updateProfileItems( { theme } );
 
 		if ( ! isError ) {
@@ -50,8 +52,10 @@ class Theme extends Component {
 		}
 	}
 
-	openDemo() {
+	openDemo( theme ) {
 		// @todo This should open a theme demo preview.
+
+		recordEvent( 'storeprofiler_store_theme_demo', { theme } );
 	}
 
 	renderTheme( theme ) {
@@ -83,6 +87,7 @@ class Theme extends Component {
 	}
 
 	onSelectTab( tab ) {
+		recordEvent( 'storeprofiler_store_theme_navigate', { navigation: tab } );
 		this.setState( { activeTab: tab } );
 	}
 


### PR DESCRIPTION
Partially fixes #2163.

This PR implements all the tracks that we can for the profiler on the `wc-admin` side. Another PR for Calypso will be coming soon.

There are a couple more events that need implemented in the theme demo PR, cc @joshuatf,  if you don't mind handling the three `wcadmin_storeprofiler_store_theme_demo_` events from the spreadsheet.

### Detailed test instructions:

* In your console, enter `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
* Walk through the various steps and see the debug messages in your console.