### PR TITLE
Fix margin between theme price and buttons

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -66,7 +66,7 @@
 	}
 
 	.woocommerce-profile-wizard__theme-name {
-		margin-top: 0;
+		margin-top: auto;
 		margin-bottom: $gap-smaller;
 		@include font-size(24);
 		font-weight: 400;
@@ -99,9 +99,8 @@
 	}
 
 	.woocommerce-profile-wizard__theme-actions {
-		margin-top: auto;
-
 		button.components-button {
+			margin-top: 13px;
 			display: block;
 			float: left;
 			min-width: 106px;


### PR DESCRIPTION
Fixes #2589

Changes margin from 16px to 13px between theme action buttons and theme price.

### Screenshots
<img width="412" alt="Screen Shot 2019-07-10 at 5 32 50 PM" src="https://user-images.githubusercontent.com/10561050/60958887-be23ee80-a339-11e9-8cb7-d48f5f675fc2.png">

### Detailed test instructions:

1.  Visit `/wp-admin/admin.php?page=wc-admin&step=theme`.
2. Make sure space between buttons and theme price is 13px.