### PR TITLE
Add countLabel prop to SearchListItem

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Card component: new `description` prop.
 - Card component: new `isInactive` prop.
 - DateRangeFilterPicker (breaking change): Introduced `onRangeSelect` prop and remove `path` prop better control.
+- SearchListItem component: new `countLabel` prop that will overwrite the `item.count` value.
 
 # 2.0.0
 - Chart legend component now uses withInstanceId HOC so the ids used in several HTML elements are unique.

--- a/packages/components/src/search-list-control/item.js
+++ b/packages/components/src/search-list-control/item.js
@@ -42,6 +42,7 @@ const getInteractionIcon = ( isSingle = false, isSelected = false ) => {
 };
 
 const SearchListItem = ( {
+	countLabel,
 	className,
 	depth = 0,
 	item,
@@ -87,7 +88,7 @@ const SearchListItem = ( {
 
 			{ !! showCount && (
 				<span className="woocommerce-search-list__item-count">
-					{ item.count }
+					{ countLabel || item.count }
 				</span>
 			) }
 		</MenuItem>
@@ -99,6 +100,10 @@ SearchListItem.propTypes = {
 	 * Additional CSS classes.
 	 */
 	className: PropTypes.string,
+	/**
+	 * Label to display if `showCount` is set to true. If undefined, it will use `item.count`.
+	 */
+	countLabel: PropTypes.node,
 	/**
 	 * Depth, non-zero if the list is hierarchical.
 	 */

--- a/packages/components/src/search-list-control/style.scss
+++ b/packages/components/src/search-list-control/style.scss
@@ -183,6 +183,7 @@
 			line-height: 1.4;
 			color: $core-grey-dark-300;
 			background: $white;
+			white-space: nowrap;
 		}
 	}
 }


### PR DESCRIPTION
In the _Reviews by Product_ block we need to display _X Reviews_ next to each product in the `SearchListControl`:
![image](https://user-images.githubusercontent.com/3616980/60589357-9bbe2e00-9d99-11e9-8769-3f900790e52f.png)


Currently, `SearchListItem` only allows showing a number (which comes from `item.count`). This PR adds a `countLabel` prop to `SearchListItem` that will overwrite what's rendered in the counter. Allowing the consumer to modify it.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/60589322-8812c780-9d99-11e9-9277-794956e810c1.png)

### Detailed test instructions:
- Modify this line:
https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/search-list-control/index.js#L107
  With this or something similar:
```ES6
		return <SearchListItem countLabel="Lorem Ipsum" showCount { ...args } />;
```
- Go to _WooCommerce_ > _DevDocs_.
- Go to _SearchListControl_ card and press _Toggle loading state_.
- Verify the count label appears next to the list names (see screenshot above).