### PR TITLE
Allow action scheduler custom data store migration

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -165,6 +165,11 @@ class FeaturePlugin {
 			return $store_class;
 		}
 
+		// Don't override if action scheduler is 3.0.0 or greater.
+		if ( version_compare( \ActionScheduler_Versions::instance()->latest_version(), '3.0', '>=' ) ) {
+			return $store_class;
+		}
+
 		return 'Automattic\WooCommerce\Admin\Overrides\WPPostStore';
 	}
 

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -230,6 +230,8 @@ class ReportsSync {
 				self::SINGLE_ORDER_IMPORT_ACTION,
 			);
 			$store->clear_pending_wcadmin_actions( $action_types );
+		} elseif ( version_compare( \ActionScheduler_Versions::instance()->latest_version(), '3.0', '>=' ) ) {
+			$store->cancel_actions_by_group( self::QUEUE_GROUP );
 		} else {
 			self::queue()->cancel_all( null, array(), self::QUEUE_GROUP );
 		}


### PR DESCRIPTION
Fixes #2766

This PR is a companion to https://github.com/Prospress/action-scheduler/pull/351 which adds new bulk cancel functions to AS 3.0.0. It updates the cancel pending WC Admin actions to use the functions in AS 3.0.0.

### Detailed test instructions:

- You may want to make a DB backup to restore after testing
- Checkout https://github.com/Prospress/action-scheduler/tree/fix/350
- Migrate to custom tables with `wp action-scheduler migrate`
- install and activate https://github.com/Prospress/action-scheduler-disable-default-runner to prevent the cron runner from processing actions
- Go to Plugins -> Active
- In a second tab go to Tools -> Scheduled Actions
- In a third tab go to Analytics -> Settings
- Uncheck the skip already imported
- Click start
- Use `wp action-scheduler run` until you receive `Completed processing action 12345 with hook: wc-admin_orders_lookup_import_batch_init`
- Switch to the Plugins tab and deactivate WC Admin
- Switch to the Scheduled Actions tab and click the `Canceled` filter
- Go to the last page of canceled actions
- You should see import actions canceled at the (UTC) time WC Admin was deactivated

### Screenshots
<img width="1076" alt="Screen Shot 2019-08-16 at 1 18 38 PM" src="https://user-images.githubusercontent.com/343847/63182213-6f4c3180-c028-11e9-89b0-beabc6dd20a2.png">

### Changelog Note:

Should not need one.