### PR TITLE
Release Scripts: Update to reflect refactor

### DIFF
--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -43,10 +43,6 @@ git pull origin master
 
 success "Pulled latest commits"
 
-composer install
-
-success "Installed PHP dependencies"
-
 status "What version would you like to release?"
 
 echo -n "Version: "

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -43,6 +43,10 @@ git pull origin master
 
 success "Pulled latest commits"
 
+composer install
+
+success "Installed PHP dependencies"
+
 status "What version would you like to release?"
 
 echo -n "Version: "

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -82,10 +82,6 @@ status "Run docs script to make sure docs are updated."
 
 npm run docs
 
-status "Remove changes to package-lock.json to prevent merge conflicts."
-
-git checkout package-lock.json
-
 status "Here are the changes so far. Make sure the following changes are reflected."
 
 echo "- docs/: folder will have changes to documentation, if any."

--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -9,8 +9,9 @@ $package_json = file_get_contents( 'package.json' );
 $package      = json_decode( $package_json );
 
 function replace_version( $filename, $package_json ) {
-	$lines        = array();
-	$file = file( $filename );
+	$lines = array();
+	$file  = file( $filename );
+	
 	foreach ( $file as $line ) {
 		if ( stripos( $line, ' * Version: ' ) !== false ) {
 			$line = " * Version: {$package_json->version}\n";

--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -7,16 +7,21 @@
 
 $package_json = file_get_contents( 'package.json' );
 $package      = json_decode( $package_json );
-$plugin_file  = file( 'woocommerce-admin.php' );
-$lines        = array();
 
-foreach ( $plugin_file as $line ) {
-	if ( stripos( $line, ' * Version: ' ) !== false ) {
-		$line = " * Version: {$package->version}\n";
+function replace_version( $filename, $package_json ) {
+	$lines        = array();
+	$file = file( $filename );
+	foreach ( $file as $line ) {
+		if ( stripos( $line, ' * Version: ' ) !== false ) {
+			$line = " * Version: {$package_json->version}\n";
+		}
+		if ( stripos( $line, ">define( 'WC_ADMIN_VERSION_NUMBER'," ) !== false ) {
+			$line = "\t\t\$this->define( 'WC_ADMIN_VERSION_NUMBER', '{$package_json->version}' );\n";
+		}
+		$lines[] = $line;
 	}
-	if ( stripos( $line, ">define( 'WC_ADMIN_VERSION_NUMBER'," ) !== false ) {
-		$line = "\t\t\$this->define( 'WC_ADMIN_VERSION_NUMBER', '{$package->version}' );\n";
-	}
-	$lines[] = $line;
+	file_put_contents( $filename, $lines );
 }
-file_put_contents( 'woocommerce-admin.php', $lines );
+
+replace_version( 'woocommerce-admin.php', $package );
+replace_version( 'src/FeaturePlugin.php', $package );


### PR DESCRIPTION
1. Don't exclude `package-lock.json` changes in the release. That file never gets included in the release anyways, but we may as well keep it up to date with the latest version.
3. Modify the prestart script to update the version numbers in correct files now that the structure has changed.

### Testing

1. change the version in `package.json`.
2. `npm run prestart`.
3. Check that `woocommerce-admin.php` and `src/FeaturePlugin.php` have correctly updated version numbers.