### PR TITLE
Onboarding: Add WebPreview component for theme previewing

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -23,6 +23,7 @@ import withSelect from 'wc-api/with-select';
 import './style.scss';
 import { recordEvent } from 'lib/tracks';
 import ThemeUploader from './uploader';
+import ThemePreview from './preview';
 
 class Theme extends Component {
 	constructor() {
@@ -30,11 +31,13 @@ class Theme extends Component {
 
 		this.state = {
 			activeTab: 'all',
+			demo: null,
 			uploadedThemes: [],
 		};
 
 		this.handleUploadComplete = this.handleUploadComplete.bind( this );
 		this.onChoose = this.onChoose.bind( this );
+		this.onClosePreview = this.onClosePreview.bind( this );
 		this.onSelectTab = this.onSelectTab.bind( this );
 		this.openDemo = this.openDemo.bind( this );
 	}
@@ -56,10 +59,15 @@ class Theme extends Component {
 		}
 	}
 
-	openDemo( theme ) {
-		// @todo This should open a theme demo preview.
+	onClosePreview() {
+		document.body.classList.remove( 'woocommerce-theme-preview-active' );
+		this.setState( { demo: null } );
+	}
 
-		recordEvent( 'storeprofiler_store_theme_live_demo', { theme } );
+	openDemo( theme ) {
+		document.body.classList.add( 'woocommerce-theme-preview-active' );
+		this.setState( { demo: theme } );
+		recordEvent( 'storeprofiler_store_theme_live_demo', { theme: theme.slug } );
 	}
 
 	renderTheme( theme ) {
@@ -95,7 +103,7 @@ class Theme extends Component {
 							{ __( 'Choose', 'woocommerce-admin' ) }
 						</Button>
 						{ demo_url && (
-							<Button isDefault onClick={ () => this.openDemo( slug ) }>
+							<Button isDefault onClick={ () => this.openDemo( theme ) }>
 								{ __( 'Live Demo', 'woocommerce-admin' ) }
 							</Button>
 						) }
@@ -157,6 +165,7 @@ class Theme extends Component {
 
 	render() {
 		const themes = this.getThemes();
+		const { demo } = this.state;
 
 		return (
 			<Fragment>
@@ -192,6 +201,9 @@ class Theme extends Component {
 						</div>
 					) }
 				</TabPanel>
+				{ demo && (
+					<ThemePreview theme={ demo } onChoose={ this.onChoose } onClose={ this.onClosePreview } />
+				) }
 			</Fragment>
 		);
 	}

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -50,6 +50,7 @@ class ThemePreview extends Component {
 					</Button>
 					<div className="woocommerce-theme-preview__theme-name">
 						{ interpolateComponents( {
+							/* translators: Describing who a previewed theme is developed by. E.g., Storefront developed by WooCommerce */
 							mixedString: sprintf(
 								__( '{{strong}}%s{{/strong}} developed by WooCommerce', 'woocommerce-admin' ),
 								title

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -46,7 +46,7 @@ class ThemePreview extends Component {
 			<div className="woocommerce-theme-preview">
 				<div className="woocommerce-theme-preview__toolbar">
 					<Button className="woocommerce-theme-preview__close" onClick={ onClose }>
-						<i className="material-icons-outlined">arrow_back</i>
+						<i className="material-icons-outlined">close</i>
 					</Button>
 					<div className="woocommerce-theme-preview__theme-name">
 						{ interpolateComponents( {

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -1,0 +1,82 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from 'newspack-components';
+import { Component } from '@wordpress/element';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { WebPreview } from '@woocommerce/components';
+
+const devices = [
+	{
+		key: 'mobile',
+		icon: 'phone_android',
+	},
+	{
+		key: 'tablet',
+		icon: 'tablet_android',
+	},
+	{
+		key: 'desktop',
+		icon: 'desktop_windows',
+	},
+];
+
+class ThemePreview extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			device: 'desktop',
+		};
+	}
+
+	render() {
+		const { onChoose, onClose, theme } = this.props;
+		const { demo_url, slug, title } = theme;
+		const { device: currentDevice } = this.state;
+
+		return (
+			<div className="woocommerce-theme-preview">
+				<div className="woocommerce-theme-preview__toolbar">
+					<Button className="woocommerce-theme-preview__close" onClick={ onClose }>
+						<i className="material-icons-outlined">arrow_back</i>
+					</Button>
+					<div className="woocommerce-theme-preview__theme-name">
+						{ interpolateComponents( {
+							mixedString: sprintf(
+								__( '{{strong}}%s{{/strong}} developed by WooCommerce', 'woocommerce-admin' ),
+								title
+							),
+							components: {
+								strong: <strong />,
+							},
+						} ) }
+					</div>
+					<div className="woocommerce-theme-preview__devices">
+						{ devices.map( device => (
+							<Button
+								key={ device.key }
+								className="woocommerce-theme-preview__device"
+								onClick={ () => this.setState( { device: device.key } ) }
+							>
+								<i className="material-icons-outlined">{ device.icon }</i>
+							</Button>
+						) ) }
+					</div>
+					<Button isPrimary onClick={ () => onChoose( slug ) }>
+						{ __( 'Choose', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+				<WebPreview src={ demo_url } title={ title } className={ `is-${ currentDevice }` } />
+			</div>
+		);
+	}
+}
+
+export default ThemePreview;

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -4,6 +4,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from 'newspack-components';
+import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
 
@@ -62,7 +63,9 @@ class ThemePreview extends Component {
 						{ devices.map( device => (
 							<Button
 								key={ device.key }
-								className="woocommerce-theme-preview__device"
+								className={ classnames( 'woocommerce-theme-preview__device', {
+									'is-selected': device.key === currentDevice,
+								} ) }
 								onClick={ () => this.setState( { device: device.key } ) }
 							>
 								<i className="material-icons-outlined">{ device.icon }</i>

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -176,3 +176,101 @@
 		margin: 0;
 	}
 }
+
+.woocommerce-theme-preview {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	max-width: 100% !important;
+	display: flex;
+	flex-direction: column;
+
+	.woocommerce-theme-preview__toolbar {
+		background: $white;
+		flex-direction: row;
+		display: flex;
+		height: 56px;
+		border-bottom: 1px solid $muriel-gray-50;
+		padding-left: $gap;
+		padding-right: $gap;
+		align-items: center;
+
+		.muriel-button.is-button.is-primary {
+			height: 40px;
+			margin: 0;
+
+			@include breakpoint( '<782px' ) {
+				margin-left: auto;
+			}
+		}
+	}
+
+	.woocommerce-theme-preview__theme-name {
+		padding-left: $gap;
+		color: #1a1a1a;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 50%;
+	}
+
+	.woocommerce-theme-preview__close {
+		padding: 0 $gap 0 0;
+		color: $muriel-gray-500;
+	}
+
+	.woocommerce-theme-preview__devices {
+		margin-left: auto;
+		margin-right: $gap-smallest;
+
+		.muriel-button {
+			padding: $gap-small;
+			color: $muriel-gray-500;
+			margin: 0;
+		}
+
+		@include breakpoint( '<782px' ) {
+			display: none;
+		}
+	}
+
+	.woocommerce-web-preview {
+		flex: 1;
+		padding: $gap-largest $gap;
+		overflow: scroll;
+
+		.woocommerce-web-preview__iframe-wrapper {
+			height: 100%;
+			border-radius: 3px;
+			box-shadow: $muriel-box-shadow-1dp;
+			overflow: hidden;
+			margin: 0 auto;
+
+			iframe {
+				display: block;
+			}
+		}
+
+		&.is-mobile .woocommerce-web-preview__iframe-wrapper {
+			max-width: 360px;
+		}
+
+		&.is-tablet .woocommerce-web-preview__iframe-wrapper {
+			max-width: 768px;
+		}
+
+		&.is-desktop .woocommerce-web-preview__iframe-wrapper {
+			max-width: 1280px;
+		}
+	}
+}
+
+.woocommerce-theme-preview-active {
+	overflow: hidden;
+
+	.woocommerce-profile-wizard__header {
+		display: none;
+	}
+}

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -223,7 +223,7 @@
 
 	.woocommerce-theme-preview__devices {
 		margin-left: auto;
-		margin-right: $gap-smallest;
+		margin-right: $gap;
 
 		.muriel-button {
 			padding: $gap-small;
@@ -268,8 +268,14 @@
 			max-width: 768px;
 		}
 
-		&.is-desktop .woocommerce-web-preview__iframe-wrapper {
-			max-width: 1280px;
+		&.is-desktop {
+			width: 100%;
+			padding: 0;
+
+			.woocommerce-web-preview__iframe-wrapper {
+				border-radius: 0;
+				box-shadow: none;
+			}
 		}
 	}
 }

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -229,6 +229,13 @@
 			padding: $gap-small;
 			color: $muriel-gray-500;
 			margin: 0;
+			border-radius: 50%;
+
+			&.is-selected,
+			&:focus {
+				background: $muriel-gray-500;
+				color: $white;
+			}
 		}
 
 		@include breakpoint( '<782px' ) {

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -86,7 +86,7 @@
 		padding: $gap;
 		display: flex;
 		flex-direction: column;
-		height: 100%;
+		margin-top: auto;
 	}
 
 	.woocommerce-profile-wizard__theme-status {

--- a/client/devdocs/examples.json
+++ b/client/devdocs/examples.json
@@ -30,5 +30,6 @@
   { "component": "Table" },
   { "component": "Tag" },
   { "component": "TextControlWithAffixes" },
-  { "component": "ViewMoreList" }
+  { "component": "ViewMoreList" },
+  { "component": "WebPreview" }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9234,8 +9234,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9253,13 +9252,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9272,18 +9269,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9386,8 +9380,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9397,7 +9390,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9410,20 +9402,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9440,7 +9429,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9513,8 +9501,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9524,7 +9511,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9600,8 +9586,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9631,7 +9616,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9649,7 +9633,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9688,13 +9671,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new component `<List />` for displaying interactive list items.
 - Fix z-index issue in `<Chart />` empty message.
 - Added a new `<SimpleSelectControl />` component.
+- Added a new `<WebPreview />` component.
 
 # 3.1.0
 - Added support for a countLabel prop on SearchListItem to allow custom counts.

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -56,3 +56,4 @@ export { default as Tag } from './tag';
 export { default as TextControlWithAffixes } from './text-control-with-affixes';
 export { default as useFilters } from './higher-order/use-filters';
 export { default as ViewMoreList } from './view-more-list';
+export { default as WebPreview } from './web-preview';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -35,3 +35,4 @@
 @import 'tag/style.scss';
 @import 'text-control-with-affixes/style.scss';
 @import 'view-more-list/style.scss';
+@import 'web-preview/style.scss';

--- a/packages/components/src/web-preview/example.md
+++ b/packages/components/src/web-preview/example.md
@@ -1,0 +1,9 @@
+```jsx
+import { WebPreview } from '@woocommerce/components';
+
+const MyWebPreview = () => (
+	<div>
+		<WebPreview src="https://themes.woocommerce.com/?name=galleria" title="My Web Preview" />
+	</div>
+);
+```

--- a/packages/components/src/web-preview/index.js
+++ b/packages/components/src/web-preview/index.js
@@ -1,0 +1,90 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component, createRef } from '@wordpress/element';
+import { noop } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Spinner from '../spinner';
+
+/**
+ * WebPreview component to display an iframe of another page.
+ */
+class WebPreview extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isLoading: true,
+		};
+
+		this.iframeRef = createRef();
+		this.setLoaded = this.setLoaded.bind( this );
+	}
+
+	componentDidMount() {
+		this.iframeRef.current.addEventListener( 'load', this.setLoaded );
+	}
+
+	setLoaded() {
+		this.setState( { isLoading: false } );
+		this.props.onLoad();
+	}
+
+	render() {
+		const { className, loading, src, title } = this.props;
+		const { isLoading } = this.state;
+
+		const classes = classnames( 'woocommerce-web-preview', className, {
+			'is-loading': isLoading,
+		} );
+
+		return (
+			<div className={ classes }>
+				{ isLoading && loading }
+				<div className="woocommerce-web-preview__iframe-wrapper">
+					<iframe
+						ref={ this.iframeRef }
+						title={ title }
+						src={ src }
+					/>
+				</div>
+			</div>
+		);
+	}
+}
+
+WebPreview.propTypes = {
+	/**
+	 * Additional class name to style the component.
+	 */
+	className: PropTypes.string,
+	/**
+	 * Content shown when iframe is still loading.
+	 */
+	loading: PropTypes.node,
+	/**
+	 * Function to fire when iframe content is loaded.
+	 */
+	onLoad: PropTypes.func,
+	/**
+	 * Iframe src to load.
+	 */
+	src: PropTypes.string.isRequired,
+	/**
+	 * Iframe title.
+	 */
+	title: PropTypes.string.isRequired,
+};
+
+WebPreview.defaultProps = {
+	loading: <Spinner />,
+	onLoad: noop,
+};
+
+export default WebPreview;

--- a/packages/components/src/web-preview/index.js
+++ b/packages/components/src/web-preview/index.js
@@ -67,7 +67,7 @@ WebPreview.propTypes = {
 	/**
 	 * Content shown when iframe is still loading.
 	 */
-	loading: PropTypes.node,
+	loadingContent: PropTypes.node,
 	/**
 	 * Function to fire when iframe content is loaded.
 	 */

--- a/packages/components/src/web-preview/index.js
+++ b/packages/components/src/web-preview/index.js
@@ -37,7 +37,7 @@ class WebPreview extends Component {
 	}
 
 	render() {
-		const { className, loading, src, title } = this.props;
+		const { className, loadingContent, src, title } = this.props;
 		const { isLoading } = this.state;
 
 		const classes = classnames( 'woocommerce-web-preview', className, {
@@ -46,7 +46,7 @@ class WebPreview extends Component {
 
 		return (
 			<div className={ classes }>
-				{ isLoading && loading }
+				{ isLoading && loadingContent }
 				<div className="woocommerce-web-preview__iframe-wrapper">
 					<iframe
 						ref={ this.iframeRef }
@@ -83,7 +83,7 @@ WebPreview.propTypes = {
 };
 
 WebPreview.defaultProps = {
-	loading: <Spinner />,
+	loadingContent: <Spinner />,
 	onLoad: noop,
 };
 

--- a/packages/components/src/web-preview/style.scss
+++ b/packages/components/src/web-preview/style.scss
@@ -1,23 +1,23 @@
 .woocommerce-web-preview {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: $muriel-gray-0;
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: $muriel-gray-0;
 
-    &.is-loading {
-        .woocommerce-web-preview__iframe-wrapper {
-            display: none;
-        }
-    }
+	&.is-loading {
+		.woocommerce-web-preview__iframe-wrapper {
+			display: none;
+		}
+	}
 
-    .woocommerce-web-preview__iframe-wrapper {
+	.woocommerce-web-preview__iframe-wrapper {
 		width: 100%;
-    }
+	}
 
-    iframe {
-        width: 100%;
-        height: 100%;
-        min-height: 400px;
-    }
+	iframe {
+		width: 100%;
+		height: 100%;
+		min-height: 400px;
+	}
 }

--- a/packages/components/src/web-preview/style.scss
+++ b/packages/components/src/web-preview/style.scss
@@ -1,0 +1,23 @@
+.woocommerce-web-preview {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: $muriel-gray-0;
+
+    &.is-loading {
+        .woocommerce-web-preview__iframe-wrapper {
+            display: none;
+        }
+    }
+
+    .woocommerce-web-preview__iframe-wrapper {
+		width: 100%;
+    }
+
+    iframe {
+        width: 100%;
+        height: 100%;
+        min-height: 400px;
+    }
+}


### PR DESCRIPTION
Fixes #2469

Adds a `WebPreview` component to load content into an iframe.  Used to preview themes in the theme step in onboarding.

### Screenshots
<img width="1355" alt="Screen Shot 2019-07-22 at 4 21 21 PM" src="https://user-images.githubusercontent.com/10561050/61617525-725c3800-ac9d-11e9-93d6-3ac35588fa38.png">

### Detailed test instructions:

1. Visit the theme step in onboarding `wp-admin/admin.php?page=wc-admin&path&step=theme`.
2. Click on "Live Demo" for any of the themes.
3.  Make sure the loader is shown when loading and that the theme preview is loaded into the iframe.
4. Check that content is resized based on the device toggle (desktop/tablet/mobile).
5. Make sure that clicking "Choose" selects the theme and completes the onboarding profiler.