### PR TITLE
Add list component to packages.

### DIFF
--- a/client/devdocs/examples.json
+++ b/client/devdocs/examples.json
@@ -13,6 +13,7 @@
   { "component": "Gravatar" },
   { "component": "ImageAsset" },
   { "component": "Link" },
+  { "component": "List" },
   { "component": "OrderStatus" },
   { "component": "Pagination" },
   { "component": "ProductImage" },

--- a/docs/components/_sidebar.md
+++ b/docs/components/_sidebar.md
@@ -22,6 +22,7 @@
     * [Gravatar](components/packages/gravatar.md)
     * [ImageAsset](components/packages/image-asset.md)
     * [Link](components/packages/link.md)
+    * [List](components/packages/list.md)
     * [OrderStatus](components/packages/order-status.md)
     * [Pagination](components/packages/pagination.md)
     * [ProductImage](components/packages/product-image.md)

--- a/docs/components/packages/list.md
+++ b/docs/components/packages/list.md
@@ -1,0 +1,20 @@
+`List` (component)
+==================
+
+Use `List` to create a list of items to display.
+
+Props
+-----
+
+### `items`
+
+- **Required**
+- Type: Array
+  - title: String - Title displayed for the list item.
+  - description: String - Description displayed beneath the list item title.
+  - before: Node - Content displayed before the list item text.
+  - after: Node - Content displayed after the list item text.
+  - onClick: Function - Click handler for this list item.
+- Default: []
+
+The list items to display.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,6 @@
 # unreleased
 - SearchListItem component: new `countLabel` prop that will overwrite the `item.count` value.
+- Add new component `<List />` for displaying interactive list items.
 
 # 3.1.0
 - Added support for a countLabel prop on SearchListItem to allow custom counts.

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -25,6 +25,7 @@ export { default as Gravatar } from './gravatar';
 export { H, Section } from './section';
 export { default as ImageAsset } from './image-asset';
 export { default as Link } from './link';
+export { default as List } from './list';
 export { default as MenuItem } from './ellipsis-menu/menu-item';
 export { default as MenuTitle } from './ellipsis-menu/menu-title';
 export { default as OrderStatus } from './order-status';

--- a/packages/components/src/list/example.md
+++ b/packages/components/src/list/example.md
@@ -1,0 +1,33 @@
+```jsx
+import { List } from '@woocommerce/components';
+import Gridicon from 'gridicons';
+
+const listItems = [
+    {
+        title: 'List item title',
+        description: 'List item description text',
+    },
+    {
+        before: <Gridicon icon="star" />,
+        title: 'List item with before icon',
+        description: 'List item description text',
+    },
+    {
+        before: <Gridicon icon="star" />,
+        after: <Gridicon icon="chevron-right" />,
+        title: 'List item with before and after icons',
+        description: 'List item description text',
+    },
+    {
+        title: 'Clickable list item',
+        description: 'List item description text',
+        onClick: () => alert( 'List item clicked' ),
+    },
+];
+
+const MyList = () => (
+	<div>
+		<List items={ listItems } />
+	</div>
+);
+```

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -1,0 +1,103 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * List component to display a list of items.
+ */
+class List extends Component {
+    handleKeyDown( event, onClick ) {
+		if ( 'function' === typeof onClick && event.keyCode === ENTER ) {
+			onClick();
+		}
+    }
+
+	render() {
+		const { className, items } = this.props;
+		const listClassName = classnames( 'woocommerce-list', className );
+
+		return (
+			<ul className={ listClassName }>
+				{ items.map( ( item, i ) => {
+					const { after, before, classes, description, onClick, title } = item;
+					const itemClassName = classnames( 'woocommerce-list__item', classes );
+
+					return (
+						<li
+							className={ itemClassName }
+							key={ i }
+							onClick={ 'function' === typeof onClick ? onClick : noop }
+							onKeyDown={ ( e ) => this.handleKeyDown( e, onClick ) }
+							role="menuitem"
+							aria-disabled="false"
+							tabIndex="0"
+						>
+                            { before &&
+                                <div className="woocommerce-list__item-before">
+                                    { before }
+                                </div>
+                            }
+                            <div className="woocommerce-list__item-text">
+                                <span className="woocommerce-list__item-title">
+                                    { title }
+                                </span>
+                                { description &&
+                                    <span className="woocommerce-list__item-description">
+                                        { description }
+                                    </span>
+                                }
+                            </div>
+                            { after &&
+                                <div className="woocommerce-list__item-after">
+                                    { after }
+                                </div>
+                            }
+						</li>
+                    );
+                } ) }
+			</ul>
+		);
+	}
+}
+
+List.propTypes = {
+	/**
+	 * Additional class name to style the component.
+	 */
+	className: PropTypes.string,
+	/**
+	 * An array of list items.
+	 */
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			/**
+			 * Title displayed for the list item.
+			 */
+			title: PropTypes.string.isRequired,
+			/**
+			 * Description displayed beneath the list item title.
+			 */
+			description: PropTypes.string,
+			/**
+			 * Content displayed before the list item text.
+			 */
+			before: PropTypes.node,
+			/**
+			 * Content displayed after the list item text.
+			 */
+			after: PropTypes.node,
+			/**
+			 * Content displayed after the list item text.
+			 */
+            onClick: PropTypes.func,
+		} )
+	).isRequired,
+};
+
+export default List;

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -1,0 +1,32 @@
+.woocommerce-list__item {
+	padding: $gap;
+	display: flex;
+	margin-bottom: 0;
+
+	.woocommerce-list__item-title {
+		display: block;
+		font-size: 16px;
+		line-height: 22px;
+		color: #1a1a1a;
+	}
+
+	.woocommerce-list__item-description {
+		display: block;
+		font-size: 14px;
+		line-height: 20px;
+		color: #50575d;
+	}
+
+	.woocommerce-list__item-before {
+		margin-right: $gap;
+		display: flex;
+		align-items: center;
+	}
+
+	.woocommerce-list__item-after {
+		margin-left: $gap;
+		display: flex;
+		align-items: center;
+		margin-left: auto;
+	}
+}

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -17,6 +17,7 @@
 @import 'filters/style.scss';
 @import 'flag/style.scss';
 @import 'gravatar/style.scss';
+@import 'list/style.scss';
 @import 'order-status/style.scss';
 @import 'pagination/style.scss';
 @import 'product-image/style.scss';


### PR DESCRIPTION
Fixes #2471

Adds a list component that can be used for the onboarding task list.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)

### Screenshots
<img width="631" alt="Screen Shot 2019-07-09 at 8 48 09 PM" src="https://user-images.githubusercontent.com/10561050/60889163-ff10fa00-a28a-11e9-845d-0c29672c9e54.png">

### Detailed test instructions:

1.  Visit the devdocs.
2.  Make sure the `List` component matches the master component style for lists in the Figma designs.