### PR TITLE
Fix slug notice when connecting to Jetpack

### DIFF
--- a/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
+++ b/includes/api/class-wc-admin-rest-onboarding-plugins-controller.php
@@ -256,7 +256,7 @@ class WC_Admin_REST_Onboarding_Plugins_Controller extends WC_REST_Data_Controlle
 		}
 
 		return( array(
-			'slug'          => $slug,
+			'slug'          => 'jetpack',
 			'name'          => __( 'Jetpack', 'woocommerce-admin' ),
 			'connectAction' => $connect_url,
 		) );


### PR DESCRIPTION
This tiny PR fixes a notice that displays when trying to connect Jetpack:

`PHP Notice:  Undefined variable: slug in includes/api/class-wc-admin-rest-onboarding-plugins-controller.php on line 259`

This slug will always be `jetpack` for the connect-jetpack endpoint.

Reported here: https://github.com/woocommerce/woocommerce-admin/issues/2752#issuecomment-519563153

### Detailed test instructions:

- Open the store profile wizard, activate Jetpack, and click connect. You should see no php notice in your error logs.
