### PR TITLE
Orders report now shows coupons in Coupon(s) column

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -192,7 +192,7 @@ export default class OrdersReportTable extends Component {
 						formattedCoupons.length ? [ formattedCoupons[ 0 ] ] : [],
 						formattedCoupons
 					),
-					value: formattedCoupons.map( coupon => coupon.label ).join( ' ' ),
+					value: formattedCoupons.map( coupon => coupon.label ).join( ', ' ),
 				},
 				{
 					display: renderCurrency( net_total, currency ),

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -192,7 +192,7 @@ export default class OrdersReportTable extends Component {
 						formattedCoupons.length ? [ formattedCoupons[ 0 ] ] : [],
 						formattedCoupons
 					),
-					value: formattedCoupons.map( item => item.code ).join( ' ' ),
+					value: formattedCoupons.map( coupon => coupon.label ).join( ' ' ),
 				},
 				{
 					display: renderCurrency( net_total, currency ),


### PR DESCRIPTION
Fixes #2745

With this PR, the `Orders` report will now show coupons in the "Coupon(s)" column.

### Screenshots
<img width="1394" alt="Screen Shot 2019-08-19 at 12 47 26 PM" src="https://user-images.githubusercontent.com/1888152/63283562-8fc1f900-c27f-11e9-9e7d-285e956c5ac6.png">
<img width="988" alt="Screen Shot 2019-08-19 at 12 47 39 PM" src="https://user-images.githubusercontent.com/1888152/63283566-92bce980-c27f-11e9-9d51-53026b8e69b1.png">


### Detailed test instructions:

- Go to `Orders` report
- Click on `Download`
- Open the CSV report
- Coupon data in the report now displayed in Dashboard and CSV