### PR TITLE
Webpack: Use wp.url instead of bundling package

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ const externals = {
 	'@wordpress/editor': { this: [ 'wp', 'editor' ] },
 	'@wordpress/element': { this: [ 'wp', 'element' ] },
 	'@wordpress/hooks': { this: [ 'wp', 'hooks' ] },
+	'@wordpress/url': { this: [ 'wp', 'url' ] },
 	'@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 	'@wordpress/keycodes': { this: [ 'wp', 'keycodes' ] },


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/2655 introduces use of `@wordpress/url` in this repo. In order to make sure we are using the `wp.url` available on the window, this PR designates the packages as an external.

This way we are not bundling the package in our buiild.

### Test

1. npm start
2. Navigate to a report or two and see the app load as usual