### PR TITLE
Update the WP.com connection parameter to match the WCCOM API

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
@@ -302,7 +302,7 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 				'home_url'     => rawurlencode( home_url() ),
 				'redirect_uri' => rawurlencode( $redirect_uri ),
 				'secret'       => rawurlencode( $secret ),
-				'from'         => 'woocommerce-onboarding',
+				'wccom-from'   => 'onboarding',
 			),
 			WC_Helper_API::url( 'oauth/authorize' )
 		);


### PR DESCRIPTION
In https://github.com/Automattic/woocommerce.com/pull/6235/, we decided to go with `wccom-from` as the parameter name for connection. This PR updates the parameter.

### Detailed test instructions:
* Test the connect button.
* For a full testing experience, test the following Calypso PR: https://github.com/Automattic/wp-calypso/pull/35193