### PR TITLE
Append '(optional)' to address line 2 label

### DIFF
--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -137,7 +137,7 @@ class StoreDetails extends Component {
 					/>
 
 					<TextControl
-						label={ __( 'Address line 2', 'woocommerce-admin' ) }
+						label={ __( 'Address line 2 (optional)', 'woocommerce-admin' ) }
 						onChange={ value => this.setState( { addressLine2: value } ) }
 						required
 						value={ addressLine2 }


### PR DESCRIPTION
Fixes #2582

Appends `(optional)` to the address line 2 label.

### Screenshots
<img width="524" alt="Screen Shot 2019-07-08 at 1 29 10 PM" src="https://user-images.githubusercontent.com/10561050/60785198-9f302b80-a184-11e9-8252-38e7d56345b9.png">

### Detailed test instructions:

1. Visit `wp-admin/admin.php?page=wc-admin&step=store-details`.
2. Check that the label is updated.