### PR TITLE
Fix bug with checking user preferences for report column visibility.

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -108,14 +108,19 @@ class ReportTable extends Component {
 	}
 
 	filterShownHeaders( headers, hiddenKeys ) {
-		if ( ! hiddenKeys || ! hiddenKeys.length ) {
-			return headers;
+		// If no user preferences, set visibilty based on column default.
+		if ( ! hiddenKeys ) {
+			return headers.map( header => ( {
+				...header,
+				visible: header.required || ! header.hiddenByDefault,
+			} ) );
 		}
 
-		return headers.map( header => {
-			const hidden = hiddenKeys.includes( header.key ) && ! header.required;
-			return { ...header, hiddenByDefault: hidden };
-		} );
+		// Set visibilty based on user preferences.
+		return headers.map( header => ( {
+			...header,
+			visible: header.required || ! hiddenKeys.includes( header.key ),
+		} ) );
 	}
 
 	render() {

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -93,7 +93,15 @@ class TableCard extends Component {
 	}
 
 	getShowCols( headers ) {
-		return headers.map( ( { key, hiddenByDefault } ) => ! hiddenByDefault && key ).filter( Boolean );
+		return headers.map( ( { key, visible } ) => {
+			if (
+				'undefined' === typeof visible ||
+				visible
+			) {
+				return key;
+			}
+			return false;
+		} ).filter( Boolean );
 	}
 
 	getVisibleHeaders() {


### PR DESCRIPTION
_(Found while reproducing https://github.com/woocommerce/woocommerce-admin/issues/2719)_

Fixes a bug introduced in https://github.com/woocommerce/woocommerce-admin/commit/7ecfb1d4639757f849a4fe329314e35e13fac44d#diff-cbe713361af618d887a218e657fcc463R53.

When there are no user preferences for column visibility on a report, the value is an empty string. Since we're storing the hidden columns, if a user chooses to show all columns, we store an empty array.

The above linked commit introduced a `.length` check which caused "don't hide anything" preferences to revert to the column default visibility.

The easiest way to see this in the Products report - SKU column.

This PR fixes the issue by removing the `.length` check and introducing a new `visible` object property rather than overloading the `hiddenByDefault` property.

### Detailed test instructions:

- On `master`
- Go to Analytics > Products
- Toggle all columns to be visible
- Refresh page
- Verify the SKU column is hidden upon refresh
- Check out this branch
- Refresh
- Verify SKU column is visible

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: report column visibility preference bug.