### PR TITLE
Add tracks event to Store Alert and Inbox Notification action clicks

### DIFF
--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -105,6 +105,25 @@ class WC_Admin_REST_Admin_Note_Action_Controller extends WC_Admin_REST_Admin_Not
 
 		$note->save();
 
+		if ( in_array( $note->get_type(), array( 'error', 'update' ) ) ) {
+			$tracks_event = 'wcadmin_store_alert_action';
+		} else {
+			$tracks_event = 'wcadmin_inbox_action_click';
+		}
+
+		wc_admin_record_tracks_event(
+			$tracks_event,
+			array(
+				'note_name'    => $note->get_name(),
+				'note_type'    => $note->get_type(),
+				'note_title'   => $note->get_title(),
+				'note_content' => $note->get_content(),
+				'note_icon'    => $note->get_icon(),
+				'action_name'  => $triggered_action->name,
+				'action_label' => $triggered_action->label,
+			)
+		);
+
 		$data = $note->get_data();
 		$data = $this->prepare_item_for_response( $data, $request );
 		$data = $this->prepare_response_for_collection( $data );

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -405,7 +405,7 @@ class WC_Admin_Reports_Sync {
 			'batch_size'   => $batch_size,
 			'type'         => 'order',
 		);
-		self::record_event( 'import_job_start', $properties );
+		wc_admin_record_tracks_event( 'import_job_start', $properties );
 
 		// When we are skipping already imported orders, the table of orders to import gets smaller in
 		// every batch, so we want to always import the first page.
@@ -421,7 +421,7 @@ class WC_Admin_Reports_Sync {
 
 		$properties['imported_count'] = $imported_count;
 
-		self::record_event( 'import_job_complete', $properties );
+		wc_admin_record_tracks_event( 'import_job_complete', $properties );
 	}
 
 	/**
@@ -681,7 +681,7 @@ class WC_Admin_Reports_Sync {
 			'batch_size'   => $batch_size,
 			'type'         => 'customer',
 		);
-		self::record_event( 'import_job_start', $properties );
+		wc_admin_record_tracks_event( 'import_job_start', $properties );
 
 		$customer_roles = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
 		// When we are skipping already imported customers, the table of customers to import gets smaller in
@@ -712,7 +712,7 @@ class WC_Admin_Reports_Sync {
 
 		$properties['imported_count'] = $imported_count;
 
-		self::record_event( 'import_job_complete', $properties );
+		wc_admin_record_tracks_event( 'import_job_complete', $properties );
 	}
 
 	/**
@@ -738,7 +738,7 @@ class WC_Admin_Reports_Sync {
 	public static function customer_lookup_delete_batch() {
 		global $wpdb;
 
-		self::record_event( 'delete_import_data_job_start', array( 'type' => 'customer' ) );
+		wc_admin_record_tracks_event( 'delete_import_data_job_start', array( 'type' => 'customer' ) );
 
 		$batch_size   = self::get_batch_size( self::CUSTOMERS_DELETE_BATCH_ACTION );
 		$customer_ids = $wpdb->get_col(
@@ -752,7 +752,7 @@ class WC_Admin_Reports_Sync {
 			WC_Admin_Reports_Customers_Data_Store::delete_customer( $customer_id );
 		}
 
-		self::record_event( 'delete_import_data_job_complete', array( 'type' => 'customer' ) );
+		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'customer' ) );
 	}
 
 	/**
@@ -780,7 +780,7 @@ class WC_Admin_Reports_Sync {
 	public static function orders_lookup_delete_batch() {
 		global $wpdb;
 
-		self::record_event( 'delete_import_data_job_start', array( 'type' => 'order' ) );
+		wc_admin_record_tracks_event( 'delete_import_data_job_start', array( 'type' => 'order' ) );
 
 		$batch_size = self::get_batch_size( self::ORDERS_DELETE_BATCH_ACTION );
 		$order_ids  = $wpdb->get_col(
@@ -794,28 +794,7 @@ class WC_Admin_Reports_Sync {
 			WC_Admin_Reports_Orders_Stats_Data_Store::delete_order( $order_id );
 		}
 
-		self::record_event( 'delete_import_data_job_complete', array( 'type' => 'order' ) );
-	}
-
-	/**
-	 * Record an event using Tracks.
-	 *
-	 * @internal WooCommerce core only includes Tracks in admin, not the REST API, so we need to include it.
-	 * @param string $event_name Event name for tracks.
-	 * @param array  $properties Properties to pass along with event.
-	 */
-	protected static function record_event( $event_name, $properties = array() ) {
-		if ( ! class_exists( 'WC_Tracks' ) ) {
-			if ( ! defined( 'WC_ABSPATH' ) || ! file_exists( WC_ABSPATH . 'includes/tracks/class-wc-tracks.php' ) ) {
-				return;
-			}
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-			include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
-		}
-		WC_Tracks::record_event( $event_name, $properties );
+		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'order' ) );
 	}
 }
 

--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -42,3 +42,25 @@ function wc_admin_url( $path, $query = array() ) {
 
 	return admin_url( 'admin.php?page=wc-admin#' . $path, dirname( __FILE__ ) );
 }
+
+/**
+ * Record an event using Tracks.
+ *
+ * @internal WooCommerce core only includes Tracks in admin, not the REST API, so we need to include it.
+ * @param string $event_name Event name for tracks.
+ * @param array  $properties Properties to pass along with event.
+ */
+function wc_admin_record_tracks_event( $event_name, $properties = array() ) {
+	if ( ! class_exists( 'WC_Tracks' ) ) {
+		if ( ! defined( 'WC_ABSPATH' ) || ! file_exists( WC_ABSPATH . 'includes/tracks/class-wc-tracks.php' ) ) {
+			return;
+		}
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
+	}
+
+	WC_Tracks::record_event( $event_name, $properties );
+}


### PR DESCRIPTION
Addresses #2474 in part.

Implements `wcadmin_inbox_action_click ` and `wcadmin_store_alert_action ` events since they're the same action on differing "types" of admin notes.

In addition to the "message name", "alert name", and "action" prescribed in the issue, I've included these properties:

* note_name
* note_type
* note_title
* note_content
* note_icon
* action_name
* action_label

### Detailed test instructions:

- Ensure you have at least one notification in your Inbox (with an action)
- Ensure you have at least on high priority notice with an action (can just change a normal note to "update" type in the DB)
- Use a filter to watch outbound HTTP requests:
```php
add_filter( 'http_request_args', function( $r, $url ) {
	error_log( $r['method'] . ' ' . $url );
	return $r;
},10, 2 );
```
- Click the inbox note action
- Verify the `wcadmin_inbox_action_click` event and props
- Click the high priority notice action
- Verify the `wcadmin_store_alert_action` event and props
