### PR TITLE
Search List Control: fix long count values cut-off in IE11

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,14 +1,14 @@
 # unreleased
-- SearchListItem component: new `countLabel` prop that will overwrite the `item.count` value.
 - AdvancedFilters component: fire `onAdvancedFilterAction` for match changes.
 - TableCard component: add `onSearch` an `onSort` function props.
 - Add new component `<List />` for displaying interactive list items.
 - Fix z-index issue in `<Chart />` empty message.
 - Added a new `<SimpleSelectControl />` component.
 - Added a new `<WebPreview />` component.
+- SearchListItem component: fix long count values being cut-off in IE11.
 
 # 3.1.0
-- Added support for a countLabel prop on SearchListItem to allow custom counts.
+- Added support for a `countLabel` prop on `SearchListItem` to allow custom counts.
 
 # 3.0.0
 - <DateInput> and <DatePicker> got a `disabled` prop.

--- a/packages/components/src/search-list-control/style.scss
+++ b/packages/components/src/search-list-control/style.scss
@@ -175,7 +175,7 @@
 		}
 
 		.woocommerce-search-list__item-count {
-			flex: 0;
+			flex: 0 1 auto;
 			padding: $gap-smallest/2 $gap-smaller;
 			border: 1px solid $core-grey-light-500;
 			border-radius: 12px;


### PR DESCRIPTION
### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/62964335-13549380-be03-11e9-8fc7-5f678bb7ab27.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/62964372-2b2c1780-be03-11e9-851b-658378541fbc.png)

### Detailed test instructions:
- Replace this line:
https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/search-list-control/index.js#L107
  with this or something similar:
```ES6
		return <SearchListItem countLabel="Lorem Ipsum" showCount { ...args } />;
```
- Go to _WooCommerce_ > _DevDocs_.
- Go to _SearchListControl_ card and press _Toggle loading state_.
- Verify the count label appears entirely in IE11.
