### PR TITLE
Onboarding: Update help tab with reset onboarding link

### DIFF
--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -34,13 +34,13 @@ function wc_admin_number_format( $number ) {
  *
  * @return string       Fully qualified URL pointing to the desired path.
  */
-function wc_admin_url( $path, $query = array() ) {
+function wc_admin_url( $path = null, $query = array() ) {
 	if ( ! empty( $query ) ) {
 		$query_string = http_build_query( $query );
-		$path         = $path . '&' . $query_string;
+		$path         = $path ? '&path=' . $path . '&' . $query_string : '';
 	}
 
-	return admin_url( 'admin.php?page=wc-admin&path=' . $path, dirname( __FILE__ ) );
+	return admin_url( 'admin.php?page=wc-admin' . $path, dirname( __FILE__ ) );
 }
 
 /**

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -48,6 +48,7 @@ class WC_Admin_Onboarding {
 		add_action( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 ); // Run after WC_Admin_Loader.
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
+		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
 	}
@@ -314,6 +315,31 @@ class WC_Admin_Onboarding {
 			return $is_loading;
 		}
 		return true;
+	}
+
+	/**
+	 * Update the help tab setup link to reset the onboarding profiler.
+	 */
+	public static function update_help_tab() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {
+			return;
+		}
+
+		$help_tabs = $screen->get_help_tabs();
+
+		foreach ( $help_tabs as $help_tab ) {
+			if ( 'woocommerce_onboard_tab' !== $help_tab['id'] ) {
+				continue;
+			}
+
+			$screen->remove_help_tab( 'woocommerce_onboard_tab' );
+			$help_tab['content'] = '<h2>' . __( 'Setup wizard', 'woocommerce-admin' ) . '</h2>' .
+				'<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
+				'<p><a href="' . wc_admin_url( '&reset_onboarding=1' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
+			$screen->add_help_tab( $help_tab );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2588

Adds a reset link to the help tab in WC.

### Screenshots
<img width="853" alt="Screen Shot 2019-07-16 at 9 37 59 PM" src="https://user-images.githubusercontent.com/10561050/61299146-1e230500-a812-11e9-94a5-bc6f00acab52.png">

### Detailed test instructions:

1. Complete or skip the profiler in the dashboard so it is no longer shown.
2. Visit any WC page in the dashboard.
3.  Open the "Help" tab at the top right.
4. Click the "Setup wizard" button under the "Setup wizard" tab.
5. Make sure that you are redirected to the dashboard and the onboarding profiler is once again displayed.