### PR TITLE
Tracks: Fix double wcadmin_ prefix.

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -50,7 +50,7 @@ class ActivityPanel extends Component {
 
 		// If a panel is being opened, or if an existing panel is already open and a different one is being opened, record a track.
 		if ( ! isPanelOpen || tabName !== currentTab ) {
-			recordEvent( 'wcadmin_activity_panel_open', { tab: tabName } );
+			recordEvent( 'activity_panel_open', { tab: tabName } );
 		}
 
 		// The WordPress Notices tab is handled differently, since they are displayed inline, so the panel should be closed,

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -17,7 +17,7 @@ const tracksDebug = debug( 'wc-admin:tracks' );
  */
 
 export function recordEvent( eventName, eventProperties ) {
-	tracksDebug( 'recordevent %s %o', eventName, eventProperties );
+	tracksDebug( 'recordevent %s %o', 'wc_admin_' + eventName, eventProperties );
 
 	if (
 		! window.wcTracks ||

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -12,7 +12,7 @@ const tracksDebug = debug( 'wc-admin:tracks' );
 /**
  * Record an event to Tracks
  *
- * @param {String} eventName The name of the event to record, always prefixed with wca_
+ * @param {String} eventName The name of the event to record, always prefixed with wcadmin_
  * @param {Object} eventProperties event properties to include in the event
  */
 

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -12,7 +12,7 @@ const tracksDebug = debug( 'wc-admin:tracks' );
 /**
  * Record an event to Tracks
  *
- * @param {String} eventName The name of the event to record, always prefixed with wcadmin_
+ * @param {String} eventName The name of the event to record, always prefixed with wc_admin_
  * @param {Object} eventProperties event properties to include in the event
  */
 


### PR DESCRIPTION
This is a follow-up to #2498 - in that PR I accidentally added the `wc_admin_` prefix to the track name, and I forgot that the base tracks logic in Woo core already adds this in for us. This resulted in the track being currently recorded as `wc_admin_wc_admin_activity_panel_open`.

I also updated the debug statement here to prefix the event name shown in the debugger so hopefully others won't make the same mistake :)

**Before:**
<img width="639" alt="prefix_debug" src="https://user-images.githubusercontent.com/22080/60298311-150fd980-98df-11e9-90ee-cd59cfed709d.png">

**After:**
<img width="587" alt="tracks-afer" src="https://user-images.githubusercontent.com/22080/60298321-19d48d80-98df-11e9-90b7-c5e499d6527f.png">

**To Test**
Follow the same testing instructions in #2498 to verify the event is being logged, and that it only has one `wc_admin` prefix.

### Changelog Note:

Fix: Track name for activity panel open event
