### PR TITLE
Disable placeholder animation when prefers-reduced-motion is set

### DIFF
--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -26,6 +26,10 @@
 	&::after {
 		content: '\00a0';
 	}
+
+	@media screen and (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
 // Adds animation to transforms


### PR DESCRIPTION
### Screenshots
![image](https://user-images.githubusercontent.com/3616980/61133863-8e522380-a4be-11e9-8746-a17af4d51afe.png)

### Detailed test instructions:

- To easily see the placeholder, modify [this line](https://github.com/woocommerce/woocommerce-admin/blob/master/client/analytics/components/report-table/index.js#L150) with:
```JSX
isLoading={ true }
```
- Go to any report and disable animations in your system.
- Verify the placeholder's opacity is no longer animated.