### PR TITLE
Fix margin around onboarding inputs

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -145,6 +145,10 @@
 	}
 
 	/* Muriel style overrides */
+	.muriel-component {
+		margin-top: $gap;
+		margin-bottom: $gap;
+	}
 	.muriel-input-text {
 		&.empty {
 			.components-base-control__label {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -38,6 +38,16 @@
 		}
 	}
 
+	.woocommerce-card__body {
+		> div:first-of-type > .components-base-control {
+			margin-top: 0;
+		}
+
+		> div:last-of-type > .components-base-control {
+			margin-bottom: 0;
+		}
+	}
+
 	.woocommerce-stepper .woocommerce-stepper__step {
 		.woocommerce-stepper__step-label {
 			color: $muriel-gray-800;


### PR DESCRIPTION
Fixes #2583

* Drops margin on first and last inputs inside onboarding cards.
* Adjusts default margin for muriel components.

### Before
<img width="495" alt="Screen Shot 2019-07-08 at 2 37 07 PM" src="https://user-images.githubusercontent.com/10561050/60787911-e4a52680-a18d-11e9-8afd-eaece34ab30a.png">


### After
<img width="510" alt="Screen Shot 2019-07-08 at 2 35 19 PM" src="https://user-images.githubusercontent.com/10561050/60787888-d0f9c000-a18d-11e9-81da-11d66f362179.png">


### Detailed test instructions:

1. Go to the onboarding profiler.
2. Walk through each step and make sure padding around card totals 16px for each side (no margin on inner elements creating additional space).