### PR TITLE
Add filter to notes datastore where clauses

### DIFF
--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -315,12 +315,13 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	public function get_notes_count( $type = array(), $status = array() ) {
 		global $wpdb;
 
-		$where_clauses = $this->get_notes_where_clauses(
-			array(
-				'type'   => $type,
-				'status' => $status,
-			)
+		$args = array(
+			'type'   => $type,
+			'status' => $status,
 		);
+
+		$where_clauses = $this->get_notes_where_clauses( $args );
+		$where_clauses = apply_filters( 'wc_admin_notes_count_where_clauses', $where_clauses, $args );
 
 		if ( ! empty( $where_clauses ) ) {
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
@@ -371,7 +372,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$where_clauses .= " AND status IN ($escaped_status_types)";
 		}
 
-		return $where_clauses;
+		return apply_filters( 'wc_admin_notes_where_clauses', $where_clauses, $args );
 	}
 
 	/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -315,13 +315,12 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	public function get_notes_count( $type = array(), $status = array() ) {
 		global $wpdb;
 
-		$args = array(
-			'type'   => $type,
-			'status' => $status,
+		$where_clauses = $this->get_notes_where_clauses(
+			array(
+				'type'   => $type,
+				'status' => $status,
+			)
 		);
-
-		$where_clauses = $this->get_notes_where_clauses( $args );
-		$where_clauses = apply_filters( 'wc_admin_notes_count_where_clauses', $where_clauses, $args );
 
 		if ( ! empty( $where_clauses ) ) {
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -371,6 +371,14 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$where_clauses .= " AND status IN ($escaped_status_types)";
 		}
 
+		/**
+		 * Filter the notes WHERE clause before retrieving the data.
+		 *
+		 * Allows modification of the notes select criterial.
+		 *
+		 * @param string $where_clauses The generated WHERE clause.
+		 * @param array  $args          The original arguments for the request.
+		 */
 		return apply_filters( 'wc_admin_notes_where_clauses', $where_clauses, $args );
 	}
 


### PR DESCRIPTION
See #2714

Add filter to notes datastore where clauses

### Detailed test instructions:

- Load notes without PR
- Go to regular WP Admin page
- Clear transients
- Switch to PR
- Verify same notes are shown

### Changelog Note:

Dev: Add filter to notes datastore where clauses.