### PR TITLE
Fix flash of unstyled content for onboarding pages

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -74,13 +74,13 @@ class ProfileWizard extends Component {
 	componentDidMount() {
 		document.documentElement.classList.remove( 'wp-toolbar' );
 		document.body.classList.add( 'woocommerce-profile-wizard__body' );
-		document.body.classList.add( 'woocommerce-dashboard__body' );
+		document.body.classList.add( 'woocommerce-admin-full-screen' );
 	}
 
 	componentWillUnmount() {
 		document.documentElement.classList.add( 'wp-toolbar' );
 		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
-		document.body.classList.remove( 'woocommerce-dashboard__body' );
+		document.body.classList.remove( 'woocommerce-admin-full-screen' );
 	}
 
 	getCurrentStep() {

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -74,30 +74,3 @@
 		padding-bottom: 10px;
 	}
 }
-
-.woocommerce-dashboard__body {
-	background: $muriel-gray-0;
-	color: $muriel-gray-600;
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
-		'Helvetica Neue', sans-serif;
-
-	#wpbody-content {
-		min-height: 100vh;
-	}
-
-	/* Hide wp-admin and WooCommerce elements when the dashboard body class is present */
-	#adminmenumain,
-	.woocommerce-layout__header,
-	.update-nag,
-	.woocommerce-store-alerts,
-	.woocommerce-message,
-	.notice,
-	.error,
-	.updated {
-		display: none;
-	}
-
-	#wpcontent {
-		margin-left: 0;
-	}
-}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -26,3 +26,45 @@
 .woocommerce-page .update-nag {
 	display: none;
 }
+
+.woocommerce-admin-is-loading {
+	#adminmenumain,
+	#wpfooter,
+	#wpadminbar,
+	.woocommerce-layout__header,
+	.update-nag,
+	.woocommerce-store-alerts,
+	.woocommerce-message,
+	.notice,
+	.error,
+	.updated {
+		display: none;
+	}
+}
+
+.woocommerce-admin-full-screen {
+	background: $muriel-gray-0;
+	color: $muriel-gray-600;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+		'Helvetica Neue', sans-serif;
+
+	#wpbody-content {
+		min-height: 100vh;
+	}
+
+	/* Hide wp-admin and WooCommerce elements when the dashboard body class is present */
+	#adminmenumain,
+	.woocommerce-layout__header,
+	.update-nag,
+	.woocommerce-store-alerts,
+	.woocommerce-message,
+	.notice,
+	.error,
+	.updated {
+		display: none;
+	}
+
+	#wpcontent {
+		margin-left: 0;
+	}
+}

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -312,7 +312,9 @@ class WC_Admin_Onboarding {
 	 */
 	public function is_loading( $is_loading ) {
 		$show_profiler = $this->should_show_profiler();
-		if ( ! $show_profiler ) {
+		$is_dashboard  = ! isset( $_GET['path'] ); // WPCS: csrf ok.
+
+		if ( ! $show_profiler || ! $is_dashboard ) {
 			return $is_loading;
 		}
 		return true;


### PR DESCRIPTION
Fixes #2656

Adds a loading class to the body when the onboarding profile page is shown to prevent admin bars and other irrelevant elements from showing.

### Before (loading)
<img width="1068" alt="Screen Shot 2019-07-18 at 7 18 44 PM" src="https://user-images.githubusercontent.com/10561050/61512346-34a4a880-aa2c-11e9-92d5-6b44f87a4d9c.png">

### After (loading)
<img width="1126" alt="Screen Shot 2019-07-19 at 1 49 40 PM" src="https://user-images.githubusercontent.com/10561050/61512351-379f9900-aa2c-11e9-8371-417e3ae665d7.png">

### Detailed test instructions:

1.  Make sure onboarding is enabled or reset.
2.  Go to the dashboard.
3.  Make sure nothing is shown while loading.
4.  Go to the other wc-admin pages.
5.  Make sure the sidebar and notices continue showing while wc-admin is loading.