### PR TITLE
Onboarding - Task List: Add store connection task

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -4,7 +4,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { noop } from 'lodash';
+import { filter, noop } from 'lodash';
+import { compose } from '@wordpress/compose';
 
 /**
  * WooCommerce dependencies
@@ -16,82 +17,11 @@ import { updateQueryString } from '@woocommerce/navigation';
  * Internal depdencies
  */
 import './style.scss';
+import Connect from './tasks/connect';
 import Products from './tasks/products';
+import withSelect from 'wc-api/with-select';
 
-const getTasks = () => {
-	const { tasks } = wcSettings.onboarding;
-
-	return [
-		{
-			key: 'connect',
-			title: __( 'Connect your store to WooCommerce.com', 'woocommerce-admin' ),
-			description: __(
-				'Install and manage your extensions directly from your Dashboard',
-				'wooocommerce-admin'
-			),
-			before: <i className="material-icons-outlined">extension</i>,
-			after: <i className="material-icons-outlined">chevron_right</i>,
-			onClick: noop,
-		},
-		{
-			key: 'products',
-			title: __( 'Add your first product', 'woocommerce-admin' ),
-			description: __(
-				'Add products manually, import from a sheet or migrate from another platform',
-				'wooocommerce-admin'
-			),
-			before: tasks.products ? (
-				<i className="material-icons-outlined">check_circle</i>
-			) : (
-				<i className="material-icons-outlined">add_box</i>
-			),
-			after: <i className="material-icons-outlined">chevron_right</i>,
-			onClick: () => updateQueryString( { task: 'products' } ),
-			container: <Products />,
-			className: tasks.products ? 'is-complete' : null,
-		},
-		{
-			key: 'personalize-store',
-			title: __( 'Personalize your store', 'woocommerce-admin' ),
-			description: __( 'Create a custom homepage and upload your logo', 'wooocommerce-admin' ),
-			before: <i className="material-icons-outlined">palette</i>,
-			after: <i className="material-icons-outlined">chevron_right</i>,
-			onClick: noop,
-		},
-		{
-			key: 'shipping',
-			title: __( 'Set up shipping', 'woocommerce-admin' ),
-			description: __( 'Configure some basic shipping rates to get started', 'wooocommerce-admin' ),
-			before: <i className="material-icons-outlined">local_shipping</i>,
-			after: <i className="material-icons-outlined">chevron_right</i>,
-			onClick: noop,
-		},
-		{
-			key: 'tax',
-			title: __( 'Set up tax', 'woocommerce-admin' ),
-			description: __(
-				'Choose how to configure tax rates - manually or automatically',
-				'wooocommerce-admin'
-			),
-			before: <i className="material-icons-outlined">account_balance</i>,
-			after: <i className="material-icons-outlined">chevron_right</i>,
-			onClick: noop,
-		},
-		{
-			key: 'payments',
-			title: __( 'Set up payments', 'woocommerce-admin' ),
-			description: __(
-				'Select which payment providers you’d like to use and configure them',
-				'wooocommerce-admin'
-			),
-			before: <i className="material-icons-outlined">payment</i>,
-			after: <i className="material-icons-outlined">chevron_right</i>,
-			onClick: noop,
-		},
-	];
-};
-
-export default class TaskDashboard extends Component {
+class TaskDashboard extends Component {
 	componentDidMount() {
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
 	}
@@ -100,9 +30,93 @@ export default class TaskDashboard extends Component {
 		document.body.classList.remove( 'woocommerce-task-dashboard__body' );
 	}
 
+	getTasks() {
+		const { tasks } = wcSettings.onboarding;
+		const { profileItems, query } = this.props;
+
+		return [
+			{
+				key: 'connect',
+				title: __( 'Connect your store to WooCommerce.com', 'woocommerce-admin' ),
+				description: __(
+					'Install and manage your extensions directly from your Dashboard',
+					'wooocommerce-admin'
+				),
+				before: <i className="material-icons-outlined">extension</i>,
+				after: <i className="material-icons-outlined">chevron_right</i>,
+				onClick: () => updateQueryString( { task: 'connect' } ),
+				container: <Connect query={ query } />,
+				visible: profileItems.items_purchased && ! profileItems.wccom_connected,
+			},
+			{
+				key: 'products',
+				title: __( 'Add your first product', 'woocommerce-admin' ),
+				description: __(
+					'Add products manually, import from a sheet or migrate from another platform',
+					'wooocommerce-admin'
+				),
+				before: tasks.products ? (
+					<i className="material-icons-outlined">check_circle</i>
+				) : (
+					<i className="material-icons-outlined">add_box</i>
+				),
+				after: <i className="material-icons-outlined">chevron_right</i>,
+				onClick: () => updateQueryString( { task: 'products' } ),
+				container: <Products />,
+				className: tasks.products ? 'is-complete' : null,
+				visible: true,
+			},
+			{
+				key: 'personalize-store',
+				title: __( 'Personalize your store', 'woocommerce-admin' ),
+				description: __( 'Create a custom homepage and upload your logo', 'wooocommerce-admin' ),
+				before: <i className="material-icons-outlined">palette</i>,
+				after: <i className="material-icons-outlined">chevron_right</i>,
+				onClick: noop,
+				visible: true,
+			},
+			{
+				key: 'shipping',
+				title: __( 'Set up shipping', 'woocommerce-admin' ),
+				description: __(
+					'Configure some basic shipping rates to get started',
+					'wooocommerce-admin'
+				),
+				before: <i className="material-icons-outlined">local_shipping</i>,
+				after: <i className="material-icons-outlined">chevron_right</i>,
+				onClick: noop,
+				visible: true,
+			},
+			{
+				key: 'tax',
+				title: __( 'Set up tax', 'woocommerce-admin' ),
+				description: __(
+					'Choose how to configure tax rates - manually or automatically',
+					'wooocommerce-admin'
+				),
+				before: <i className="material-icons-outlined">account_balance</i>,
+				after: <i className="material-icons-outlined">chevron_right</i>,
+				onClick: noop,
+				visible: true,
+			},
+			{
+				key: 'payments',
+				title: __( 'Set up payments', 'woocommerce-admin' ),
+				description: __(
+					'Select which payment providers you’d like to use and configure them',
+					'wooocommerce-admin'
+				),
+				before: <i className="material-icons-outlined">payment</i>,
+				after: <i className="material-icons-outlined">chevron_right</i>,
+				onClick: noop,
+				visible: true,
+			},
+		];
+	}
+
 	getCurrentTask() {
 		const { task } = this.props.query;
-		const currentTask = getTasks().find( s => s.key === task );
+		const currentTask = this.getTasks().find( s => s.key === task );
 
 		if ( ! currentTask ) {
 			return null;
@@ -113,6 +127,7 @@ export default class TaskDashboard extends Component {
 
 	render() {
 		const currentTask = this.getCurrentTask();
+		const tasks = filter( this.getTasks(), task => task.visible );
 
 		return (
 			<Fragment>
@@ -127,7 +142,7 @@ export default class TaskDashboard extends Component {
 								'woocommerce-admin'
 							) }
 						>
-							<List items={ getTasks() } />
+							<List items={ tasks } />
 						</Card>
 					) }
 				</div>
@@ -135,3 +150,11 @@ export default class TaskDashboard extends Component {
 		);
 	}
 }
+
+export default compose(
+	withSelect( select => {
+		const { getProfileItems } = select( 'wc-api' );
+		const profileItems = getProfileItems();
+		return { profileItems };
+	} )
+)( TaskDashboard );

--- a/client/dashboard/task-list/tasks/connect.js
+++ b/client/dashboard/task-list/tasks/connect.js
@@ -93,14 +93,15 @@ class Connect extends Component {
 			if ( connectResponse && connectResponse.success ) {
 				await this.props.updateProfileItems( { wccom_connected: true } );
 				if ( ! this.props.isProfileItemsError ) {
-					// @todo Extensions are not currently installed. This will be handled on WCCOM.
 					this.props.createNotice(
 						'success',
 						__(
-							'Store connected to WooCommerce.com and extensions installed successfully.',
+							'Store connected to WooCommerce.com and extensions are being installed.',
 							'woocommerce-admin'
 						)
 					);
+
+					// @todo Show a notice for when extensions are correctly installed.
 
 					document.body.classList.remove( 'woocommerce-admin-is-loading' );
 					getHistory().push( this.baseQuery() );

--- a/client/dashboard/task-list/tasks/connect.js
+++ b/client/dashboard/task-list/tasks/connect.js
@@ -1,0 +1,140 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import apiFetch from '@wordpress/api-fetch';
+import { withDispatch } from '@wordpress/data';
+import { omit } from 'lodash';
+
+/**
+ * WooCommerce depdencies
+ */
+import { getHistory, getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal depdencies
+ */
+import { NAMESPACE } from 'wc-api/onboarding/constants';
+import withSelect from 'wc-api/with-select';
+
+class Connect extends Component {
+	componentDidMount() {
+		document.body.classList.add( 'woocommerce-admin-is-loading' );
+		const { query } = this.props;
+
+		if ( '1' === query.deny ) {
+			this.errorMessage(
+				__(
+					'You must click approve to install your extensions and connect to WooCommerce.com.',
+					'woocommerce-admin'
+				)
+			);
+			return;
+		}
+
+		if ( ! query[ 'wccom-connected' ] || ! query.request_token ) {
+			this.request();
+			return;
+		}
+		this.finish();
+	}
+
+	baseQuery() {
+		const { query } = this.props;
+		const baseQuery = omit( { ...query, page: 'wc-admin' }, [
+			'task',
+			'wccom-connected',
+			'request_token',
+			'deny',
+		] );
+		return getNewPath( {}, '/', baseQuery );
+	}
+
+	errorMessage(
+		message = __(
+			'There was an error connecting to WooCommerce.com. Please try again.',
+			'woocommerce-admin'
+		)
+	) {
+		document.body.classList.remove( 'woocommerce-admin-is-loading' );
+		getHistory().push( this.baseQuery() );
+		this.props.createNotice( 'error', message );
+	}
+
+	async request() {
+		try {
+			const connectResponse = await apiFetch( {
+				path: `${ NAMESPACE }/onboarding/plugins/request-wccom-connect`,
+				method: 'POST',
+			} );
+			if ( connectResponse && connectResponse.connectAction ) {
+				window.location = connectResponse.connectAction;
+				return;
+			}
+			throw new Error();
+		} catch ( err ) {
+			this.errorMessage();
+		}
+	}
+
+	async finish() {
+		const { query } = this.props;
+		try {
+			const connectResponse = await apiFetch( {
+				path: `${ NAMESPACE }/onboarding/plugins/finish-wccom-connect`,
+				method: 'POST',
+				data: {
+					request_token: query.request_token,
+				},
+			} );
+			if ( connectResponse && connectResponse.success ) {
+				await this.props.updateProfileItems( { wccom_connected: true } );
+				if ( ! this.props.isProfileItemsError ) {
+					// @todo Extensions are not currently installed. This will be handled on WCCOM.
+					this.props.createNotice(
+						'success',
+						__(
+							'Store connected to WooCommerce.com and extensions installed successfully.',
+							'woocommerce-admin'
+						)
+					);
+
+					document.body.classList.remove( 'woocommerce-admin-is-loading' );
+					getHistory().push( this.baseQuery() );
+				} else {
+					this.errorMessage();
+				}
+
+				return;
+			}
+			throw new Error();
+		} catch ( err ) {
+			this.errorMessage();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default compose(
+	withSelect( select => {
+		const { getProfileItemsError } = select( 'wc-api' );
+
+		const isProfileItemsError = Boolean( getProfileItemsError() );
+
+		return { isProfileItemsError };
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateProfileItems } = dispatch( 'wc-api' );
+		return {
+			createNotice,
+			updateProfileItems,
+		};
+	} )
+)( Connect );

--- a/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
@@ -72,6 +72,32 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 				'schema' => array( $this, 'get_connect_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/request-wccom-connect',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'request_wccom_connect' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_connect_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/finish-wccom-connect',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'finish_wccom_connect' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_connect_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -234,6 +260,137 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 			'name'          => __( 'Jetpack', 'woocommerce-admin' ),
 			'connectAction' => $connect_url,
 		) );
+	}
+
+	/**
+	 *  Kicks off the WCCOM Connect process.
+	 *
+	 * @return array Connection URL for WooCommerce.com
+	 */
+	public function request_wccom_connect() {
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php';
+		if ( ! class_exists( 'WC_Helper_API' ) ) {
+			return new WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce-admin' ), 404 );
+		}
+
+		// Request new authorization.
+		$redirect_uri = add_query_arg(
+			array(
+				'page'            => 'wc-admin',
+				'task'            => 'connect',
+				'wccom-connected' => 1,
+			),
+			admin_url( 'admin.php' )
+		);
+
+		$request = WC_Helper_API::post(
+			'oauth/request_token',
+			array(
+				'body' => array(
+					'home_url'     => home_url(),
+					'redirect_uri' => $redirect_uri,
+				),
+			)
+		);
+
+		$code = wp_remote_retrieve_response_code( $request );
+		if ( 200 !== $code ) {
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+		}
+
+		$secret = json_decode( wp_remote_retrieve_body( $request ) );
+		if ( empty( $secret ) ) {
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+		}
+
+		do_action( 'woocommerce_helper_connect_start' );
+
+		$connect_url = add_query_arg(
+			array(
+				'home_url'     => rawurlencode( home_url() ),
+				'redirect_uri' => rawurlencode( $redirect_uri ),
+				'secret'       => rawurlencode( $secret ),
+				'from'         => 'woocommerce-onboarding',
+			),
+			WC_Helper_API::url( 'oauth/authorize' )
+		);
+
+		// Redirect to local calypso instead of production.
+		// @todo WordPress.com Connect / the OAuth flow does not currently respect this, but a patch is in the works to make this easier.
+		if ( defined( 'WOOCOMMERCE_CALYPSO_LOCAL' ) && WOOCOMMERCE_CALYPSO_LOCAL ) {
+			$connect_url = add_query_arg(
+				array(
+					'calypso_env' => 'development',
+				),
+				$connect_url
+			);
+		}
+
+		return( array(
+			'connectAction' => $connect_url,
+		) );
+	}
+
+	/**
+	 * Finishes connecting to WooCommerce.com.
+	 *
+	 * @param  object $rest_request Request details.
+	 * @return array Contains success status.
+	 */
+	public function finish_wccom_connect( $rest_request ) {
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php';
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-updater.php';
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
+		if ( ! class_exists( 'WC_Helper_API' ) ) {
+			return new WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce-admin' ), 404 );
+		}
+
+		// Obtain an access token.
+		$request = WC_Helper_API::post(
+			'oauth/access_token',
+			array(
+				'body' => array(
+					'request_token' => wp_unslash( $rest_request['request_token'] ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					'home_url'      => home_url(),
+				),
+			)
+		);
+
+		$code = wp_remote_retrieve_response_code( $request );
+		if ( 200 !== $code ) {
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+		}
+
+		$access_token = json_decode( wp_remote_retrieve_body( $request ), true );
+		if ( ! $access_token ) {
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+		}
+
+		WC_Helper_Options::update(
+			'auth',
+			array(
+				'access_token'        => $access_token['access_token'],
+				'access_token_secret' => $access_token['access_token_secret'],
+				'site_id'             => $access_token['site_id'],
+				'user_id'             => get_current_user_id(),
+				'updated'             => time(),
+			)
+		);
+
+		if ( ! WC_Helper::_flush_authentication_cache() ) {
+			WC_Helper_Options::update( 'auth', array() );
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to WooCommerce.com. Please try again.', 'woocommerce-admin' ), 500 );
+		}
+
+		delete_transient( '_woocommerce_helper_subscriptions' );
+		WC_Helper_Updater::flush_updates_cache();
+
+		do_action( 'woocommerce_helper_connected' );
+
+		return array(
+			'success' => true,
+		);
 	}
 
 	/**

--- a/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
@@ -273,15 +273,7 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 			return new WP_Error( 'woocommerce_rest_helper_not_active', __( 'There was an error loading the WooCommerce.com Helper API.', 'woocommerce-admin' ), 404 );
 		}
 
-		// Request new authorization.
-		$redirect_uri = add_query_arg(
-			array(
-				'page'            => 'wc-admin',
-				'task'            => 'connect',
-				'wccom-connected' => 1,
-			),
-			admin_url( 'admin.php' )
-		);
+		$redirect_uri = wc_admin_url( '&task=connect&wccom-connected=1' );
 
 		$request = WC_Helper_API::post(
 			'oauth/request_token',

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -96,6 +96,8 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
+
 		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
 		$item_schema     = $this->get_item_schema();
 
@@ -103,6 +105,9 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 		foreach ( $item_schema['properties'] as $key => $property_schema ) {
 			$items[ $key ] = isset( $onboarding_data[ $key ] ) ? $onboarding_data[ $key ] : null;
 		}
+
+		$wccom_auth               = WC_Helper_Options::get( 'auth' );
+		$items['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
 		$item = $this->prepare_item_for_response( $items, $request );
 		$data = $this->prepare_response_for_collection( $item );
@@ -313,6 +318,13 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 			'setup_client'        => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'wccom_connected'     => array(
+				'type'              => 'boolean',
+				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',

--- a/includes/features/onboarding/class-wc-admin-onboarding.php
+++ b/includes/features/onboarding/class-wc-admin-onboarding.php
@@ -301,6 +301,10 @@ class WC_Admin_Onboarding {
 	public function component_settings( $settings ) {
 		$profile = get_option( 'wc_onboarding_profile', array() );
 
+		include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
+		$wccom_auth                 = WC_Helper_Options::get( 'auth' );
+		$profile['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
+
 		$settings['onboarding'] = array(
 			'industries' => self::get_allowed_industries(),
 			'profile'    => $profile,

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -97,7 +97,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 12, $properties );
+		$this->assertCount( 13, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
@@ -108,6 +108,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'other_platform', $properties );
 		$this->assertArrayHasKey( 'business_extensions', $properties );
 		$this->assertArrayHasKey( 'theme', $properties );
+		$this->assertArrayHasKey( 'wccom_connected', $properties );
 		$this->assertArrayHasKey( 'items_purchased', $properties );
 		$this->assertArrayHasKey( 'setup_client', $properties );
 	}


### PR DESCRIPTION
Fixes #2476.

Note that this PR only implements the `wc-admin` bits. We still need to redesign the connection screen (our responsibility) and handle extension installation (Alpha’s responsibility). See #2600.

Screenshots:

<img width="776" alt="Screen Shot 2019-07-30 at 12 58 49 PM" src="https://user-images.githubusercontent.com/689165/62149511-e44e0600-b2c9-11e9-9197-a5311c761412.png">

<img width="810" alt="Screen Shot 2019-07-30 at 12 59 02 PM" src="https://user-images.githubusercontent.com/689165/62149524-e7e18d00-b2c9-11e9-8644-c1bc9261a859.png">

<img width="800" alt="Screen Shot 2019-07-30 at 12 59 25 PM" src="https://user-images.githubusercontent.com/689165/62149535-eb751400-b2c9-11e9-9bf8-b73df02ce726.png">

To Test:

* Make sure you are disconnected from WooCommerce.com via WooCommerce > Extensions > WooCommerce.com Subscriptions.
* In `client/dashboard/index.js` set `requiredTasksComplete` to false.
* Make sure the profiler is either marked as `skipped` or `completed`.
* Make sure the profiler has `items_purchased` set too `true`.
* Visit the dashboard, and you should see the connect step. If `items_purchased` is `false` or you are already connected, the step will not display.
* Test clicking the task, you should be taken to WooCommerce WordPress.com OAuth screen.
* Test denying and approving. You should get the relevant error or success messages.
* After connecting, go back to the extension screen and verify that you are connected.