### PR TITLE
update order activity panel to check for all time orders

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -28,12 +28,12 @@ import withSelect from 'wc-api/with-select';
 
 class OrdersPanel extends Component {
 	renderEmptyCard() {
-		const { hasNonActionableOrders } = this.props;
-		if ( hasNonActionableOrders ) {
+		const { hasActionableOrders } = this.props;
+		if ( hasActionableOrders ) {
 			return (
 				<ActivityCard
 					className="woocommerce-empty-activity-card"
-					title={ __( 'You have no orders to fulfill', 'woocommerce-admin' ) }
+					title={ __( 'You have no new orders to fulfill', 'woocommerce-admin' ) }
 					icon={ <Gridicon icon="checkmark" size={ 48 } /> }
 				>
 					{ __( "Good job, you've fulfilled all of your new orders!", 'woocommerce-admin' ) }
@@ -283,6 +283,7 @@ export default compose(
 		const allOrdersQuery = {
 			page: 1,
 			per_page: 0,
+			after: '1970-01-01T00:00:01',
 		};
 
 		const totalNonActionableOrders = getReportItems( 'orders', allOrdersQuery ).totalResults;

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -44,6 +44,7 @@ export function getUnreadOrders( select ) {
 		page: 1,
 		per_page: 0,
 		status_is: orderStatuses,
+		after: '1970-01-01T00:00:01',
 	};
 
 	const totalOrders = getReportItems( 'orders', ordersQuery ).totalResults;


### PR DESCRIPTION
Fixes #2309

The order panel did not have a `hasNonActionableOrders` prop so the no orders empty card was always being displayed when there were no current actionable orders. This PR also 

- updates the all orders query to find if there are any orders vs orders in the last week
- updates the icon title to specify `no new orders`

For the reviewer, should the unread indicator also check for any orders?

### Detailed test instructions:

- Have at least 1 order with processing or on-hold status in the last 7 days
- Check that the order shows in he orders panel
- Cancel that order
- Reload the order panel to check that the no new orders card is shown

### Changelog Note:

Fix: order activity panel check for existing orders.