### PR TITLE
Update List actionable items to be wrapped with Link

### DIFF
--- a/client/dashboard/task-list/tasks/products.js
+++ b/client/dashboard/task-list/tasks/products.js
@@ -20,10 +20,7 @@ const subTasks = [
 		),
 		before: <i className="material-icons-outlined">add_box</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
-		onClick: () =>
-			( window.location.href = getAdminLink(
-				'post-new.php?post_type=product&wc_onboarding_active_task=products'
-			) ),
+		href: getAdminLink( 'post-new.php?post_type=product&wc_onboarding_active_task=products' ),
 	},
 	{
 		title: __( 'Import', 'woocommerce-admin' ),
@@ -33,10 +30,9 @@ const subTasks = [
 		),
 		before: <i className="material-icons-outlined">import_export</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
-		onClick: () =>
-			( window.location.href = getAdminLink(
-				'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
-			) ),
+		href: getAdminLink(
+			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
+		),
 	},
 	{
 		title: __( 'Migrate', 'woocommerce-admin' ),
@@ -47,7 +43,8 @@ const subTasks = [
 		before: <i className="material-icons-outlined">cloud_download</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
 		// @todo This should be replaced with the in-app purchase iframe when ready.
-		onClick: () => window.open( 'https://woocommerce.com/products/cart2cart/', '_blank' ),
+		href: 'https://woocommerce.com/products/cart2cart/',
+		target: '_blank',
 	},
 ];
 

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -46,3 +46,4 @@ $muriel-box-shadow-1dp: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0
 	0 1px 3px 0 rgba(0, 0, 0, 0.12);
 $muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14),
 	0 3px 14px 2px rgba(0, 0, 0, 0.12);
+$muriel-primary-500: #005fb7;

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -3,20 +3,18 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { Component } from '@wordpress/element';
-import { ENTER } from '@wordpress/keycodes';
+import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import Link from '../link';
 
 /**
  * List component to display a list of items.
  */
 class List extends Component {
-    handleKeyDown( event, onClick ) {
-		if ( 'function' === typeof onClick && event.keyCode === ENTER ) {
-			onClick();
-		}
-    }
-
 	render() {
 		const { className, items } = this.props;
 		const listClassName = classnames( 'woocommerce-list', className );
@@ -24,42 +22,45 @@ class List extends Component {
 		return (
 			<ul className={ listClassName }>
 				{ items.map( ( item, i ) => {
-					const { after, before, className: itemClasses, description, onClick, title } = item;
-					const hasAction = 'function' === typeof onClick;
+					const { after, before, className: itemClasses, description, href, onClick, title } = item;
+					const hasAction = 'function' === typeof onClick || href;
 					const itemClassName = classnames( 'woocommerce-list__item', itemClasses, {
 						'has-action': hasAction,
 					} );
+					const ActionTag = hasAction ? Link : Fragment;
+					const actionProps = hasAction ? {
+						href: href ? href : '#',
+						onClick: 'function' === typeof onClick ? onClick : null,
+						type: 'external',
+					} : {};
 
 					return (
 						<li
 							className={ itemClassName }
 							key={ i }
-							onClick={ hasAction ? onClick : null }
-							onKeyDown={ ( e ) => hasAction ? this.handleKeyDown( e, onClick ) : null }
-							role="menuitem"
-							aria-disabled="false"
-							tabIndex="0"
 						>
-                            { before &&
-                                <div className="woocommerce-list__item-before">
-                                    { before }
-                                </div>
-                            }
-                            <div className="woocommerce-list__item-text">
-                                <span className="woocommerce-list__item-title">
-                                    { title }
-                                </span>
-                                { description &&
-                                    <span className="woocommerce-list__item-description">
-                                        { description }
-                                    </span>
-                                }
-                            </div>
-                            { after &&
-                                <div className="woocommerce-list__item-after">
-                                    { after }
-                                </div>
-                            }
+							<ActionTag { ...actionProps }>
+								{ before &&
+									<div className="woocommerce-list__item-before">
+										{ before }
+									</div>
+								}
+								<div className="woocommerce-list__item-text">
+									<span className="woocommerce-list__item-title">
+										{ title }
+									</span>
+									{ description &&
+										<span className="woocommerce-list__item-description">
+											{ description }
+										</span>
+									}
+								</div>
+								{ after &&
+									<div className="woocommerce-list__item-after">
+										{ after }
+									</div>
+								}
+							</ActionTag>
 						</li>
                     );
                 } ) }
@@ -79,29 +80,33 @@ List.propTypes = {
 	items: PropTypes.arrayOf(
 		PropTypes.shape( {
 			/**
-			 * Title displayed for the list item.
+			 * Content displayed after the list item text.
 			 */
-			title: PropTypes.string.isRequired,
-			/**
-			 * Description displayed beneath the list item title.
-			 */
-			description: PropTypes.string,
+			after: PropTypes.node,
 			/**
 			 * Content displayed before the list item text.
 			 */
 			before: PropTypes.node,
 			/**
-			 * Content displayed after the list item text.
+			 * Additional class name to style the list item.
 			 */
-			after: PropTypes.node,
+			className: PropTypes.string,
+			/**
+			 * Description displayed beneath the list item title.
+			 */
+			description: PropTypes.string,
+			/**
+			 * Href attribute used in a Link wrapped around the item.
+			 */
+			href: PropTypes.string,
 			/**
 			 * Content displayed after the list item text.
 			 */
 			onClick: PropTypes.func,
 			/**
-			 * Additional class name to style the list item.
+			 * Title displayed for the list item.
 			 */
-			className: PropTypes.string,
+			title: PropTypes.string.isRequired,
 		} )
 	).isRequired,
 };

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -22,7 +22,7 @@ class List extends Component {
 		return (
 			<ul className={ listClassName }>
 				{ items.map( ( item, i ) => {
-					const { after, before, className: itemClasses, description, href, onClick, title } = item;
+					const { after, before, className: itemClasses, description, href, onClick, target, title } = item;
 					const hasAction = 'function' === typeof onClick || href;
 					const itemClassName = classnames( 'woocommerce-list__item', itemClasses, {
 						'has-action': hasAction,
@@ -31,6 +31,7 @@ class List extends Component {
 					const actionProps = hasAction ? {
 						href: href ? href : '#',
 						onClick: 'function' === typeof onClick ? onClick : null,
+						target: target,
 						type: 'external',
 					} : {};
 
@@ -103,6 +104,10 @@ List.propTypes = {
 			 * Content displayed after the list item text.
 			 */
 			onClick: PropTypes.func,
+			/**
+			 * Target attribute used for Link wrapper.
+			 */
+			target: PropTypes.string,
 			/**
 			 * Title displayed for the list item.
 			 */

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -4,6 +4,7 @@
  */
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
 import PropTypes from 'prop-types';
 
 /**
@@ -15,12 +16,18 @@ import Link from '../link';
  * List component to display a list of items.
  */
 class List extends Component {
+	handleKeyDown( event, onClick ) {
+		if ( 'function' === typeof onClick && event.keyCode === ENTER ) {
+			onClick();
+		}
+	}
+
 	render() {
 		const { className, items } = this.props;
 		const listClassName = classnames( 'woocommerce-list', className );
 
 		return (
-			<ul className={ listClassName }>
+			<ul className={ listClassName } role="menu">
 				{ items.map( ( item, i ) => {
 					const { after, before, className: itemClasses, description, href, onClick, target, title } = item;
 					const hasAction = 'function' === typeof onClick || href;
@@ -28,12 +35,17 @@ class List extends Component {
 						'has-action': hasAction,
 					} );
 					const InnerTag = href ? Link : 'div';
-					const actionProps = {
+
+					const innerTagProps = {
 						className: 'woocommerce-list__item-inner',
-						href: href,
 						onClick: 'function' === typeof onClick ? onClick : null,
-						target: target,
-						type: 'external',
+						'aria-disabled': hasAction ? 'false' : null,
+						tabIndex: hasAction ? '0' : null,
+						role: hasAction ? 'menuitem' : null,
+						onKeyDown: ( e ) => hasAction ? this.handleKeyDown( e, onClick ) : null,
+						target: href ? target : null,
+						type: href ? 'external' : null,
+						href: href,
 					};
 
 					return (
@@ -41,7 +53,7 @@ class List extends Component {
 							className={ itemClassName }
 							key={ i }
 						>
-							<InnerTag { ...actionProps }>
+							<InnerTag { ...innerTagProps }>
 								{ before &&
 									<div className="woocommerce-list__item-before">
 										{ before }

--- a/packages/components/src/list/index.js
+++ b/packages/components/src/list/index.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
@@ -27,20 +27,21 @@ class List extends Component {
 					const itemClassName = classnames( 'woocommerce-list__item', itemClasses, {
 						'has-action': hasAction,
 					} );
-					const ActionTag = hasAction ? Link : Fragment;
-					const actionProps = hasAction ? {
-						href: href ? href : '#',
+					const InnerTag = href ? Link : 'div';
+					const actionProps = {
+						className: 'woocommerce-list__item-inner',
+						href: href,
 						onClick: 'function' === typeof onClick ? onClick : null,
 						target: target,
 						type: 'external',
-					} : {};
+					};
 
 					return (
 						<li
 							className={ itemClassName }
 							key={ i }
 						>
-							<ActionTag { ...actionProps }>
+							<InnerTag { ...actionProps }>
 								{ before &&
 									<div className="woocommerce-list__item-before">
 										{ before }
@@ -61,7 +62,7 @@ class List extends Component {
 										{ after }
 									</div>
 								}
-							</ActionTag>
+							</InnerTag>
 						</li>
                     );
                 } ) }

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -1,15 +1,13 @@
 .woocommerce-list__item {
-	padding: $gap;
 	display: flex;
 	align-items: center;
 	margin-bottom: 0;
 
 	&.has-action {
-		padding: 0;
 		cursor: pointer;
 	}
 
-	> a {
+	> .woocommerce-list__item-inner {
 		text-decoration: none;
 		width: 100%;
 		display: flex;

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -13,6 +13,10 @@
 		display: flex;
 		align-items: center;
 		padding: $gap;
+
+		&:focus {
+			box-shadow: inset 0 0 0 1px $muriel-primary-500, inset 0 0 0 2px #fff;
+		}
 	}
 
 	.woocommerce-list__item-title {

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -5,7 +5,16 @@
 	margin-bottom: 0;
 
 	&.has-action {
+		padding: 0;
 		cursor: pointer;
+	}
+
+	> a {
+		text-decoration: none;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		padding: $gap;
 	}
 
 	.woocommerce-list__item-title {


### PR DESCRIPTION
Fixes #2672

Updates the list items to be wrapped with links to be more a11y friendly.

### Screenshots
<img width="749" alt="Screen Shot 2019-08-12 at 6 05 34 PM" src="https://user-images.githubusercontent.com/10561050/62858027-cbaf0880-bd2b-11e9-9f7f-90a62316099b.png">


### Detailed test instructions:

1. Check that list items continue working in both the DevDocs and the task list dashboard.
2. Check that list actions are accessible.