### PR TITLE
Dependencies: use WP installation version of wp.components

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ const externals = {
 	'@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 	'@wordpress/keycodes': { this: [ 'wp', 'keycodes' ] },
+	'@wordpress/components': { this: [ 'wp', 'components' ] },
 	tinymce: 'tinymce',
 	moment: 'moment',
 	react: 'React',


### PR DESCRIPTION
Use `window.wp.components` instead of bundling `@wordpress/components`.

Our usage of the lastest npm version of components is problematic on two fronts:

1. Increased bundle size
2. Dependencies of `@wordpress/components` may not be available because they aren’t included in WordPress yet.

### Detailed test instructions:

1. `npm start` and see the app fail.
2. Update and activate Gutenberg plugin.
3. See the app load correctly.

Of course we should wait until we get the `<SnackbarList />` issue resolved first so development can continue.