### PR TITLE
Always return columns in ‘posts_fields’ filters.

### DIFF
--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -135,8 +135,10 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 */
 	public static function add_wp_query_fields( $select, $wp_query ) {
 		if ( $wp_query->get( 'low_in_stock' ) ) {
-			return $select . ', low_stock_amount_meta.meta_value AS low_stock_amount';
+			$select .= ', low_stock_amount_meta.meta_value AS low_stock_amount';
 		}
+
+		return $select;
 	}
 
 	/**


### PR DESCRIPTION
Fixes a filter that doesn't always return in the `/products` endpoint.

_Introduced in https://github.com/woocommerce/woocommerce-admin/pull/2442_

### Detailed test instructions:

- On `master`
- Go to Analytics > Products
- Attempt to filter on a single product
- Notice an error in the network response
- Check out this branch
- Go to Analytics > Products
- Attempt to filter on a single product
- Verify it works as expected

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

None needed - fixing an unreleased bug.
