### PR TITLE
Notes: Only check for scheduled snooze action hourly 

### DIFF
--- a/includes/notes/class-wc-admin-notes.php
+++ b/includes/notes/class-wc-admin-notes.php
@@ -152,11 +152,17 @@ class WC_Admin_Notes {
 	 * Schedule unsnooze notes event.
 	 */
 	public static function schedule_unsnooze_notes() {
-		$queue = WC()->queue();
-		$next  = $queue->get_next( self::UNSNOOZE_HOOK );
 
-		if ( ! $next ) {
-			$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK, array(), self::QUEUE_GROUP );
+		$snooze_checked_transient_key = sprintf( '%s_checked', self::UNSNOOZE_HOOK );
+
+		if ( 'yes' !== get_transient( $snooze_checked_transient_key ) ) {
+			$queue = WC()->queue();
+			$next  = $queue->get_next( self::UNSNOOZE_HOOK );
+
+			if ( ! $next ) {
+				$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK, array(), self::QUEUE_GROUP );
+			}
+			set_transient( $snooze_checked_transient_key, 'yes', HOUR_IN_SECONDS );
 		}
 	}
 


### PR DESCRIPTION
Fixes #2591

Only check for scheduled snooze action hourly rather than on every `admin_init` request. I've added a transient check to take advantage of object caching.

The transient expiration could safely be set to `DAY_IN_SECONDS` to further reduce queries. I've gone with `HOUR_IN_SECONDS` to align it with the scheduled action's recurrence though.

### Detailed test instructions:

1. Load admin page, check this query is run: `SELECT p.ID FROM wp_posts p WHERE p.post_title='woocommerce_update_marketplace_suggestions' AND p.post_type='scheduled-action' AND p.post_status='pending' ORDER BY post_date_gmt ASC LIMIT 1`
2. Load admin page again to check that query _isn't_ run
3. Wait an hour
4. Repeat steps 1 & 2.

### Changelog Note:

* Performance: check for scheduled snooze action once per hour instead of every admin request.
