### PR TITLE
Update core subclasses to be PSR-4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
       "includes/core-functions.php",
       "includes/feature-config.php",
       "includes/page-controller/page-controller-functions.php"
-    ]
+    ],
+    "psr-4": {
+      "Automattic\\WooCommerce\\Admin\\": "src/"
+    }
   }
 }

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\WC_Admin_Order;
+
 /**
  * WC_Admin_Reports_Sync Class.
  */

--- a/includes/class-wc-admin-reports-sync.php
+++ b/includes/class-wc-admin-reports-sync.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\WC_Admin_Order;
+use \Automattic\WooCommerce\Admin\WC_Admin_Order_Refund;
 
 /**
  * WC_Admin_Reports_Sync Class.

--- a/src/WC_Admin_Order.php
+++ b/src/WC_Admin_Order.php
@@ -7,16 +7,18 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Order class.
  */
-class WC_Admin_Order extends WC_Order {
+class WC_Admin_Order extends \WC_Order {
 	/**
 	 * Order traits.
 	 */
-	use WC_Admin_Order_Trait;
+	use \WC_Admin_Order_Trait;
 
 	/**
 	 * Holds refund amounts and quantities for the order.
@@ -42,8 +44,9 @@ class WC_Admin_Order extends WC_Order {
 	 * @return string
 	 */
 	public static function order_class_name( $classname, $order_type, $order_id ) {
+		// @todo - Only substitute class when necessary (during sync).
 		if ( 'WC_Order' === $classname ) {
-			return 'WC_Admin_Order';
+			return '\Automattic\WooCommerce\Admin\WC_Admin_Order';
 		} else {
 			return $classname;
 		}
@@ -55,7 +58,7 @@ class WC_Admin_Order extends WC_Order {
 	 * @return int
 	 */
 	public function get_report_customer_id() {
-		return WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $this );
+		return \WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $this );
 	}
 
 	/**
@@ -64,7 +67,7 @@ class WC_Admin_Order extends WC_Order {
 	 * @return bool
 	 */
 	public function is_returning_customer() {
-		return WC_Admin_Reports_Orders_Stats_Data_Store::is_returning_customer( $this );
+		return \WC_Admin_Reports_Orders_Stats_Data_Store::is_returning_customer( $this );
 	}
 
 	/**

--- a/src/WC_Admin_Order.php
+++ b/src/WC_Admin_Order.php
@@ -18,7 +18,7 @@ class WC_Admin_Order extends \WC_Order {
 	/**
 	 * Order traits.
 	 */
-	use \WC_Admin_Order_Trait;
+	use \Automattic\WooCommerce\Admin\WC_Admin_Order_Trait;
 
 	/**
 	 * Holds refund amounts and quantities for the order.

--- a/src/WC_Admin_Order_Refund.php
+++ b/src/WC_Admin_Order_Refund.php
@@ -18,7 +18,7 @@ class WC_Admin_Order_Refund extends \WC_Order_Refund {
 	/**
 	 * Order traits.
 	 */
-	use \WC_Admin_Order_Trait;
+	use \Automattic\WooCommerce\Admin\WC_Admin_Order_Trait;
 
 	/**
 	 * Add filter(s) required to hook WC_Admin_Order_Refund class to substitute WC_Order_Refund.

--- a/src/WC_Admin_Order_Refund.php
+++ b/src/WC_Admin_Order_Refund.php
@@ -7,16 +7,18 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Order_Refund class.
  */
-class WC_Admin_Order_Refund extends WC_Order_Refund {
+class WC_Admin_Order_Refund extends \WC_Order_Refund {
 	/**
 	 * Order traits.
 	 */
-	use WC_Admin_Order_Trait;
+	use \WC_Admin_Order_Trait;
 
 	/**
 	 * Add filter(s) required to hook WC_Admin_Order_Refund class to substitute WC_Order_Refund.
@@ -35,8 +37,9 @@ class WC_Admin_Order_Refund extends WC_Order_Refund {
 	 * @return string
 	 */
 	public static function order_class_name( $classname, $order_type, $order_id ) {
+		// @todo - Only substitute class when necessary (during sync).
 		if ( 'WC_Order_Refund' === $classname ) {
-			return 'WC_Admin_Order_Refund';
+			return '\Automattic\WooCommerce\Admin\WC_Admin_Order_Refund';
 		} else {
 			return $classname;
 		}
@@ -54,7 +57,7 @@ class WC_Admin_Order_Refund extends WC_Order_Refund {
 			return false;
 		}
 
-		return WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $parent_order );
+		return \WC_Admin_Reports_Customers_Data_Store::get_or_create_customer_from_order( $parent_order );
 	}
 
 	/**

--- a/src/WC_Admin_Order_Trait.php
+++ b/src/WC_Admin_Order_Trait.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**


### PR DESCRIPTION
Partially addresses #2712.

This PR updates `WC_Admin_Order`, `WC_Admin_Order_Refund`, and `WC_Admin_Order_Trait` to be PSR-4 autoloaded.

It also introduces the `Automattic\WooCommerce\Admin` namespace.

### Detailed test instructions:

- Verify that WordPress and WooCommerce Admin pages load without PHP errors

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
