### PR TITLE
Prevent onboarding from running on non-admin pages

### DIFF
--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -45,6 +45,10 @@ class WC_Admin_Onboarding {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		$this->includes();
 		add_action( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 ); // Run after WC_Admin_Loader.
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );


### PR DESCRIPTION
Fixes #2700

Returns early if not an admin page.

### Detailed test instructions:

1.  Attempt to recreate the error noted in #2700.
2.  Since I wasn't able to recreate this error, optionally throw a `wp_die( "This shouldn't run" );` in the `WC_Admin_Onboarding` constructor after the admin page check
3.  Make sure this code does not interfere with the checkout ajax calls.
