### PR TITLE
Onboarding: Add a "this store is being setup for a client" store detail field

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -216,6 +216,10 @@
 		border-color: transparent;
 	}
 
+	.muriel-checkbox label.components-checkbox-control__label {
+		margin-left: $gap-smaller;
+	}
+
 	.muriel-checkbox input[type='checkbox'] {
 		width: 18px;
 		height: 18px;

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -310,6 +310,13 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
+			'setup_client'        => array(
+				'type'              => 'boolean',
+				'description'       => __( 'Whether or not this store was setup for a client.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
 		);
 
 		return apply_filters( 'woocommerce_onboarding_profile_properties', $properties );

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -97,7 +97,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 11, $properties );
+		$this->assertCount( 12, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
@@ -109,6 +109,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'business_extensions', $properties );
 		$this->assertArrayHasKey( 'theme', $properties );
 		$this->assertArrayHasKey( 'items_purchased', $properties );
+		$this->assertArrayHasKey( 'setup_client', $properties );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2686.

This PR adds a "This store is being set up for a client" checkbox to the store details page. It adds the answer to tracks, as well as a new profiler field.

### Screenshots

<img width="569" alt="Screen Shot 2019-07-31 at 1 14 03 PM" src="https://user-images.githubusercontent.com/689165/62232986-90a8ee80-b395-11e9-82a6-c9017ea110fb.png">

### Detailed test instructions:

* Go to the store details page `/wp-admin/admin.php?page=wc-admin&step=store-details` and verify that the checkbox is present. 
* Test saving the value. Check the tracks call and profiler REST API data.
