### PR TITLE
Notes: Type cast is_snoozeable on insert.

### DIFF
--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -31,7 +31,7 @@ class WC_Admin_Notes_Data_Store extends WC_Data_Store_WP implements WC_Object_Da
 			'icon'         => $note->get_icon(),
 			'status'       => $note->get_status(),
 			'source'       => $note->get_source(),
-			'is_snoozable' => $note->get_is_snoozable(),
+			'is_snoozable' => (int) $note->get_is_snoozable(),
 		);
 
 		$note_to_be_inserted['content_data']  = wp_json_encode( $note->get_content_data() );

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -176,6 +176,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 1, count( $notes ) );
 		$this->assertEquals( $notes[0]['title'], 'PHPUNIT_TEST_NOTE_2_TITLE' );
+		$this->assertEquals( $notes[0]['is_snoozable'], true );
 	}
 
 
@@ -247,6 +248,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 3, count( $notes ) );
 		$this->assertEquals( $notes[0]['title'], 'PHPUNIT_TEST_NOTE_1_TITLE' );
+		$this->assertEquals( $notes[0]['is_snoozable'], false );
 		$this->assertEquals( $notes[1]['title'], 'PHPUNIT_TEST_NOTE_2_TITLE' );
 		$this->assertEquals( $notes[2]['title'], 'PHPUNIT_TEST_NOTE_3_TITLE' );
 

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -35,6 +35,7 @@ class WC_Helper_Admin_Notes {
 		$note_1->set_icon( 'info' );
 		$note_1->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_1->set_source( 'PHPUNIT_TEST' );
+		$note_1->set_is_snoozable( false );
 		$note_1->add_action(
 			'PHPUNIT_TEST_NOTE_1_ACTION_1_SLUG',
 			'PHPUNIT_TEST_NOTE_1_ACTION_1_LABEL',
@@ -56,6 +57,7 @@ class WC_Helper_Admin_Notes {
 		$note_2->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_2->set_source( 'PHPUNIT_TEST' );
 		$note_2->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note_2->set_is_snoozable( true );
 		// This note has no actions.
 		$note_2->save();
 


### PR DESCRIPTION
Fixes #2572

While I wasn't able to fully re-create the initial bug, this branch seeks to properly type cast the `is_snoozable` value before insertion into the notes database table. I've also modified the unit tests to test the setting/retrieval of the `is_snoozable` value.

### Detailed test instructions:

- Verify unit tests pass

### Changelog Note:

Fix: Cast is_snoozable as int prior to database save
