### PR TITLE
Fix warnings in report segmenting

### DIFF
--- a/src/API/Reports/Segmenter.php
+++ b/src/API/Reports/Segmenter.php
@@ -151,6 +151,10 @@ class Segmenter {
 
 		foreach ( $result1 as $segment_data ) {
 			$segment_id = $segment_data[ $segment_dimension ];
+			if ( ! isset( $segment_labels[ $segment_id ] ) ) {
+				continue;
+			}
+
 			unset( $segment_data[ $segment_dimension ] );
 			$result_segments[ $segment_id ] = array(
 				'segment_label' => $segment_labels[ $segment_id ],
@@ -161,6 +165,10 @@ class Segmenter {
 
 		foreach ( $result2 as $segment_data ) {
 			$segment_id = $segment_data[ $segment_dimension ];
+			if ( ! isset( $segment_labels[ $segment_id ] ) ) {
+				continue;
+			}
+
 			unset( $segment_data[ $segment_dimension ] );
 			if ( ! isset( $result_segments[ $segment_id ] ) ) {
 				$result_segments[ $segment_id ] = array(
@@ -216,14 +224,19 @@ class Segmenter {
 		$segment_labels  = $this->get_segment_labels();
 
 		foreach ( $result1 as $segment_data ) {
+			$segment_id = $segment_data[ $segment_dimension ];
+			if ( ! isset( $segment_labels[ $segment_id ] ) ) {
+				continue;
+			}
+
 			$time_interval = $segment_data['time_interval'];
 			if ( ! isset( $result_segments[ $time_interval ] ) ) {
 				$result_segments[ $time_interval ]             = array();
 				$result_segments[ $time_interval ]['segments'] = array();
 			}
+
 			unset( $segment_data['time_interval'] );
 			unset( $segment_data['datetime_anchor'] );
-			$segment_id = $segment_data[ $segment_dimension ];
 			unset( $segment_data[ $segment_dimension ] );
 			$segment_datum = array(
 				'segment_label' => $segment_labels[ $segment_id ],
@@ -234,14 +247,19 @@ class Segmenter {
 		}
 
 		foreach ( $result2 as $segment_data ) {
+			$segment_id = $segment_data[ $segment_dimension ];
+			if ( ! isset( $segment_labels[ $segment_id ] ) ) {
+				continue;
+			}
+
 			$time_interval = $segment_data['time_interval'];
 			if ( ! isset( $result_segments[ $time_interval ] ) ) {
 				$result_segments[ $time_interval ]             = array();
 				$result_segments[ $time_interval ]['segments'] = array();
 			}
+
 			unset( $segment_data['time_interval'] );
 			unset( $segment_data['datetime_anchor'] );
-			$segment_id = $segment_data[ $segment_dimension ];
 			unset( $segment_data[ $segment_dimension ] );
 
 			if ( ! isset( $result_segments[ $time_interval ]['segments'][ $segment_id ] ) ) {


### PR DESCRIPTION
Fixes #2775

This PR is a based on #2710 and fixes 4 warnings that might occur while building report segments. With WB_DEBUG enabled the warning output causes the result of the api request to be ignored.

### Detailed test instructions:

**You may need to experiment with categories to find ones that break the chart without this PR.**
1. Use `wc-smooth-generator` to generate 1000 order between Jan 1 & Jul 15
2. Use `wp action-scheduler run` to import the generated orders
3. Set default date filter to year to date
4. Go to Analytics -> Categories
5. Do a comparison report between the top two categories
6. Force a refresh of the page using the browser refresh
7. Chart should render every time
8. Verify no warnings are output to debug log during load / refresh.

### Changelog Note:

Fix: Charts being partially rendered on long time periods.