### PR TITLE
Release 0.17.0

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -61,6 +61,10 @@ else
 	exit 1
 fi
 
+# Install PHP dependencies
+status "Gathering PHP dependencies... 🐿️"
+composer install --no-dev
+
 # Run the build.
 status "Generating build... 👷‍♀️"
 npm run build
@@ -78,6 +82,8 @@ zip -r woocommerce-admin.zip \
 	$build_files \
 	languages/woocommerce-admin.pot \
 	languages/woocommerce-admin.php \
-	readme.txt
+	readme.txt \
+	src/ \
+	vendor/
 
 success "Done. You've built WooCommerce Admin! 🎉 "

--- a/docs/components/_sidebar.md
+++ b/docs/components/_sidebar.md
@@ -19,6 +19,7 @@
     * [EmptyContent](components/packages/empty-content.md)
     * [Filters](components/packages/filters.md)
     * [Flag](components/packages/flag.md)
+    * [Form](components/packages/form.md)
     * [Gravatar](components/packages/gravatar.md)
     * [ImageAsset](components/packages/image-asset.md)
     * [Link](components/packages/link.md)
@@ -41,3 +42,4 @@
     * [Tag](components/packages/tag.md)
     * [TextControlWithAffixes](components/packages/text-control-with-affixes.md)
     * [ViewMoreList](components/packages/view-more-list.md)
+    * [WebPreview](components/packages/web-preview.md)

--- a/docs/components/packages/form.md
+++ b/docs/components/packages/form.md
@@ -1,0 +1,51 @@
+`Form` (component)
+==================
+
+A form component to handle form state and provide input helper props.
+
+Props
+-----
+
+### `children`
+
+- Type: *
+- Default: null
+
+A renderable component in which to pass this component's state and helpers.
+Generally a number of input or other form elements.
+
+### `errors`
+
+- Type: Object
+- Default: `{}`
+
+Object of all initial errors to store in state.
+
+### `initialValues`
+
+- Type: Object
+- Default: `{}`
+
+Object key:value pair list of all initial field values.
+
+### `onSubmitCallback`
+
+- Type: Function
+- Default: `noop`
+
+Function to call when a form is submitted with valid fields.
+
+### `validate`
+
+- Type: Function
+- Default: null
+
+A function that is passed a list of all values and
+should return an `errors` object with error response.
+
+### `touched`
+
+- Type: undefined
+- Default: `{}`
+
+

--- a/docs/components/packages/stepper.md
+++ b/docs/components/packages/stepper.md
@@ -27,17 +27,19 @@ The current step's key.
 - Type: Array
   - key: String - Key used to identify step.
   - label: String - Label displayed in stepper.
+  - description: String - Description displayed beneath the label.
   - isComplete: Boolean - Optionally mark a step complete regardless of step index.
+  - content: ReactNode - Content displayed when the step is active.
 - Default: null
 
 An array of steps used.
 
-### `direction`
+### `isVertical`
 
-- Type: One of: 'horizontal', 'vertical'
-- Default: `'horizontal'`
+- Type: Boolean
+- Default: `false`
 
-Direction of the stepper.
+If the stepper is vertical instead of horizontal.
 
 ### `isPending`
 

--- a/docs/components/packages/web-preview.md
+++ b/docs/components/packages/web-preview.md
@@ -1,0 +1,45 @@
+`WebPreview` (component)
+========================
+
+WebPreview component to display an iframe of another page.
+
+Props
+-----
+
+### `className`
+
+- Type: String
+- Default: null
+
+Additional class name to style the component.
+
+### `loadingContent`
+
+- Type: ReactNode
+- Default: `<Spinner />`
+
+Content shown when iframe is still loading.
+
+### `onLoad`
+
+- Type: Function
+- Default: `noop`
+
+Function to fire when iframe content is loaded.
+
+### `src`
+
+- **Required**
+- Type: String
+- Default: null
+
+Iframe src to load.
+
+### `title`
+
+- **Required**
+- Type: String
+- Default: null
+
+Iframe title.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9303,8 +9303,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9322,13 +9321,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9341,18 +9338,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9455,8 +9449,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9466,7 +9459,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9479,20 +9471,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9509,7 +9498,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9582,8 +9570,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9593,7 +9580,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9669,8 +9655,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9700,7 +9685,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9718,7 +9702,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9757,13 +9740,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "homepage": "https://woocommerce.github.io/woocommerce-admin/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,26 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Changelog ==
 
+= 0.17.0 2019-08-15 =
+
+- Fix: chart data fetch/render over long time periods #2785 (Analytics)
+- Task: update the class filename exclusion to /src/ for PSR-4 #2794
+- Tweak: Increase zIndex on popover elements. #2777
+- Fix: chart display when comparing categories. #2710 (Analytics)
+- Fix: Allow WooCommerce Admin to be deleted through the plugin screen when WooCommerce is not active. #2762
+- Fix: Charts being partially rendered on long time periods. #2776 (Analytics)
+- Task: update WC tested to version to 3.7.0 #2782
+- Fix: Customer last active date showing `Invalid date`. #2764 (Analytics)
+- Task: Update report endpoints to be PSR-4 autoloaded  #2755 (Build)
+- Bug: Fix daily cron event (PSR-4) #2754 (Build)
+- Fix: issue where product category update button was not always clickable #2753
+- Fix: Add version parameter to `_doing_it_wrong` on `current_screen`. #2733
+- Task: Update feature classes to be PSR-4 autoloaded. #2736 (Build)
+- Fix: Short circuit admin title filter when applied by third parties too early. #2744
+- Fix: chart display when comparing categories. #2708 (Analytics)
+- Bug: Only apply current submenu CSS reset on non-embed pages. #2687
+- Dev: Add `wc_admin_get_feature_config` filter to feature config array. #2689
+
 = 0.16.0 2019-07-24 =
 
 - Tweak: Change verbiage of feedback notification. #2677

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -121,7 +121,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.16.0' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.17.0' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 0.16.0
+ * Version: 0.17.0
  * Requires at least: 5.2.0
  * Requires PHP: 5.6.20
  *


### PR DESCRIPTION
Changes for release `0.17.0`

### Build Changes

The plugin build script now includes `composer install --no-dev` to pull in autoloader files. When bundling up the zip, I also made sure to include the `/src` and `/vendor` folders. The vendors will only be the non-dev dependencies because the vendor folder is initially deleted.

**NB:** Since the prestart script that updates version numbers automatically is now out of date, I did it manually in this PR. Changes to the script will be handled in https://github.com/woocommerce/woocommerce-admin/pull/2796