### PR TITLE
add filter to feature config array

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -296,7 +296,7 @@ class WC_Admin_Feature_Plugin {
 		if ( ! function_exists( 'wc_admin_get_feature_config' ) ) {
 			require_once WC_ADMIN_ABSPATH . '/includes/feature-config.php';
 		}
-		$feature_config = wc_admin_get_feature_config();
+		$feature_config = apply_filters( 'wc_admin_get_feature_config', wc_admin_get_feature_config() );
 		$features       = array_keys( array_filter( $feature_config ) );
 		return $features;
 	}


### PR DESCRIPTION
This PR adds a filter to allow plugins to add/remove features from the feature config array. While this will be generally useful in single site, it will allow enabling features per site in multisite without dynamically creating a function for each site.


### Detailed test instructions:

- Add a filter to `wc_admin_get_feature_config` and remove one of the array elements (eg. `devdocs`)
- Load the dashboard and check that the menu item is not present


### Changelog Note:

Dev: Add `wc_admin_get_feature_config` filter to feature config array.