### PR TITLE
restore devdocs URLs after hash removal

### DIFF
--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -12,6 +12,7 @@ import { find, get } from 'lodash';
 import ComponentExample from './example';
 import ComponentDocs from './docs';
 import { Card, Link } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/navigation';
 import examples from './examples.json';
 import './style.scss';
 
@@ -62,10 +63,16 @@ export default class extends Component {
 								component ? (
 									componentName
 								) : (
-									<Link href={ `/devdocs/${ filePath }` }>{ componentName }</Link>
+									<Link href={ getAdminLink( `?page=wc-admin&path=/devdocs/${ filePath }` ) }>
+										{ componentName }
+									</Link>
 								)
 							}
-							action={ component ? <Link href={ '/devdocs' }>Full list</Link> : null }
+							action={
+								component ? (
+									<Link href={ getAdminLink( '?page=wc-admin&path=/devdocs' ) }>Full list</Link>
+								) : null
+							}
 						>
 							<ComponentExample
 								asyncName={ componentName }


### PR DESCRIPTION
Fixes #2595

This is a followup PR to #2444. It updates the devDocs Links to use the path query parameter.

### Detailed test instructions:

- Go to WooCommerce -> DevDocs
- Click on a few component links
- Component documentation pages should load

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Use correct links in DevDocs.