### PR TITLE
Update uploader component to use snackbar notices

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/uploader.js
+++ b/client/dashboard/profile-wizard/steps/theme/uploader.js
@@ -41,7 +41,7 @@ class ThemeUploader extends Component {
 	}
 
 	uploadTheme( file ) {
-		const { addNotice, onUploadComplete } = this.props;
+		const { createNotice, onUploadComplete } = this.props;
 		this.setState( { isUploading: true } );
 
 		const body = new FormData();
@@ -51,12 +51,12 @@ class ThemeUploader extends Component {
 			.then( response => {
 				onUploadComplete( response );
 				this.setState( { isUploading: false } );
-				addNotice( { status: response.status, message: response.message } );
+				createNotice( response.status, response.message );
 			} )
 			.catch( error => {
 				this.setState( { isUploading: false } );
 				if ( error && error.message ) {
-					addNotice( { status: 'error', message: error.message } );
+					createNotice( 'error', error.message );
 				}
 			} );
 	}
@@ -118,7 +118,7 @@ ThemeUploader.defaultProps = {
 
 export default compose(
 	withDispatch( dispatch => {
-		const { addNotice } = dispatch( 'wc-admin' );
-		return { addNotice };
+		const { createNotice } = dispatch( 'core/notices' );
+		return { createNotice };
 	} )
 )( ThemeUploader );


### PR DESCRIPTION
Fixes #2626

Fixes notice dispatch updates that were merged around the same time as the uploader component.

### Screenshots
<img width="789" alt="Screen Shot 2019-07-10 at 2 45 15 PM" src="https://user-images.githubusercontent.com/10561050/60946738-88730b80-a321-11e9-94cf-90de20c6a597.png">

### Detailed test instructions:

1.  Go to the theme step in onboarding - `/wp-admin/admin.php?page=wc-admin&step=theme`
2.  Check that no error is thrown and notices show with the new snackbar when uploading a theme.