### PR TITLE
Fix product reports for simple products converted to variable.

### DIFF
--- a/src/API/Reports/Segmenter.php
+++ b/src/API/Reports/Segmenter.php
@@ -378,6 +378,15 @@ class Segmenter {
 				$segments[]            = $id;
 				$segment_labels[ $id ] = $segment->get_name();
 			}
+
+			// If no variations were specified, add a segment for the parent product (variation = 0).
+			// This is to catch simple products with prior sales converted into variable products.
+			// See: https://github.com/woocommerce/woocommerce-admin/issues/2719.
+			if ( empty( $this->query_args['variations'] ) ) {
+				$parent_object = wc_get_product( $this->query_args['product_includes'][0] );
+				$segments[]        = 0;
+				$segment_labels[0] = $parent_object->get_name();
+			}
 		} elseif ( 'category' === $this->query_args['segmentby'] ) {
 			$args = array(
 				'taxonomy' => 'product_cat',

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -177,32 +177,39 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$extended_attributes = apply_filters( 'woocommerce_rest_reports_variations_extended_attributes', $this->extended_attributes, $product_data );
 				$product             = wc_get_product( $product_data['product_id'] );
 				$variations          = array();
-				if ( method_exists( $product, 'get_available_variations' ) ) {
-					$variations = $product->get_available_variations();
-				}
-				foreach ( $variations as $variation ) {
-					if ( (int) $variation['variation_id'] === (int) $product_data['variation_id'] ) {
-						$attributes        = array();
-						$variation_product = wc_get_product( $variation['variation_id'] );
-						foreach ( $extended_attributes as $extended_attribute ) {
-							$function = 'get_' . $extended_attribute;
-							if ( is_callable( array( $variation_product, $function ) ) ) {
-								$value                                = $variation_product->{$function}();
-								$extended_info[ $extended_attribute ] = $value;
-							}
-						}
-						foreach ( $variation['attributes'] as $attribute_name => $attribute ) {
-							$name         = str_replace( 'attribute_', '', $attribute_name );
-							$option_term  = get_term_by( 'slug', $attribute, $name );
-							$attributes[] = array(
-								'id'     => wc_attribute_taxonomy_id_by_name( $name ),
-								'name'   => str_replace( 'pa_', '', $name ),
-								'option' => $option_term && ! is_wp_error( $option_term ) ? $option_term->name : $attribute,
-							);
-						}
-						$extended_info['attributes'] = $attributes;
+
+				// Base extended info off the parent variable product if the variation ID is 0.
+				// This is caused by simple products with prior sales being converted into variable products.
+				// See: https://github.com/woocommerce/woocommerce-admin/issues/2719.
+				$variation_id      = (int) $product_data['variation_id'];
+				$variation_product = ( 0 === $variation_id ) ? $product : wc_get_product( $variation_id );
+				$attributes        = array();
+
+				foreach ( $extended_attributes as $extended_attribute ) {
+					$function = 'get_' . $extended_attribute;
+					if ( is_callable( array( $variation_product, $function ) ) ) {
+						$value                                = $variation_product->{$function}();
+						$extended_info[ $extended_attribute ] = $value;
 					}
 				}
+
+				// If this is a variation, add its attributes.
+				if ( 0 < $variation_id ) {
+					$variation_attributes = $variation_product->get_variation_attributes();
+
+					foreach ( $variation_attributes as $attribute_name => $attribute ) {
+						$name         = str_replace( 'attribute_', '', $attribute_name );
+						$option_term  = get_term_by( 'slug', $attribute, $name );
+						$attributes[] = array(
+							'id'     => wc_attribute_taxonomy_id_by_name( $name ),
+							'name'   => str_replace( 'pa_', '', $name ),
+							'option' => $option_term && ! is_wp_error( $option_term ) ? $option_term->name : $attribute,
+						);
+					}
+				}
+
+				$extended_info['attributes'] = $attributes;
+
 				// If there is no set low_stock_amount, use the one in user settings.
 				if ( '' === $extended_info['low_stock_amount'] ) {
 					$extended_info['low_stock_amount'] = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -138,7 +138,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( $order_status_filter ) {
 			$sql_query_params['from_clause']  .= " JOIN {$wpdb->prefix}wc_order_stats ON {$order_product_lookup_table}.order_id = {$wpdb->prefix}wc_order_stats.order_id";
 			$sql_query_params['where_clause'] .= " AND ( {$order_status_filter} )";
-			$sql_query_params['where_clause'] .= ' AND variation_id > 0';
 		}
 
 		return $sql_query_params;
@@ -289,7 +288,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 									{$sql_query_params['where_time_clause']}
 									{$sql_query_params['where_clause']}
 								GROUP BY
-									variation_id
+									product_id, variation_id
 								) AS tt"
 				); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
@@ -317,7 +316,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 						{$sql_query_params['where_time_clause']}
 						{$sql_query_params['where_clause']}
 					GROUP BY
-						variation_id
+						product_id, variation_id
 				{$suffix}
 					{$right_join}
 					{$sql_query_params['outer_from_clause']}


### PR DESCRIPTION
Fixes #2719.

This PR seeks to fix Product Report data when a Simple product (that has sales) has been converted into a Variable product.

We were previously excluding products from the query where `variation_id = 0`. Since the orders placed for the original Simple product have `0` for the `variation_id`, they were being excluded from the single product report.

This PR:
* Adds the simple product orders to the report dataset by removing the `WHERE` clause that omits the `0` value `variation_id`s
* Adds the simple product to the report chart and table by including a new segment label for the `0` variation using the original product name

**This PR does not:**

Handle comparisons including the original simple product. It will simply be omitted from results if selected since the variation ID is `0`.

### Screenshots

**Before**

![FireShot Capture 022 - Products ‹ Analytics ‹ WooC_ - http___local wordpress test_wp-admin_admin php](https://user-images.githubusercontent.com/63922/63297023-4a082f00-c285-11e9-85b3-6da43947e74f.png)

**After**

![FireShot Capture 021 - Products ‹ Analytics ‹ WooC_ - http___local wordpress test_wp-admin_admin php](https://user-images.githubusercontent.com/63922/63296928-19c09080-c285-11e9-9e5c-3908872f06e8.png)


### Detailed test instructions:

- Follow the steps to reproduce in the issue: https://github.com/woocommerce/woocommerce-admin/issues/2719
- Verify that selecting the single product in the Products Report shows sales for both the original product and the variation

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: handle simple to variable product changes in reports.