### PR TITLE
update the class filename exclusion to /src/ for PSR-4

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,7 +28,7 @@
 	</rule>
 
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
-		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
+		<exclude-pattern>src/*</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
 		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
 	</rule>


### PR DESCRIPTION
see #2711

Composer autoloading moved the classes in the `/includes/` folder to `/src/`. This PR updates the phpcs class name rule exclusion folder from `includes` to `src` and now excludes the entire folder.

