### PR TITLE
Stock notifs: fix low_stock_amount for variations

### DIFF
--- a/includes/api/class-wc-admin-rest-products-controller.php
+++ b/includes/api/class-wc-admin-rest-products-controller.php
@@ -119,10 +119,13 @@ class WC_Admin_REST_Products_Controller extends WC_REST_Products_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function prepare_object_for_response( $object, $request ) {
-		$data = parent::prepare_object_for_response( $object, $request );
-		if ( $request->get_param( 'low_in_stock' ) && is_numeric( $object->low_stock_amount ) ) {
-			$data->data['low_stock_amount'] = $object->low_stock_amount;
+		$data        = parent::prepare_object_for_response( $object, $request );
+		$object_data = $object->get_data();
+
+		if ( $request->get_param( 'low_in_stock' ) && is_numeric( $object_data['low_stock_amount'] ) ) {
+			$data->data['low_stock_amount'] = $object_data['low_stock_amount'];
 		}
+
 		return $data;
 	}
 


### PR DESCRIPTION
Fixes: Low stock variable products not shown in Stock notifications, from https://github.com/woocommerce/woocommerce-admin/pull/2442#pullrequestreview-254942165

Items that are `low_in_stock` weren't being returned by the `/products?low_in_stock=true` endpoint. 

![Screen Shot 2019-06-27 at 12 20 05 PM](https://user-images.githubusercontent.com/1922453/60224467-9e6ede00-98d6-11e9-9bb3-1a1ae912223b.png)

error logs also showed this error:

```text
[01-Jul-2019 03:45:44 UTC] low_stock_amount was called incorrectly. Product properties should not be accessed directly. Backtrace: require('wp-blog-header.php'), wp, WP->main, WP->parse_request, do_action_ref_array('parse_request'), WP_Hook->do_action, WP_Hook->apply_filters, rest_api_loaded, WP_REST_Server->serve_request, WP_REST_Server->dispatch, WC_Admin_REST_Products_Controller->get_items, WC_REST_CRUD_Controller->get_items, WC_Admin_REST_Products_Controller->prepare_object_for_response, WC_Abstract_Legacy_Product->__get, wc_doing_it_wrong. This message was added in version 3.0.
```

This PR fixes incorrect access of data on `WC_Data` instance and the issue is resolved

### Detailed test instructions:

1. Make sure you have a variation of a product in low stock. Stock must be managed at the variation level.
<img width="954" alt="Screen Shot 2019-07-01 at 3 55 07 PM" src="https://user-images.githubusercontent.com/1922453/60409694-d2b90600-9c18-11e9-89ea-98f2552a62b5.png">
2. Go to any page with notifications panel.
3. Make sure the variation is shown in the Stock panel as being low in stock.

