### PR TITLE
Add `help` prop to SimpleSelectControl to properly show errors.

### DIFF
--- a/docs/components/packages/simple-select-control.md
+++ b/docs/components/packages/simple-select-control.md
@@ -44,3 +44,10 @@ A function that receives the value of the new option that is being selected as i
 
 The currently value of the select element.
 
+### `help`
+
+- Type: One of type: string, node
+- Default: null
+
+If this property is added, a help text will be generated using help property as the content.
+

--- a/packages/components/src/simple-select-control/index.js
+++ b/packages/components/src/simple-select-control/index.js
@@ -3,10 +3,11 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Dropdown, Button, NavigableMenu, withFocusOutside } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Fragment, Component } from '@wordpress/element';
 import { map, find } from 'lodash';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * A component for displaying a material styled 'simple' select control.
@@ -62,7 +63,7 @@ class SimpleSelectControl extends Component {
 	}
 
 	render() {
-		const { options, label, className } = this.props;
+		const { options, label, className, instanceId, help } = this.props;
 		const { currentValue, isFocused } = this.state;
 		const onChange = ( value ) => {
 			this.onChange( value );
@@ -72,8 +73,11 @@ class SimpleSelectControl extends Component {
 		const isEmpty = currentValue === '' || currentValue === null;
 		const currentOption = find( options, ( { value } ) => value === currentValue );
 
+		const id = `simple-select-control-${ instanceId }`;
+
 		return (
 			<Dropdown
+				id={ id }
 				className={ classNames(
 					'woocommerce-simple-select-control__dropdown',
 					'components-base-control',
@@ -87,19 +91,22 @@ class SimpleSelectControl extends Component {
 				contentClassName="woocommerce-simple-select-control__dropdown-content"
 				position="center"
 				renderToggle={ ( { isOpen, onToggle } ) => (
-					<Button
-						className="woocommerce-simple-select-control__selector"
-						onClick={ () => this.handleOnClick( onToggle ) }
-						onFocus={ () => this.handleOnFocus() }
-						aria-expanded={ isOpen }
-						aria-label={ ! isEmpty ? sprintf(
-							/* translators: Label: Current Value for a Select Dropddown */
-							__( '%s: %s' ), label, currentOption && currentOption.label
-						) : label }
-					>
-						<span className="woocommerce-simple-select-control__label">{ label }</span>
-						<span className="woocommerce-simple-select-control__value">{ currentOption && currentOption.label }</span>
-					</Button>
+					<Fragment>
+						<Button
+							className="woocommerce-simple-select-control__selector"
+							onClick={ () => this.handleOnClick( onToggle ) }
+							onFocus={ () => this.handleOnFocus() }
+							aria-expanded={ isOpen }
+							aria-label={ ! isEmpty ? sprintf(
+								/* translators: Label: Current Value for a Select Dropddown */
+								__( '%s: %s' ), label, currentOption && currentOption.label
+							) : label }
+						>
+							<span className="woocommerce-simple-select-control__label">{ label }</span>
+							<span className="woocommerce-simple-select-control__value">{ currentOption && currentOption.label }</span>
+						</Button>
+						{ !! help && <p id={ id + '__help' } className="components-base-control__help">{ help }</p> }
+					</Fragment>
 				) }
 				renderContent={ ( { onClose } ) => (
 					<NavigableMenu>
@@ -171,6 +178,13 @@ SimpleSelectControl.propTypes = {
 	 * The currently value of the select element.
 	 */
 	value: PropTypes.string,
+	/**
+	 * If this property is added, a help text will be generated using help property as the content.
+	 */
+	help: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.node,
+	] ),
 };
 
-export default withFocusOutside( SimpleSelectControl );
+export default withFocusOutside( withInstanceId( SimpleSelectControl ) );


### PR DESCRIPTION
Fixes #2750.

This PR adds the `help` prop (like other WP/Muriel components have), so that we can properly show validation errors below the input.

### Screenshots

<img width="538" alt="Screen Shot 2019-08-05 at 12 42 53 PM" src="https://user-images.githubusercontent.com/689165/62481216-d132ae80-b77f-11e9-9b99-b5e8fac6227f.png">

### Detailed test instructions:

* Visit wp-admin/admin.php?page=wc-admin&step=business-details
* Try to hit "Continue" without selecting any options.
* Note the fields get highlighted in red, and the error text is shown.

### Changelog Note:
None needed (Component not released yet)

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
