### PR TITLE
Onboarding: Change margins on industry intro paragraph.

### DIFF
--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -68,7 +68,9 @@ class Industry extends Component {
 				<H className="woocommerce-profile-wizard__header-title">
 					{ __( 'In which industry does the store operate?', 'woocommerce-admin' ) }
 				</H>
-				<p>{ __( 'Choose any that apply' ) }</p>
+				<p className="woocommerce-profile-wizard__intro-paragraph">
+					{ __( 'Choose any that apply' ) }
+				</p>
 				<Card className="woocommerce-profile-wizard__industry-card">
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ Object.keys( industries ).map( slug => {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -104,6 +104,11 @@
 		margin-bottom: $gap;
 	}
 
+	.woocommerce-profile-wizard__intro-paragraph {
+		margin-top: 5px;
+		margin-bottom: 18px;
+	}
+
 	.woocommerce-profile-wizard__container {
 		margin-top: $gap-larger;
 		margin-left: auto;


### PR DESCRIPTION
Fixes #2585

Style tweaks per @jameskoster's feedback

### Screenshots

__Before__
![before-intro-paragraph](https://user-images.githubusercontent.com/22080/60918271-c8fe5680-a247-11e9-8e1f-ce0697b0cb53.png)

__After__
![spacing-after](https://user-images.githubusercontent.com/22080/60918304-db789000-a247-11e9-9375-70d750c6f4b7.png)

### Detailed test instructions:

- View at `wp-admin/admin.php?page=wc-admin&step=industry`

### Changelog Note:

Tweak: Adjust styling on industry step of OBW.
