### PR TITLE
Fix react-spring breaking IE11.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -148,6 +148,8 @@ const webpackConfig = {
 		],
 		alias: {
 			'gutenberg-components': path.resolve( __dirname, 'node_modules/@wordpress/components/src' ),
+			// @todo - remove once https://github.com/WordPress/gutenberg/pull/16196 is released.
+			'react-spring': 'react-spring/web.cjs',
 		},
 	},
 	plugins: [


### PR DESCRIPTION
Fixes #2693.

This PR seeks to resolve the `react-spring` conflict with IE11 by temporarily aliasing the import like in this Gutenberg PR: https://github.com/WordPress/gutenberg/pull/16196.

Once the `@wordpress/components` package is updated to include the changes in the referenced PR, we can remove the alias.

### Detailed test instructions:

- Open any WooCommerce Admin page in IE11
- Verify it renders

