### PR TITLE
Fix: propType validation warnings on embedded pages

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -99,15 +99,15 @@ class Layout extends Component {
 Layout.propTypes = {
 	isEmbedded: PropTypes.bool,
 	page: PropTypes.shape( {
-		container: PropTypes.func.isRequired,
-		path: PropTypes.string.isRequired,
+		container: PropTypes.func,
+		path: PropTypes.string,
 		breadcrumbs: PropTypes.oneOfType( [
 			PropTypes.func,
 			PropTypes.arrayOf(
 				PropTypes.oneOfType( [ PropTypes.arrayOf( PropTypes.string ), PropTypes.string ] )
 			),
 		] ).isRequired,
-		wpOpenMenu: PropTypes.string.isRequired,
+		wpOpenMenu: PropTypes.string,
 	} ).isRequired,
 };
 


### PR DESCRIPTION
`<Layout />` propTypes for `page` marked some properties as `isRequired`. Embedded pages don't make use of those properties so propType validation warnings were thrown on embedded pages.

1. Go to an embedded page.
2. Make sure there are no warnings/errors.

