### PR TITLE
Fix groupby for category segmentation in reports.

### DIFF
--- a/includes/class-wc-admin-reports-coupons-stats-segmenting.php
+++ b/includes/class-wc-admin-reports-coupons-stats-segmenting.php
@@ -295,7 +295,7 @@ class WC_Admin_Reports_Coupons_Stats_Segmenting extends WC_Admin_Reports_Segment
 			RIGHT JOIN {$wpdb->prefix}term_taxonomy ON {$wpdb->prefix}term_relationships.term_taxonomy_id = {$wpdb->prefix}term_taxonomy.term_taxonomy_id
 			";
 			$segmenting_where          = " AND taxonomy = 'product_cat'";
-			$segmenting_groupby        = 'wp_term_taxonomy.term_taxonomy_id';
+			$segmenting_groupby        = 'wp_term_taxonomy.term_id';
 			$segmenting_dimension_name = 'category_id';
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );

--- a/includes/class-wc-admin-reports-orders-stats-segmenting.php
+++ b/includes/class-wc-admin-reports-orders-stats-segmenting.php
@@ -390,7 +390,7 @@ class WC_Admin_Reports_Orders_Stats_Segmenting extends WC_Admin_Reports_Segmenti
 			RIGHT JOIN {$wpdb->prefix}term_taxonomy ON {$wpdb->prefix}term_relationships.term_taxonomy_id = {$wpdb->prefix}term_taxonomy.term_taxonomy_id
 			";
 			$segmenting_where          = " AND taxonomy = 'product_cat'";
-			$segmenting_groupby        = 'wp_term_taxonomy.term_taxonomy_id';
+			$segmenting_groupby        = 'wp_term_taxonomy.term_id';
 			$segmenting_dimension_name = 'category_id';
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );

--- a/includes/class-wc-admin-reports-products-stats-segmenting.php
+++ b/includes/class-wc-admin-reports-products-stats-segmenting.php
@@ -179,7 +179,7 @@ class WC_Admin_Reports_Products_Stats_Segmenting extends WC_Admin_Reports_Segmen
 			RIGHT JOIN {$wpdb->prefix}term_taxonomy ON {$wpdb->prefix}term_relationships.term_taxonomy_id = {$wpdb->prefix}term_taxonomy.term_taxonomy_id
 			";
 			$segmenting_where          = " AND taxonomy = 'product_cat'";
-			$segmenting_groupby        = 'wp_term_taxonomy.term_taxonomy_id';
+			$segmenting_groupby        = 'wp_term_taxonomy.term_id';
 			$segmenting_dimension_name = 'category_id';
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );


### PR DESCRIPTION
Found while trying to diagnose #1849.

This PR seeks to fix the database column used for grouping when segmenting reports by category.

Use `term_id` which correlates to the actual taxonomy term rather than `term_taxonomy_id` which is an ID used in the relationship table.

### Screenshots

Before:

<img width="1231" alt="Screen Shot 2019-07-25 at 3 14 29 PM" src="https://user-images.githubusercontent.com/63922/61969636-3f18f200-af98-11e9-92a4-39e7d6de6049.png">

After:

<img width="1221" alt="Screen Shot 2019-07-25 at 3 29 30 PM" src="https://user-images.githubusercontent.com/63922/61969661-4b9d4a80-af98-11e9-9d59-40609a83a19e.png">

### Detailed test instructions:

I used the WCCOM dataset to test this.

- Compare the Themes and Storefront Extension categories (Categories Report) for the 2018 year.
- Note that the chart does not render data, but the table is correct
- Check out this branch
- Note that the chart does render data

### Changelog Note:

Fix: chart display when comparing categories.
