### PR TITLE
Update feature classes to be PSR-4 autoloaded.

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -9,6 +9,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Features\WC_Admin_Onboarding;
+
 /**
  * Onboarding Profile controller.
  *

--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -130,7 +130,7 @@ class WC_Admin_Loader {
 		$features = self::get_features();
 		foreach ( $features as $feature ) {
 			$feature = strtolower( str_replace( '-', '_', $feature ) );
-			$feature = 'WC_Admin_' . ucwords( $feature, '_' );
+			$feature = 'Automattic\WooCommerce\Admin\Features\WC_Admin_' . ucwords( $feature, '_' );
 
 			if ( class_exists( $feature ) ) {
 				new $feature;

--- a/src/Features/WC_Admin_Activity_Panels.php
+++ b/src/Features/WC_Admin_Activity_Panels.php
@@ -6,6 +6,8 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Features;
+
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Settings_Notes;
 

--- a/src/Features/WC_Admin_Analytics.php
+++ b/src/Features/WC_Admin_Analytics.php
@@ -6,6 +6,8 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Features;
+
 /**
  * Contains backend logic for the Analytics feature.
  */

--- a/src/Features/WC_Admin_Analytics_Dashboard.php
+++ b/src/Features/WC_Admin_Analytics_Dashboard.php
@@ -6,6 +6,8 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Features;
+
 /**
  * Contains backend logic for the dashboard feature.
  */

--- a/src/Features/WC_Admin_Onboarding.php
+++ b/src/Features/WC_Admin_Onboarding.php
@@ -6,6 +6,8 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Features;
+
 /**
  * Contains backend logic for the onboarding profile and checklist feature.
  */
@@ -228,9 +230,9 @@ class WC_Admin_Onboarding {
 		}
 
 		foreach ( $themes as $theme ) {
-			$directory = new RecursiveDirectoryIterator( $theme->theme_root . '/' . $theme->stylesheet );
-			$iterator  = new RecursiveIteratorIterator( $directory );
-			$files     = new RegexIterator( $iterator, '/^.+\.php$/i', RecursiveRegexIterator::GET_MATCH );
+			$directory = new \RecursiveDirectoryIterator( $theme->theme_root . '/' . $theme->stylesheet );
+			$iterator  = new \RecursiveIteratorIterator( $directory );
+			$files     = new \RegexIterator( $iterator, '/^.+\.php$/i', \RecursiveRegexIterator::GET_MATCH );
 
 			foreach ( $files as $file ) {
 				$content = file_get_contents( $file[0] );
@@ -357,14 +359,14 @@ class WC_Admin_Onboarding {
 	 */
 	public static function reset_onboarding() {
 		if (
-			! WC_Admin_Loader::is_admin_page() ||
+			! \WC_Admin_Loader::is_admin_page() ||
 			! isset( $_GET['reset_onboarding'] ) || // WPCS: CSRF ok.
 			1 !== absint( $_GET['reset_onboarding'] ) // WPCS: CSRF ok.
 		) {
 			return;
 		}
 
-		$request = new WP_REST_Request( 'POST', '/wc-admin/v1/onboarding/profile' );
+		$request = new \WP_REST_Request( 'POST', '/wc-admin/v1/onboarding/profile' );
 		$request->set_headers( array( 'content-type' => 'application/json' ) );
 		$request->set_body(
 			wp_json_encode(

--- a/src/Features/WC_Admin_Onboarding_Tasks.php
+++ b/src/Features/WC_Admin_Onboarding_Tasks.php
@@ -6,6 +6,8 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin\Features;
+
 /**
  * Contains the logic for completing onboarding tasks.
  */


### PR DESCRIPTION
Partially addresses #2712.

This PR updates the feature loading classes to be PSR-4 autoloaded.

### Detailed test instructions:

- `composer install`
- Verify that WordPress and WooCommerce Admin pages load without PHP errors
- Verify that onboarding works
- Turn off a feature (`feature-config.php`) and verify it doesn't load