### PR TITLE
Tracks: Add chart and table events

### DIFF
--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -22,6 +22,7 @@ import { formatCurrency } from '@woocommerce/currency';
 import { getSummaryNumbers } from 'wc-api/reports/utils';
 import ReportError from 'analytics/components/report-error';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 /**
  * Component to render summary numbers in reports.
@@ -46,7 +47,15 @@ export class ReportSummary extends Component {
 	}
 
 	render() {
-		const { charts, isRequesting, query, selectedChart, summaryData } = this.props;
+		const {
+			charts,
+			isRequesting,
+			query,
+			selectedChart,
+			summaryData,
+			endpoint,
+			report,
+		} = this.props;
 		const { isError, isRequesting: isSummaryDataRequesting } = summaryData;
 
 		if ( isError ) {
@@ -87,7 +96,13 @@ export class ReportSummary extends Component {
 						prevValue={ prevValue }
 						selected={ isSelected }
 						value={ value }
-						onLinkClickCallback={ onToggle }
+						onLinkClickCallback={ () => {
+							// Wider than a certain breakpoint, there is no dropdown so avoid calling onToggle.
+							if ( onToggle ) {
+								onToggle();
+							}
+							recordEvent( 'analytics_chart_tab_click', { report: report || endpoint, key } );
+						} }
 					/>
 				);
 			} );
@@ -150,6 +165,10 @@ ReportSummary.propTypes = {
 	 * Data to display in the SummaryNumbers.
 	 */
 	summaryData: PropTypes.object,
+	/**
+	 * Report name, if different than the endpoint.
+	 */
+	report: PropTypes.string,
 };
 
 ReportSummary.defaultProps = {

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -24,7 +24,7 @@ import { getReportChartData, getReportTableData } from 'wc-api/reports/utils';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { extendTableData } from './utils';
-
+import { recordEvent } from 'lib/tracks';
 import './style.scss';
 
 const TABLE_FILTER = 'woocommerce_admin_report_table';
@@ -141,6 +141,9 @@ class ReportTable extends Component {
 				/>
 				<TableCard
 					downloadable={ downloadable }
+					onClickDownload={ () => {
+						recordEvent( 'analytics_table_download', { report: endpoint, rows: totalResults } );
+					} }
 					headers={ filteredHeaders }
 					ids={ ids }
 					isLoading={ isLoading }

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -61,6 +61,7 @@ export default class CategoriesReport extends Component {
 					query={ chartQuery }
 					selectedChart={ getSelectedChart( query.chart, charts ) }
 					filters={ filters }
+					report="categories"
 				/>
 				<ReportChart
 					filters={ filters }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2474

Adds the following Tracks events.

* wcadmin_analytics_chart_tab_click
* wcadmin_analytics_table_download

### Detailed test instructions:

1. In your console `localStorage.setItem( 'debug', 'wc-admin:*' );`
1. Visit any report with a chart.
2. Click summary numbers and see events fired.
3. Confirm functionality is intact on narrow viewport.
4. Visit any report with tabular data.
5. Click "Download" and see the event fired.
6. Make sure event names and payloads are correct.

### Notes
* When running in development mode, you shouldn't see an actual call to t.gif happening in your network tab.