### PR TITLE
Add priority 3 Tracks events

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -66,7 +66,8 @@ class ReportTable extends Component {
 		}
 	}
 
-	onPageChange() {
+	onPageChange( newPage, source ) {
+		const { endpoint } = this.props;
 		this.scrollPointRef.current.scrollIntoView();
 		const tableElement = this.scrollPointRef.current.nextSibling.querySelector(
 			'.woocommerce-table__table'
@@ -75,6 +76,14 @@ class ReportTable extends Component {
 
 		if ( focusableElements.length ) {
 			focusableElements[ 0 ].focus();
+		}
+
+		if ( source ) {
+			if ( 'goto' === source ) {
+				recordEvent( 'analytics_table_go_to_page', { report: endpoint, page: newPage } );
+			} else {
+				recordEvent( 'analytics_table_page_click', { report: endpoint, direction: source } );
+			}
 		}
 	}
 

--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -18,6 +18,7 @@ import { stringifyQuery } from '@woocommerce/navigation';
  */
 import { formatParams } from './utils';
 import HistoricalDataLayout from './layout';
+import { recordEvent } from 'lib/tracks';
 
 class HistoricalData extends Component {
 	constructor() {
@@ -100,6 +101,7 @@ class HistoricalData extends Component {
 		this.setState( {
 			activeImport: false,
 		} );
+		recordEvent( 'analytics_import_delete_previous' );
 	}
 
 	onReimportData() {

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -127,6 +127,12 @@ class CustomizableDashboard extends Component {
 			// Yes, lets insert.
 			sections.splice( newIndex, 0, movedSection );
 			this.updateSections( sections );
+
+			const eventProps = {
+				key: movedSection.key,
+				direction: 0 < change ? 'down' : 'up',
+			};
+			recordEvent( 'dash_section_order_change', eventProps );
 		} else {
 			// No, lets try the next one.
 			this.onMove( index, change + change );

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -103,7 +103,9 @@ class CustomizableDashboard extends Component {
 			toggledSection.isVisible = ! toggledSection.isVisible;
 			sections.push( toggledSection );
 
-			if ( ! toggledSection.isVisible ) {
+			if ( toggledSection.isVisible ) {
+				recordEvent( 'dash_section_add', { key: toggledSection.key } );
+			} else {
 				recordEvent( 'dash_section_remove', { key: toggledSection.key } );
 			}
 

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -86,6 +86,7 @@ class CustomizableDashboard extends Component {
 
 	onSectionTitleUpdate( updatedKey ) {
 		return updatedTitle => {
+			recordEvent( 'dash_section_rename', { key: updatedKey } );
 			this.updateSection( updatedKey, { title: updatedTitle } );
 		};
 	}

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -43,6 +43,7 @@ class DashboardCharts extends Component {
 				[ 'dashboard_chart_type' ]: chartType,
 			};
 			this.props.updateCurrentUserData( userDataFields );
+			recordEvent( 'dash_charts_type_toggle', { chart_type: chartType } );
 		};
 	}
 

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -139,6 +139,7 @@ class DashboardCharts extends Component {
 				[ 'dashboard_chart_interval' ]: this.state.interval,
 			};
 			this.props.updateCurrentUserData( userDataFields );
+			recordEvent( 'dash_charts_interval', { interval } );
 		} );
 	};
 

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -38,7 +38,7 @@ class Pagination extends Component {
 		if ( page - 1 < 1 ) {
 			return;
 		}
-		onPageChange( page - 1 );
+		onPageChange( page - 1, 'previous' );
 	}
 
 	nextPage( event ) {
@@ -47,7 +47,7 @@ class Pagination extends Component {
 		if ( page + 1 > this.pageCount ) {
 			return;
 		}
-		onPageChange( page + 1 );
+		onPageChange( page + 1, 'next' );
 	}
 
 	perPageChange( perPage ) {
@@ -71,7 +71,7 @@ class Pagination extends Component {
 		const newPage = parseInt( event.target.value, 10 );
 
 		if ( newPage !== page && isFinite( newPage ) && newPage > 0 && this.pageCount && this.pageCount >= newPage ) {
-			onPageChange( newPage );
+			onPageChange( newPage, 'goto' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #2605.

Introduces the following new Tracks events:

Event | Description | Props | Priority | Status
-- | -- | -- | -- | --
wcadmin_dash_section_order_change | When a user moves a dashboard section up or down | section type ( charts, leaderboards, performance indicators ), direction | 3
wcadmin_dash_section_add | When a user adds a section to the dashboard | section type | 3
wcadmin_dash_section_rename | When a user renames a dashboard section | section type ( charts, leaderboards, performance indicators ) | 3
wcadmin_dash_section_add | When a user adds a section to the dashboard | section type | 3
wcadmin_dash_charts_interval | When a user changes the interval for the dashboard charts | interval: hour, day, week, month etc | 3
wcadmin_dash_charts_type_toggle | When a user changes the chart type shown in chart sections | chart_type - type of chart toggled to ( line or bar ) | 3
wcadmin_analytics_table_page_click | When a user clicks the directional arrows in the table pagination footer < > | report name, direction | 3
wcadmin_analytics_table_go_to_page | When a user selects an option from "go to page" in the pagination of the table | report name, page number | 3
wcadmin_analytics_settings_save | When a user saves settings on the analytics settings page | date range value, excluded statuses, actionable statuses | 3
wcadmin_analytics_settings_reset_defaults | When a user resets the analytics settings to defaults | 3
wcadmin_analytics_import_delete_previous | When a user deletes existing report lookup table data | 3

### Detailed test instructions:
- Turn on tracks debug: `localStorage.setItem( 'debug', 'wc-admin:*' );`
- Perform the actions described in the table above
- Verify the tracks events are generated with the appropriate data
