### PR TITLE
show example extension list as list in readme

### DIFF
--- a/docs/examples/extensions/README.md
+++ b/docs/examples/extensions/README.md
@@ -22,6 +22,6 @@ You can make changes to Javascript and PHP files in the example and see changes 
 
 ## Example Extensions
 
-`add-report` - Create a "Hello World" report page.
-`dashboard-section` - Adding a custom "section" to the new dashboard area.
-`table-column` - An example of how to add column(s) to any report.
+- `add-report` - Create a "Hello World" report page.
+- `dashboard-section` - Adding a custom "section" to the new dashboard area.
+- `table-column` - An example of how to add column(s) to any report.


### PR DESCRIPTION
This PR is a formatting fix for the extension examples readme. Currently the extension list is being shown as a paragraph. This PR adds markdown list items for the list.

See https://github.com/woocommerce/woocommerce-admin/blob/fix/example-readme-format/docs/examples/extensions/README.md vs https://github.com/woocommerce/woocommerce-admin/blob/master/docs/examples/extensions/README.md
