### PR TITLE
exclude old WC auto-draft orders from import

### DIFF
--- a/client/analytics/settings/historical-data/layout.js
+++ b/client/analytics/settings/historical-data/layout.js
@@ -86,7 +86,7 @@ class HistoricalDataLayout extends Component {
 										total={ customersTotal }
 									/>
 									<HistoricalDataProgress
-										label={ __( 'Orders', 'woocommerce-admin' ) }
+										label={ __( 'Orders and Refunds', 'woocommerce-admin' ) }
 										progress={ ordersProgress }
 										total={ ordersTotal }
 									/>

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -365,7 +365,7 @@ class WC_Admin_Reports_Sync {
 		$count = $wpdb->get_var(
 			"SELECT COUNT(*) FROM {$wpdb->posts}
 			WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
-			AND post_status NOT IN ( 'auto-draft', 'trash' )
+			AND post_status NOT IN ( 'wc-auto-draft', 'auto-draft', 'trash' )
 			{$where_clause}"
 		); // WPCS: unprepared SQL ok.
 


### PR DESCRIPTION
Fixes #2427

WordPress automatically creates a post of post type X when loading the post edit screen. By defualt the auto created post has a post status of `auto-draft`. WP cleans the database daily of posts with the `auto-draft` status. WooCommerce used to (until 3.6.0) change the status of these posts to `wc-auto-draft` (https://github.com/woocommerce/woocommerce/commit/ae17d6f3bdbe4f55b5d9f569dc9624bcca588618). As a result, these posts were not automatically cleaned up by WP.

This PR excludes the old WC auto draft posts from the import process.

### Detailed test instructions:

- Go to Analytics -> Settings
- Uncheck Skip previous
- Compare order count to (WC Orders screen) All orders + Refunded order counts

### Changelog Note:

Fix: exclude old WC auto-draft orders from import