### PR TITLE
Update admin notes classes to be PSR-4.

### DIFF
--- a/includes/api/class-wc-admin-rest-admin-note-action-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-note-action-controller.php
@@ -9,6 +9,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
 /**
  * REST API Admin Note Action controller class.
  *

--- a/includes/api/class-wc-admin-rest-admin-notes-controller.php
+++ b/includes/api/class-wc-admin-rest-admin-notes-controller.php
@@ -9,6 +9,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
 /**
  * REST API Admin Notes controller class.
  *

--- a/includes/data-stores/class-wc-admin-notes-data-store.php
+++ b/includes/data-stores/class-wc-admin-notes-data-store.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
 /**
  * WC Admin Note Data Store (Custom Tables)
  */

--- a/includes/features/activity-panel/class-wc-admin-activity-panel.php
+++ b/includes/features/activity-panel/class-wc-admin-activity-panel.php
@@ -6,6 +6,9 @@
  * @package Woocommerce Admin
  */
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Settings_Notes;
+
 /**
  * Contains backend logic for the activity panel feature.
  */

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -7,12 +7,14 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Note class.
  */
-class WC_Admin_Note extends WC_Data {
+class WC_Admin_Note extends \WC_Data {
 
 	// Note types.
 	const E_WC_ADMIN_NOTE_ERROR         = 'error';   // used for presenting error conditions.
@@ -53,7 +55,7 @@ class WC_Admin_Note extends WC_Data {
 			'title'         => '-',
 			'content'       => '-',
 			'icon'          => 'info',
-			'content_data'  => new stdClass(),
+			'content_data'  => new \stdClass(),
 			'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED,
 			'source'        => 'woocommerce',
 			'date_created'  => '0000-00-00 00:00:00',
@@ -76,7 +78,7 @@ class WC_Admin_Note extends WC_Data {
 			$this->set_object_read( true );
 		}
 
-		$this->data_store = WC_Data_Store::load( 'admin-note' );
+		$this->data_store = \WC_Data_Store::load( 'admin-note' );
 		if ( $this->get_id() > 0 ) {
 			$this->data_store->read( $this );
 		}
@@ -391,7 +393,7 @@ class WC_Admin_Note extends WC_Data {
 		$allowed_type = false;
 
 		// Make sure $content_data is stdClass Object or an array.
-		if ( ! ( $content_data instanceof stdClass ) ) {
+		if ( ! ( $content_data instanceof \stdClass ) ) {
 			$this->error( 'admin_note_invalid_data', __( 'The admin note content_data prop must be an instance of stdClass.', 'woocommerce-admin' ) );
 		}
 

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -5,6 +5,8 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -58,7 +60,7 @@ class WC_Admin_Notes {
 	 * @return array Array of arrays.
 	 */
 	public static function get_notes( $context = 'edit', $args = array() ) {
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$raw_notes  = $data_store->get_notes( $args );
 		$notes      = array();
 		foreach ( (array) $raw_notes as $raw_note ) {
@@ -91,7 +93,7 @@ class WC_Admin_Notes {
 		if ( false !== $note_id ) {
 			try {
 				return new WC_Admin_Note( $note_id );
-			} catch ( Exception $e ) {
+			} catch ( \Exception $e ) {
 				return false;
 			}
 		}
@@ -106,7 +108,7 @@ class WC_Admin_Notes {
 	 * @return int
 	 */
 	public static function get_notes_count( $type = array(), $status = array() ) {
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		return $data_store->get_notes_count( $type, $status );
 	}
 
@@ -116,7 +118,7 @@ class WC_Admin_Notes {
 	 * @param string $name Name to search for.
 	 */
 	public static function delete_notes_with_name( $name ) {
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( $name );
 		foreach ( (array) $note_ids as $note_id ) {
 			$note = new WC_Admin_Note( $note_id );
@@ -128,13 +130,13 @@ class WC_Admin_Notes {
 	 * Clear note snooze status if the reminder date has been reached.
 	 */
 	public static function unsnooze_notes() {
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$raw_notes  = $data_store->get_notes(
 			array(
 				'status' => array( WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED ),
 			)
 		);
-		$now        = new DateTime();
+		$now        = new \DateTime();
 
 		foreach ( $raw_notes as $raw_note ) {
 			$note          = new WC_Admin_Note( $raw_note );
@@ -170,7 +172,7 @@ class WC_Admin_Notes {
 	 * Clears all queued actions.
 	 */
 	public static function clear_queued_actions() {
-		$store = ActionScheduler::store();
+		$store = \ActionScheduler::store();
 
 		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
 			// If we're using our data store, call our bespoke deletion method.

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,7 +28,7 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 	protected static function possibly_add_admin_giving_feedback_note() {
 		$name = 'wc-admin-store-notice-giving-feedback';
 
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// We already have this note? Then exit, we're done.
 		$note_ids = $data_store->get_notes_with_name( $name );

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -19,13 +21,13 @@ class WC_Admin_Notes_Historical_Data {
 	 * Creates a note for regenerating historical data.
 	 */
 	public static function add_note() {
-		$is_upgrading = get_option( WC_Admin_Install::VERSION_OPTION );
+		$is_upgrading = get_option( \WC_Admin_Install::VERSION_OPTION );
 		if ( $is_upgrading ) {
 			return;
 		}
 
 		// First, see if orders exist and if we've already created this kind of note so we don't do it again.
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 		$orders     = wc_get_orders(
 			array(

--- a/src/Notes/WC_Admin_Notes_Mobile_App.php
+++ b/src/Notes/WC_Admin_Notes_Mobile_App.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -38,7 +40,7 @@ class WC_Admin_Notes_Mobile_App {
 			return;
 		}
 
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// We already have this note? Then exit, we're done.
 		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );

--- a/src/Notes/WC_Admin_Notes_New_Sales_Record.php
+++ b/src/Notes/WC_Admin_Notes_New_Sales_Record.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -24,7 +26,7 @@ class WC_Admin_Notes_New_Sales_Record {
 	 * @return floatval
 	 */
 	public static function sum_sales_for_date( $date ) {
-		$order_query = new WC_Order_Query( array( 'date_created' => $date ) );
+		$order_query = new \WC_Order_Query( array( 'date_created' => $date ) );
 		$orders      = $order_query->get_orders();
 		$total       = 0;
 

--- a/src/Notes/WC_Admin_Notes_Order_Milestones.php
+++ b/src/Notes/WC_Admin_Notes_Order_Milestones.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/src/Notes/WC_Admin_Notes_Settings_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Settings_Notes.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -26,7 +28,7 @@ class WC_Admin_Notes_Settings_Notes {
 	protected static function possibly_add_notice_setting_moved_note() {
 		$name = 'wc-admin-store-notice-setting-moved';
 
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// We already have this note? Then exit, we're done.
 		$note_ids = $data_store->get_notes_with_name( $name );

--- a/src/Notes/WC_Admin_Notes_Welcome_Message.php
+++ b/src/Notes/WC_Admin_Notes_Welcome_Message.php
@@ -7,7 +7,10 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
+
 /**
  * WC_Admin_Notes_Welcome_Message.
  */
@@ -19,13 +22,13 @@ class WC_Admin_Notes_Welcome_Message {
 	 */
 	public static function add_welcome_note() {
 		// Check if plugin is upgrading if yes then don't create this note.
-		$is_upgrading = get_option( WC_Admin_Install::VERSION_OPTION );
+		$is_upgrading = get_option( \WC_Admin_Install::VERSION_OPTION );
 		if ( $is_upgrading ) {
 			return;
 		}
 
 		// See if we've already created this kind of note so we don't do it again.
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 		if ( ! empty( $note_ids ) ) {
 			return;

--- a/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
@@ -7,6 +7,8 @@
  * @package WooCommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Notes;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -104,7 +106,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 	 */
 	public function check_connection() {
 		if ( ! $this->is_connected() ) {
-			$data_store = WC_Data_Store::load( 'admin-note' );
+			$data_store = \WC_Data_Store::load( 'admin-note' );
 			$note_ids   = $data_store->get_notes_with_name( self::CONNECTION_NOTE_NAME );
 			if ( ! empty( $note_ids ) ) {
 				// We already have a connection note. Exit early.
@@ -122,7 +124,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 	 * @return bool
 	 */
 	public function is_connected() {
-		$auth = WC_Helper_Options::get( 'auth' );
+		$auth = \WC_Helper_Options::get( 'auth' );
 		return ( ! empty( $auth['access_token'] ) );
 	}
 
@@ -136,7 +138,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 			return false;
 		}
 
-		$auth = WC_Helper_Options::get( 'auth' );
+		$auth = \WC_Helper_Options::get( 'auth' );
 		return absint( $auth['site_id'] );
 	}
 
@@ -154,7 +156,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 		$product_ids = array();
 
 		if ( $this->is_connected() ) {
-			$subscriptions = WC_Helper::get_subscriptions();
+			$subscriptions = \WC_Helper::get_subscriptions();
 
 			foreach ( (array) $subscriptions as $subscription ) {
 				if ( in_array( $site_id, $subscription['connections'], true ) ) {
@@ -216,7 +218,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 	public function prune_inactive_subscription_notes() {
 		$active_product_ids = $this->get_subscription_active_product_ids();
 
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( self::SUBSCRIPTION_NOTE_NAME );
 
 		foreach ( (array) $note_ids as $note_id ) {
@@ -239,7 +241,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 	public function find_note_for_product_id( $product_id ) {
 		$product_id = intval( $product_id );
 
-		$data_store = WC_Data_Store::load( 'admin-note' );
+		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( self::SUBSCRIPTION_NOTE_NAME );
 		foreach ( (array) $note_ids as $note_id ) {
 			$note             = WC_Admin_Notes::get_note( $note_id );
@@ -418,7 +420,7 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 
 		$this->prune_inactive_subscription_notes();
 
-		$subscriptions      = WC_Helper::get_subscriptions();
+		$subscriptions      = \WC_Helper::get_subscriptions();
 		$active_product_ids = $this->get_subscription_active_product_ids();
 
 		foreach ( (array) $subscriptions as $subscription ) {

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -5,6 +5,9 @@
  * @package WooCommerce\Tests\API
  */
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
 /**
  * Class WC_Tests_API_Admin_Notes
  */

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\Framework\Helpers
  */
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
 /**
  * Class WC_Helper_Admin_Notes.
  *

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -19,6 +19,12 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
+
 /**
  * Autoload packages.
  *


### PR DESCRIPTION
Partially addresses #2712.

This PR updates the Admin Notes classes to be PSR-4 autoloaded.

It also introduces the `Automattic\WooCommerce\Admin\Notes` namespace.

### Detailed test instructions:

- Verify that WordPress and WooCommerce Admin pages load without PHP errors
- Verify that Admin notes load and you can take actions / snooze them

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
