### PR TITLE
Update theme subclasses to be PSR-4.

### DIFF
--- a/includes/api/class-wc-admin-rest-themes-controller.php
+++ b/includes/api/class-wc-admin-rest-themes-controller.php
@@ -9,6 +9,9 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\WC_Admin_Theme_Upgrader;
+use Automattic\WooCommerce\Admin\WC_Admin_Theme_Upgrader_Skin;
+
 /**
  * Themes controller.
  *

--- a/src/WC_Admin_Theme_Upgrader.php
+++ b/src/WC_Admin_Theme_Upgrader.php
@@ -5,12 +5,14 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Theme_Upgrader Class.
  */
-class WC_Admin_Theme_Upgrader extends Theme_Upgrader {
+class WC_Admin_Theme_Upgrader extends \Theme_Upgrader {
 	/**
 	 * Install a theme package.
 	 *

--- a/src/WC_Admin_Theme_Upgrader_Skin.php
+++ b/src/WC_Admin_Theme_Upgrader_Skin.php
@@ -5,12 +5,14 @@
  * @package WooCommerce Admin/Classes
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Theme_Upgrader_Skin Class.
  */
-class WC_Admin_Theme_Upgrader_Skin extends Theme_Upgrader_Skin {
+class WC_Admin_Theme_Upgrader_Skin extends \Theme_Upgrader_Skin {
 	/**
 	 * Hide the skin header display.
 	 */


### PR DESCRIPTION
Partially addresses #2712.

This PR updates `WC_Admin_Theme_Upgrader` and `WC_Admin_Theme_Upgrader_Skin` to be PSR-4 autoloaded.

### Detailed test instructions:

- Verify that WordPress and WooCommerce Admin pages load without PHP errors
- Test the onboarding flow theme step

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
