### PR TITLE
Onboarding - Fix navigation handling on the `skip` link

### DIFF
--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -195,9 +195,9 @@ class Start extends Component {
 				</Card>
 
 				<p>
-					<Link href="#" onClick={ this.skipWizard }>
+					<Button isLink className="woocommerce-profile-wizard__skip" onClick={ this.skipWizard }>
 						{ __( 'Proceed without Jetpack or WooCommerce Services', 'woocommerce-admin' ) }
-					</Link>
+					</Button>
 				</p>
 			</Fragment>
 		);

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -5,6 +5,13 @@
 		color: $muriel-gray-600;
 	}
 
+	.woocommerce-profile-wizard__skip.components-button.is-link {
+		color: $muriel-gray-600;
+		margin-top: 0;
+		margin-bottom: 0;
+		font-weight: normal;
+	}
+
 	.woocommerce-card {
 		margin-top: $gap;
 


### PR DESCRIPTION
Fixes #2670.

The "Proceed without Jetpack or WooCommerce Services" was attempting to navigate to '#' which was actually dropping '?page=wc-admin' off of the URL and causing navigation problems.

Since we just need a click handler to fire (the user remains on the main dashboard page), this usage is updated with a button.

### Detailed test instructions:

* /wp-admin/admin.php?page=wc-admin
* Click "Proceed without Jetpack or WooCommerce Services"
* The profile wizard should be dismissed, and the dashboard should display (no navigation should occur).
