### PR TITLE
Settings: Better structure to settings page, and protect form changes

### DIFF
--- a/client/analytics/settings/historical-data/layout.js
+++ b/client/analytics/settings/historical-data/layout.js
@@ -8,6 +8,11 @@ import { isNil } from 'lodash';
 import { SECOND } from '@fresh-data/framework';
 
 /**
+ * WooCommerce dependencies
+ */
+import { SectionHeader } from '@woocommerce/components';
+
+/**
  * Internal dependencies
  */
 import { DEFAULT_REQUIREMENT } from 'wc-api/constants';
@@ -50,45 +55,45 @@ class HistoricalDataLayout extends Component {
 
 		return (
 			<Fragment>
-				<div className="woocommerce-setting">
-					<div className="woocommerce-setting__label" id="import-historical-data-label">
-						{ __( 'Import Historical Data:', 'woocommerce-admin' ) }
-					</div>
-					<div className="woocommerce-setting__input">
-						<span className="woocommerce-setting__help">
-							{ __(
-								'This tool populates historical analytics data by processing customers ' +
-									'and orders created prior to activating WooCommerce Admin.',
-								'woocommerce-admin'
+				<SectionHeader title={ __( 'Import Historical Data', 'woocommerce-admin' ) } />
+				<div className="woocommerce-settings__wrapper">
+					<div className="woocommerce-setting">
+						<div className="woocommerce-setting__input">
+							<span className="woocommerce-setting__help">
+								{ __(
+									'This tool populates historical analytics data by processing customers ' +
+										'and orders created prior to activating WooCommerce Admin.',
+									'woocommerce-admin'
+								) }
+							</span>
+							{ status !== 'finished' && (
+								<Fragment>
+									<HistoricalDataPeriodSelector
+										dateFormat={ dateFormat }
+										disabled={ inProgress }
+										onPeriodChange={ onPeriodChange }
+										onDateChange={ onDateChange }
+										value={ period }
+									/>
+									<HistoricalDataSkipCheckbox
+										disabled={ inProgress }
+										checked={ skipChecked }
+										onChange={ onSkipChange }
+									/>
+									<HistoricalDataProgress
+										label={ __( 'Registered Customers', 'woocommerce-admin' ) }
+										progress={ customersProgress }
+										total={ customersTotal }
+									/>
+									<HistoricalDataProgress
+										label={ __( 'Orders', 'woocommerce-admin' ) }
+										progress={ ordersProgress }
+										total={ ordersTotal }
+									/>
+								</Fragment>
 							) }
-						</span>
-						{ status !== 'finished' && (
-							<Fragment>
-								<HistoricalDataPeriodSelector
-									dateFormat={ dateFormat }
-									disabled={ inProgress }
-									onPeriodChange={ onPeriodChange }
-									onDateChange={ onDateChange }
-									value={ period }
-								/>
-								<HistoricalDataSkipCheckbox
-									disabled={ inProgress }
-									checked={ skipChecked }
-									onChange={ onSkipChange }
-								/>
-								<HistoricalDataProgress
-									label={ __( 'Registered Customers', 'woocommerce-admin' ) }
-									progress={ customersProgress }
-									total={ customersTotal }
-								/>
-								<HistoricalDataProgress
-									label={ __( 'Orders', 'woocommerce-admin' ) }
-									progress={ ordersProgress }
-									total={ ordersTotal }
-								/>
-							</Fragment>
-						) }
-						<HistoricalDataStatus importDate={ importDate } status={ status } />
+							<HistoricalDataStatus importDate={ importDate } status={ status } />
+						</div>
 					</div>
 				</div>
 				<HistoricalDataActions

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -36,9 +36,19 @@ class Settings extends Component {
 		this.state = {
 			settings,
 			saving: false,
+			isDirty: false,
 		};
 
 		this.handleInputChange = this.handleInputChange.bind( this );
+		this.warnIfUnsavedChanges = this.warnIfUnsavedChanges.bind( this );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'beforeunload', this.warnIfUnsavedChanges );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'beforeunload', this.warnIfUnsavedChanges );
 	}
 
 	componentDidCatch( error ) {
@@ -48,6 +58,18 @@ class Settings extends Component {
 		/* eslint-disable no-console */
 		console.warn( error );
 		/* eslint-enable no-console */
+	}
+
+	warnIfUnsavedChanges( event ) {
+		const { isDirty } = this.state;
+
+		if ( isDirty ) {
+			event.returnValue = __(
+				'You have unsaved changes. If you proceed, they will be lost.',
+				'woocommerce-admin'
+			);
+			return event.returnValue;
+		}
 	}
 
 	resetDefaults = () => {
@@ -64,7 +86,8 @@ class Settings extends Component {
 
 	componentDidUpdate() {
 		const { addNotice, isError, isRequesting } = this.props;
-		const { saving } = this.state;
+		const { saving, isDirty } = this.state;
+		let newIsDirtyState = isDirty;
 
 		if ( saving && ! isRequesting ) {
 			if ( ! isError ) {
@@ -72,6 +95,7 @@ class Settings extends Component {
 					status: 'success',
 					message: __( 'Your settings have been successfully saved.', 'woocommerce-admin' ),
 				} );
+				newIsDirtyState = false;
 			} else {
 				addNotice( {
 					status: 'error',
@@ -82,7 +106,7 @@ class Settings extends Component {
 				} );
 			}
 			/* eslint-disable react/no-did-update-set-state */
-			this.setState( { saving: false } );
+			this.setState( { saving: false, isDirty: newIsDirtyState } );
 			/* eslint-enable react/no-did-update-set-state */
 		}
 	}
@@ -122,7 +146,7 @@ class Settings extends Component {
 			settings[ name ] = value;
 		}
 
-		this.setState( { settings } );
+		this.setState( { settings, isDirty: true } );
 	}
 
 	render() {

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -158,8 +158,8 @@ class Settings extends Component {
 							{ __( 'Save Changes', 'woocommerce-admin' ) }
 						</Button>
 					</div>
-					<HistoricalData addNotice={ addNotice } />
 				</div>
+				<HistoricalData addNotice={ addNotice } />
 			</Fragment>
 		);
 	}

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -129,7 +129,9 @@ class Settings extends Component {
 	saveChanges = () => {
 		this.persistChanges( this.state );
 		this.props.updateSettings( { wc_admin: this.state.settings } );
-		this.setState( { saving: true } );
+
+		// TODO: remove this optimistic set of isDirty to false once #2541 is resolved.
+		this.setState( { saving: true, isDirty: false } );
 	};
 
 	handleInputChange( e ) {

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -181,7 +181,7 @@ class Settings extends Component {
 							{ __( 'Reset Defaults', 'woocommerce-admin' ) }
 						</Button>
 						<Button isPrimary onClick={ this.saveChanges }>
-							{ __( 'Save Changes', 'woocommerce-admin' ) }
+							{ __( 'Save Settings', 'woocommerce-admin' ) }
 						</Button>
 					</div>
 				</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8990,8 +8990,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9009,13 +9008,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9028,18 +9025,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9142,8 +9136,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9153,7 +9146,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9166,20 +9158,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9196,7 +9185,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9269,8 +9257,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9280,7 +9267,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9356,8 +9342,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9387,7 +9372,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9405,7 +9389,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9444,13 +9427,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },


### PR DESCRIPTION
Fixes #2449

This branch seeks to make the Analytics | Settings page a bit less confusing looking by adding in a proper section header to the Historical Data area, and it adds tracking to the state to set the page as `isDirty` if any changes are made, and subsequently warns users they have unsaved changes prior to navigating away.

**Before**
![image](https://user-images.githubusercontent.com/22080/60370889-908b8c80-99ac-11e9-9fbf-ec1e0423bc46.png)

**After**
![image](https://user-images.githubusercontent.com/22080/60370759-46a2a680-99ac-11e9-97f2-0d344502536c.png)

**Notes / Known Issues**
_Attempted to Core_
I initially wanted to use WP Core's `<UnsavedChangesWarning />` for this but it has a [hardcoded state check](https://github.com/WordPress/gutenberg/blob/d95c7d61d8ca284394a5aa77e9f74f9b3aaea24e/packages/editor/src/components/unsaved-changes-warning/index.js#L44) that is tied into the editor's state. In a prior life, this core component supported manually setting the dirty state via a prop, but that was [deprecated last october](https://github.com/WordPress/gutenberg/pull/10952) so I opted to _emulate_ their approach here.

_Warning not shown when navigating via react-router_
The warning of unsaved changes only works on the settings page if you are navigating to a non-wc-admin page, or if doing a hard refresh. I found [this awesome approach](https://stackoverflow.com/questions/32841757/detecting-user-leaving-page-with-react-router) on stackoverflow to use a built in tool from `react-router` to add support for this events, but after implementing I was hitting [this bug in react-router](https://github.com/ReactTraining/react-router/issues/5405) - which even though using the `<Prompt />` component from react-router to stop navigation works, the address bar still updates and causes all sorts of janky-behavior.

_Saving settings prompt not shown_
While working on this branch I also noticed that when I was saving new settings, the notice was not being shown, and the `isDirty` state was not being reset. At first I thought this was a bug in this branch, but indeed it exists in master. So I opened #2541 and added in a temporary fix here to optimistically set the form state back to clean when a save event is triggered. 46968fd

### Detailed test instructions:

- Open Analytics | Settings - note how amazing the new Historical Data Import section header looks.
- After the awe has subsided, change the settings form above, then attempt to navigate to a non-wc-admin page ( like Products ), and prepare yourself for some JS alert goodness.
- Click cancel, and save your change, then navigate away happily.

### Changelog Note:

Fix: Update layout of Settings Page and notify users when settings are not saved.
