### PR TITLE
Nav: Hide nav on block editor.

### DIFF
--- a/includes/page-controller/class-wc-admin-page-controller.php
+++ b/includes/page-controller/class-wc-admin-page-controller.php
@@ -336,6 +336,12 @@ class WC_Admin_Page_Controller {
 			$is_connected_page = isset( $current_page['js_page'] ) ? ! $current_page['js_page'] : true;
 		}
 
+		// Disable embed on the block editor.
+		$current_screen = get_current_screen();
+		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+			$is_connected_page = false;
+		}
+
 		/**
 		 * Whether or not the current page is an existing page connected to this controller.
 		 *


### PR DESCRIPTION
Fixes #2649 

Currently, if a site is configured to use the block editor on product pages, the WooCommerce Admin nav bar is covering up the top navigation/save action bar of the editor:

__Before__
![image](https://user-images.githubusercontent.com/22080/61335152-5827e300-a7e1-11e9-8831-dfcaa083dabe.png)

Per discussion with @jameskoster - we are opting to disable the wc-admin nav bar if the block editor is in use, and that is what this branch does!

__After__
![image](https://user-images.githubusercontent.com/22080/61335201-81487380-a7e1-11e9-8b5f-3106a7e46fcc.png)

### Detailed test instructions:
To test this out, a quick easy way to force the block editor to be used on your local install is to change the following line in `includes/class-wc-post-types.php` of woo core:

```
diff --git a/includes/class-wc-post-types.php b/includes/class-wc-post-types.php
index 7de16656d..c2eb4e92c 100644
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -585,7 +585,8 @@ class WC_Post_Types {
         * @return bool
         */
        public static function gutenberg_can_edit_post_type( $can_edit, $post_type ) {
-               return 'product' === $post_type ? false : $can_edit;
+               return true;
+               //return 'product' === $post_type ? false : $can_edit;
        }
 
        /**
```

- Once you have done that, edit a product or create a new product on `master`
- Verify the bug exists
- Apply this patch, repeat the first step, and see that the entirety of the block editor is visible
- Remove your hack to woo core files, unless you want to block edit all those products.

### Changelog Note:

Tweak: Disable navigation bar on block editor.
