### PR TITLE
Update Stepper component with new props and styles

### DIFF
--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -165,7 +165,7 @@ class Plugins extends Component {
 
 				<Card className="woocommerce-profile-wizard__plugins-card">
 					<Stepper
-						direction="vertical"
+						isVertical={ true }
 						currentStep={ step }
 						isPending={ isPending }
 						steps={ [

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -46,8 +46,8 @@
 			}
 		}
 
-		.woocommerce-spinner__circle {
-			stroke: $muriel-hot-purple-600;
+		.woocommerce-spinner {
+			background: $muriel-hot-purple-600;
 		}
 	}
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -410,10 +410,6 @@
 }
 
 .woocommerce-profile-wizard__plugins-card {
-	.woocommerce-stepper {
-		box-shadow: none;
-	}
-
 	.woocommerce-profile-wizard__plugins-actions {
 		text-align: left;
 		margin-left: 64px;
@@ -444,9 +440,10 @@
 
 	.woocommerce-stepper {
 		margin: 0 $gap 0 $gap;
-		background: transparent;
-		box-shadow: none;
-		margin-bottom: 0;
 		width: 100%;
+	}
+
+	.woocommerce-stepper__steps {
+		margin: 0;
 	}
 }

--- a/packages/components/src/stepper/example.md
+++ b/packages/components/src/stepper/example.md
@@ -8,20 +8,28 @@ const MyStepper = withState( {
 } )( ( { currentStep, isComplete, isPending, setState } ) => {
 	const steps = [
 		{
-			label: 'First',
 			key: 'first',
+			label: 'First',
+			description: 'Step item description',
+			content: <div>First step content.</div>,
 		},
 		{
-			label: 'Second',
 			key: 'second',
+			label: 'Second',
+			description: 'Step item description',
+			content: <div>Second step content.</div>,
 		},
 		{
 			label: 'Third',
 			key: 'third',
+			description: 'Step item description',
+			content: <div>Third step content.</div>,
 		},
 		{
 			label: 'Fourth',
 			key: 'fourth',
+			description: 'Step item description',
+			content: <div>Fourth step content.</div>,
 		},
 	];
 
@@ -71,12 +79,14 @@ const MyStepper = withState( {
 			isPending={ isPending }
 		/>
 
+		<br />
+
 		<Stepper
 			isPending={ isPending }
 			direction="vertical"
 			steps={ steps }
 			currentStep={ currentStep }
-			/>
+		/>
 	</div>
 	);
 } );

--- a/packages/components/src/stepper/example.md
+++ b/packages/components/src/stepper/example.md
@@ -83,7 +83,7 @@ const MyStepper = withState( {
 
 		<Stepper
 			isPending={ isPending }
-			direction="vertical"
+			isVertical={ true }
 			steps={ steps }
 			currentStep={ currentStep }
 		/>

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -19,40 +19,56 @@ class Stepper extends Component {
 	render() {
 		const { className, currentStep, steps, direction, isPending } = this.props;
 		const currentIndex = steps.findIndex( s => currentStep === s.key );
+		const content = steps[ currentIndex ].content;
 		const stepperClassName = classnames( 'woocommerce-stepper', className, {
 			'is-vertical': 'vertical' === direction,
 		} );
 
 		return (
 			<div className={ stepperClassName }>
-				{ steps.map( ( step, i ) => {
-					const { key, label, isComplete } = step;
-					const stepClassName = classnames( 'woocommerce-stepper__step', {
-						'is-active': key === currentStep,
-						'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
-					} );
+				<div className="woocommerce-stepper__steps">
+					{ steps.map( ( step, i ) => {
+						const { key, label, description, isComplete } = step;
+						const stepClassName = classnames( 'woocommerce-stepper__step', {
+							'is-active': key === currentStep,
+							'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
+						} );
 
-					const icon = currentStep === key && isPending ? <Spinner /> : (
-						<div className="woocommerce-stepper__step-icon">
-							<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
-							<CheckIcon />
-						</div>
-					);
-
-					return (
-						<Fragment key={ key } >
-							<div
-								className={ stepClassName }
-							>
-								{ icon }
-								<span className="woocommerce-stepper__step-label">
-									{ label }
-								</span>
+						const icon = currentStep === key && isPending ? <Spinner /> : (
+							<div className="woocommerce-stepper__step-icon">
+								<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
+								<CheckIcon />
 							</div>
-							<div className="woocommerce-stepper__step-divider" />
-						</Fragment>
-                    );
-                } ) }
+						);
+
+						return (
+							<Fragment key={ key } >
+								<div
+									className={ stepClassName }
+								>
+									{ icon }
+									<div className="woocommerce-stepper__step-text">
+										<span className="woocommerce-stepper__step-label">
+											{ label }
+										</span>
+										{ description &&
+											<span className="woocommerce-stepper__step-description">
+												{ description }
+											</span>
+										}
+									</div>
+								</div>
+								<div className="woocommerce-stepper__step-divider" />
+							</Fragment>
+						);
+					} ) }
+				</div>
+
+				{ content &&
+					<div className="woocommerce-stepper_content">
+						{ content }
+					</div>
+				}
 			</div>
 		);
 	}
@@ -81,9 +97,17 @@ Stepper.propTypes = {
 			 */
 			label: PropTypes.string.isRequired,
 			/**
+			 * Description displayed beneath the label.
+			 */
+			description: PropTypes.string,
+			/**
 			 * Optionally mark a step complete regardless of step index.
 			 */
-            isComplete: PropTypes.bool,
+			isComplete: PropTypes.bool,
+			/**
+			 * Content displayed when the step is active.
+			 */
+			content: PropTypes.node,
 		} )
 	).isRequired,
 

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -16,12 +16,26 @@ import CheckIcon from './check-icon';
  * A stepper component to indicate progress in a set number of steps.
  */
 class Stepper extends Component {
+	renderCurrentStepContent() {
+		const { currentStep, steps } = this.props;
+		const step = steps.find( s => currentStep === s.key );
+
+		if ( ! step.content ) {
+			return null;
+		}
+
+		return (
+			<div className="woocommerce-stepper_content">
+				{ step.content }
+			</div>
+		);
+	}
+
 	render() {
-		const { className, currentStep, steps, direction, isPending } = this.props;
+		const { className, currentStep, steps, isVertical, isPending } = this.props;
 		const currentIndex = steps.findIndex( s => currentStep === s.key );
-		const content = steps[ currentIndex ].content;
 		const stepperClassName = classnames( 'woocommerce-stepper', className, {
-			'is-vertical': 'vertical' === direction,
+			'is-vertical': isVertical,
 		} );
 
 		return (
@@ -29,12 +43,13 @@ class Stepper extends Component {
 				<div className="woocommerce-stepper__steps">
 					{ steps.map( ( step, i ) => {
 						const { key, label, description, isComplete } = step;
+						const isCurrentStep = key === currentStep;
 						const stepClassName = classnames( 'woocommerce-stepper__step', {
-							'is-active': key === currentStep,
+							'is-active': isCurrentStep,
 							'is-complete': 'undefined' !== typeof isComplete ? isComplete : currentIndex > i,
 						} );
 
-						const icon = currentStep === key && isPending ? <Spinner /> : (
+						const icon = isCurrentStep && isPending ? <Spinner /> : (
 							<div className="woocommerce-stepper__step-icon">
 								<span className="woocommerce-stepper__step-number">{ i + 1 }</span>
 								<CheckIcon />
@@ -56,19 +71,16 @@ class Stepper extends Component {
 												{ description }
 											</span>
 										}
+										{ isCurrentStep && isVertical && this.renderCurrentStepContent() }
 									</div>
 								</div>
-								<div className="woocommerce-stepper__step-divider" />
+									{ ! isVertical && <div className="woocommerce-stepper__step-divider" /> }
 							</Fragment>
 						);
 					} ) }
 				</div>
 
-				{ content &&
-					<div className="woocommerce-stepper_content">
-						{ content }
-					</div>
-				}
+				{ ! isVertical && this.renderCurrentStepContent() }
 			</div>
 		);
 	}
@@ -112,9 +124,9 @@ Stepper.propTypes = {
 	).isRequired,
 
 	/**
-	 * Direction of the stepper.
+	 * If the stepper is vertical instead of horizontal.
 	 */
-	direction: PropTypes.oneOf( [ 'horizontal', 'vertical' ] ),
+	isVertical: PropTypes.bool,
 
 	/**
 	 * Optionally mark the current step as pending to show a spinner.
@@ -123,7 +135,7 @@ Stepper.propTypes = {
 };
 
 Stepper.defaultProps = {
-	direction: 'horizontal',
+	isVertical: false,
 	isPending: false,
 };
 

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -1,21 +1,35 @@
 .woocommerce-stepper {
 	background: $muriel-white;
 	box-shadow: $muriel-box-shadow-1dp;
-	display: flex;
-	justify-content: space-around;
-	align-items: center;
-	margin-bottom: $gap-large;
-	padding-left: $gap;
-	padding-right: $gap;
-	font-size: 16px;
+
+	.woocommerce-stepper__steps {
+		display: flex;
+		justify-content: space-around;
+		align-items: center;
+		margin-bottom: $gap-large;
+		padding-left: $gap;
+		padding-right: $gap;
+		font-size: 16px;
+	}
 
 	.woocommerce-stepper__step {
 		display: inline-flex;
-		align-items: center;
 		padding: $gap-small;
 		font-weight: 400;
 		color: $muriel-gray-900;
 		height: 48px;
+
+		.woocommerce-stepper__step-label {
+			line-height: 24px;
+		}
+
+		.woocommerce-stepper__step-description {
+			display: block;
+			font-size: 14px;
+			color: $muriel-gray-500;
+			font-weight: 400;
+			margin-top: 2px;
+		}
 
 		svg {
 			display: none;
@@ -89,8 +103,10 @@
 	}
 
 	&.is-vertical {
-		align-items: initial;
-		flex-direction: column;
+		.woocommerce-stepper__steps {
+			align-items: initial;
+			flex-direction: column;
+		}
 
 		.woocommerce-stepper__step-divider {
 			border-bottom: 0;

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -33,13 +33,16 @@
 
 		.woocommerce-spinner {
 			display: block;
-			margin-left: -$gap-smaller;
-			margin-right: $gap-smallest;
+			margin-right: $gap-small;
 			max-height: $step-icon-size;
+			min-width: auto;
+			width: 24px;
+			border-radius: 50%;
+			background: $muriel-hot-blue-500;
 		}
 
 		.woocommerce-spinner__circle {
-			stroke: $muriel-hot-blue-500;
+			stroke: $white;
 		}
 
 		&.is-active,

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -123,13 +123,13 @@
 			position: absolute;
 			left: $step-icon-size / 2 + $gap-smaller;
 			top: $step-icon-size + ( $gap-smaller * 2 );
-			height: calc( 100% -  #{$step-icon-size} - #{ $gap-smaller * 2 } );
+			height: calc(100% - #{$step-icon-size} - #{ $gap-smaller * 2 });
 			border-left: 1px solid $muriel-gray-50;
 		}
 
 		.woocommerce-stepper__step:last-child {
 			min-height: auto;
-			&:after {
+			&::after {
 				display: none;
 			}
 		}

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -1,20 +1,14 @@
 .woocommerce-stepper {
-	background: $muriel-white;
-	box-shadow: $muriel-box-shadow-1dp;
-
 	.woocommerce-stepper__steps {
 		display: flex;
 		justify-content: space-around;
-		align-items: center;
 		margin-bottom: $gap-large;
-		padding-left: $gap;
-		padding-right: $gap;
 		font-size: 16px;
 	}
 
 	.woocommerce-stepper__step {
 		display: inline-flex;
-		padding: $gap-small;
+		padding: $gap-smaller;
 		font-weight: 400;
 		color: $muriel-gray-900;
 		height: 48px;
@@ -24,7 +18,7 @@
 		}
 
 		.woocommerce-stepper__step-description {
-			display: block;
+			display: none;
 			font-size: 14px;
 			color: $muriel-gray-500;
 			font-weight: 400;
@@ -84,8 +78,10 @@
 	}
 
 	.woocommerce-stepper__step-divider {
+		align-self: flex-start;
 		flex-grow: 1;
 		border-bottom: 1px solid $muriel-gray-50;
+		margin-top: 20px;
 
 		&:last-child {
 			display: none;
@@ -112,7 +108,8 @@
 			border-bottom: 0;
 			border-left: 1px solid $muriel-gray-50;
 			height: 50px;
-			margin-left: 24px;
+			margin-top: 0;
+			margin-left: 20px;
 		}
 
 		.woocommerce-stepper__step-label {
@@ -121,6 +118,10 @@
 
 		.woocommerce-stepper__step-icon {
 			margin-right: $gap-small;
+		}
+
+		.woocommerce-stepper__step-description {
+			display: block;
 		}
 	}
 }

--- a/packages/components/src/stepper/style.scss
+++ b/packages/components/src/stepper/style.scss
@@ -1,20 +1,22 @@
 .woocommerce-stepper {
+	$step-icon-size: 24px;
+
 	.woocommerce-stepper__steps {
 		display: flex;
 		justify-content: space-around;
 		margin-bottom: $gap-large;
-		font-size: 16px;
 	}
 
 	.woocommerce-stepper__step {
 		display: inline-flex;
 		padding: $gap-smaller;
 		font-weight: 400;
-		color: $muriel-gray-900;
-		height: 48px;
+		position: relative;
 
 		.woocommerce-stepper__step-label {
-			line-height: 24px;
+			color: $muriel-gray-900;
+			line-height: $step-icon-size;
+			font-size: 16px;
 		}
 
 		.woocommerce-stepper__step-description {
@@ -33,6 +35,7 @@
 			display: block;
 			margin-left: -$gap-smaller;
 			margin-right: $gap-smallest;
+			max-height: $step-icon-size;
 		}
 
 		.woocommerce-spinner__circle {
@@ -48,8 +51,11 @@
 		}
 
 		&.is-active {
-			font-weight: 600;
+			.woocommerce-stepper__step-icon {
+				font-weight: 600;
+			}
 			.woocommerce-stepper__step-label {
+				font-weight: 600;
 				margin: 0;
 			}
 		}
@@ -65,12 +71,13 @@
 	}
 
 	.woocommerce-stepper__step-icon {
+		font-size: 16px;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		width: 24px;
-		height: 24px;
-		min-width: 24px;
+		width: $step-icon-size;
+		height: $step-icon-size;
+		min-width: $step-icon-size;
 		margin-right: $gap-small;
 		background: $muriel-gray-50;
 		color: $muriel-gray-600;
@@ -81,7 +88,7 @@
 		align-self: flex-start;
 		flex-grow: 1;
 		border-bottom: 1px solid $muriel-gray-50;
-		margin-top: 20px;
+		margin-top: $step-icon-size / 2 + $gap-smaller;
 
 		&:last-child {
 			display: none;
@@ -104,12 +111,24 @@
 			flex-direction: column;
 		}
 
-		.woocommerce-stepper__step-divider {
-			border-bottom: 0;
+		.woocommerce-stepper__step {
+			min-height: 90px;
+		}
+
+		.woocommerce-stepper__step::after {
+			content: '';
+			position: absolute;
+			left: $step-icon-size / 2 + $gap-smaller;
+			top: $step-icon-size + ( $gap-smaller * 2 );
+			height: calc( 100% -  #{$step-icon-size} - #{ $gap-smaller * 2 } );
 			border-left: 1px solid $muriel-gray-50;
-			height: 50px;
-			margin-top: 0;
-			margin-left: 20px;
+		}
+
+		.woocommerce-stepper__step:last-child {
+			min-height: auto;
+			&:after {
+				display: none;
+			}
 		}
 
 		.woocommerce-stepper__step-label {
@@ -122,6 +141,10 @@
 
 		.woocommerce-stepper__step-description {
 			display: block;
+		}
+
+		.woocommerce-stepper_content {
+			margin-top: $gap-smaller;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2716

* Adds `description` and `content` props to the Stepper.
* Reduces unused styles in Stepper.
* Fixes some minor styling issues in Stepper and allows the vertical Stepper divider to vary in height.
* Updates Spinner style in Stepper (@justinshreve let me know if this was changed somewhere, but tried to style this to closely match the base component for the stepper).

### Screenshots
<img width="684" alt="Screen Shot 2019-07-31 at 4 10 33 PM" src="https://user-images.githubusercontent.com/10561050/62195246-26507800-b3ae-11e9-8136-c73195e2590d.png">

### Detailed test instructions:

1. Go to the devdocs.
2. Make sure the Stepper behaves as expected and new content/description props work as expected.
3. Go to the onboarding profiler.
4. Make sure the header stepper and `plugin` step Steppers continue working as expected.