### PR TITLE
Customizable dashboard: handle turned off feature flag

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -43,9 +43,9 @@ class Dashboard extends Component {
 		return (
 			<Fragment>
 				<ReportFilters query={ query } path={ path } />
-				<StorePerformance query={ query } />
-				<DashboardCharts query={ query } path={ path } />
-				<Leaderboards query={ query } />
+				<StorePerformance query={ query } hiddenBlocks={ [] } />
+				<DashboardCharts query={ query } path={ path } hiddenBlocks={ [] } />
+				<Leaderboards query={ query } hiddenBlocks={ [] } />
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2230

Handle a `analytics-dashboard/customizable` feature flag value of `false`. Now that this feature is pretty much ready, its unlikely to happen, but I'd like to fix it while its on my mind.

### Detailed test instructions:

1. In `config/development.json` turn the `analytics-dashboard/customizable` to false. 
2. Re-start the app via `npm start`.
3. See the Dashboard render without error.

