### PR TITLE
Update fresh-data to 0.7.0 release

### DIFF
--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -41,11 +41,6 @@ function createWcApiSpec() {
 		},
 		operations: {
 			read( resourceNames ) {
-				if ( document.hidden ) {
-					// Don't do any read updates while the tab isn't active.
-					return [];
-				}
-
 				return [
 					...imports.operations.read( resourceNames ),
 					...items.operations.read( resourceNames ),

--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -3,18 +3,11 @@
  * External dependencies
  */
 import { ApiClient } from '@fresh-data/framework';
-import { createStore as createReduxStore } from 'redux';
 
 /**
  * Internal dependencies
  */
-import reducer from './reducer';
-
-function createStore( name ) {
-	const devTools = window.__REDUX_DEVTOOLS_EXTENSION__;
-
-	return createReduxStore( reducer, devTools && devTools( { name: name, instanceId: name } ) );
-}
+import createStore from './create-store';
 
 function createDataHandlers( store ) {
 	return {

--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -39,6 +39,8 @@ function createApiClient( name, apiSpec ) {
 	};
 	store.subscribe( storeChanged );
 
+	storeChanged();
+
 	return apiClient;
 }
 

--- a/client/wc-api/wp-data-store/create-api-client.js
+++ b/client/wc-api/wp-data-store/create-api-client.js
@@ -12,12 +12,6 @@ import createStore from './create-store';
 function createDataHandlers( store ) {
 	return {
 		dataRequested: resourceNames => {
-			// This is a temporary fix until it can be resolved upstream in fresh-data.
-			// See: https://github.com/woocommerce/woocommerce-admin/pull/2387/files#r292355276
-			if ( document.hidden ) {
-				return;
-			}
-
 			store.dispatch( {
 				type: 'FRESH_DATA_REQUESTED',
 				resourceNames,

--- a/client/wc-api/wp-data-store/index.js
+++ b/client/wc-api/wp-data-store/index.js
@@ -17,37 +17,12 @@ if ( 'development' === process.env.NODE_ENV ) {
 function createWcApiStore() {
 	const apiClient = createApiClient( 'wc-api', wcApiSpec );
 
-	function getComponentSelectors( component ) {
-		const componentRequirements = [];
-
-		return {
-			selectors: apiClient.getSelectors( componentRequirements ),
-			onComplete: () => {
-				if ( 0 === componentRequirements.length ) {
-					apiClient.clearComponentRequirements( component );
-				} else {
-					apiClient.setComponentRequirements( component, componentRequirements );
-				}
-			},
-			onUnmount: () => {
-				apiClient.clearComponentRequirements( component );
-			},
-		};
-	}
-
 	return {
-		// The wrapped function for getSelectors is temporary code.
-		//
-		// @todo Remove the `() =>` after the `@wordpress/data` PR is merged:
-		// https://github.com/WordPress/gutenberg/pull/11460
-		//
-		getSelectors: () => context => {
-			const component = context && context.component ? context.component : context;
-			return getComponentSelectors( component );
+		getSelectors: () => {
+			return apiClient.getSelectors();
 		},
 		getActions() {
-			const mutations = apiClient.getMutations();
-			return mutations;
+			return apiClient.getMutations();
 		},
 		subscribe: apiClient.subscribe,
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,9 +1199,9 @@
       }
     },
     "@fresh-data/framework": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.6.1.tgz",
-      "integrity": "sha512-UCaLX/WgLPputWvfnB2IK0Im3f78hrut+2epLoG2MqP7GRnM7vFzxYfQdCdIocP+SqtkKSwPaJwwTeHMeVFvBg==",
+      "version": "0.7.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.7.0-beta.0.tgz",
+      "integrity": "sha512-EunC210+m/pDlF8ZmGzV0UA3UKXsP+qqaJRHU9Y/dULEW7xki0kvp6P52ykRptcYQquayUPEORn/90qBMDI/cQ==",
       "requires": {
         "@babel/runtime": "^7.4.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,9 +1199,9 @@
       }
     },
     "@fresh-data/framework": {
-      "version": "0.7.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.7.0-beta.0.tgz",
-      "integrity": "sha512-EunC210+m/pDlF8ZmGzV0UA3UKXsP+qqaJRHU9Y/dULEW7xki0kvp6P52ykRptcYQquayUPEORn/90qBMDI/cQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@fresh-data/framework/-/framework-0.7.0.tgz",
+      "integrity": "sha512-WW/eZA3d6wwoX6/h1qiwoc8vdvmopEihg2tH6iYYD/r4vRx+UhJcoD1iJRjPzRwJsTmyTCJ/VZKOd2VGGvg7qQ==",
       "requires": {
         "@babel/runtime": "^7.4.2"
       }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "@fresh-data/framework": "0.7.0-beta.0",
+    "@fresh-data/framework": "0.7.0",
     "@wordpress/api-fetch": "2.2.8",
     "@wordpress/components": "8.3.1",
     "@wordpress/data": "4.9.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     }
   },
   "dependencies": {
-    "@fresh-data/framework": "0.6.1",
+    "@fresh-data/framework": "0.7.0-beta.0",
     "@wordpress/api-fetch": "2.2.8",
     "@wordpress/components": "8.3.1",
     "@wordpress/data": "4.9.1",


### PR DESCRIPTION
fresh-data has recently had a significant refactor, see:
https://github.com/Automattic/fresh-data/issues/203

This is a PR to update wc-admin to use the new fresh-data version, which
is mostly backwards compatible with a couple of changes.

This PR also removes woocommerce-admin's support for hidden tabs because that functionality was added directly to fresh-data now.

### Detailed test instructions:

0. In client/wc-api/constants.js, change default freshness from 30 mins to 2 minutes for testing.
1. Check any page which uses fresh-data for queries (revenue analytics, for example).
2. Open browser dev console, enter line: `localStorage.setItem('debug', 'fresh-data:*')`
3. Refresh on this page, and you should see lots of debug output on fetching data.
4. Wait 2 minutes, and you should see the data re-fetch automatically.
5. Now, switch to another tab, and you should see in the debug output "App has become hidden..." and "Cancelling next update." messages.
6. Immediately switch back to app tab, and you should see "App has become visible again..." and "Scheduling next update for ### seconds from now." messages. However, you should see no actual fetch activity until it's been 2 minutes from the last update.
7. Switch back to another tab and wait longer than 2 minutes, verify that no fetches occur.
8. Switch back to app tab and fetches should immediately occur again.

(Note: visibility should also toggle when browser is minimized or when switching to another workspace)

### Changelog Note:

Performance: Update fresh-data to refactored version with built-in visibility support.
