### PR TITLE
Add WC support check for child themes

### DIFF
--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -215,14 +215,22 @@ class WC_Admin_Onboarding {
 	 * @return bool
 	 */
 	public static function has_woocommerce_support( $theme ) {
-		$directory = new RecursiveDirectoryIterator( $theme->theme_root . '/' . $theme->stylesheet );
-		$iterator  = new RecursiveIteratorIterator( $directory );
-		$files     = new RegexIterator( $iterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH );
+		$themes = array( $theme );
+		if ( $theme->get( 'Template' ) ) {
+			$parent_theme = wp_get_theme( $theme->get( 'Template' ) );
+			$themes[]     = $parent_theme;
+		}
 
-		foreach ( $files as $file ) {
-			$content = file_get_contents( $file[0] );
-			if ( preg_match( '/add_theme_support\(([^(]*)(\'|\")woocommerce(\'|\")([^(]*)/si', $content, $matches ) ) {
-				return true;
+		foreach ( $themes as $theme ) {
+			$directory = new RecursiveDirectoryIterator( $theme->theme_root . '/' . $theme->stylesheet );
+			$iterator  = new RecursiveIteratorIterator( $directory );
+			$files     = new RegexIterator( $iterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH );
+
+			foreach ( $files as $file ) {
+				$content = file_get_contents( $file[0] );
+				if ( preg_match( '/add_theme_support\(([^(]*)(\'|\")woocommerce(\'|\")([^(]*)/si', $content, $matches ) ) {
+					return true;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #2590

Checks if the child or parent theme have declared WC support.

### Screenshots
<img width="832" alt="Screen Shot 2019-07-10 at 5 08 26 PM" src="https://user-images.githubusercontent.com/10561050/60956443-65525700-a335-11e9-95af-8a3b4ba702cb.png">

### Detailed test instructions:

1.  Install any theme that does not declare WC support but has a parent theme that does.
2. Delete the themes transient - `wc_onboarding_themes`
3. Visit `wp-admin/admin.php?page=wc-admin&step=theme` and make sure the child theme does not have the red "WC not-supported icon."