### PR TITLE
PSR-4ify the sync class.

### DIFF
--- a/includes/api/class-wc-admin-rest-reports-import-controller.php
+++ b/includes/api/class-wc-admin-rest-reports-import-controller.php
@@ -9,6 +9,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
+
 /**
  * Reports Imports controller.
  *

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -174,7 +174,7 @@ class WC_Admin_Notes {
 	public static function clear_queued_actions() {
 		$store = \ActionScheduler::store();
 
-		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
+		if ( is_a( $store, 'Automattic\WooCommerce\Admin\WC_Admin_ActionScheduler_WPPostStore' ) ) {
 			// If we're using our data store, call our bespoke deletion method.
 			$action_types = array( self::UNSNOOZE_HOOK );
 			$store->clear_pending_wcadmin_actions( $action_types );

--- a/src/WC_Admin_ActionScheduler_WPPostStore.php
+++ b/src/WC_Admin_ActionScheduler_WPPostStore.php
@@ -5,10 +5,12 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 /**
  * Class WC Admin Action Scheduler Store.
  */
-class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
+class WC_Admin_ActionScheduler_WPPostStore extends \ActionScheduler_wpPostStore {
 	/**
 	 * Action scheduler job priority (lower numbers are claimed first).
 	 */
@@ -24,7 +26,7 @@ class WC_Admin_ActionScheduler_WPPostStore extends ActionScheduler_wpPostStore {
 	 * @param DateTime               $scheduled_date Action schedule.
 	 * @return array Post data array for usage in wp_insert_post().
 	 */
-	protected function create_post_array( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
+	protected function create_post_array( \ActionScheduler_Action $action, \DateTime $scheduled_date = null ) {
 		$postdata = parent::create_post_array( $action, $scheduled_date );
 
 		if ( 0 === strpos( $postdata['post_title'], 'wc-admin_' ) ) {

--- a/src/WC_Admin_Report_Exporter.php
+++ b/src/WC_Admin_Report_Exporter.php
@@ -95,7 +95,7 @@ class WC_Admin_Report_Exporter {
 		$report_batch_args = array( $export_id, $report_type, $report_args );
 
 		if ( 0 < $num_batches ) {
-			\WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, self::REPORT_EXPORT_ACTION, $report_batch_args );
+			WC_Admin_Reports_Sync::queue_batches( 1, $num_batches, self::REPORT_EXPORT_ACTION, $report_batch_args );
 		}
 
 		return $total_rows;

--- a/src/WC_Admin_Reports_Sync.php
+++ b/src/WC_Admin_Reports_Sync.php
@@ -5,10 +5,9 @@
  * @package WooCommerce Admin/Classes
  */
 
-defined( 'ABSPATH' ) || exit;
+namespace Automattic\WooCommerce\Admin;
 
-use \Automattic\WooCommerce\Admin\WC_Admin_Order;
-use \Automattic\WooCommerce\Admin\WC_Admin_Order_Refund;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports_Sync Class.
@@ -127,7 +126,7 @@ class WC_Admin_Reports_Sync {
 	 */
 	public static function regenerate_report_data( $days, $skip_existing ) {
 		if ( self::is_importing() ) {
-			return new WP_Error( 'wc_admin_import_in_progress', __( 'An import is already in progress.  Please allow the previous import to complete before beginning a new one.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'wc_admin_import_in_progress', __( 'An import is already in progress.  Please allow the previous import to complete before beginning a new one.', 'woocommerce-admin' ) );
 		}
 
 		self::reset_import_stats( $days, $skip_existing );
@@ -154,7 +153,7 @@ class WC_Admin_Reports_Sync {
 		$previous_import_date = get_option( 'wc_admin_imported_from_date' );
 		$current_import_date  = $days ? date( 'Y-m-d 00:00:00', time() - ( DAY_IN_SECONDS * $days ) ) : -1;
 
-		if ( ! $previous_import_date || -1 === $current_import_date || new DateTime( $previous_import_date ) > new DateTime( $current_import_date ) ) {
+		if ( ! $previous_import_date || -1 === $current_import_date || new \DateTime( $previous_import_date ) > new \DateTime( $current_import_date ) ) {
 			update_option( 'wc_admin_imported_from_date', $current_import_date );
 		}
 	}
@@ -208,7 +207,7 @@ class WC_Admin_Reports_Sync {
 	 * Clears all queued actions.
 	 */
 	public static function clear_queued_actions() {
-		$store = ActionScheduler::store();
+		$store = \ActionScheduler::store();
 
 		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
 			// If we're using our data store, call our bespoke deletion method.
@@ -314,11 +313,11 @@ class WC_Admin_Reports_Sync {
 		add_action( 'save_post', array( __CLASS__, 'schedule_single_order_import' ) );
 		add_action( 'woocommerce_refund_created', array( __CLASS__, 'schedule_single_order_import' ) );
 
-		WC_Admin_Reports_Orders_Stats_Data_Store::init();
-		WC_Admin_Reports_Customers_Data_Store::init();
-		WC_Admin_Reports_Coupons_Data_Store::init();
-		WC_Admin_Reports_Products_Data_Store::init();
-		WC_Admin_Reports_Taxes_Data_Store::init();
+		\WC_Admin_Reports_Orders_Stats_Data_Store::init();
+		\WC_Admin_Reports_Customers_Data_Store::init();
+		\WC_Admin_Reports_Coupons_Data_Store::init();
+		\WC_Admin_Reports_Products_Data_Store::init();
+		\WC_Admin_Reports_Taxes_Data_Store::init();
 	}
 
 	/**
@@ -457,10 +456,10 @@ class WC_Admin_Reports_Sync {
 
 		$result = array_sum(
 			array(
-				WC_Admin_Reports_Orders_Stats_Data_Store::sync_order( $order_id ),
-				WC_Admin_Reports_Products_Data_Store::sync_order_products( $order_id ),
-				WC_Admin_Reports_Coupons_Data_Store::sync_order_coupons( $order_id ),
-				WC_Admin_Reports_Taxes_Data_Store::sync_order_taxes( $order_id ),
+				\WC_Admin_Reports_Orders_Stats_Data_Store::sync_order( $order_id ),
+				\WC_Admin_Reports_Products_Data_Store::sync_order_products( $order_id ),
+				\WC_Admin_Reports_Coupons_Data_Store::sync_order_coupons( $order_id ),
+				\WC_Admin_Reports_Taxes_Data_Store::sync_order_taxes( $order_id ),
 			)
 		);
 
@@ -630,7 +629,7 @@ class WC_Admin_Reports_Sync {
 			add_action( 'pre_user_query', array( __CLASS__, 'exclude_existing_customers_from_query' ) );
 		}
 
-		$customer_query = new WP_User_Query( $query_args );
+		$customer_query = new \WP_User_Query( $query_args );
 
 		remove_action( 'pre_user_query', array( __CLASS__, 'exclude_existing_customers_from_query' ) );
 
@@ -707,7 +706,7 @@ class WC_Admin_Reports_Sync {
 
 		foreach ( $customer_ids as $customer_id ) {
 			// @todo Schedule single customer update if this fails?
-			WC_Admin_Reports_Customers_Data_Store::update_registered_customer( $customer_id );
+			\WC_Admin_Reports_Customers_Data_Store::update_registered_customer( $customer_id );
 		}
 
 		$imported_count = get_option( 'wc_admin_import_customers_count', 0 );
@@ -752,7 +751,7 @@ class WC_Admin_Reports_Sync {
 		);
 
 		foreach ( $customer_ids as $customer_id ) {
-			WC_Admin_Reports_Customers_Data_Store::delete_customer( $customer_id );
+			\WC_Admin_Reports_Customers_Data_Store::delete_customer( $customer_id );
 		}
 
 		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'customer' ) );
@@ -794,7 +793,7 @@ class WC_Admin_Reports_Sync {
 		);
 
 		foreach ( $order_ids as $order_id ) {
-			WC_Admin_Reports_Orders_Stats_Data_Store::delete_order( $order_id );
+			\WC_Admin_Reports_Orders_Stats_Data_Store::delete_order( $order_id );
 		}
 
 		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'order' ) );

--- a/src/WC_Admin_Reports_Sync.php
+++ b/src/WC_Admin_Reports_Sync.php
@@ -209,7 +209,7 @@ class WC_Admin_Reports_Sync {
 	public static function clear_queued_actions() {
 		$store = \ActionScheduler::store();
 
-		if ( is_a( $store, 'WC_Admin_ActionScheduler_WPPostStore' ) ) {
+		if ( is_a( $store, 'Automattic\WooCommerce\Admin\WC_Admin_ActionScheduler_WPPostStore' ) ) {
 			// If we're using our data store, call our bespoke deletion method.
 			$action_types = array(
 				self::QUEUE_BATCH_ACTION,

--- a/tests/api-init.php
+++ b/tests/api-init.php
@@ -6,6 +6,8 @@
  * @since 3.5.0
  */
 
+use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
+
 /**
  * Class WC_Tests_API_Init
  */

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Tests\API
  */
 
+use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
+
 /**
  * Reports Import REST API Test Class
  *

--- a/tests/batch-queue.php
+++ b/tests/batch-queue.php
@@ -6,6 +6,8 @@
  * @since 3.5.0
  */
 
+use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
+
 /**
  * Reports Generation Batch Queue Test Class
  *

--- a/tests/queue-priority.php
+++ b/tests/queue-priority.php
@@ -6,6 +6,8 @@
  * @since 3.5.0
  */
 
+use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
+
 /**
  * Reports Generation Batch Queue Prioritizaion Test Class
  *

--- a/tests/queue-priority.php
+++ b/tests/queue-priority.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
+use Automattic\WooCommerce\Admin\WC_Admin_ActionScheduler_wpPostStore;
 
 /**
  * Reports Generation Batch Queue Prioritizaion Test Class

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -222,7 +222,7 @@ class WC_Admin_Feature_Plugin {
 			return $store_class;
 		}
 
-		return 'WC_Admin_ActionScheduler_WPPostStore';
+		return 'Automattic\WooCommerce\Admin\WC_Admin_ActionScheduler_WPPostStore';
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -25,6 +25,7 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
 use Automattic\WooCommerce\Admin\WC_Admin_Report_Exporter;
+use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
 
 /**
  * Autoload packages.


### PR DESCRIPTION
Partially addresses #2712.

This PR updates `WC_Admin_Reports_Sync` to be PSR-4 autoloaded.

### Detailed test instructions:

- Verify that WordPress and WooCommerce Admin pages load without PHP errors
- Test the Historical Data Import, verify function (including cancelling import)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
