### PR TITLE
Short circuit admin title filter when applied by third parties too early.

### DIFF
--- a/includes/class-wc-admin-loader.php
+++ b/includes/class-wc-admin-loader.php
@@ -478,7 +478,13 @@ class WC_Admin_Loader {
 	 * @todo Can we do some URL rewriting so we can figure out which page they are on server side?
 	 */
 	public static function update_admin_title( $admin_title ) {
-		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
+		if (
+			! did_action( 'current_screen' ) ||
+			(
+				! self::is_admin_page() &&
+				! self::is_embed_page()
+			)
+		) {
 			return $admin_title;
 		}
 


### PR DESCRIPTION
Bail out of our `admin_title` filter if it's invoked before `current_screen`.

Prevents issues like https://github.com/xwp/pwa-wp/issues/206 from triggering the doing it wrong error.

### Detailed test instructions:

- Invoke the error by using the PWA plugin -or-
```php
add_action( 'admin_init', function() {
        apply_filters( 'admin_title', 'test', 'test' );
});
```

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
