### PR TITLE
Fix category report comparison chart render.

### DIFF
--- a/src/API/Reports/Products/Stats/Segmenter.php
+++ b/src/API/Reports/Products/Stats/Segmenter.php
@@ -99,8 +99,9 @@ class Segmenter extends ReportsSegmenter {
 		$product_segmenting_table = $wpdb->prefix . 'wc_order_product_lookup';
 
 		// LIMIT offset, rowcount needs to be updated to LIMIT offset, rowcount * max number of segments.
-		$limit_parts      = explode( ',', $intervals_query['limit'] );
-		$orig_rowcount    = intval( $limit_parts[1] );
+		$limit_parts   = explode( ',', $intervals_query['limit'] );
+		$orig_rowcount = intval( $limit_parts[1] );
+		// @todo - this is breaking intervals.
 		$segmenting_limit = $limit_parts[0] . ',' . $orig_rowcount * count( $this->get_all_segments() );
 
 		// Can't get all the numbers from one query, so split it into one query for product-level numbers and one for order-level numbers (which first need to have orders uniqued).
@@ -120,8 +121,7 @@ class Segmenter extends ReportsSegmenter {
 						{$intervals_query['where_clause']}
 						$segmenting_where
 					GROUP BY
-						time_interval, $segmenting_groupby
-					$segmenting_limit",
+						time_interval, $segmenting_groupby",
 			ARRAY_A
 		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 

--- a/src/API/Reports/Products/Stats/Segmenter.php
+++ b/src/API/Reports/Products/Stats/Segmenter.php
@@ -98,12 +98,13 @@ class Segmenter extends ReportsSegmenter {
 
 		$product_segmenting_table = $wpdb->prefix . 'wc_order_product_lookup';
 
-		// LIMIT offset, rowcount needs to be updated to LIMIT offset, rowcount * max number of segments.
-		$limit_parts   = explode( ',', $intervals_query['limit'] );
-		$orig_rowcount = intval( $limit_parts[1] );
-		// @todo - this is breaking intervals.
-		$segmenting_limit = $limit_parts[0] . ',' . $orig_rowcount * count( $this->get_all_segments() );
-
+		// LIMIT offset, rowcount needs to be updated to a multiple of the number of segments.
+		preg_match( '/LIMIT (\d+)\s?,\s?(\d+)/', $intervals_query['limit'], $limit_parts );
+		$segment_count    = count( $this->get_all_segments() );
+		$orig_offset      = intval( $limit_parts[1] );
+		$orig_rowcount    = intval( $limit_parts[2] );
+		$segmenting_limit = $wpdb->prepare( 'LIMIT %d, %d', $orig_offset * $segment_count, $orig_rowcount * $segment_count );
+		
 		// Can't get all the numbers from one query, so split it into one query for product-level numbers and one for order-level numbers (which first need to have orders uniqued).
 		// Product-level numbers.
 		$segments_products = $wpdb->get_results(
@@ -121,7 +122,8 @@ class Segmenter extends ReportsSegmenter {
 						{$intervals_query['where_clause']}
 						$segmenting_where
 					GROUP BY
-						time_interval, $segmenting_groupby",
+						time_interval, $segmenting_groupby
+					$segmenting_limit",
 			ARRAY_A
 		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
@@ -186,6 +188,12 @@ class Segmenter extends ReportsSegmenter {
 			$segmenting_where          = " AND taxonomy = 'product_cat'";
 			$segmenting_groupby        = 'wp_term_taxonomy.term_id';
 			$segmenting_dimension_name = 'category_id';
+
+			// Restrict our search space for category comparisons.
+			if ( isset( $this->query_args['categories'] ) ) {
+				$category_ids = implode( ',', $this->get_all_segments() );
+				$segmenting_where .= " AND wp_term_taxonomy.term_taxonomy_id IN ( $category_ids )";
+			}
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );
 		}

--- a/src/API/Reports/Segmenter.php
+++ b/src/API/Reports/Segmenter.php
@@ -566,12 +566,10 @@ class Segmenter {
 		}
 
 		foreach ( $intervals_segments as $time_interval => $segment ) {
-			if ( ! isset( $intervals[ $time_interval ] ) ) {
-				$intervals[ $time_interval ]['segments'] = array();
+			if ( isset( $intervals[ $time_interval ] ) ) {
+				$intervals[ $time_interval ]['segments'] = $segment['segments'];
 			}
-			$intervals[ $time_interval ]['segments'] = $segment['segments'];
 		}
-
 		// To remove time interval keys (so that REST response is formatted correctly).
 		$intervals = array_values( $intervals );
 	}


### PR DESCRIPTION
Remove limit from segmentation query and avoid adding dates outside of the initial interval query to response.

Fixes #1849.

This PR seeks to fix the rendering of the chart component when comparing Categories on a report.

It does so by removing the `LIMIT`clause from the query (which seems to cause necessary segments to be omitted, and unnecessary ones to be included) and by omitting time intervals from the response for the given paging parameters.

I'm leaving this as "In Progress" because I'd like some feedback from @peterfabian who originally implemented this.

### Screenshots

<img width="1232" alt="Screen Shot 2019-07-26 at 4 12 38 PM" src="https://user-images.githubusercontent.com/63922/62051179-d2dcff00-b1e0-11e9-9eb8-1c5656618db6.png">

### Detailed test instructions:

- Go to the category report
- Create a comparison
- Change the date range to a quarter or longer (ie: last quarter, last year etc)
- Ensure your period is set to Day
- Note the complete comparison is rendered

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: chart display when comparing categories.