### PR TITLE
Fix missing nav on connected admin pages.

### DIFF
--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -50,7 +50,7 @@ class WC_Admin_Onboarding {
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
-		add_action( 'admin_init', array( $this, 'reset_onboarding' ) );
+		add_action( 'current_screen', array( $this, 'reset_onboarding' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
 	}

--- a/includes/page-controller/class-wc-admin-page-controller.php
+++ b/includes/page-controller/class-wc-admin-page-controller.php
@@ -187,6 +187,12 @@ class WC_Admin_Page_Controller {
 	 * @return array|boolean Current page or false if not registered with this controller.
 	 */
 	public function get_current_page() {
+		// If 'current_screen' hasn't fired yet, the current page calculation
+		// will fail which causes `false` to be returned for all subsquent calls.
+		if ( ! did_action( 'current_screen' ) ) {
+			_doing_it_wrong( __FUNCTION__, esc_html__( 'Current page retreival should be called on or after the `current_screen` hook.', 'woocommerce-admin' ) );
+		}
+
 		if ( is_null( $this->current_page ) ) {
 			$this->determine_current_page();
 		}


### PR DESCRIPTION
The nav bar disappeared from connected admin pages after https://github.com/woocommerce/woocommerce-admin/commit/881f209.

The root cause was calling `WC_Admin_Loader::is_admin_page()` before the `current_screen` hook had fired. This caused the page controller class to return `false` for all calls to `get_current_page()`, breaking the rest of the plugin's detection for enqueuing scripts, etc. 

This PR seeks to change the onboarding reset callback to the `current_screen` hook as well as introduce a "doing it wrong" if `get_current_page()` is called before `current_screen`.

### Detailed test instructions:

- Go to WooCommerce > Orders
- Verify the nav bar displays
- Go to WooCommerce > Settings
- Verify the nav bar displays
