### PR TITLE
Header: Adjust sizes at all breakpoints

### DIFF
--- a/client/analytics/components/report-table/style.scss
+++ b/client/analytics/components/report-table/style.scss
@@ -11,12 +11,8 @@
 	.woocommerce-feature-enabled-activity-panels & {
 		top: -#{$adminbar-height + $large-header-height + $gap};
 
-		@include breakpoint( '<782px' ) {
+		@include breakpoint( '<1280px' ) {
 			top: -#{$adminbar-height-mobile + $small-header-height + $gap};
-		}
-
-		@include breakpoint( '782px-960px' ) {
-			top: -#{$adminbar-height + $medium-header-height + $gap};
 		}
 	}
 }

--- a/client/analytics/components/report-table/style.scss
+++ b/client/analytics/components/report-table/style.scss
@@ -9,10 +9,10 @@
 	}
 
 	.woocommerce-feature-enabled-activity-panels & {
-		top: -#{$adminbar-height + $large-header-height + $gap};
+		top: -#{$adminbar-height + $header-height + $gap};
 
-		@include breakpoint( '<1280px' ) {
-			top: -#{$adminbar-height-mobile + $small-header-height + $gap};
+		@include breakpoint( '<782px' ) {
+			top: -#{$adminbar-height-mobile + $header-height + $gap};
 		}
 	}
 }

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -6,7 +6,7 @@
 	align-items: center;
 	position: fixed;
 	right: 0;
-	height: $medium-header-height;
+	height: $small-header-height;
 
 	@include breakpoint( '<782px' ) {
 		position: relative;
@@ -22,7 +22,7 @@
 		max-width: 280px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( '>1280px' ) {
 		height: $large-header-height;
 		max-width: 400px;
 	}
@@ -35,10 +35,10 @@
 .woocommerce-layout__activity-panel-tabs {
 	width: 100%;
 	display: flex;
-	height: $medium-header-height;
+	height: $small-header-height;
 	justify-content: flex-end;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( '>1280px' ) {
 		height: $large-header-height;
 	}
 
@@ -76,8 +76,8 @@
 		min-width: 80px;
 		width: 100%;
 		font-size: 11px;
-		height: $medium-header-height;
-		@include breakpoint( '>960px' ) {
+		height: $small-header-height;
+		@include breakpoint( '>1280px' ) {
 			font-size: 13px;
 			height: $large-header-height;
 		}
@@ -192,24 +192,24 @@
 }
 
 .woocommerce-layout__activity-panel-wrapper {
-	height: calc(100vh - #{$medium-header-height + $small-header-height + $adminbar-height-mobile});
+	height: calc(100vh - #{$small-header-height + $small-header-height + $adminbar-height-mobile});
 	background: $core-grey-light-200;
 	box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	width: 0;
 	@include activity-panel-slide();
 	position: fixed;
 	right: 0;
-	top: #{$medium-header-height + $small-header-height + $adminbar-height-mobile};
+	top: #{$small-header-height + $small-header-height + $adminbar-height-mobile};
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: auto;
 
-	@include breakpoint( '782px-960px' ) {
-		height: calc(100vh - #{$medium-header-height + $adminbar-height});
-		top: #{$medium-header-height + $adminbar-height};
+	@include breakpoint( '782px-1280px' ) {
+		height: calc(100vh - #{$small-header-height + $adminbar-height});
+		top: #{$small-header-height + $adminbar-height};
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( '>1280px' ) {
 		height: calc(100vh - #{$large-header-height + $adminbar-height});
 		top: #{$large-header-height + $adminbar-height};
 	}

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -6,7 +6,7 @@
 	align-items: center;
 	position: fixed;
 	right: 0;
-	height: $small-header-height;
+	height: $header-height;
 
 	@include breakpoint( '<782px' ) {
 		position: relative;
@@ -23,7 +23,6 @@
 	}
 
 	@include breakpoint( '>1280px' ) {
-		height: $large-header-height;
 		max-width: 400px;
 	}
 
@@ -35,12 +34,8 @@
 .woocommerce-layout__activity-panel-tabs {
 	width: 100%;
 	display: flex;
-	height: $small-header-height;
+	height: $header-height;
 	justify-content: flex-end;
-
-	@include breakpoint( '>1280px' ) {
-		height: $large-header-height;
-	}
 
 	.dashicon,
 	.gridicon {
@@ -76,11 +71,7 @@
 		min-width: 80px;
 		width: 100%;
 		font-size: 11px;
-		height: $small-header-height;
-		@include breakpoint( '>1280px' ) {
-			font-size: 13px;
-			height: $large-header-height;
-		}
+		height: $header-height;
 
 		&.is-active {
 			color: $core-grey-dark-700;
@@ -147,7 +138,7 @@
 .woocommerce-layout__activity-panel-mobile-toggle {
 	margin-right: 10px;
 	max-width: 48px;
-	height: $small-header-height;
+	height: $header-height;
 	position: fixed;
 	top: $adminbar-height-mobile;
 	right: 0;
@@ -192,26 +183,21 @@
 }
 
 .woocommerce-layout__activity-panel-wrapper {
-	height: calc(100vh - #{$small-header-height + $small-header-height + $adminbar-height-mobile});
+	height: calc(100vh - #{$header-height + $header-height + $adminbar-height-mobile});
 	background: $core-grey-light-200;
 	box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	width: 0;
 	@include activity-panel-slide();
 	position: fixed;
 	right: 0;
-	top: #{$small-header-height + $small-header-height + $adminbar-height-mobile};
+	top: #{$header-height + $header-height + $adminbar-height-mobile};
 	z-index: 1000;
 	overflow-x: hidden;
 	overflow-y: auto;
 
-	@include breakpoint( '782px-1280px' ) {
-		height: calc(100vh - #{$small-header-height + $adminbar-height});
-		top: #{$small-header-height + $adminbar-height};
-	}
-
-	@include breakpoint( '>1280px' ) {
-		height: calc(100vh - #{$large-header-height + $adminbar-height});
-		top: #{$large-header-height + $adminbar-height};
+	@include breakpoint( '>782px' ) {
+		height: calc(100vh - #{$header-height + $adminbar-height});
+		top: #{$header-height + $adminbar-height};
 	}
 
 	&.is-open {

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -8,7 +8,7 @@
 	box-sizing: border-box;
 	border-bottom: 1px solid $white;
 	padding: 0;
-	height: $large-header-height;
+	height: $small-header-height;
 	position: fixed;
 	width: 100%;
 	top: $adminbar-height;
@@ -19,13 +19,8 @@
 	}
 
 	@include breakpoint( '<782px' ) {
-		top: $adminbar-height-mobile;
-		height: $small-header-height;
 		flex-flow: row wrap;
-	}
-
-	@include breakpoint( '782px-960px' ) {
-		height: $medium-header-height;
+		top: $adminbar-height-mobile;
 	}
 
 	.woocommerce-layout__header-breadcrumbs {
@@ -38,12 +33,7 @@
 		line-height: $small-header-height;
 		background: $white;
 
-		@include breakpoint( '782px-960px' ) {
-			height: $medium-header-height;
-			line-height: $medium-header-height;
-		}
-
-		@include breakpoint( '>960px' ) {
+		@include breakpoint( '>1280px' ) {
 			height: $large-header-height;
 			line-height: $large-header-height;
 		}

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -8,7 +8,7 @@
 	box-sizing: border-box;
 	border-bottom: 1px solid $white;
 	padding: 0;
-	height: $small-header-height;
+	height: $header-height;
 	position: fixed;
 	width: 100%;
 	top: $adminbar-height;
@@ -29,14 +29,9 @@
 		padding: 0 0 0 $fallback-gutter-large;
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
-		height: $small-header-height;
-		line-height: $small-header-height;
+		height: $header-height;
+		line-height: $header-height;
 		background: $white;
-
-		@include breakpoint( '>1280px' ) {
-			height: $large-header-height;
-			line-height: $large-header-height;
-		}
 
 		span + span::before {
 			content: ' / ';

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -15,7 +15,6 @@ $gap-smallest: 4px;
 
 // Header
 $small-header-height: 50px;
-$medium-header-height: 60px;
 $large-header-height: 80px;
 
 // @todo Remove this spacing variable

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -14,8 +14,7 @@ $gap-smaller: 8px;
 $gap-smallest: 4px;
 
 // Header
-$small-header-height: 50px;
-$large-header-height: 80px;
+$header-height: 56px;
 
 // @todo Remove this spacing variable
 $spacing: 16px;

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -21,11 +21,7 @@
 	}
 
 	#woocommerce-embedded-root.is-embed-loading + #wpbody .wrap {
-		padding-top: $large-header-height + 40;
-
-		@include breakpoint( '782px-960px' ) {
-			padding-top: $medium-header-height + 40;
-		}
+		padding-top: $small-header-height + 40;
 
 		@include breakpoint( '<782px' ) {
 			padding-top: 30px;
@@ -34,15 +30,7 @@
 
 	#screen-meta,
 	#screen-meta-links {
-		top: $large-header-height;
-
-		@include breakpoint( '782px-960px' ) {
-			top: $medium-header-height;
-		}
-
-		@include breakpoint( '<782px' ) {
-			top: $small-header-height;
-		}
+		top: $small-header-height;
 	}
 
 	#screen-meta {
@@ -59,6 +47,7 @@
 	}
 
 	.woocommerce-layout__header {
+		height: $small-header-height;
 		&.is-scrolled {
 			box-shadow: 0 8px 16px 0 rgba(85, 93, 102, 0.3);
 		}
@@ -66,6 +55,11 @@
 		.woocommerce-layout__header-breadcrumbs {
 			margin-top: 0;
 			margin-bottom: 0;
+
+			@include breakpoint( '>1280px' ) {
+				height: $small-header-height;
+				line-height: $small-header-height;
+			}
 		}
 	}
 
@@ -80,11 +74,7 @@
 
 	.woocommerce-layout__primary {
 		margin: 0;
-		padding-top: $large-header-height + 20;
-
-		@include breakpoint( '782px-960px' ) {
-			padding-top: $medium-header-height + 20;
-		}
+		padding-top: $small-header-height + 20;
 
 		@include breakpoint( '<782px' ) {
 			padding-top: 10px;
@@ -103,6 +93,20 @@
 	.woocommerce-layout__activity-panel-tabs {
 		animation: isLoaded;
 		animation-duration: 2000ms;
+
+		.woocommerce-layout__activity-panel-tab {
+			@include breakpoint( '>1280px' ) {
+				font-size: 11px;
+				height: $small-header-height;
+			}
+		}
+	}
+
+	.woocommerce-layout__activity-panel-wrapper {
+		@include breakpoint( '>1280px' ) {
+			height: calc(100vh - #{$small-header-height + $adminbar-height});
+			top: #{$small-header-height + $adminbar-height};
+		}
 	}
 
 	.woocommerce-layout__notice-list-show {

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -21,7 +21,7 @@
 	}
 
 	#woocommerce-embedded-root.is-embed-loading + #wpbody .wrap {
-		padding-top: $small-header-height + 40;
+		padding-top: $header-height + 40;
 
 		@include breakpoint( '<782px' ) {
 			padding-top: 30px;
@@ -30,7 +30,7 @@
 
 	#screen-meta,
 	#screen-meta-links {
-		top: $small-header-height;
+		top: $header-height;
 	}
 
 	#screen-meta {
@@ -47,7 +47,7 @@
 	}
 
 	.woocommerce-layout__header {
-		height: $small-header-height;
+		height: $header-height;
 		&.is-scrolled {
 			box-shadow: 0 8px 16px 0 rgba(85, 93, 102, 0.3);
 		}
@@ -55,11 +55,6 @@
 		.woocommerce-layout__header-breadcrumbs {
 			margin-top: 0;
 			margin-bottom: 0;
-
-			@include breakpoint( '>1280px' ) {
-				height: $small-header-height;
-				line-height: $small-header-height;
-			}
 		}
 	}
 
@@ -74,7 +69,7 @@
 
 	.woocommerce-layout__primary {
 		margin: 0;
-		padding-top: $small-header-height + 20;
+		padding-top: $header-height + 20;
 
 		@include breakpoint( '<782px' ) {
 			padding-top: 10px;
@@ -93,20 +88,6 @@
 	.woocommerce-layout__activity-panel-tabs {
 		animation: isLoaded;
 		animation-duration: 2000ms;
-
-		.woocommerce-layout__activity-panel-tab {
-			@include breakpoint( '>1280px' ) {
-				font-size: 11px;
-				height: $small-header-height;
-			}
-		}
-	}
-
-	.woocommerce-layout__activity-panel-wrapper {
-		@include breakpoint( '>1280px' ) {
-			height: calc(100vh - #{$small-header-height + $adminbar-height});
-			top: #{$small-header-height + $adminbar-height};
-		}
 	}
 
 	.woocommerce-layout__notice-list-show {


### PR DESCRIPTION
Fixes #2337 
Fixes #2287 

From discussion in both the issues above, this PR changes the sizing of the Header and Activity Panels to a uniform 56px across all breakpoints. By doing so, this also addresses the bug that was causing the TinyMCE toolbar from being hidden behind the header on products with a large amount of content in the description.

### Screenshots

_Product Edit Page Before with obscured toolbar_
![product-toolbar-before](https://user-images.githubusercontent.com/22080/60554545-dcac3900-9cec-11e9-8128-263243336216.png)

_Product Edit Page with change_
![product-toolbar-scroll-after](https://user-images.githubusercontent.com/22080/60554553-e635a100-9cec-11e9-8b9f-57c1d7acaf87.png)

_Dashboard Before_
![dashboard-before](https://user-images.githubusercontent.com/22080/60554569-ec2b8200-9cec-11e9-9d7a-2ff3605d4c2f.png)

_Dashboard After_
![dashboard-after](https://user-images.githubusercontent.com/22080/60554575-f2b9f980-9cec-11e9-9462-cc0f9252791e.png)

_Breakpoints in action_
![breakpoints](https://user-images.githubusercontent.com/22080/60554583-fb123480-9cec-11e9-8ad6-837e02f2a8a5.gif)

### Detailed test instructions:

- Browse both wc-admin js pages, and embeded pages at a variety of viewport widths
- Open/close activity panels at the various widths and page types and ensure all is happy.### Changelog Note:

Fix: Change size of Header to 56px - fixes bug in product edit page toolbar being hidden.

/cc @mikkamp 
