### PR TITLE
Pass "show data picker" prop to underlying component in ReportFilters.

### DIFF
--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -61,13 +61,14 @@ export default class ReportFilters extends Component {
 	}
 
 	render() {
-		const { query, path, filters, advancedFilters } = this.props;
+		const { advancedFilters, filters, path, query, showDatePicker } = this.props;
 		return (
 			<Filters
 				query={ query }
 				path={ path }
 				filters={ filters }
 				advancedFilters={ advancedFilters }
+				showDatePicker={ showDatePicker }
 				onDateSelect={ this.trackDateSelect }
 				onFilterSelect={ this.trackFilterSelect }
 				onAdvancedFilterAction={ this.trackAdvancedFilterAction }


### PR DESCRIPTION
Fixes errant date picker on the Customers Report.

Fixes #2773.

The date range picker was errantly displaying on the Customers Report because the `showDatePicker` prop wasn't being passed down to the underlying `ReportFilters` component.

### Screenshots

![Screen Shot 2019-08-16 at 10 06 35 AM](https://user-images.githubusercontent.com/63922/63184953-8d586880-c00d-11e9-8ff8-598d64a390e5.png)

### Detailed test instructions:

- Go to Analytics > Customers
- Verify there is no date picker

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: remove date picker from Customers Report.