### PR TITLE
Replace 'stringifyQuery' with 'addQueryArgs'

### DIFF
--- a/client/analytics/settings/historical-data/index.js
+++ b/client/analytics/settings/historical-data/index.js
@@ -3,15 +3,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
 import moment from 'moment';
 import { withSpokenMessages } from '@wordpress/components';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -110,9 +106,10 @@ class HistoricalData extends Component {
 
 	onStartImport() {
 		const { period, skipChecked } = this.state;
-		const path =
-			'/wc/v4/reports/import' +
-			stringifyQuery( formatParams( this.dateFormat, period, skipChecked ) );
+		const path = addQueryArgs(
+			'/wc/v4/reports/import',
+			formatParams( this.dateFormat, period, skipChecked )
+		);
 		const errorMessage = __(
 			'There was a problem rebuilding your report data.',
 			'woocommerce-admin'

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -2,13 +2,14 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { identity } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
-import { getIdsFromQuery, stringifyQuery } from '@woocommerce/navigation';
+import { getIdsFromQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -30,11 +31,13 @@ export function getRequestByIdString( path, handleData = identity ) {
 		if ( idList.length < 1 ) {
 			return Promise.resolve( [] );
 		}
-		const payload = stringifyQuery( {
+		const payload = {
 			include: idList.join( ',' ),
 			per_page: idList.length,
-		} );
-		return apiFetch( { path: pathString + payload } ).then( data => data.map( handleData ) );
+		};
+		return apiFetch( { path: addQueryArgs( pathString, payload ) } ).then( data =>
+			data.map( handleData )
+		);
 	};
 }
 

--- a/client/wc-api/imports/operations.js
+++ b/client/wc-api/imports/operations.js
@@ -2,13 +2,9 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { omit } from 'lodash';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -33,7 +29,7 @@ function read( resourceNames, fetch = apiFetch ) {
 		const query = getResourceIdentifier( resourceName );
 		const fetchArgs = {
 			parse: false,
-			path: NAMESPACE + `/${ endpoint }${ stringifyQuery( omit( query, [ 'timestamp' ] ) ) }`,
+			path: addQueryArgs( `${ NAMESPACE }/${ endpoint }`, omit( query, [ 'timestamp' ] ) ),
 		};
 
 		try {

--- a/client/wc-api/items/operations.js
+++ b/client/wc-api/items/operations.js
@@ -3,12 +3,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -36,7 +32,7 @@ function read( resourceNames, fetch = apiFetch ) {
 		const prefix = getResourcePrefix( resourceName );
 		const endpoint = typeEndpointMap[ prefix ];
 		const query = getResourceIdentifier( resourceName );
-		const url = NAMESPACE + `/${ endpoint }${ stringifyQuery( query ) }`;
+		const url = addQueryArgs( `${ NAMESPACE }/${ endpoint }`, query );
 		const isUnboundedRequest = -1 === query.per_page;
 
 		try {

--- a/client/wc-api/notes/operations.js
+++ b/client/wc-api/notes/operations.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -31,7 +27,7 @@ function readNoteQueries( resourceNames, fetch ) {
 
 	return filteredNames.map( async resourceName => {
 		const query = getResourceIdentifier( resourceName );
-		const url = `${ NAMESPACE }/admin/notes${ stringifyQuery( query ) }`;
+		const url = addQueryArgs( `${ NAMESPACE }/admin/notes`, query );
 
 		try {
 			const response = await fetch( {

--- a/client/wc-api/reports/items/operations.js
+++ b/client/wc-api/reports/items/operations.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -41,7 +37,7 @@ function read( resourceNames, fetch = apiFetch ) {
 		const query = getResourceIdentifier( resourceName );
 		const fetchArgs = {
 			parse: false,
-			path: NAMESPACE + '/reports/' + endpoint + stringifyQuery( query ),
+			path: addQueryArgs( `${ NAMESPACE }/reports/${ endpoint }`, query ),
 		};
 
 		try {

--- a/client/wc-api/reports/stats/operations.js
+++ b/client/wc-api/reports/stats/operations.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -54,9 +50,9 @@ function read( resourceNames, fetch = apiFetch ) {
 		};
 
 		if ( statEndpoints.indexOf( endpoint ) >= 0 ) {
-			fetchArgs.path = NAMESPACE + '/reports/' + endpoint + '/stats' + stringifyQuery( query );
+			fetchArgs.path = addQueryArgs( `${ NAMESPACE }/reports/${ endpoint }/stats`, query );
 		} else {
-			fetchArgs.path = endpoint + stringifyQuery( query );
+			fetchArgs.path = addQueryArgs( endpoint, query );
 		}
 
 		try {

--- a/client/wc-api/reviews/operations.js
+++ b/client/wc-api/reviews/operations.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,7 +20,7 @@ function readReviewQueries( resourceNames, fetch ) {
 
 	return filteredNames.map( async resourceName => {
 		const query = getResourceIdentifier( resourceName );
-		const url = `${ NAMESPACE }/products/reviews${ stringifyQuery( query ) }`;
+		const url = addQueryArgs( `${ NAMESPACE }/products/reviews`, query );
 
 		try {
 			const response = await fetch( {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@wordpress/i18n": "3.4.0",
     "@wordpress/keycodes": "2.3.0",
     "@wordpress/scripts": "3.2.1",
+    "@wordpress/url": "^2.6.0",
     "@wordpress/viewport": "2.4.0",
     "browser-filesaver": "1.1.1",
     "classnames": "2.2.6",

--- a/packages/components/src/search/autocompleters/categories.js
+++ b/packages/components/src/search/autocompleters/categories.js
@@ -3,13 +3,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import interpolateComponents from 'interpolate-components';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -26,16 +22,12 @@ export default {
 	name: 'categories',
 	className: 'woocommerce-search__product-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				search,
-				per_page: 10,
-				orderby: 'count',
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/products/categories${ payload }` } );
+		const query = search ? {
+			search,
+			per_page: 10,
+			orderby: 'count',
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/products/categories', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( cat ) {

--- a/packages/components/src/search/autocompleters/coupons.js
+++ b/packages/components/src/search/autocompleters/coupons.js
@@ -3,13 +3,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import interpolateComponents from 'interpolate-components';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -26,15 +22,11 @@ export default {
 	name: 'coupons',
 	className: 'woocommerce-search__coupon-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				search,
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/coupons${ payload }` } );
+		const query = search ? {
+			search,
+			per_page: 10,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/coupons', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( coupon ) {

--- a/packages/components/src/search/autocompleters/customers.js
+++ b/packages/components/src/search/autocompleters/customers.js
@@ -3,13 +3,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import interpolateComponents from 'interpolate-components';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -26,16 +22,12 @@ export default {
 	name: 'customers',
 	className: 'woocommerce-search__customers-result',
 	options( name ) {
-		let payload = '';
-		if ( name ) {
-			const query = {
-				search: name,
-				searchby: 'name',
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/customers${ payload }` } );
+		const query = name ? {
+			search: name,
+			searchby: 'name',
+			per_page: 10,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/customers', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {

--- a/packages/components/src/search/autocompleters/download-ips.js
+++ b/packages/components/src/search/autocompleters/download-ips.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,14 +20,10 @@ export default {
 	name: 'download-ips',
 	className: 'woocommerce-search__download-ip-result',
 	options( match ) {
-		let payload = '';
-		if ( match ) {
-			const query = {
-				match,
-			};
-			payload = stringifyQuery( query );
-			return apiFetch( { path: `/wc/v4/data/download-ips${ payload }` } );
-		}
+		const query = match ? {
+			match,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/data/download-ips', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( download ) {

--- a/packages/components/src/search/autocompleters/emails.js
+++ b/packages/components/src/search/autocompleters/emails.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,16 +20,12 @@ export default {
 	name: 'emails',
 	className: 'woocommerce-search__emails-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				search,
-				searchby: 'email',
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/customers${ payload }` } );
+		const query = search ? {
+			search,
+			searchby: 'email',
+			per_page: 10,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/customers', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -2,12 +2,8 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -24,15 +20,11 @@ export default {
 	name: 'orders',
 	className: 'woocommerce-search__order-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				number: search,
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-			return apiFetch( { path: `/wc/v4/orders${ payload }` } );
-		}
+		const query = search ? {
+			number: search,
+			per_page: 10,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/orders', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( order ) {

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -3,13 +3,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import interpolateComponents from 'interpolate-components';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -27,16 +23,12 @@ export default {
 	name: 'products',
 	className: 'woocommerce-search__product-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				search: search,
-				per_page: 10,
-				orderby: 'popularity',
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/products${ payload }` } );
+		const query = search ? {
+			search,
+			per_page: 10,
+			orderby: 'popularity',
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/products', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( product ) {

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -3,13 +3,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import interpolateComponents from 'interpolate-components';
-
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -26,15 +22,11 @@ export default {
 	name: 'taxes',
 	className: 'woocommerce-search__tax-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				code: search,
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/taxes${ payload }` } );
+		const query = search ? {
+			code: search,
+			per_page: 10,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/taxes', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( tax ) {

--- a/packages/components/src/search/autocompleters/usernames.js
+++ b/packages/components/src/search/autocompleters/usernames.js
@@ -2,15 +2,14 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-/**
- * WooCommerce dependencies
- */
-import { stringifyQuery } from '@woocommerce/navigation';
+
 /**
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
+
 /**
  * A customer username completer.
  * See https://github.com/WordPress/gutenberg/tree/master/packages/components/src/autocomplete#the-completer-interface
@@ -21,16 +20,12 @@ export default {
 	name: 'usernames',
 	className: 'woocommerce-search__usernames-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				search,
-				searchby: 'username',
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-		}
-		return apiFetch( { path: `/wc/v4/customers${ payload }` } );
+		const query = search ? {
+			search,
+			searchby: 'username',
+			per_page: 10,
+		} : {};
+		return apiFetch( { path: addQueryArgs( '/wc/v4/customers', query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( customer ) {

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -2,12 +2,13 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
  * WooCommerce dependencies
  */
-import { stringifyQuery, getQuery } from '@woocommerce/navigation';
+import { getQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -40,19 +41,15 @@ export default {
 	name: 'products',
 	className: 'woocommerce-search__product-result',
 	options( search ) {
-		let payload = '';
-		if ( search ) {
-			const query = {
-				search,
-				per_page: 10,
-			};
-			payload = stringifyQuery( query );
-		}
+		const query = search ? {
+			search,
+			per_page: 10,
+		} : {};
 		const product = getQuery().products;
 		if ( ! product || product.includes( ',' ) ) {
 			console.warn( 'Invalid product id supplied to Variations autocompleter' );
 		}
-		return apiFetch( { path: `/wc/v4/products/${ product }/variations${ payload }` } );
+		return apiFetch( { path: addQueryArgs( `/wc/v4/products/${ product }/variations`, query ) } );
 	},
 	isDebounced: true,
 	getOptionKeywords( variation ) {

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `getHistory` updated to reflect path parameters in url query.
 - `getNewPath` also updated to reflect path parameters in url query.
+- `stringifyQuery` method is no longer available, instead use `addQueryArgs` from `@wordpress/url` package.
 
 # 2.1.1
 

--- a/packages/navigation/README.md
+++ b/packages/navigation/README.md
@@ -42,15 +42,6 @@ Get the current path from history.
 
 **Returns**: <code>String</code> - Current path.
 
-### stringifyQuery(query) ⇒ <code>String</code>
-Converts a query object to a query string.
-
-**Returns**: <code>String</code> - Query string.
-
-| Param | Type | Description |
-| --- | --- | --- |
-| query | <code>Object</code> | parameters to be converted. |
-
 ### getTimeRelatedQuery(query) ⇒ <code>Object</code>
 Gets time related parameters from a query.
 

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -2,8 +2,9 @@
 /**
  * External dependencies
  */
-import { isEmpty, pick, uniq } from 'lodash';
-import { parse, stringify } from 'qs';
+import { addQueryArgs } from '@wordpress/url';
+import { parse } from 'qs';
+import { pick, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,14 +37,6 @@ export const getAdminLink = path => wcSettings.adminUrl + path;
  * @return {String}  Current path.
  */
 export const getPath = () => getHistory().location.pathname;
-
-/**
- * Converts a query object to a query string.
- *
- * @param {Object} query parameters to be converted.
- * @return {String} Query string.
- */
-export const stringifyQuery = query => ( isEmpty( query ) ? '' : '?' + stringify( query ) );
 
 /**
  * Gets query parameters that should persist between screens or updates
@@ -99,8 +92,7 @@ export function getSearchWords( query = navUtils.getQuery() ) {
  * @return {String}  Updated URL merging query params into existing params.
  */
 export function getNewPath( query, path = getPath(), currentQuery = getQuery() ) {
-	const queryString = stringifyQuery( { page: 'wc-admin', path, ...currentQuery, ...query } );
-	return `admin.php${ queryString }`;
+	return addQueryArgs( 'admin.php', { page: 'wc-admin', path, ...currentQuery, ...query } );
 }
 
 /**


### PR DESCRIPTION
`@wordpress/url` includes a method named `addQueryArgs` which does exactly the same than our `stringifyQuery`. Given that `@wordpress/url` is already a child dependency, it makes sense using that one instead of duplicating it.

This PR does exactly that, replaces all instances of `stringifyQuery` with `addQueryArgs`.

### Detailed test instructions:

- Basically we need to test that all API calls keep working. Testing the different reports, the autocompleters, the _Import Historical Data_...