### PR TITLE
Activity Panels: Fix notification indicator css.

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -99,18 +99,16 @@
 			height: 4px;
 			display: inline-block;
 			border-radius: 50%;
-			top: 10px;
+			top: 8px;
 			left: 50%;
 
 			@include breakpoint( '782px-960px' ) {
-				top: 8px;
 				right: 18px;
 				left: initial;
 				margin-left: 0;
 			}
 
 			@include breakpoint( '>960px' ) {
-				top: 16px;
 				right: 28px;
 				left: initial;
 				margin-left: 0;


### PR DESCRIPTION
Props to @dechov for [letting me know](https://github.com/woocommerce/woocommerce-admin/pull/2562#issuecomment-512028115) that I introduced a regression in #2562 when I failed to change the top attribute for the unread indicators in the activity panels.

In this PR I've set it to 8px for all breakpoints, which was the mid breakpoint size prior to that PR.

/cc @jameskoster to verify this looks correct:

![image](https://user-images.githubusercontent.com/22080/61339969-17d26000-a7f5-11e9-863e-6e2b5a19bf25.png)

![image](https://user-images.githubusercontent.com/22080/61339979-26207c00-a7f5-11e9-92c5-a37ac82aefe1.png)

### Changelog Note:

Fix: Location of unread indicators in activity panel.
