### PR TITLE
Wait until all chart data page requests are complete before rendering.

### DIFF
--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -274,6 +274,7 @@ export function getReportChartData( options ) {
 		let isError = false;
 		const pagedData = [];
 		const totalPages = Math.ceil( stats.totalResults / MAX_PER_PAGE );
+		let pagesFetched = 1;
 
 		for ( let i = 2; i <= totalPages; i++ ) {
 			const nextQuery = { ...requestQuery, page: i };
@@ -288,7 +289,9 @@ export function getReportChartData( options ) {
 			}
 
 			pagedData.push( _data );
-			if ( i === totalPages ) {
+			pagesFetched++;
+
+			if ( pagesFetched === totalPages ) {
 				isFetching = false;
 				break;
 			}


### PR DESCRIPTION
Fixes #2775. Pairs with https://github.com/woocommerce/woocommerce-admin/pull/2710 and https://github.com/woocommerce/woocommerce-admin/pull/2776.

When fetching data for charts with more than 1 page (100 items) of data, there is a chance that the request for the last page finishes before an earlier page, causing that page to be omitted from the chart render. This results in a single line connecting points across a long time scale.

This PR seeks to enforce that all page requests have finished before rendering the chart.

**Note**: when you do reproduce the bug, switching chart modes (line/bar) restores the data.

### Screenshots

**Before:**

<img width="1225" alt="Screen Shot 2019-08-13 at 3 36 13 PM" src="https://user-images.githubusercontent.com/63922/62982131-1ab67580-bde0-11e9-9970-cebcaf2e47f9.png">

**After:**

<img width="1234" alt="Screen Shot 2019-08-13 at 3 31 26 PM" src="https://user-images.githubusercontent.com/63922/62981926-759b9d00-bddf-11e9-9cee-ae7c23de0ea8.png">


### Detailed test instructions:

- Follow instructions on https://github.com/woocommerce/woocommerce-admin/issues/2775
- **OR** test with a large existing dataset over a year period, with day interval
- Verify that a "middle" page of results never drops off a chart render
<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: chart data fetch/render over long time periods