### PR TITLE
remove constant eliminated by PSR-4

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -118,7 +118,6 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_ABSPATH', dirname( __DIR__ ) . '/' );
 		$this->define( 'WC_ADMIN_DIST_JS_FOLDER', 'dist/' );
 		$this->define( 'WC_ADMIN_DIST_CSS_FOLDER', 'dist/' );
-		$this->define( 'WC_ADMIN_FEATURES_PATH', WC_ADMIN_ABSPATH . 'includes/features/' );
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.


### PR DESCRIPTION
See #2712

This PR removes the definition of `WC_ADMIN_FEATURES_PATH` which was eliminated by the PSR-4 conversion.

### Detailed test instructions:

- Search the source code to ensure the constant no longer exists in the code base
- Check the dashboard to ensure the app still functions

### Changelog Note:

None needed.
