### PR TITLE
Onboarding: Fix checkbox group label color

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -372,6 +372,10 @@
 				left: 3px;
 			}
 
+			label.components-checkbox-control__label {
+				color: $muriel-gray-800;
+			}
+
 			label.components-checkbox-control__label,
 			.components-base-control__help {
 				margin-left: $gap-large * 2;


### PR DESCRIPTION
Fixes #2587

Updates checkbox label color. 

### Screenshots
<img width="506" alt="Screen Shot 2019-07-10 at 6 08 12 PM" src="https://user-images.githubusercontent.com/10561050/60961077-ea416e80-a33d-11e9-9ce2-3cf23ee3b10f.png">


### Detailed test instructions:

1. Visit the industry and product type onboarding steps.
2. Make sure that the color of the checkbox label matches `$muriel-gray-800` (#2b2d2f).
