### PR TITLE
Chart: Remove z-index from empty message

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 - AdvancedFilters component: fire `onAdvancedFilterAction` for match changes.
 - TableCard component: add `onSearch` an `onSort` function props.
 - Add new component `<List />` for displaying interactive list items.
+- Fix z-index issue in `<Chart />` empty message.
 
 # 3.1.0
 - Added support for a countLabel prop on SearchListItem to allow custom counts.

--- a/packages/components/src/chart/d3chart/style.scss
+++ b/packages/components/src/chart/d3chart/style.scss
@@ -34,7 +34,6 @@
 		right: 0;
 		top: 0;
 		text-align: center;
-		z-index: 1;
 
 		@include breakpoint( '<782px' ) {
 			@include font-size( 13 );


### PR DESCRIPTION
Sometimes a fix is easier than creating an issue :) - I noticed this while testing recently, and @beaulebens reported it in slack this week too. The empty message shown on charts had a z-index set, which caused it to float above things like the Date Picker, and section toggles in the dashboard. 

__Before__
![image](https://user-images.githubusercontent.com/22080/61139873-216b6900-a47f-11e9-8855-cd1170e30d57.png)

The fix here just removes the z-index value which was added in #1979 ( /cc @Aljullu in case there is a case that still warrants the need for the z-index on the empty message ).

__After__
![Dashboard ‹ bend outdoors — WooCommerce 2019-07-12 08-27-15](https://user-images.githubusercontent.com/22080/61139923-4069fb00-a47f-11e9-8333-fa1748448a5c.png)
### Detailed test instructions:

- Select a date range where no data will be shown in charts on the dashboard
- Shrink your viewport so the popover shown when clicking the kebab menu on the chart section will overlap a chart with an empty message
- Verify the empty message is not shown on top of the kebab menu

### Changelog Note:

Fix: Z-index issue in empty message on chart
