### PR TITLE
Tests setup: bring in Woo Core dependencies

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -180,10 +180,12 @@ install_deps() {
 	cd "wp-content/plugins/"
 	# As zip file does not include tests, we have to get it from git repo.
 	git clone --depth 1 https://github.com/woocommerce/woocommerce.git
-	cd "$WP_CORE_DIR"
+
 	# Bring in WooCommerce Core dependencies
-	ls composer.json
+	cd "woocommerce"
 	composer install
+
+	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce
 
 	if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -181,6 +181,8 @@ install_deps() {
 	# As zip file does not include tests, we have to get it from git repo.
 	git clone --depth 1 https://github.com/woocommerce/woocommerce.git
 	cd "$WP_CORE_DIR"
+	# Bring in WooCommerce Core dependencies
+	composer install
 	php wp-cli.phar plugin activate woocommerce
 
 	if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -182,6 +182,7 @@ install_deps() {
 	git clone --depth 1 https://github.com/woocommerce/woocommerce.git
 	cd "$WP_CORE_DIR"
 	# Bring in WooCommerce Core dependencies
+	ls composer.json
 	composer install
 	php wp-cli.phar plugin activate woocommerce
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -183,7 +183,7 @@ install_deps() {
 
 	# Bring in WooCommerce Core dependencies
 	cd "woocommerce"
-	composer install
+	composer install --no-dev
 
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce


### PR DESCRIPTION
Travis CI tests have been failing lately. This is because WooCommerce Core now has a new build step to install dependencies as of https://github.com/woocommerce/woocommerce/pull/23957.

### Test

1. See the build step succeed on this branch.

Alternatively, locally updated Woo to master and see PHP unit tests fail, then composer install and see them succeed.