### PR TITLE
increase the popover zIndex from 1 to 2

### DIFF
--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -56,7 +56,7 @@
 	}
 
 	.components-popover:not(.is-mobile) {
-		z-index: 1; /* below of woocommerce-layout__header */
+		z-index: 2; /* below of woocommerce-layout__header */
 	}
 }
 


### PR DESCRIPTION
Fixes #2647 
Fixes #2772

This PR increases the zIndex of the `component-popover` class from 1 to 2. The table summary/pagination has a zIndex of 1.

### Detailed test instructions:

- Open the revenue report
- Select a date range of 3 days
- Click the column visibility on the table
- Popover should show over footer
- Open the Customer report
- Add a filter registered since using today's date
- click on the date selection again
- calendar control should show over footer

### Changelog Note:

Tweak: Increase zIndex on popover elements.