### PR TITLE
Settings: Fix wsod when no actionable statuses are set.

### DIFF
--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -24,6 +24,13 @@ const defaultOrderStatuses = [
 	'pending',
 	'on-hold',
 ];
+
+const actionableOrderStatuses = Array.isArray(
+	wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses
+)
+	? wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses
+	: [];
+
 const orderStatuses = Object.keys( wcSettings.orderStatuses )
 	.filter( status => status !== 'refunded' )
 	.map( key => {
@@ -87,7 +94,7 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 				'These orders will show up in the Orders tab under the activity panel.',
 			'woocommerce-admin'
 		),
-		initialValue: [ ...wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses ] || [],
+		initialValue: actionableOrderStatuses,
 		defaultValue: DEFAULT_ACTIONABLE_STATUSES,
 	},
 	{

--- a/client/analytics/settings/config.js
+++ b/client/analytics/settings/config.js
@@ -31,6 +31,12 @@ const actionableOrderStatuses = Array.isArray(
 	? wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses
 	: [];
 
+const excludedOrderStatuses = Array.isArray(
+	wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses
+)
+	? wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses
+	: [];
+
 const orderStatuses = Object.keys( wcSettings.orderStatuses )
 	.filter( status => status !== 'refunded' )
 	.map( key => {
@@ -70,8 +76,7 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 				strong: <strong />,
 			},
 		} ),
-		initialValue:
-			[ ...wcSettings.wcAdminSettings.woocommerce_excluded_report_order_statuses ] || [],
+		initialValue: [ ...excludedOrderStatuses ],
 		defaultValue: [ 'pending', 'cancelled', 'failed' ],
 	},
 	{
@@ -94,7 +99,7 @@ export const analyticsSettings = applyFilters( SETTINGS_FILTER, [
 				'These orders will show up in the Orders tab under the activity panel.',
 			'woocommerce-admin'
 		),
-		initialValue: actionableOrderStatuses,
+		initialValue: [ ...actionableOrderStatuses ],
 		defaultValue: DEFAULT_ACTIONABLE_STATUSES,
 	},
 	{

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -628,7 +628,7 @@ class WC_Admin_Loader {
 		$settings['wcAdminSettings']         = array();
 
 		foreach ( $wc_admin_group_settings as $setting ) {
-			if ( ! empty( $setting['id'] ) && ! empty( $setting['value'] ) ) {
+			if ( ! empty( $setting['id'] ) ) {
 				$settings['wcAdminSettings'][ $setting['id'] ] = $setting['value'];
 			}
 		}


### PR DESCRIPTION
There have been a number of bug reports in the forums akin to [this one](https://wordpress.org/support/topic/shows-blank-screen/page/2/#post-11697728) where all screens in wc-admin are white-screen-o-deathing with an error message like:

![image](https://user-images.githubusercontent.com/22080/60629944-c06fd100-9dac-11e9-80bd-2abdea0809cf.png)

I then looked at spread operator usage across the code base, in hopes that something jumped out at me that would be a code path eval'ed on all wc-admin pages, and I focused in on the fix presented here. While I'm not 100% certain this is the cause of all the reports of this bug, this PR fixes a flow where the exact same error is thrown, and crashes all wc-admin pages.

I'm hoping the user [here](https://wordpress.org/support/topic/shows-blank-screen/page/2/#post-11697904) will respond with a screenshot to confirm that is what caused this issue on their site 🤞 

### Steps to create the bug

- On `master` visit Analytics | Settings
- Uncheck all boxes under the actionable order statuses section
- Click save settings, and refresh the page, note the error

### Detailed test instructions:

- Apply this branch, and repeat the steps above.

### Changelog Note:

Fix: Prevent error when no actionable order statuses are set
