### PR TITLE
Settings: Fix notice shown after save.

### DIFF
--- a/client/wc-api/settings/selectors.js
+++ b/client/wc-api/settings/selectors.js
@@ -36,7 +36,23 @@ const isGetSettingsRequesting = getResource => group => {
 		return true;
 	}
 
-	return lastRequested > lastReceived;
+	// This selector is used by other "groups", so return early if not looking at wc_admin settings.
+	if ( 'wc_admin' !== group ) {
+		return lastRequested > lastReceived;
+	}
+
+	// Mutation operations for `wc_admin` settings update a different resource (batch endpoint) in fresh-data.
+	// As such we must use lastReceived stamp from that resource to properly compare lastRequested to lastReceived.
+	const { lastReceived: lastMutationReceived } = getResource(
+		getResourceName( 'settings/wc_admin', 'woocommerce_actionable_order_statuses' )
+	);
+
+	// If we don't have a lastReceived on mutations, use the standard resource times.
+	if ( isNil( lastMutationReceived ) ) {
+		return lastRequested > lastReceived;
+	}
+
+	return lastRequested > lastMutationReceived;
 };
 
 export default {

--- a/client/wc-api/settings/selectors.js
+++ b/client/wc-api/settings/selectors.js
@@ -10,6 +10,7 @@ import { isNil } from 'lodash';
  */
 import { DEFAULT_REQUIREMENT } from '../constants';
 import { getResourceName } from '../utils';
+import { analyticsSettings } from 'analytics/settings/config';
 
 const getSettings = ( getResource, requireResource ) => (
 	group,
@@ -43,8 +44,11 @@ const isGetSettingsRequesting = getResource => group => {
 
 	// Mutation operations for `wc_admin` settings update a different resource (batch endpoint) in fresh-data.
 	// As such we must use lastReceived stamp from that resource to properly compare lastRequested to lastReceived.
+	const settingName = analyticsSettings.length
+		? analyticsSettings[ 0 ].name
+		: 'woocommerce_actionable_order_statuses';
 	const { lastReceived: lastMutationReceived } = getResource(
-		getResourceName( 'settings/wc_admin', 'woocommerce_actionable_order_statuses' )
+		getResourceName( 'settings/wc_admin', settingName )
 	);
 
 	// If we don't have a lastReceived on mutations, use the standard resource times.


### PR DESCRIPTION
Fixes #2541 

Currently when you save settings changes on the Analytics | Settings screen, the message informing you that your changes have been saved is not being displayed. As mentioned in the original issue, this was being caused due to the `lastReceived` timestamp on the settings resource not being update on save/mutation.

This appears to be due to the fact that `updateSettings` [calls a batch endpoint](https://github.com/woocommerce/woocommerce-admin/blob/master/client/wc-api/settings/operations.js#L43) and as such, the responses are persisted in a different part of the resource state tree.

The change proposed here is to detect if the group being selected is `wc_admin`, and if so, check to see if we have a `lastReceived` there and use it in the logic to determine if indeed `isGetSettingsRequesting`.

### Screenshots
![save-success](https://user-images.githubusercontent.com/22080/61331371-b4d1d080-a7d6-11e9-8a01-f2f48d477481.gif)

### Detailed test instructions:

Might be nice to test this on master first to see the bug in action...

- Go to Analytics | Settings
- Change a setting, click save
- Note the success toaster message
- Refresh the page and verify your settings indeed have saved.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Bug that was preventing confirmation dialog from showing after saving settings.
