### PR TITLE
Update color-studio to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5638,8 +5638,9 @@
       }
     },
     "color-studio": {
-      "version": "github:automattic/color-studio#2569acb85214ac2413ab5e8ac7b87b04227ba4c4",
-      "from": "github:automattic/color-studio#1.0.4",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/color-studio/-/color-studio-1.0.5.tgz",
+      "integrity": "sha512-XW2pF7K4v0wd4G9oab7wxiaf07wW1chv5ZSEsKZ0aY8clS05/hnb1x5gNwytH949S0Tu9v9J6ttKaNebCt3gpg==",
       "dev": true
     },
     "colormin": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-es2015-template-literals": "6.22.0",
     "chalk": "2.4.2",
-    "color-studio": "github:automattic/color-studio#1.0.4",
+    "color-studio": "1.0.5",
     "concurrently": "4.1.1",
     "copy-webpack-plugin": "5.0.3",
     "cross-env": "5.2.0",


### PR DESCRIPTION
This PR updates `color-studio` to 1.0.5, and updates it to pull via `npm` now that it is a published package, instead of pulling from GitHub.

To Test:
* `npm install`
* `npm start` to make sure it builds
* Optional: Go to the devdocs and view the `Stepper` component (the blue is pulled from `color-studio`).