### PR TITLE
Add revenue question to the business details page

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -21,6 +21,7 @@ import { numberFormat } from '@woocommerce/number';
 import { H, Card, SimpleSelectControl, Form } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
+import { formatCurrency } from '@woocommerce/currency';
 
 class BusinessDetails extends Component {
 	constructor() {
@@ -30,6 +31,7 @@ class BusinessDetails extends Component {
 			other_platform: '',
 			product_count: '',
 			selling_venues: '',
+			revenue: '',
 			facebook: true,
 			mailchimp: true,
 		};
@@ -42,12 +44,13 @@ class BusinessDetails extends Component {
 
 	async onContinue( values ) {
 		const { createNotice, goToNextStep, isError, updateProfileItems } = this.props;
-		const { facebook, mailchimp, other_platform, product_count, selling_venues } = values;
+		const { facebook, mailchimp, other_platform, product_count, revenue, selling_venues } = values;
 		const businessExtensions = this.getBusinessExtensions( values );
 
 		recordEvent( 'storeprofiler_store_business_details_continue', {
 			product_number: product_count,
 			already_selling: 'no' !== selling_venues,
+			revenue,
 			used_platform: other_platform,
 			install_facebook: facebook,
 			install_mailchimp: mailchimp,
@@ -56,6 +59,7 @@ class BusinessDetails extends Component {
 		await updateProfileItems( {
 			other_platform,
 			product_count,
+			revenue,
 			selling_venues,
 			business_extensions: businessExtensions,
 		} );
@@ -81,6 +85,13 @@ class BusinessDetails extends Component {
 				) {
 					errors.other_platform = __( 'This field is required', 'woocommerce-admin' );
 				}
+			} else if ( 'revenue' === name ) {
+				if (
+					! values.revenue.length &&
+					[ 'other', 'brick-mortar', 'brick-mortar-other' ].includes( values.selling_venues )
+				) {
+					errors.revenue = __( 'This field is required', 'woocommerce-admin' );
+				}
 			} else if ( ! this.extensions.includes( name ) && ! values[ name ].length ) {
 				errors[ name ] = __( 'This field is required', 'woocommerce-admin' );
 			}
@@ -93,18 +104,15 @@ class BusinessDetails extends Component {
 		return keys( pickBy( values ) ).filter( name => this.extensions.includes( name ) );
 	}
 
-	getNumberRangeString( min, max = false ) {
+	getNumberRangeString( min, max = false, format = numberFormat ) {
 		if ( ! max ) {
-			return sprintf(
-				_x( '%s+', 'store product count', 'woocommerce-admin' ),
-				numberFormat( min )
-			);
+			return sprintf( _x( '%s+', 'store product count', 'woocommerce-admin' ), format( min ) );
 		}
 
 		return sprintf(
 			_x( '%s - %s', 'store product count', 'woocommerce-admin' ),
-			numberFormat( min ),
-			numberFormat( max )
+			format( min ),
+			format( max )
 		);
 	}
 
@@ -199,6 +207,42 @@ class BusinessDetails extends Component {
 			},
 		];
 
+		const revenueOptions = [
+			{
+				value: 'none',
+				label: sprintf(
+					_x( "%s (I'm just getting started)", '$0 revenue amount', 'woocommerce-admin' ),
+					formatCurrency( 0 )
+				),
+			},
+			{
+				value: 'up-to-2500',
+				label: sprintf(
+					_x( 'Up to %s', 'Up to a certain revenue amount', 'woocommerce-admin' ),
+					formatCurrency( 2500 )
+				),
+			},
+			{
+				value: '2500-10000',
+				label: this.getNumberRangeString( 2500, 10000, formatCurrency ),
+			},
+			{
+				value: '10000-50000',
+				label: this.getNumberRangeString( 10000, 50000, formatCurrency ),
+			},
+			{
+				value: '50000-250000',
+				label: this.getNumberRangeString( 50000, 250000, formatCurrency ),
+			},
+			{
+				value: 'more-than-250000',
+				label: sprintf(
+					_x( 'More than %s', 'More than a certain revenue amount', 'woocommerce-admin' ),
+					formatCurrency( 250000 )
+				),
+			},
+		];
+
 		const sellingVenueOptions = [
 			{
 				value: 'no',
@@ -274,6 +318,17 @@ class BusinessDetails extends Component {
 										required
 										{ ...getInputProps( 'selling_venues' ) }
 									/>
+
+									{ [ 'other', 'brick-mortar', 'brick-mortar-other' ].includes(
+										values.selling_venues
+									) && (
+										<SimpleSelectControl
+											label={ __( "What's your current annual revenue?", 'woocommerce-admin' ) }
+											options={ revenueOptions }
+											required
+											{ ...getInputProps( 'revenue' ) }
+										/>
+									) }
 
 									{ [ 'other', 'brick-mortar-other' ].includes( values.selling_venues ) && (
 										<SimpleSelectControl

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -50,19 +50,30 @@ class BusinessDetails extends Component {
 		recordEvent( 'storeprofiler_store_business_details_continue', {
 			product_number: product_count,
 			already_selling: 'no' !== selling_venues,
+			currency: wcSettings.currency.code,
 			revenue,
 			used_platform: other_platform,
 			install_facebook: facebook,
 			install_mailchimp: mailchimp,
 		} );
 
-		await updateProfileItems( {
+		const _updates = {
 			other_platform,
 			product_count,
 			revenue,
 			selling_venues,
 			business_extensions: businessExtensions,
+		};
+
+		// Remove possible empty values like `revenue` and `other_platform`.
+		const updates = {};
+		Object.keys( _updates ).forEach( key => {
+			if ( _updates[ key ] !== '' ) {
+				updates[ key ] = _updates[ key ];
+			}
 		} );
+
+		await updateProfileItems( updates );
 
 		if ( ! isError ) {
 			goToNextStep();

--- a/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-profile-controller.php
@@ -274,6 +274,21 @@ class WC_Admin_REST_Onboarding_Profile_Controller extends WC_REST_Data_Controlle
 					'brick-mortar-other',
 				),
 			),
+			'revenue'      => array(
+				'type'              => 'string',
+				'description'       => __( 'Current annual revenue of the store.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'none',
+					'up-to-2500',
+					'2500-10000',
+					'10000-50000',
+					'50000-250000',
+					'more-than-250000',
+				),
+			),
 			'other_platform'      => array(
 				'type'              => 'string',
 				'description'       => __( 'Name of other platform used to sell.', 'woocommerce-admin' ),

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -97,7 +97,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 13, $properties );
+		$this->assertCount( 14, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
@@ -105,6 +105,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'product_types', $properties );
 		$this->assertArrayHasKey( 'product_count', $properties );
 		$this->assertArrayHasKey( 'selling_venues', $properties );
+		$this->assertArrayHasKey( 'revenue', $properties );
 		$this->assertArrayHasKey( 'other_platform', $properties );
 		$this->assertArrayHasKey( 'business_extensions', $properties );
 		$this->assertArrayHasKey( 'theme', $properties );


### PR DESCRIPTION
Closes #2743.

This PR adds a new revenue question to the business details form. It should only show if the user answers that they are currently selling elsewhere. 

### Screenshots

<img width="545" alt="Screen Shot 2019-08-07 at 2 38 26 PM" src="https://user-images.githubusercontent.com/689165/62648817-881a6000-b921-11e9-9095-abe15639cf8b.png">

<img width="533" alt="Screen Shot 2019-08-07 at 2 38 32 PM" src="https://user-images.githubusercontent.com/689165/62648822-8cdf1400-b921-11e9-8fb6-2d7c1c940bb7.png">

### Detailed test instructions:
* Reset the profile wizard (go to the WooCommerce orders page, click help, and then setup wizard).
* Visit the business details page `/wp-admin/admin.php?page=wc-admin&step=business-details`.
* Test the revenue question, and the different behaviors depending on what you answered for the already selling question. Verify an error shows if submitted empty.
* You can inspect the API call or analytics call to make sure the answer is saved.