### PR TITLE
Tracks: Fix Link onclick

### DIFF
--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -4,7 +4,7 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { omitBy, isUndefined } from 'lodash';
+import { omitBy, isUndefined, snakeCase } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -45,7 +45,11 @@ export default class ReportFilters extends Component {
 				recordEvent( 'analytics_filters_remove', { report, filter: data.key } );
 				break;
 			case 'filter':
-				recordEvent( 'analytics_filters_filter', { report, ...data } );
+				const snakeCaseData = Object.keys( data ).reduce( ( result, property ) => {
+					result[ snakeCase( property ) ] = data[ property ];
+					return result;
+				}, {} );
+				recordEvent( 'analytics_filters_filter', { report, snakeCaseData } );
 				break;
 			case 'clear_all':
 				recordEvent( 'analytics_filters_clear_all', { report } );

--- a/packages/components/src/filters/advanced/index.js
+++ b/packages/components/src/filters/advanced/index.js
@@ -198,7 +198,7 @@ class AdvancedFilters extends Component {
 		const { activeFilters, match } = this.state;
 		const availableFilterKeys = this.getAvailableFilterKeys();
 		const updateHref = this.getUpdateHref( activeFilters, match );
-		const updateDisabled = window.location.hash && ( window.location.hash.substr( 1 ) === updateHref || 0 === activeFilters.length );
+		const updateDisabled = ( 'admin.php' + window.location.search === updateHref ) || 0 === activeFilters.length;
 		const isEnglish = this.isEnglish();
 		return (
 			<Card className="woocommerce-filters-advanced woocommerce-analytics__card" title={ this.getTitle() }>

--- a/packages/components/src/link/index.js
+++ b/packages/components/src/link/index.js
@@ -4,6 +4,7 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { partial } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -18,9 +19,18 @@ class Link extends Component {
 	// @todo Investigate further if we can use <Link /> directly.
 	// With React Router 5+, <RouterLink /> cannot be used outside of the main <Router /> elements,
 	// which seems to include components imported from @woocommerce/components. For now, we can use the history object directly.
-	wcAdminLinkHandler( e ) {
-		e.preventDefault();
-		getHistory().push( e.target.closest( 'a' ).getAttribute( 'href' ) );
+	wcAdminLinkHandler( onClick, event ) {
+		event.preventDefault();
+
+		// If there is an onclick event, execute it.
+		const onClickResult = onClick ? onClick( event ) : true;
+
+		// Mimic browser behavior and only continue if onClickResult is not explicitly false.
+		if ( onClickResult === false ) {
+			return;
+		}
+
+		getHistory().push( event.target.closest( 'a' ).getAttribute( 'href' ) );
 	}
 
 	render() {
@@ -39,7 +49,7 @@ class Link extends Component {
 		};
 
 		if ( 'wc-admin' === type ) {
-			passProps.onClick = this.wcAdminLinkHandler;
+			passProps.onClick = partial( this.wcAdminLinkHandler, passProps.onClick );
 		}
 
 		return (


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/2444 Changed logic involving `onClick` props passed to `<Link />` components such that onclicks weren't being executed, including Tracks events.

This PR makes 3 fixes:

* Make sure onclicks are executed.
* Snake case Tracks events property names for `wcadmin_analytics_filters_filter`.
* Fix logic that enables/disables the "Filter" button because it was based on the old url scheme.

### Detailed test instructions

1. In your console `localStorage.setItem( 'debug', 'wc-admin:*' );`
2. Analytics > Orders > Advanced Filters
3. Choose a filter or two, click "Filter"
4. See the event fired.
5. See the "Filter" button disable.

We don't have any configs that are in camel case, so I'm not really sure how to test that part.

