### PR TITLE
Only apply current submenu CSS reset on non-embed pages.

### DIFF
--- a/client/stylesheets/_index.scss
+++ b/client/stylesheets/_index.scss
@@ -3,6 +3,27 @@
 // Import our wp-admin reset.
 @import './shared/_reset.scss';
 
+// Some WooCommerce Admin page specific resets.
+.woocommerce-page {
+	.wp-has-current-submenu::after {
+		right: 0;
+		border: 8px solid transparent;
+		content: ' ';
+		height: 0;
+		width: 0;
+		position: absolute;
+		pointer-events: none;
+		border-right-color: #f1f1f1;
+		top: 0;
+		margin-top: 10px;
+
+		@include breakpoint( '<960px' ) {
+			border-width: 4px;
+			margin-top: 14px;
+		}
+	}
+}
+
 // Import any global styles.
 @import './shared/_global.scss';
 

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -38,24 +38,6 @@
 			padding-bottom: 1px;
 		}
 	}
-
-	.wp-has-current-submenu::after {
-		right: 0;
-		border: 8px solid transparent;
-		content: ' ';
-		height: 0;
-		width: 0;
-		position: absolute;
-		pointer-events: none;
-		border-right-color: #f1f1f1;
-		top: 0;
-		margin-top: 10px;
-
-		@include breakpoint( '<960px' ) {
-			border-width: 4px;
-			margin-top: 14px;
-		}
-	}
 }
 
 .woocommerce-layout * {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/459

Only applies the "current submenu" CSS reset on pages rendered using React in WooCommerce Admin - the application of the reset on embed pages causes a 🐟mouth effect. This causes @timmyc to run off for months at a time to go fishing. 😛 

### Detailed test instructions:

- Enable Calypsoify
- Go to WooCommerce > Dashboard
- Verify the WooCommerce menu has **a single arrow** denoting "current"
- Go to WooCommerce > Orders
- Verify the WooCommerce menu has **a single arrow** denoting "current"

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
