### PR TITLE
Update report export classes to be PSR-4.

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-export-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-export-controller.php
@@ -11,6 +11,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\WC_Admin_Report_Exporter;
+
 /**
  * Reports Export controller.
  *

--- a/src/WC_Admin_Report_CSV_Exporter.php
+++ b/src/WC_Admin_Report_CSV_Exporter.php
@@ -5,6 +5,8 @@
  * @package WooCommerce/Export
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -19,7 +21,7 @@ if ( ! class_exists( 'WC_CSV_Batch_Exporter', false ) ) {
 /**
  * WC_Admin_Report_CSV_Exporter Class.
  */
-class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
+class WC_Admin_Report_CSV_Exporter extends \WC_CSV_Batch_Exporter {
 	/**
 	 * Type of report being exported.
 	 *
@@ -102,15 +104,15 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 */
 	protected function map_report_controller() {
 		$controller_map = array(
-			'products'   => 'WC_Admin_REST_Reports_Products_Controller',
-			'variations' => 'WC_Admin_REST_Reports_Variations_Controller',
-			'orders'     => 'WC_Admin_REST_Reports_Orders_Controller',
-			'categories' => 'WC_Admin_REST_Reports_Categories_Controller',
-			'taxes'      => 'WC_Admin_REST_Reports_Taxes_Controller',
-			'coupons'    => 'WC_Admin_REST_Reports_Coupons_Controller',
-			'stock'      => 'WC_Admin_REST_Reports_Stock_Controller',
-			'downloads'  => 'WC_Admin_REST_Reports_Downloads_Controller',
-			'customers'  => 'WC_Admin_REST_Reports_Customers_Controller',
+			'products'   => '\WC_Admin_REST_Reports_Products_Controller',
+			'variations' => '\WC_Admin_REST_Reports_Variations_Controller',
+			'orders'     => '\WC_Admin_REST_Reports_Orders_Controller',
+			'categories' => '\WC_Admin_REST_Reports_Categories_Controller',
+			'taxes'      => '\WC_Admin_REST_Reports_Taxes_Controller',
+			'coupons'    => '\WC_Admin_REST_Reports_Coupons_Controller',
+			'stock'      => '\WC_Admin_REST_Reports_Stock_Controller',
+			'downloads'  => '\WC_Admin_REST_Reports_Downloads_Controller',
+			'customers'  => '\WC_Admin_REST_Reports_Customers_Controller',
 		);
 
 		if ( isset( $controller_map[ $this->report_type ] ) ) {
@@ -175,7 +177,7 @@ class WC_Admin_Report_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * Prepare data for export.
 	 */
 	public function prepare_data_to_export() {
-		$request  = new WP_REST_Request( 'GET', "/wc/v4/reports/{$this->report_type}" );
+		$request  = new \WP_REST_Request( 'GET', "/wc/v4/reports/{$this->report_type}" );
 		$params   = $this->controller->get_collection_params();
 		$defaults = array();
 

--- a/src/WC_Admin_Report_Exporter.php
+++ b/src/WC_Admin_Report_Exporter.php
@@ -5,6 +5,8 @@
  * @package WooCommerce/Export
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -93,7 +95,7 @@ class WC_Admin_Report_Exporter {
 		$report_batch_args = array( $export_id, $report_type, $report_args );
 
 		if ( 0 < $num_batches ) {
-			WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, self::REPORT_EXPORT_ACTION, $report_batch_args );
+			\WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, self::REPORT_EXPORT_ACTION, $report_batch_args );
 		}
 
 		return $total_rows;

--- a/tests/reports/class-wc-tests-reports-coupons.php
+++ b/tests/reports/class-wc-tests-reports-coupons.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\Coupons
  */
 
+use \Automattic\WooCommerce\Admin\WC_Admin_Report_CSV_Exporter;
+
 /**
  * Class WC_Tests_Reports_Coupons
  */

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
+use Automattic\WooCommerce\Admin\WC_Admin_Report_Exporter;
 
 /**
  * Autoload packages.


### PR DESCRIPTION
Partially addresses #2712.

This PR updates `WC_Admin_Report_Exporter` and `WC_Admin_Report_CSV_Exporter ` to be PSR-4 autoloaded.


### Detailed test instructions:

- Verify that WordPress and WooCommerce Admin pages load without PHP errors
- Test the Report Export endpoints:
- `POST /wc/v4/reports/orders/export`
(using body)
```json
{
    "report_args": {
        "after": "2019-01-01T00:00:00"
    }
}
```
- `GET /wc/v4/reports/orders/export/<id here>/status` (get URL from `POST` response)
- When 100%, `download_url` should be in status response
- Open download URL in browser
- Verify CSV contents

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
