### PR TITLE
Add inbox notice promoting the Facebook extension.

### DIFF
--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -122,8 +122,9 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		return apply_filters(
 			'woocommerce_onboarding_plugins_whitelist',
 			array(
-				'jetpack'              => 'jetpack/jetpack.php',
-				'woocommerce-services' => 'woocommerce-services/woocommerce-services.php',
+				'facebook-for-woocommerce' => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
+				'jetpack'                  => 'jetpack/jetpack.php',
+				'woocommerce-services'     => 'woocommerce-services/woocommerce-services.php',
 			)
 		);
 	}

--- a/src/Events.php
+++ b/src/Events.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Extension;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Giving_Feedback_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
@@ -60,5 +61,6 @@ class Events {
 		WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();
 		WC_Admin_Notes_Giving_Feedback_Notes::add_notes_for_admin_giving_feedback();
 		WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();
+		WC_Admin_Notes_Facebook_Extension::possibly_add_facebook_note();
 	}
 }

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin;
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Extension;	
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
@@ -151,6 +152,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Historical_Data();
 		new WC_Admin_Notes_Order_Milestones();
 		new WC_Admin_Notes_Welcome_Message();
+		new WC_Admin_Notes_Facebook_Extension();
 	}
 
 	/**

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WC Admin Note Traits
+ *
+ * WC Admin Note Traits class that houses shared functionality across notes.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * NoteTraits class.
+ */
+trait NoteTraits {
+    /**
+     * Test how long WooCommerce Admin has been active.
+     *
+     * @param int $seconds Time in seconds to check.
+     * @return bool Whether or not WooCommerce admin has been active for $seconds.
+     */
+    public static function wc_admin_active_for( $seconds ) {
+        // Getting install timestamp reference class-wc-admin-install.php.
+		$wc_admin_installed = get_option( 'wc_admin_install_timestamp', false );
+
+        if ( false === $wc_admin_installed ) {
+            update_option( 'wc_admin_install_timestamp', time() );
+            
+            return false;
+		}
+
+        return ( ( time() - $wc_admin_installed ) >= $seconds );
+    }
+}

--- a/src/Notes/WC_Admin_Notes_Facebook_Extension.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Extension.php
@@ -15,6 +15,10 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_Facebook_Extension
  */
 class WC_Admin_Notes_Facebook_Extension {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
 
 	/**
 	 * Name of the note for use in the database.
@@ -32,23 +36,15 @@ class WC_Admin_Notes_Facebook_Extension {
 	 * Possibly add Facebook extension note.
 	 */
 	public static function possibly_add_facebook_note() {
-		$wc_admin_installed = get_option( 'wc_admin_install_timestamp', false );
-		if ( false === $wc_admin_installed ) {
-			$wc_admin_installed = time();
-			update_option( 'wc_admin_install_timestamp', $wc_admin_installed );
-		}
-
 		// Only show the Facebook note to stores with products.
 		$products = wp_count_posts( 'product' );
 		if ( (int) $products->publish < 1 ) {
 			return;
 		}
 
-		$current_time          = time();
-		$three_days_in_seconds = 3 * DAY_IN_SECONDS;
-
 		// We want to show the Facebook note after day 3.
-		if ( $current_time - $wc_admin_installed < $three_days_in_seconds ) {
+		$three_days_in_seconds = 3 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $three_days_in_seconds ) ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Facebook_Extension.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Extension.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WooCommerce Admin Facebook Extension Note Provider.
+ *
+ * Adds a note to the merchant's inbox showing the benefits of the Facebook extension.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Facebook_Extension
+ */
+class WC_Admin_Notes_Facebook_Extension {
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-facebook-extension';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_admin_note_action_install-now', array( $this, 'install_facebook_extension' ) );
+	}
+
+	/**
+	 * Possibly add Facebook extension note.
+	 */
+	public static function possibly_add_facebook_note() {
+		$wc_admin_installed = get_option( 'wc_admin_install_timestamp', false );
+		if ( false === $wc_admin_installed ) {
+			$wc_admin_installed = time();
+			update_option( 'wc_admin_install_timestamp', $wc_admin_installed );
+		}
+
+		// Only show the Facebook note to stores with products.
+		$products = wp_count_posts( 'product' );
+		if ( (int) $products->publish < 1 ) {
+			return;
+		}
+
+		$current_time          = time();
+		$three_days_in_seconds = 3 * DAY_IN_SECONDS;
+
+		// We want to show the Facebook note after day 3.
+		if ( $current_time - $wc_admin_installed < $three_days_in_seconds ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		include_once ABSPATH . '/wp-admin/includes/plugin.php';
+
+		$content = __( 'Grow your business by targeting the right people and driving sales with Facebook. You can install this free extension now.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Market on Facebook', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'thumbs-up' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/products/facebook/', WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+		$note->add_action( 'install-now', __( 'Install now', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+
+		// Create the note as "actioned" if the Facebook extension is already installed.
+		if ( 0 === validate_plugin( 'facebook-for-woocommerce/facebook-for-woocommerce.php' ) ) {
+			$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+		}
+
+		$note->save();
+	}
+
+	/**
+	 * Install Facebook extension when note is actioned.
+	 */
+	public function install_facebook_extension( $note ) {
+		if ( self::NOTE_NAME === $note->get_name() ) {
+			$plugin    = array( 'plugin' => 'facebook-for-woocommerce' );
+			$installer = new \Automattic\WooCommerce\Admin\API\OnboardingPlugins();
+			$result    = $installer->install_plugin( $plugin );
+
+			if ( is_wp_error( $result ) ) {
+				// @todo Reset note actioned status?
+				return;
+			}
+
+			$installer->activate_plugin( $plugin );
+		}
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -16,6 +16,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Admin_Notes_Giving_Feedback_Notes {
 	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
 	 * Add notes for admin giving feedback.
 	 */
 	public static function add_notes_for_admin_giving_feedback() {
@@ -36,18 +41,9 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 			return;
 		}
 
-		// Getting install timestamp reference class-wc-admin-install.php.
-		$wc_admin_installed = get_option( 'wc_admin_install_timestamp', false );
-		if ( false === $wc_admin_installed ) {
-			$wc_admin_installed = time();
-			update_option( 'wc_admin_install_timestamp', $wc_admin_installed );
-		}
-
-		$current_time          = time();
-		$three_days_in_seconds = 259200;
-
 		// We need to show Admin Giving feeback notification after 3 days of install.
-		if ( $current_time - $wc_admin_installed < $three_days_in_seconds ) {
+		$three_days_in_seconds = 3 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $three_days_in_seconds ) ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Mobile_App.php
+++ b/src/Notes/WC_Admin_Notes_Mobile_App.php
@@ -15,6 +15,10 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_Mobile_App
  */
 class WC_Admin_Notes_Mobile_App {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
 
 	/**
 	 * Name of the note for use in the database.
@@ -25,18 +29,9 @@ class WC_Admin_Notes_Mobile_App {
 	 * Possibly add mobile app note.
 	 */
 	public static function possibly_add_mobile_app_note() {
-
-		$wc_admin_installed = get_option( 'wc_admin_install_timestamp', false );
-		if ( false === $wc_admin_installed ) {
-			$wc_admin_installed = time();
-			update_option( 'wc_admin_install_timestamp', $wc_admin_installed );
-		}
-
-		$current_time        = time();
-		$two_days_in_seconds = 172800;
-
 		// We want to show the mobile app note after day 2.
-		if ( $current_time - $wc_admin_installed < $two_days_in_seconds ) {
+		$two_days_in_seconds = 2 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $two_days_in_seconds ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2538.

This PR introduces an inbox notice to prompt stores with at least 1 product that have had WooCommerce admin installed for at least 3 days to install the Facebook extension if they already haven't.

The install mechanism reuses code written for the Onboarding flow.

_cc: @pmcpinto_

### Screenshots

![Screen Shot 2019-08-14 at 7 34 29 PM](https://user-images.githubusercontent.com/63922/63069383-80336080-becb-11e9-8f02-3a5b41b2cb15.png)

### Detailed test instructions:

- Ensure you do not have the Facebook for WooCommerce Extension installed
- Ensure your store has a published product (or more)
- Use Crontrol to run the `wc_admin_daily` job
- Open the WooCommerce > Dashboard
- Verify the facebook note appears in the inbox
- Verify the "learn more" button function
- Verify the "install now" button function (check Plugins > Installed after)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add Facebook extension inbox note.