### PR TITLE
Ignore empty wp notice elements.

### DIFF
--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -84,14 +84,15 @@ class WordPressNotices extends Component {
 			const notice = notices.children[ i ];
 			if ( ! notice ) {
 				continue;
+			} else if ( 0 === notice.innerHTML.length ) {
+				// Ignore empty elements in this part of the DOM.
+				continue;
 			} else if ( ! this.shouldCollapseNotice( notice ) ) {
 				uncollapsedTargetArea.insertAdjacentElement( 'afterend', notice );
 			} else {
 				count++;
 			}
 		}
-
-		count = count - 1; // Remove 1 for `wp-header-end` which is a child of wp__notice-list
 
 		this.props.onCountUpdate( count );
 		this.setState( { count, notices, noticesOpen, screenMeta, screenLinks } );


### PR DESCRIPTION
Fixes #2520 

In 2520 @derekakelly [shared a screenshot of their admin notices DOM](https://github.com/woocommerce/woocommerce-admin/issues/2520#issuecomment-506615509) which had a few empty divs, one of which I tracked down to be from [WooCommerce Order Status Manager](https://woocommerce.com/products/woocommerce-order-status-manager/). This empty div being added on all wp-admin pages was causing wc-admin's WP notices logic to falsely think there was a WP notice to display - which resulted in the problem outlined in the original issue.

The change proposed here is to see if the `innerHTML` of notices is empty, and if so skip over them when counting admin notices to show.

### Detailed test instructions:

- Install WooCommerce Order Status Manager, and activate, so you can see the bug happening
- Install this branch, verify the bug no longer happens
- Bonus points, do something to create a proper admin notice to appear, [here is a code snippet](https://github.com/woocommerce/woocommerce-admin/issues/2520#issuecomment-506514788) and verify that the "W" activity panel shows a notice is present, and clicking on the panel shows your test notification.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: WordPress Notifications Activity Panel falsely saying there are notices to be seen.
