### PR TITLE
Automate pre-release tasks

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -122,6 +122,8 @@ const printProjectColumns = async () => {
 		json: true,
 	}
 
+	console.log( chalk.yellow( 'Gathering columns from the project board, https://github.com/orgs/woocommerce/projects/2' ) );
+
 	return requestPromise( options )
 		.then( data => {
 			console.log( ' ' );

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -35,11 +35,11 @@ fi
 
 status "Lets release WooCommerce Admin 🎉"
 
-#git checkout master || { error "ERROR: Unable to checkout master branch." ; exit 1; }
+git checkout master || { error "ERROR: Unable to checkout master branch." ; exit 1; }
 
 success "Checked out master branch"
 
-#git pull origin master
+git pull origin master
 
 success "Pulled latest commits"
 
@@ -60,7 +60,7 @@ fi
 
 status "creating a release branch"
 
-#git checkout -b $branch || { error "ERROR: Unable to create release branch." ; exit 1; }
+git checkout -b $branch || { error "ERROR: Unable to create release branch." ; exit 1; }
 
 success "Release branch created: ${branch}"
 

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Enable nicer messaging for build status.
+BLUE_BOLD='\033[1;34m';
+GREEN_BOLD='\033[1;32m';
+RED_BOLD='\033[1;31m';
+YELLOW_BOLD='\033[1;33m';
+COLOR_RESET='\033[0m';
+
+error () {
+	echo -e "\n🤯 ${RED_BOLD}$1${COLOR_RESET}\n"
+}
+status () {
+	echo -e "\n👩‍💻 ${BLUE_BOLD}$1${COLOR_RESET}\n"
+}
+success () {
+	echo -e "\n✅ ${GREEN_BOLD}$1${COLOR_RESET}\n"
+}
+warning () {
+	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+}
+
+# Make sure there are no changes in the working tree.
+changed=
+if ! git diff --exit-code > /dev/null; then
+	changed="file(s) modified"
+elif ! git diff --cached --exit-code > /dev/null; then
+	changed="file(s) staged"
+fi
+if [ ! -z "$changed" ]; then
+	git status
+	error "ERROR: Cannot start pre-release with dirty working tree. ☝️  Commit your changes and try again."
+	exit 1
+fi
+
+status "Lets release WooCommerce Admin 🎉"
+
+#git checkout master || { error "ERROR: Unable to checkout master branch." ; exit 1; }
+
+success "Checked out master branch"
+
+#git pull origin master
+
+success "Pulled latest commits"
+
+status "What version would you like to release?"
+
+echo -n "Version: "
+
+read release
+
+branch="release/${release}"
+
+exists=`git show-ref refs/heads/${branch}`
+
+if [ -n "$exists" ]; then
+    error "ERROR: release branch already exists."
+    exit 1
+fi
+
+status "creating a release branch"
+
+#git checkout -b $branch || { error "ERROR: Unable to create release branch." ; exit 1; }
+
+success "Release branch created: ${branch}"
+
+status "Bumping version to ${release}"
+
+npm --no-git-tag-version version $release || { error "ERROR: Invalid version number." ; exit 1; }
+
+success "Version bumped successfully"
+
+status "Run prestart scripts to propagate version numbers and update dependencies."
+
+npm run prestart
+
+status "Run docs script to make sure docs are updated."
+
+npm run docs
+
+status "Remove changes to package-lock.json to prevent merge conflicts."
+
+git checkout package-lock.json
+
+status "Here are the changes so far. Make sure the following changes are reflected."
+
+echo "- docs/: folder will have changes to documentation, if any."
+echo "- package.json: new version number."
+echo "- woocommerce-admin.php: new version numbers."
+echo -e "\n"
+echo -e "\n"
+
+git status

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test:update-snapshots": "jest --updateSnapshot --config tests/js/jest.config.json",
     "test:watch": "npm run test -- --watch",
     "example": "webpack --config docs/examples/extensions/examples.config.js --watch",
-    "changelog": "node ./bin/changelog.js "
+    "changelog": "node ./bin/changelog.js ",
+    "pre-release": "./bin/pre-release.sh"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR introduces a script automate some pre release tasks. As much as I enjoy the anxiety of trying to remember if I pulled the latest from master before I created a new branch, I think this will reduce some overhead to releasing wc-admin. I hope to automate the process in chunks with the goal to ultimately have it all automated.

See P90Yrv-er for full steps to release.

### Detailed test instructions:

1. `npm run pre-release` with a dirty working tree. See it fail.
2. `npm run pre-release` and enter a non semver version number like `33` when prompted. See it fail.
3. `npm run pre-release` and bump to `0.17.0` or something that makes sense. See the program run.
4. Ensure the following

- A new branch is created
- `git log` to make sure the last commit is same as master
- `docs/` folder will have changes to documentation, if any
- package.json will have a new version number
- woocommerce-admin.php will have a new version number in two places.

Bonus: `npm run changelog` to see the changes in a prompt to include the project board url.,