### PR TITLE
Notice: Update feedback notice verbiage and action.

### DIFF
--- a/includes/notes/class-wc-admin-notes-giving-feedback-notes.php
+++ b/includes/notes/class-wc-admin-notes-giving-feedback-notes.php
@@ -51,8 +51,8 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 
 		// Otherwise, create our new note.
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Giving feedback', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Are you enjoying the new WooCommerce experience? We\'d love to get your feedback.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Review your experience', 'woocommerce-admin' ) );
+		$note->set_content( __( 'If you like WooCommerce Admin please leave us a 5 star rating. A huge thanks in advance!', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'info' );
@@ -60,8 +60,8 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'share-feedback',
-			__( 'Share feedback', 'woocommerce-admin' ),
-			'https://github.com/woocommerce/woocommerce-admin/issues/new/choose'
+			__( 'Review', 'woocommerce-admin' ),
+			'https://wordpress.org/support/plugin/woocommerce-admin/reviews/?rate=5#new-post'
 		);
 		$note->save();
 	}


### PR DESCRIPTION
Closes #2486

This branch updates the text and action associated with the Feedback notice, and now prompts users to leave Feedback on the .org repository.

As you can see in the screenshot below, it appears we might have a bug with the timestamp display in the inbox. The new notification shown is _in the future_ - I will file a bug for that so we can follow up on it in a different PR.

### Screenshots

<img width="507" alt="Dashboard ‹ bend outdoors — WooCommerce 2019-07-19 11-51-45" src="https://user-images.githubusercontent.com/22080/61558522-264e9080-aa1c-11e9-8fa4-b9050d5aa174.png">

### Detailed test instructions:

Couple of manual things you need to do to help make testing this PR happen a bit more quickly. First up, you need to delete the current feedback notice which likely is already in your test db:

`DELETE FROM `wp_wc_admin_notes` WHERE name = 'wc-admin-store-notice-giving-feedback'`
**note your db table prefix might be different, so adjust accordingly**

Next up, unless you really want to wait for wpcron to do its thing, you can manually call the method that possibly creates this notification:

```
diff --git a/woocommerce-admin.php b/woocommerce-admin.php
index 0cd368a2..71d35549 100755
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -165,6 +165,8 @@ class WC_Admin_Feature_Plugin {
                require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-notes-order-milestones.php';
                require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-notes-mobile-app.php';
                require_once WC_ADMIN_ABSPATH . 'includes/notes/class-wc-admin-notes-welcome-message.php';
+
+               WC_Admin_Notes_Giving_Feedback_Notes::add_notes_for_admin_giving_feedback();
        }
 
        /**
```

- Okay once that is all done, you can now open up any woo page, and expand the inbox tab to see the notification.
- Click on the action and verify a new window is opened and you are on the feedback page for woocommerce-admin with a ⭐️⭐️⭐️⭐️⭐️ rating pre-selected.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Tweak: Change verbiage of feedback notification.
