### PR TITLE
Update padding for checkbox group cards

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -293,7 +293,7 @@ class BusinessDetails extends Component {
 				</H>
 				<p>{ __( 'Tell us about the business' ) }</p>
 
-				<Card className="woocommerce-profile-wizard__product-types-card">
+				<Card>
 					<SelectControl
 						label={ __( 'How many products will you add?', 'woocommerce-admin' ) }
 						onChange={ value => this.updateValue( 'product_count', value ) }

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -87,7 +87,7 @@ class Industry extends Component {
 				<p className="woocommerce-profile-wizard__intro-paragraph">
 					{ __( 'Choose any that apply' ) }
 				</p>
-				<Card className="woocommerce-profile-wizard__industry-card">
+				<Card className="has-checkbox-group">
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ Object.keys( industries ).map( slug => {
 							return (

--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -95,7 +95,7 @@ class ProductTypes extends Component {
 				</H>
 				<p>{ __( 'Choose any that apply' ) }</p>
 
-				<Card className="woocommerce-profile-wizard__product-types-card">
+				<Card className="has-checkbox-group">
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ Object.keys( productTypes ).map( slug => {
 							const helpText = interpolateComponents( {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -27,20 +27,14 @@
 
 		button {
 			display: flex;
-			margin: $gap auto 0;
+			margin: $gap-smaller auto 0;
 			min-width: 310px;
 			max-width: 100%;
 			justify-content: center;
 		}
-	}
 
-	.woocommerce-card__body {
-		> div:first-of-type > .components-base-control {
-			margin-top: 0;
-		}
-
-		> div:last-of-type > .components-base-control {
-			margin-bottom: 0;
+		&.has-checkbox-group .woocommerce-card__body {
+			padding: 0 0 $gap;
 		}
 	}
 
@@ -298,12 +292,6 @@
 		}
 	}
 
-	.woocommerce-profile-wizard__product-types-card {
-		.woocommerce-profile-wizard__benefit-content {
-			margin-left: 12px;
-		}
-	}
-
 	.woocommerce-profile-wizard__toggle {
 		label {
 			font-size: 14px;
@@ -369,14 +357,14 @@
 			margin-top: 0;
 			margin-bottom: 0;
 			position: relative;
-			padding-top: $gap;
-			padding-bottom: $gap;
+			padding: $gap-small $gap;
+			min-height: 56px;
 
 			&::after {
 				content: '';
 				position: absolute;
-				left: $gap-large * 2;
-				width: calc(100% - #{$gap * 2});
+				left: $gap-large * 2 + $gap;
+				width: calc(100% - #{$gap-large * 2 + $gap});
 				height: 1px;
 				background-color: $muriel-gray-50;
 				bottom: 0;
@@ -409,16 +397,11 @@
 				color: $muriel-gray-600;
 				font-size: 14px;
 				line-height: 20px;
-				margin-top: 2px;
-			}
-
-			&:first-of-type {
-				padding-top: 0;
+				margin-top: 3px;
+				margin-bottom: 0;
 			}
 
 			&:last-of-type {
-				padding-bottom: 0;
-
 				&::after {
 					display: none;
 				}


### PR DESCRIPTION
Fixes #2586

Updates checkbox group spacing to match Figma designs.

@jameskoster Let me know if this looks good or any more tweaks are needed.  I had to change some of the recommended CSS to get both checkbox groups styles to match designs.

### Screenshots
<img width="503" alt="Screen Shot 2019-07-10 at 10 17 18 PM" src="https://user-images.githubusercontent.com/10561050/60976587-8e3c1180-a360-11e9-87d1-c2cd999ae449.png">
<img width="497" alt="Screen Shot 2019-07-10 at 10 17 00 PM" src="https://user-images.githubusercontent.com/10561050/60976588-8ed4a800-a360-11e9-8476-9b403c7d8c61.png">


### Detailed test instructions:

1.  Go through all onboarding steps and make sure padding/spacing on checkboxes, cards, and buttons matches Figma styles.