### PR TITLE
Onboarding: Add theme uploader component

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -22,6 +22,7 @@ import { Card, H } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import './style.scss';
 import { recordEvent } from 'lib/tracks';
+import ThemeUploader from './uploader';
 
 class Theme extends Component {
 	constructor() {
@@ -175,6 +176,7 @@ class Theme extends Component {
 					{ () => (
 						<div className="woocommerce-profile-wizard__themes">
 							{ themes && themes.map( theme => this.renderTheme( theme ) ) }
+							<ThemeUploader />
 						</div>
 					) }
 				</TabPanel>

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -30,8 +30,10 @@ class Theme extends Component {
 
 		this.state = {
 			activeTab: 'all',
+			uploadedThemes: [],
 		};
 
+		this.handleUploadComplete = this.handleUploadComplete.bind( this );
 		this.onChoose = this.onChoose.bind( this );
 		this.onSelectTab = this.onSelectTab.bind( this );
 		this.openDemo = this.openDemo.bind( this );
@@ -129,17 +131,27 @@ class Theme extends Component {
 	}
 
 	getThemes() {
+		const { activeTab, uploadedThemes } = this.state;
 		const { themes } = wcSettings.onboarding;
-		const { activeTab } = this.state;
+		themes.concat( uploadedThemes );
+		const allThemes = [ ...themes, ...uploadedThemes ];
 
 		switch ( activeTab ) {
 			case 'paid':
-				return themes.filter( theme => this.getPriceValue( theme.price ) > 0 );
+				return allThemes.filter( theme => this.getPriceValue( theme.price ) > 0 );
 			case 'free':
-				return themes.filter( theme => this.getPriceValue( theme.price ) <= 0 );
+				return allThemes.filter( theme => this.getPriceValue( theme.price ) <= 0 );
 			case 'all':
 			default:
-				return themes;
+				return allThemes;
+		}
+	}
+
+	handleUploadComplete( upload ) {
+		if ( 'success' === upload.status && upload.theme_data ) {
+			this.setState( {
+				uploadedThemes: [ ...this.state.uploadedThemes, upload.theme_data ],
+			} );
 		}
 	}
 
@@ -176,7 +188,7 @@ class Theme extends Component {
 					{ () => (
 						<div className="woocommerce-profile-wizard__themes">
 							{ themes && themes.map( theme => this.renderTheme( theme ) ) }
-							<ThemeUploader />
+							<ThemeUploader onUploadComplete={ this.handleUploadComplete } />
 						</div>
 					) }
 				</TabPanel>

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -126,6 +126,7 @@
 	}
 
 	.components-drop-zone__provider {
+		min-height: 400px;
 		display: flex;
 		flex-direction: column;
 		align-items: center;

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -125,8 +125,11 @@
 		height: 100%;
 	}
 
+	&.is-uploading .components-drop-zone__provider {
+		min-height: 382px;
+	}
+
 	.components-drop-zone__provider {
-		min-height: 400px;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -134,6 +137,20 @@
 		border-radius: 2px;
 		background: #f6f6f6;
 		border: 1px dashed #b0b5b8;
+	}
+
+	.components-form-file-upload {
+		flex: 1;
+		width: 100%;
+	}
+
+	.components-form-file-upload > .components-button {
+		flex: 1;
+		flex-direction: column;
+		margin: 0;
+		width: 100%;
+		height: 100%;
+		min-height: 380px;
 
 		> .gridicon {
 			width: 48px;
@@ -142,6 +159,10 @@
 			path {
 				fill: #50575d;
 			}
+		}
+
+		.dashicons-upload {
+			display: none;
 		}
 	}
 

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -155,9 +155,4 @@
 		@include font-size(14);
 		margin: 0;
 	}
-
-	.components-spinner {
-		transform: scale(1.5);
-		margin-bottom: $gap-small;
-	}
 }

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -116,3 +116,47 @@
 		}
 	}
 }
+
+.woocommerce-profile-wizard__body .woocommerce-theme-uploader.woocommerce-card {
+	margin: 0;
+	position: relative;
+
+	.woocommerce-card__body {
+		height: 100%;
+	}
+
+	.components-drop-zone__provider {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		border-radius: 2px;
+		background: #f6f6f6;
+		border: 1px dashed #b0b5b8;
+
+		> .gridicon {
+			width: 48px;
+			height: 48px;
+
+			path {
+				fill: #50575d;
+			}
+		}
+	}
+
+	.woocommerce-theme-uploader__title {
+		margin: $gap-smaller 0;
+		@include font-size(24);
+		font-weight: 400;
+	}
+
+	p {
+		@include font-size(14);
+		margin: 0;
+	}
+
+	.components-spinner {
+		transform: scale(1.5);
+		margin-bottom: $gap-small;
+	}
+}

--- a/client/dashboard/profile-wizard/steps/theme/uploader.js
+++ b/client/dashboard/profile-wizard/steps/theme/uploader.js
@@ -7,7 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { DropZoneProvider, DropZone } from '@wordpress/components';
+import { DropZoneProvider, DropZone, FormFileUpload } from '@wordpress/components';
 import Gridicon from 'gridicons';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
@@ -26,18 +26,23 @@ class ThemeUploader extends Component {
 			isUploading: false,
 		};
 
+		this.handleFilesUpload = this.handleFilesUpload.bind( this );
 		this.handleFilesDrop = this.handleFilesDrop.bind( this );
 	}
 
 	handleFilesDrop( files ) {
 		const file = files[ 0 ];
+		this.uploadTheme( file );
+	}
 
-		this.setState( { isUploading: true } );
+	handleFilesUpload( e ) {
+		const file = e.target.files[ 0 ];
 		this.uploadTheme( file );
 	}
 
 	uploadTheme( file ) {
 		const { addNotice, onUploadComplete } = this.props;
+		this.setState( { isUploading: true } );
 
 		const body = new FormData();
 		body.append( 'pluginzip', file );
@@ -69,11 +74,13 @@ class ThemeUploader extends Component {
 				<DropZoneProvider>
 					{ ! isUploading ? (
 						<Fragment>
-							<Gridicon icon="cloud-upload" />
-							<H className="woocommerce-theme-uploader__title">
-								{ __( 'Upload a theme', 'woocommerce-admin' ) }
-							</H>
-							<p>{ __( 'Drop a theme zip file here to upload', 'woocommerce-admin' ) }</p>
+							<FormFileUpload accept=".zip" onChange={ this.handleFilesUpload }>
+								<Gridicon icon="cloud-upload" />
+								<H className="woocommerce-theme-uploader__title">
+									{ __( 'Upload a theme', 'woocommerce-admin' ) }
+								</H>
+								<p>{ __( 'Drop a theme zip file here to upload', 'woocommerce-admin' ) }</p>
+							</FormFileUpload>
 							<DropZone
 								label={ __( 'Drop your theme zip file here', 'woocommerce-admin' ) }
 								onFilesDrop={ this.handleFilesDrop }

--- a/client/dashboard/profile-wizard/steps/theme/uploader.js
+++ b/client/dashboard/profile-wizard/steps/theme/uploader.js
@@ -7,7 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { DropZoneProvider, DropZone, Spinner } from '@wordpress/components';
+import { DropZoneProvider, DropZone } from '@wordpress/components';
 import Gridicon from 'gridicons';
 import { noop } from 'lodash';
 import PropTypes from 'prop-types';
@@ -16,7 +16,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { Card, H } from '@woocommerce/components';
+import { Card, H, Spinner } from '@woocommerce/components';
 
 class ThemeUploader extends Component {
 	constructor() {
@@ -81,7 +81,7 @@ class ThemeUploader extends Component {
 						</Fragment>
 					) : (
 						<Fragment>
-							<Spinner key="spinner" />
+							<Spinner />
 							<H className="woocommerce-theme-uploader__title">
 								{ __( 'Uploading theme', 'woocommerce-admin' ) }
 							</H>

--- a/client/dashboard/profile-wizard/steps/theme/uploader.js
+++ b/client/dashboard/profile-wizard/steps/theme/uploader.js
@@ -1,0 +1,96 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { DropZoneProvider, DropZone, Spinner } from '@wordpress/components';
+import Gridicon from 'gridicons';
+import { withDispatch } from '@wordpress/data';
+
+/**
+ * WooCommerce dependencies
+ */
+import { Card, H } from '@woocommerce/components';
+
+class ThemeUploader extends Component {
+	constructor() {
+		super();
+
+		this.state = {
+			isUploading: false,
+		};
+
+		this.handleFilesDrop = this.handleFilesDrop.bind( this );
+	}
+
+	handleFilesDrop( files ) {
+		const file = files[ 0 ];
+
+		this.setState( { isUploading: true } );
+		this.uploadTheme( file );
+	}
+
+	uploadTheme( file ) {
+		const { addNotice } = this.props;
+
+		const body = new FormData();
+		body.append( 'pluginzip', file );
+
+		return apiFetch( { path: '/wc-admin/v1/themes', method: 'POST', body } )
+			.then( response => {
+				this.setState( { isUploading: false } );
+				addNotice( { status: response.status, message: response.message } );
+				if ( 'success' === response.status ) {
+					// @todo Add theme to list of themes; maybe add prop onThemeInstall.
+				}
+			} )
+			.catch( error => {
+				this.setState( { isUploading: false } );
+				if ( error && error.message ) {
+					addNotice( { status: 'error', message: error.message } );
+				}
+			} );
+	}
+
+	render() {
+		const { isUploading } = this.state;
+
+		return (
+			<Card className="woocommerce-theme-uploader">
+				<DropZoneProvider>
+					{ ! isUploading ? (
+						<Fragment>
+							<Gridicon icon="cloud-upload" />
+							<H className="woocommerce-theme-uploader__title">
+								{ __( 'Upload a theme', 'woocommerce-admin' ) }
+							</H>
+							<p>{ __( 'Drop a theme zip file here to upload', 'woocommerce-admin' ) }</p>
+							<DropZone
+								label={ __( 'Drop your theme zip file here', 'woocommerce-admin' ) }
+								onFilesDrop={ this.handleFilesDrop }
+							/>
+						</Fragment>
+					) : (
+						<Fragment>
+							<Spinner key="spinner" />
+							<H className="woocommerce-theme-uploader__title">
+								{ __( 'Uploading theme', 'woocommerce-admin' ) }
+							</H>
+							<p>{ __( 'Your theme is being uploaded', 'woocommerce-admin' ) }</p>
+						</Fragment>
+					) }
+				</DropZoneProvider>
+			</Card>
+		);
+	}
+}
+
+export default compose(
+	withDispatch( dispatch => {
+		const { addNotice } = dispatch( 'wc-admin' );
+		return { addNotice };
+	} )
+)( ThemeUploader );

--- a/includes/api/class-wc-admin-rest-themes-controller.php
+++ b/includes/api/class-wc-admin-rest-themes-controller.php
@@ -89,11 +89,19 @@ class WC_Admin_REST_Themes_Controller extends WC_REST_Data_Controller {
 		}
 
 		if ( ! is_wp_error( $install ) && isset( $install['destination_name'] ) ) {
+			$theme  = $install['destination_name'];
 			$result = array(
 				'status'  => 'success',
 				'message' => $upgrader->strings['process_success'],
-				'theme'   => $install['destination_name'],
+				'theme'   => $theme,
 			);
+
+			/**
+			 * Fires when a theme is successfully installed.
+			 *
+			 * @param string $theme The theme name.
+			 */
+			do_action( 'woocommerce_theme_installed', $theme );
 		} else {
 			if ( is_wp_error( $install ) && $install->get_error_code() ) {
 				$error_message = isset( $upgrader->strings[ $install->get_error_code() ] ) ? $upgrader->strings[ $install->get_error_code() ] : $install->get_error_data();


### PR DESCRIPTION
Fixes #2470

Adds a theme uploader component to the theme browser.

Took a few liberties with the `isUploading` state so probably need a design review.

### Accessibility

I'm wondering if we need an accessible approach and/or default uploader when clicked.

### Screenshots
![theme-upload](https://user-images.githubusercontent.com/10561050/60647914-62f18800-9e71-11e9-973a-9ba1d4afe991.gif)

### Detailed test instructions:

1.  Visit the theme browser in onboarding `wp-admin/admin.php?page=wc-admin&step=theme`.
2.  Drag and drop a valid theme zip into the uploader area.
3.  Make sure the theme is installed successfully and gets added to the theme browser.
4. Upload the same theme or an invalid theme and note the correct error is displayed.
