### PR TITLE
convert zero last active date to null in customer query

### DIFF
--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -134,6 +134,12 @@ export default class CustomersReportTable extends Component {
 				name
 			);
 
+			const dateLastActive = date_last_active ? (
+				<Date date={ date_last_active } visibleFormat={ defaultTableDateFormat } />
+			) : (
+				'—'
+			);
+
 			const dateRegistered = date_registered ? (
 				<Date date={ date_registered } visibleFormat={ defaultTableDateFormat } />
 			) : (
@@ -159,9 +165,7 @@ export default class CustomersReportTable extends Component {
 					value: username,
 				},
 				{
-					display: date_last_active && (
-						<Date date={ date_last_active } visibleFormat={ defaultTableDateFormat } />
-					),
+					display: dateLastActive,
 					value: date_last_active,
 				},
 				{

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -48,7 +48,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		'state'            => 'state',
 		'postcode'         => 'postcode',
 		'date_registered'  => 'date_registered',
-		'date_last_active' => 'IF( date_last_active < 1, NULL, date_last_active ) AS date_last_active',
+		'date_last_active' => 'IF( date_last_active <= "0000-00-00 00:00:00", NULL, date_last_active ) AS date_last_active',
 		'orders_count'     => 'SUM( CASE WHEN parent_id = 0 THEN 1 ELSE 0 END ) as orders_count',
 		'total_spend'      => 'SUM( gross_total ) as total_spend',
 		'avg_order_value'  => '( SUM( gross_total ) / COUNT( order_id ) ) as avg_order_value',

--- a/includes/data-stores/class-wc-admin-reports-customers-data-store.php
+++ b/includes/data-stores/class-wc-admin-reports-customers-data-store.php
@@ -48,7 +48,7 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 		'state'            => 'state',
 		'postcode'         => 'postcode',
 		'date_registered'  => 'date_registered',
-		'date_last_active' => 'date_last_active',
+		'date_last_active' => 'IF( date_last_active < 1, NULL, date_last_active ) AS date_last_active',
 		'orders_count'     => 'SUM( CASE WHEN parent_id = 0 THEN 1 ELSE 0 END ) as orders_count',
 		'total_spend'      => 'SUM( gross_total ) as total_spend',
 		'avg_order_value'  => '( SUM( gross_total ) / COUNT( order_id ) ) as avg_order_value',
@@ -391,7 +391,6 @@ class WC_Admin_Reports_Customers_Data_Store extends WC_Admin_Reports_Data_Store 
 			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
 				return $data;
 			}
-
 			$customer_data = $wpdb->get_results(
 				"SELECT
 						{$selections}


### PR DESCRIPTION
Fixes #2746

This PR converts the customer `date_last_active` to `NULL` when it's a zero date. It also adds a `'—'` placeholder in the customer table when the `date_last_active` is `NULL`.

### Detailed test instructions:

- In the `wp_wc_customer_lookup` table change `date_last_active` to `0000-00-00 00:00:00` on at least one customer
- Load Analytics -> Customers
- Use page navigation to find that customer in the table
- The placeholder should show for the last active date

### Changelog Note:

Fix: Customer last active date showing `Invalid date`.