### PR TITLE
Remove path from URL in root/dashboard page

### DIFF
--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -92,7 +92,11 @@ export function getSearchWords( query = navUtils.getQuery() ) {
  * @return {String}  Updated URL merging query params into existing params.
  */
 export function getNewPath( query, path = getPath(), currentQuery = getQuery() ) {
-	return addQueryArgs( 'admin.php', { page: 'wc-admin', path, ...currentQuery, ...query } );
+	const args = { page: 'wc-admin', ...currentQuery, ...query };
+	if ( '/' !== path ) {
+		args.path = path;
+	}
+	return addQueryArgs( 'admin.php', args );
 }
 
 /**


### PR DESCRIPTION
Fixes #2668

Remove the path param from the URL on dashboard pages.  Previously `updateQueryString` would add `&path=%2f` to the URL causing errors on route change or refresh.

### Detailed test instructions:

1.  Enable the onboarding profiler or task list.
2. Try continuing to the next step, navigating back and forth, and refreshing.
3. Make sure `&path=...` does not get appended to any routes in the dashboard.
4. Make sure other routes continue to work as expected.