### PR TITLE
Add theme demo track events

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -60,14 +60,16 @@ class Theme extends Component {
 	}
 
 	onClosePreview() {
+		const { demo } = this.state;
+		recordEvent( 'storeprofiler_store_theme_demo_close', { theme: demo.slug } );
 		document.body.classList.remove( 'woocommerce-theme-preview-active' );
 		this.setState( { demo: null } );
 	}
 
 	openDemo( theme ) {
+		recordEvent( 'storeprofiler_store_theme_live_demo', { theme: theme.slug } );
 		document.body.classList.add( 'woocommerce-theme-preview-active' );
 		this.setState( { demo: theme } );
-		recordEvent( 'storeprofiler_store_theme_live_demo', { theme: theme.slug } );
 	}
 
 	renderTheme( theme ) {
@@ -160,6 +162,8 @@ class Theme extends Component {
 			this.setState( {
 				uploadedThemes: [ ...this.state.uploadedThemes, upload.theme_data ],
 			} );
+
+			recordEvent( 'storeprofiler_store_theme_upload', { theme: upload.theme_data.slug } );
 		}
 	}
 

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -42,10 +42,10 @@ class Theme extends Component {
 		this.openDemo = this.openDemo.bind( this );
 	}
 
-	async onChoose( theme ) {
+	async onChoose( theme, location = '' ) {
 		const { createNotice, goToNextStep, isError, updateProfileItems } = this.props;
 
-		recordEvent( 'storeprofiler_store_theme_choose', { theme } );
+		recordEvent( 'storeprofiler_store_theme_choose', { theme, location } );
 		await updateProfileItems( { theme } );
 
 		if ( ! isError ) {
@@ -100,7 +100,7 @@ class Theme extends Component {
 						<Button
 							isPrimary={ Boolean( demo_url ) }
 							isDefault={ ! Boolean( demo_url ) }
-							onClick={ () => this.onChoose( slug ) }
+							onClick={ () => this.onChoose( slug, 'card' ) }
 						>
 							{ __( 'Choose', 'woocommerce-admin' ) }
 						</Button>

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -45,7 +45,8 @@ class ThemePreview extends Component {
 	}
 
 	handleDeviceClick( device ) {
-		recordEvent( 'storeprofiler_store_theme_demo_device', { device } );
+		const { theme } = this.props;
+		recordEvent( 'storeprofiler_store_theme_demo_device', { device, theme: theme.slug } );
 		this.setState( { device } );
 	}
 

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -13,6 +13,11 @@ import interpolateComponents from 'interpolate-components';
  */
 import { WebPreview } from '@woocommerce/components';
 
+/**
+ * Internal depdencies
+ */
+import { recordEvent } from 'lib/tracks';
+
 const devices = [
 	{
 		key: 'mobile',
@@ -35,6 +40,13 @@ class ThemePreview extends Component {
 		this.state = {
 			device: 'desktop',
 		};
+
+		this.handleDeviceClick = this.handleDeviceClick.bind( this );
+	}
+
+	handleDeviceClick( device ) {
+		recordEvent( 'storeprofiler_store_theme_demo_device', { device } );
+		this.setState( { device } );
 	}
 
 	render() {
@@ -67,7 +79,7 @@ class ThemePreview extends Component {
 								className={ classnames( 'woocommerce-theme-preview__device', {
 									'is-selected': device.key === currentDevice,
 								} ) }
-								onClick={ () => this.setState( { device: device.key } ) }
+								onClick={ () => this.handleDeviceClick( device.key ) }
 							>
 								<i className="material-icons-outlined">{ device.icon }</i>
 							</Button>

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -85,7 +85,7 @@ class ThemePreview extends Component {
 							</Button>
 						) ) }
 					</div>
-					<Button isPrimary onClick={ () => onChoose( slug ) }>
+					<Button isPrimary onClick={ () => onChoose( slug, 'preview' ) }>
 						{ __( 'Choose', 'woocommerce-admin' ) }
 					</Button>
 				</div>


### PR DESCRIPTION
Fixes #2632 

Adds tracking events to the theme demo buttons.

### Detailed test instructions:

1.  Open the theme step of the onboarding.
2.  In your console, enter `localStorage.setItem( 'debug', 'wc-admin:tracks' );`
3.  Open a demo, change the device view, and close the demo.
4.  Make sure each of the above 3 events is tracked.
5.  Open a demo again and click "Choose" to make sure that is also tracked.