### PR TITLE
Ensure content to wrapper alignment during Activity Panel transitions

### DIFF
--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -34,6 +34,7 @@ class ActivityPanel extends Component {
 	constructor() {
 		super( ...arguments );
 		this.togglePanel = this.togglePanel.bind( this );
+		this.clearPanel = this.clearPanel.bind( this );
 		this.toggleMobile = this.toggleMobile.bind( this );
 		this.renderTab = this.renderTab.bind( this );
 		this.updateNoticeFlag = this.updateNoticeFlag.bind( this );
@@ -72,12 +73,18 @@ class ActivityPanel extends Component {
 			) {
 				return {
 					isPanelOpen: ! state.isPanelOpen,
-					currentTab: state.isPanelOpen ? '' : tabName,
+					currentTab: tabName,
 					mobileOpen: ! state.isPanelOpen,
 				};
 			}
 			return { currentTab: tabName };
 		} );
+	}
+
+	clearPanel() {
+		this.setState(
+			( { isPanelOpen } ) => ( isPanelOpen ? null : { currentTab: '' } )
+		);
 	}
 
 	// On smaller screen, the panel buttons are hidden behind a toggle.
@@ -169,17 +176,20 @@ class ActivityPanel extends Component {
 		} );
 
 		return (
-			<div className={ classNames } tabIndex={ 0 } role="tabpanel" aria-label={ tab.title }>
-				{ ( isPanelOpen && (
-					<div
-						className="woocommerce-layout__activity-panel-content"
-						key={ 'activity-panel-' + currentTab }
-						id={ 'activity-panel-' + currentTab }
-					>
-						{ this.getPanelContent( currentTab ) }
-					</div>
-				) ) ||
-					null }
+			<div
+				className={ classNames }
+				tabIndex={ 0 }
+				role="tabpanel"
+				aria-label={ tab.title }
+				onTransitionEnd={ this.clearPanel }
+			>
+				<div
+					className="woocommerce-layout__activity-panel-content"
+					key={ 'activity-panel-' + currentTab }
+					id={ 'activity-panel-' + currentTab }
+				>
+					{ this.getPanelContent( currentTab ) }
+				</div>
 			</div>
 		);
 	}

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -200,7 +200,7 @@ class ActivityPanel extends Component {
 	renderTab( tab, i ) {
 		const { currentTab, isPanelOpen } = this.state;
 		const className = classnames( 'woocommerce-layout__activity-panel-tab', {
-			'is-active': tab.name === currentTab,
+			'is-active': isPanelOpen && tab.name === currentTab,
 			'has-unread': tab.unread,
 		} );
 

--- a/client/header/activity-panel/index.js
+++ b/client/header/activity-panel/index.js
@@ -42,6 +42,7 @@ class ActivityPanel extends Component {
 			isPanelOpen: false,
 			mobileOpen: false,
 			currentTab: '',
+			isPanelSwitching: false,
 			hasWordPressNotices: false,
 		};
 	}
@@ -77,13 +78,13 @@ class ActivityPanel extends Component {
 					mobileOpen: ! state.isPanelOpen,
 				};
 			}
-			return { currentTab: tabName };
+			return { currentTab: tabName, isPanelSwitching: true };
 		} );
 	}
 
 	clearPanel() {
 		this.setState(
-			( { isPanelOpen } ) => ( isPanelOpen ? null : { currentTab: '' } )
+			( { isPanelOpen } ) => ( isPanelOpen ? { isPanelSwitching: false } : { currentTab: '' } )
 		);
 	}
 
@@ -164,7 +165,7 @@ class ActivityPanel extends Component {
 	}
 
 	renderPanel() {
-		const { isPanelOpen, currentTab } = this.state;
+		const { isPanelOpen, currentTab, isPanelSwitching } = this.state;
 
 		const tab = find( this.getTabs(), { name: currentTab } );
 		if ( ! tab ) {
@@ -173,6 +174,7 @@ class ActivityPanel extends Component {
 
 		const classNames = classnames( 'woocommerce-layout__activity-panel-wrapper', {
 			'is-open': isPanelOpen,
+			'is-switching': isPanelSwitching,
 		} );
 
 		return (
@@ -182,6 +184,7 @@ class ActivityPanel extends Component {
 				role="tabpanel"
 				aria-label={ tab.title }
 				onTransitionEnd={ this.clearPanel }
+				onAnimationEnd={ this.clearPanel }
 			>
 				<div
 					className="woocommerce-layout__activity-panel-content"

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -178,7 +178,7 @@
 	transition-duration: 300ms;
 	transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
 	@media screen and (prefers-reduced-motion: reduce) {
-		transition: none;
+		transition-duration: 1ms;
 	}
 }
 

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -174,7 +174,9 @@
 }
 
 @mixin activity-panel-slide {
-	transition: width 300ms cubic-bezier(0.42, 0, 0.58, 1);
+	transition-property: transform box-shadow;
+	transition-duration: 300ms;
+	transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
 	@media screen and (prefers-reduced-motion: reduce) {
 		transition: none;
 	}
@@ -183,8 +185,11 @@
 .woocommerce-layout__activity-panel-wrapper {
 	height: calc(100vh - #{$header-height + $header-height + $adminbar-height-mobile});
 	background: $core-grey-light-200;
-	box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
-	width: 0;
+	width: 510px;
+	@include breakpoint( '<782px' ) {
+		width: 100%;
+	}
+	transform: translateX(100%);
 	@include activity-panel-slide();
 	position: fixed;
 	right: 0;
@@ -199,11 +204,8 @@
 	}
 
 	&.is-open {
-		@include activity-panel-slide();
-		width: 510px;
-		@include breakpoint( '<782px' ) {
-			width: 100%;
-		}
+		transform: initial;
+		box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	}
 
 	.woocommerce-layout__activity-panel-content {

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -73,18 +73,27 @@
 		font-size: 11px;
 		height: $header-height;
 
+		&::before {
+			background-color: $woocommerce;
+			bottom: 0;
+			content: '';
+			height: 0;
+			opacity: 0;
+			transition-property: height, opacity;
+			transition-duration: 300ms;
+			transition-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+			left: 0;
+			position: absolute;
+			right: 0;
+		}
+
 		&.is-active {
 			color: $core-grey-dark-700;
 			box-shadow: none;
 
 			&::before {
-				background-color: $woocommerce;
-				bottom: 0;
-				content: '';
 				height: 3px;
-				left: 0;
-				position: absolute;
-				right: 0;
+				opacity: 1;
 			}
 		}
 

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -208,7 +208,7 @@
 		box-shadow: 0 12px 12px 0 rgba(85, 93, 102, 0.3);
 	}
 
-	.woocommerce-layout__activity-panel-content {
+	&.is-switching {
 		animation: tabSwitch;
 		animation-duration: 300ms;
 


### PR DESCRIPTION
Modifies CSS transitions – and times DOM changes around them – in order to sync the Activity Panel content (and active tab indicator) with the wrapper.

- https://github.com/woocommerce/woocommerce-admin/commit/5904e3c36e2e946ca5631d49bb7c2d52ddf91983 transitions transform to avoid reflow and wrapping (screenshots: [opening](https://cloudup.com/iKWtyfaG_9K) vs [opened](https://cloudup.com/if-MEG_3Vv8))
- https://github.com/woocommerce/woocommerce-admin/commit/7ad8ac1efc041616d166322978d8ac09d43531a8 keeps content until end of transition to avoid abrupt exit ([screenshot](https://cloudup.com/iPxchbTUnLP))
- https://github.com/woocommerce/woocommerce-admin/commit/307dbd1667f8eeb7238eb25150c2aafcdfa723b3 moves tab switch animation from content to wrapper to avoid separation ([screenshot](https://cloudup.com/iYo2JcCs3yb))
- https://github.com/woocommerce/woocommerce-admin/commit/5e55cf0e97fbd7f75793a7928fab724453cb106b adds a small transition to the active tab indicator to match panel timing

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)

### Screenshots

`master` | this branch
-- | --
![activity-panel-transitions-before](https://user-images.githubusercontent.com/1867547/61841199-ed6e4b80-ae61-11e9-8432-559622eb2aa5.gif) | ![activity-panel-transitions-after](https://user-images.githubusercontent.com/1867547/61841214-f4955980-ae61-11e9-9848-29b43f01a54c.gif)

### Detailed test instructions:

- Go to any screen with the Header / Activity Panel
- Click an Activity Panel tab to open, and confirm no intermediate text wrapping
- Switch to another tab, and confirm no separation between wrapper and content
- Close by clicking outside, and confirm no abrupt disappearance of content

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->