### PR TITLE
ReportTable: Add back in ids array generation.

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -123,6 +123,7 @@ class ReportTable extends Component {
 		const { headers, ids, rows, summary } = applyFilters( TABLE_FILTER, {
 			endpoint,
 			headers: getHeadersContent(),
+			ids: itemIdField ? items.data.map( item => item[ itemIdField ] ) : [],
 			rows: getRowsContent( items.data ),
 			totals,
 			summary: getSummary ? getSummary( totals, totalResults ) : null,


### PR DESCRIPTION
Fixes #2570

It appears this regression was introduced as part of #2440 ( /cc @psealock  )- which added in the new filter functionality for the table, but while doing so removed the generation of the `ids` prop that is subsequently passed to `<Table />` and used for the comparison logic.

### Detailed test instructions:

- First verify the error on `master` by opening any report that offers compare functionality in the table ( Categories, Taxes, Products etc ).
- Click on a checkbox in a table row, note the error
- Apply this branch, repeat the steps and verify you can compare multiple items, and no error occurs.

### Changelog Note:

Fix: Compare checkboxes in report tables
