### PR TITLE
Dashboard: Add Tracks events

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -21,6 +21,7 @@ import './style.scss';
 import defaultSections from './default-sections';
 import Section from './section';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -101,6 +102,10 @@ class CustomizableDashboard extends Component {
 			const toggledSection = sections.splice( index, 1 ).shift();
 			toggledSection.isVisible = ! toggledSection.isVisible;
 			sections.push( toggledSection );
+
+			if ( ! toggledSection.isVisible ) {
+				recordEvent( 'dash_section_remove', { key: toggledSection.key } );
+			}
 
 			this.updateSections( sections );
 		};

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -23,6 +23,7 @@ import { getAllowedIntervalsForQuery } from '@woocommerce/date';
 import ChartBlock from './block';
 import { uniqCharts } from './config';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 import './style.scss';
 
 class DashboardCharts extends Component {
@@ -66,13 +67,21 @@ class DashboardCharts extends Component {
 					<Fragment>
 						<MenuTitle>{ __( 'Charts', 'woocommerce-admin' ) }</MenuTitle>
 						{ uniqCharts.map( chart => {
+							const key = chart.endpoint + '_' + chart.key;
+							const checked = ! hiddenBlocks.includes( key );
 							return (
 								<MenuItem
-									checked={ ! hiddenBlocks.includes( chart.endpoint + '_' + chart.key ) }
+									checked={ checked }
 									isCheckbox
 									isClickable
 									key={ chart.endpoint + '_' + chart.key }
-									onInvoke={ () => onToggleHiddenBlock( chart.endpoint + '_' + chart.key )() }
+									onInvoke={ () => {
+										onToggleHiddenBlock( key )();
+										recordEvent( 'dash_charts_chart_toggle', {
+											status: checked ? 'off' : 'on',
+											key,
+										} );
+									} }
 								>
 									{ __( `${ chart.label }`, 'woocommerce-admin' ) }
 								</MenuItem>

--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -19,6 +19,7 @@ import { EllipsisMenu, MenuItem, MenuTitle, SectionHeader } from '@woocommerce/c
  */
 import Leaderboard from 'analytics/components/leaderboard';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 import './style.scss';
 
 class Leaderboards extends Component {
@@ -64,13 +65,20 @@ class Leaderboards extends Component {
 					<Fragment>
 						<MenuTitle>{ __( 'Leaderboards', 'woocommerce-admin' ) }</MenuTitle>
 						{ allLeaderboards.map( leaderboard => {
+							const checked = ! hiddenBlocks.includes( leaderboard.id );
 							return (
 								<MenuItem
-									checked={ ! hiddenBlocks.includes( leaderboard.id ) }
+									checked={ checked }
 									isCheckbox
 									isClickable
 									key={ leaderboard.id }
-									onInvoke={ () => onToggleHiddenBlock( leaderboard.id )() }
+									onInvoke={ () => {
+										onToggleHiddenBlock( leaderboard.id )();
+										recordEvent( 'dash_leaderboards_toggle', {
+											status: checked ? 'off' : 'on',
+											key: leaderboard.id,
+										} );
+									} }
 								>
 									{ leaderboard.label }
 								</MenuItem>

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -31,6 +31,7 @@ import {
 } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import './style.scss';
+import { recordEvent } from 'lib/tracks';
 
 class StorePerformance extends Component {
 	renderMenu() {
@@ -65,7 +66,13 @@ class StorePerformance extends Component {
 									isCheckbox
 									isClickable
 									key={ i }
-									onInvoke={ () => onToggleHiddenBlock( indicator.stat )() }
+									onInvoke={ () => {
+										onToggleHiddenBlock( indicator.stat )();
+										recordEvent( 'dash_indicators_toggle', {
+											status: checked ? 'off' : 'on',
+											key: indicator.stat,
+										} );
+									} }
 								>
 									{ sprintf( __( 'Show %s', 'woocommerce-admin' ), indicator.label ) }
 								</MenuItem>
@@ -152,6 +159,9 @@ class StorePerformance extends Component {
 								prevLabel={ prevLabel }
 								prevValue={ secondaryValue }
 								delta={ delta }
+								onLinkClickCallback={ () => {
+									recordEvent( 'dash_indicators_click', { key: indicator.stat } );
+								} }
 							/>
 						);
 					} )


### PR DESCRIPTION
Partially addresses https://github.com/woocommerce/woocommerce-admin/issues/2474

Adds the following Tracks events.

* wcadmin_dash_section_remove
* wcadmin_dash_charts_chart_toggle
* wcadmin_dash_indicators_toggle
* wcadmin_dash_indicators_click
* wcadmin_dash_leaderboards_toggle

### Detailed test instructions:

1. In your console `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Visit Dashboard.
2. Remove a section, see an event fired.
3. Toggle portions of each section (charts, leaderboards, performance indicators), see an event fired.
4. Click on a performance indicator to navigate to a report, see an event fired.
5. Make sure the event names and payloads are correct.

### Notes
* When running in development mode, you shouldn't see an actual call to t.gif happening in your network tab.