### PR TITLE
only run uninstall functions if dependencies are available

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -8,11 +8,5 @@
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 require_once dirname( __FILE__ ) . '/woocommerce-admin.php';
-
-if ( WC_Admin_Feature_Plugin::instance()->check_dependencies() ) {
-	WC_Admin_Feature_Plugin::instance()->includes();
-} else {
-	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-install.php';
-}
-
+require_once dirname( __FILE__ ) . '/includes/class-wc-admin-install.php';
 WC_Admin_Install::delete_table_data();

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,5 +11,8 @@ require_once dirname( __FILE__ ) . '/woocommerce-admin.php';
 
 if ( WC_Admin_Feature_Plugin::instance()->check_dependencies() ) {
 	WC_Admin_Feature_Plugin::instance()->includes();
-	WC_Admin_Install::delete_table_data();
+} else {
+	require_once dirname( __FILE__ ) . '/includes/class-wc-admin-install.php';
 }
+
+WC_Admin_Install::delete_table_data();

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,5 +9,7 @@ defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 require_once dirname( __FILE__ ) . '/woocommerce-admin.php';
 
-WC_Admin_Feature_Plugin::instance()->includes();
-WC_Admin_Install::delete_table_data();
+if ( WC_Admin_Feature_Plugin::instance()->check_dependencies() ) {
+	WC_Admin_Feature_Plugin::instance()->includes();
+	WC_Admin_Install::delete_table_data();
+}

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -222,7 +222,7 @@ class WC_Admin_Feature_Plugin {
 	 *
 	 * @return bool
 	 */
-	public function check_dependencies() {
+	protected function check_dependencies() {
 		$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.6', '>=' );
 		if ( ! $woocommerce_minimum_met ) {
 			return false;

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -222,7 +222,7 @@ class WC_Admin_Feature_Plugin {
 	 *
 	 * @return bool
 	 */
-	protected function check_dependencies() {
+	public function check_dependencies() {
 		$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.6', '>=' );
 		if ( ! $woocommerce_minimum_met ) {
 			return false;


### PR DESCRIPTION
Fixes #2657

This PR adds a dependency check to the uninstall script. If WooCommerce is not active, the plugin is uninstalled without clearing the plugin specific data. It is unlikely that a site owner with significant WC data will be removing this plugin while WC is inactive. For the folks test driving WC & WCA this will not leave a significant amount of data behind.

### Detailed test instructions:

- Build the production version of the plugin
- Install it in a test install
- Activate both WC & WCA
- Deactivate WC (WCA should also deactivate)
- Delete WCA through to plugin screen

### Changelog Note:

Fix: Allow WooCommerce Admin to be deleted through the plugin screen when WooCommerce is not active.