### PR TITLE
display local time on note instead of UTC

### DIFF
--- a/client/header/activity-panel/panels/inbox.js
+++ b/client/header/activity-panel/panels/inbox.js
@@ -93,7 +93,7 @@ class InboxPanel extends Component {
 					actioned: 'unactioned' !== note.status,
 				} ) }
 				title={ note.title }
-				date={ note.date_created_gmt }
+				date={ note.date_created }
 				icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
 				unread={
 					! lastRead ||


### PR DESCRIPTION
Fixes #2006

This PR changes the notes display date prop from `date_created_gmt` to
 `date_created`.

### Detailed test instructions:

- Update the `date_created` on an actionable note to the current time UTC
`update wp_wc_admin_notes set date_created = '2019-08-20 20:29:57' where note_id = 1234;`
- Set you WP install to UTC-4 (America/New York)
- Open the notes panel
- The updated note will say `4 hours from now`
- Switch to this PR
- The updated note will say `Now`

### Changelog Note:

Fix: Date calculation on notes being double adjusted to UTC.