### PR TITLE
Fix daily cron event (PSR-4)

### DIFF
--- a/src/WC_Admin_Events.php
+++ b/src/WC_Admin_Events.php
@@ -6,7 +6,13 @@
  * @package Woocommerce Admin
  */
 
+namespace Automattic\WooCommerce\Admin;
+
 defined( 'ABSPATH' ) || exit;
+
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Giving_Feedback_Notes;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
 
 /**
  * WC_Admin_Events Class.

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
+use Automattic\WooCommerce\Admin\WC_Admin_Events;
 use Automattic\WooCommerce\Admin\WC_Admin_Report_Exporter;
 use Automattic\WooCommerce\Admin\WC_Admin_Reports_Sync;
 


### PR DESCRIPTION
Fixes the `wc_admin_daily` cron event that broke during PSR-4ification.

### Detailed test instructions:

- Use WP Crontrol to run the `wc_admin_daily` cron job
- Verify there are no PHP errors

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
