### PR TITLE
Update page controller to be PSR-4.

### DIFF
--- a/includes/page-controller/page-controller-functions.php
+++ b/includes/page-controller/page-controller-functions.php
@@ -5,6 +5,8 @@
  * @package Woocommerce Admin
  */
 
+use Automattic\WooCommerce\Admin\WC_Admin_Page_Controller;
+
 /**
  * Connect an existing page to WooCommerce Admin.
  * Passthrough to WC_Admin_Page_Controller::connect_page().

--- a/src/WC_Admin_Page_Controller.php
+++ b/src/WC_Admin_Page_Controller.php
@@ -5,6 +5,10 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
 /**
  * WC_Admin_Page_Controller
  */
@@ -257,7 +261,7 @@ class WC_Admin_Page_Controller {
 		);
 
 		// Tabs that have sections as well.
-		$wc_emails    = WC_Emails::instance();
+		$wc_emails    = \WC_Emails::instance();
 		$wc_email_ids = array_map( 'sanitize_title', array_keys( $wc_emails->get_emails() ) );
 
 		$tabs_with_sections = apply_filters(


### PR DESCRIPTION
Partially addresses #2712.

This PR updates `WC_Admin_Page_Controller` to be PSR-4 autoloaded.

### Detailed test instructions:

- Verify that WordPress and WooCommerce Admin pages load without PHP errors

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
