### PR TITLE
Onboarding - Profile Wizard: Update plugin installation step to deal with previously installed plugins

### DIFF
--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -2,21 +2,30 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { difference } from 'lodash';
+import { difference, get } from 'lodash';
 import { withDispatch } from '@wordpress/data';
+
+/**
+ * WooCommerce depdencies
+ */
+import { H, Stepper, Card } from '@woocommerce/components';
+import { updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal depdencies
  */
-import { H, Stepper, Card } from '@woocommerce/components';
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
 
-const plugins = [ 'jetpack', 'woocommerce-services' ];
+const pluginsToInstall = [ 'jetpack', 'woocommerce-services' ];
+const plugins = difference(
+	pluginsToInstall,
+	get( wcSettings, [ 'onboarding', 'activePlugins' ], [] )
+);
 
 class Plugins extends Component {
 	constructor() {
@@ -30,11 +39,20 @@ class Plugins extends Component {
 	}
 
 	componentDidMount() {
+		if ( 0 === plugins.length ) {
+			return updateQueryString( { step: 'store-details' } );
+		}
 		this.props.installPlugins( plugins );
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { createNotice, errors, installedPlugins, jetpackConnectUrl } = this.props;
+		const {
+			createNotice,
+			errors,
+			installedPlugins,
+			activatedPlugins,
+			jetpackConnectUrl,
+		} = this.props;
 
 		if ( jetpackConnectUrl ) {
 			window.location = jetpackConnectUrl;
@@ -49,6 +67,17 @@ class Plugins extends Component {
 		) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( { step: 'activate' } );
+			/* eslint-enable react/no-did-update-set-state */
+		}
+
+		// If Jetpack was already connected, we can go to store details after WCS is activated.
+		if (
+			! plugins.includes( 'jetpack' ) &&
+			prevProps.activatedPlugins.length !== plugins.length &&
+			activatedPlugins.length === plugins.length
+		) {
+			/* eslint-disable react/no-did-update-set-state */
+			return updateQueryString( { step: 'store-details' } );
 			/* eslint-enable react/no-did-update-set-state */
 		}
 	}
@@ -71,6 +100,10 @@ class Plugins extends Component {
 		const { hasErrors, isRequesting } = this.props;
 		const { step } = this.state;
 
+		const pluginNames = plugins.includes( 'jetpack' )
+			? __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' )
+			: __( 'WooCommerce Services', 'woocommerce-admin' );
+
 		return (
 			<Fragment>
 				<H className="woocommerce-profile-wizard__header-title">
@@ -84,11 +117,11 @@ class Plugins extends Component {
 						isPending={ isRequesting && ! hasErrors }
 						steps={ [
 							{
-								label: __( 'Install Jetpack and WooCommerce Services', 'woocommerce-admin' ),
+								label: sprintf( __( 'Install %s', 'woocommerce-admin' ), pluginNames ),
 								key: 'install',
 							},
 							{
-								label: __( 'Activate Jetpack and WooCommerce Services', 'woocommerce-admin' ),
+								label: sprintf( __( 'Activate %s', 'woocommerce-admin' ), pluginNames ),
 								key: 'activate',
 							},
 						] }

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -23,6 +23,7 @@ import withSelect from 'wc-api/with-select';
 import { pluginNames } from 'wc-api/onboarding/constants';
 
 const pluginsToInstall = [ 'jetpack', 'woocommerce-services' ];
+// We want to use the cached version of activePlugins here, otherwise the list we are dealing with could update as plugins are activated.
 const plugins = difference(
 	pluginsToInstall,
 	get( wcSettings, [ 'onboarding', 'activePlugins' ], [] )

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -20,6 +20,7 @@ import { updateQueryString } from '@woocommerce/navigation';
  */
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
+import { pluginNames } from 'wc-api/onboarding/constants';
 
 const pluginsToInstall = [ 'jetpack', 'woocommerce-services' ];
 const plugins = difference(
@@ -100,9 +101,9 @@ class Plugins extends Component {
 		const { hasErrors, isRequesting } = this.props;
 		const { step } = this.state;
 
-		const pluginNames = plugins.includes( 'jetpack' )
-			? __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' )
-			: __( 'WooCommerce Services', 'woocommerce-admin' );
+		const pluginLabel = plugins.includes( 'jetpack' )
+			? Object.values( pluginNames ).join( ' & ' )
+			: pluginNames[ 'woocommerce-services' ];
 
 		return (
 			<Fragment>
@@ -117,11 +118,11 @@ class Plugins extends Component {
 						isPending={ isRequesting && ! hasErrors }
 						steps={ [
 							{
-								label: sprintf( __( 'Install %s', 'woocommerce-admin' ), pluginNames ),
+								label: sprintf( __( 'Install %s', 'woocommerce-admin' ), pluginLabel ),
 								key: 'install',
 							},
 							{
-								label: sprintf( __( 'Activate %s', 'woocommerce-admin' ), pluginNames ),
+								label: sprintf( __( 'Activate %s', 'woocommerce-admin' ), pluginLabel ),
 								key: 'activate',
 							},
 						] }
@@ -183,7 +184,7 @@ export default compose(
 			errors.push( installationErrors[ plugin ].message )
 		);
 		if ( jetpackConnectUrlError ) {
-			errors.push( jetpackConnectUrlError );
+			errors.push( jetpackConnectUrlError.message );
 		}
 		const hasErrors = Boolean( errors.length );
 

--- a/client/dashboard/profile-wizard/steps/start/images/card.js
+++ b/client/dashboard/profile-wizard/steps/start/images/card.js
@@ -1,0 +1,33 @@
+/** @format */
+/*eslint-disable max-len*/
+
+export default () => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<g>
+			<mask
+				id="card_mask"
+				mask-type="alpha"
+				maskUnits="userSpaceOnUse"
+				x="2"
+				y="4"
+				width="20"
+				height="16"
+			>
+				<path
+					id="icon/action/payment_24px_2"
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M20 4H4C2.89 4 2.01 4.89 2.01 6L2 18C2 19.11 2.89 20 4 20H20C21.11 20 22 19.11 22 18V6C22 4.89 21.11 4 20 4ZM20 18H4V12H20V18ZM4 8H20V6H4V8Z"
+					fill="white"
+				/>
+			</mask>
+			<g mask="url(#card_mask)">
+				<g>
+					<rect width="24" height="24" fill="#50575D" />
+				</g>
+			</g>
+		</g>
+	</svg>
+);
+
+/*eslint-enable max-len*/

--- a/client/dashboard/profile-wizard/steps/start/images/print.js
+++ b/client/dashboard/profile-wizard/steps/start/images/print.js
@@ -1,0 +1,32 @@
+/** @format */
+/*eslint-disable max-len*/
+
+export default () => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<g>
+			<mask
+				id="print_mask"
+				mask-type="alpha"
+				maskUnits="userSpaceOnUse"
+				x="2"
+				y="3"
+				width="20"
+				height="18"
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M19 8H18V3H6V8H5C3.34 8 2 9.34 2 11V17H6V21H18V17H22V11C22 9.34 20.66 8 19 8ZM8 5H16V8H8V5ZM16 19V17V15H8V19H16ZM18 15V13H6V15H4V11C4 10.45 4.45 10 5 10H19C19.55 10 20 10.45 20 11V15H18ZM17 11.5C17 10.9477 17.4477 10.5 18 10.5C18.5523 10.5 19 10.9477 19 11.5C19 12.0523 18.5523 12.5 18 12.5C17.4477 12.5 17 12.0523 17 11.5Z"
+					fill="white"
+				/>
+			</mask>
+			<g mask="url(#print_mask)">
+				<g>
+					<rect width="24" height="24" fill="#50575D" />
+				</g>
+			</g>
+		</g>
+	</svg>
+);
+
+/*eslint-enable max-len*/

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -29,6 +29,8 @@ import PrintIcon from './images/print';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 
+// @todo Port to wc-api for use in other parts of the application
+const activatedPlugins = get( wcSettings, [ 'onboarding', 'activePlugins' ], [] );
 const benefits = [
 	{
 		title: __( 'Security', 'woocommerce-admin' ),
@@ -37,7 +39,7 @@ const benefits = [
 			'Jetpack automatically blocks brute force attacks to protect your store from unauthorized access.',
 			'woocommerce-admin'
 		),
-		plugins: [ 'jetpack' ],
+		visible: ! activatedPlugins.includes( 'jetpack' ),
 	},
 	{
 		title: __( 'Sales Tax', 'woocommerce-admin' ),
@@ -46,7 +48,7 @@ const benefits = [
 			'With WooCommerce Services we ensure that the correct rate of tax is charged on all of your orders.',
 			'woocommerce-admin'
 		),
-		plugins: [ 'jetpack', 'woocommerce-services' ],
+		visible: true,
 	},
 	{
 		title: __( 'Speed', 'woocommerce-admin' ),
@@ -55,7 +57,7 @@ const benefits = [
 			'Cache your images and static files on our own powerful global network of servers and speed up your site.',
 			'woocommerce-admin'
 		),
-		plugins: [ 'jetpack' ],
+		visible: ! activatedPlugins.includes( 'jetpack' ),
 	},
 	{
 		title: __( 'Mobile App', 'woocommerce-admin' ),
@@ -64,7 +66,7 @@ const benefits = [
 			'Your store in your pocket. Manage orders, receive sales notifications, and more. Only with a Jetpack connection.',
 			'woocommerce-admin'
 		),
-		plugins: [ 'jetpack' ],
+		visible: ! activatedPlugins.includes( 'jetpack' ),
 	},
 	{
 		title: __( 'Print your own shipping labels', 'woocommerce-admin' ),
@@ -73,7 +75,9 @@ const benefits = [
 			'Save time at the Post Office by printing USPS shipping labels at home.',
 			'woocommerce-admin'
 		),
-		plugins: [ 'woocommerce-services' ],
+		visible:
+			activatedPlugins.includes( 'jetpack' ) &&
+			! activatedPlugins.includes( 'woocommerce-services' ),
 	},
 	{
 		title: __( 'Simple payment setup', 'woocommerce-admin' ),
@@ -82,7 +86,9 @@ const benefits = [
 			'WooCommerce Services enables us to provision Stripe and Paypal accounts quickly and easily for you.',
 			'woocommerce-admin'
 		),
-		plugins: [ 'woocommerce-services' ],
+		visible:
+			activatedPlugins.includes( 'jetpack' ) &&
+			! activatedPlugins.includes( 'woocommerce-services' ),
 	},
 ];
 
@@ -100,7 +106,6 @@ class Start extends Component {
 	}
 
 	componentDidMount() {
-		const activatedPlugins = get( wcSettings, [ 'onboarding', 'activePlugins' ], [] );
 		if (
 			activatedPlugins.includes( 'jetpack' ) &&
 			activatedPlugins.includes( 'woocommerce-services' )
@@ -168,25 +173,18 @@ class Start extends Component {
 		);
 	}
 
-	getBenefits() {
-		const activatedPlugins = get( wcSettings, [ 'onboarding', 'activePlugins' ], [] );
-		if ( activatedPlugins.includes( 'jetpack' ) ) {
-			return filter( benefits, benefit => benefit.plugins.includes( 'woocommerce-services' ) );
-		}
-		return filter( benefits, benefit => benefit.plugins.includes( 'jetpack' ) );
-	}
-
 	renderBenefits() {
 		return (
 			<div className="woocommerce-profile-wizard__benefits">
-				{ this.getBenefits().map( benefit => this.renderBenefit( benefit ) ) }
+				{ filter( benefits, benefit => benefit.visible ).map( benefit =>
+					this.renderBenefit( benefit )
+				) }
 			</div>
 		);
 	}
 
 	render() {
 		const { allowTracking } = this.state;
-		const activatedPlugins = get( wcSettings, [ 'onboarding', 'activePlugins' ], [] );
 		const pluginNames = activatedPlugins.includes( 'jetpack' )
 			? __( 'WooCommerce Services', 'woocommerce-admin' )
 			: __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' );

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -9,7 +9,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch } from '@wordpress/data';
-import { get, filter } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * WooCommerce depdencies
@@ -29,69 +29,6 @@ import PrintIcon from './images/print';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 
-// @todo Port to wc-api for use in other parts of the application
-const activatedPlugins = get( wcSettings, [ 'onboarding', 'activePlugins' ], [] );
-const benefits = [
-	{
-		title: __( 'Security', 'woocommerce-admin' ),
-		icon: <SecurityIcon />,
-		description: __(
-			'Jetpack automatically blocks brute force attacks to protect your store from unauthorized access.',
-			'woocommerce-admin'
-		),
-		visible: ! activatedPlugins.includes( 'jetpack' ),
-	},
-	{
-		title: __( 'Sales Tax', 'woocommerce-admin' ),
-		icon: <SalesTaxIcon />,
-		description: __(
-			'With WooCommerce Services we ensure that the correct rate of tax is charged on all of your orders.',
-			'woocommerce-admin'
-		),
-		visible: true,
-	},
-	{
-		title: __( 'Speed', 'woocommerce-admin' ),
-		icon: <SpeedIcon />,
-		description: __(
-			'Cache your images and static files on our own powerful global network of servers and speed up your site.',
-			'woocommerce-admin'
-		),
-		visible: ! activatedPlugins.includes( 'jetpack' ),
-	},
-	{
-		title: __( 'Mobile App', 'woocommerce-admin' ),
-		icon: <MobileAppIcon />,
-		description: __(
-			'Your store in your pocket. Manage orders, receive sales notifications, and more. Only with a Jetpack connection.',
-			'woocommerce-admin'
-		),
-		visible: ! activatedPlugins.includes( 'jetpack' ),
-	},
-	{
-		title: __( 'Print your own shipping labels', 'woocommerce-admin' ),
-		icon: <PrintIcon />,
-		description: __(
-			'Save time at the Post Office by printing USPS shipping labels at home.',
-			'woocommerce-admin'
-		),
-		visible:
-			activatedPlugins.includes( 'jetpack' ) &&
-			! activatedPlugins.includes( 'woocommerce-services' ),
-	},
-	{
-		title: __( 'Simple payment setup', 'woocommerce-admin' ),
-		icon: <CardIcon />,
-		description: __(
-			'WooCommerce Services enables us to provision Stripe and Paypal accounts quickly and easily for you.',
-			'woocommerce-admin'
-		),
-		visible:
-			activatedPlugins.includes( 'jetpack' ) &&
-			! activatedPlugins.includes( 'woocommerce-services' ),
-	},
-];
-
 class Start extends Component {
 	constructor() {
 		super( ...arguments );
@@ -107,8 +44,8 @@ class Start extends Component {
 
 	componentDidMount() {
 		if (
-			activatedPlugins.includes( 'jetpack' ) &&
-			activatedPlugins.includes( 'woocommerce-services' )
+			this.props.activePlugins.includes( 'jetpack' ) &&
+			this.props.activePlugins.includes( 'woocommerce-services' )
 		) {
 			return updateQueryString( { step: 'store-details' } );
 		}
@@ -173,10 +110,72 @@ class Start extends Component {
 		);
 	}
 
+	getBenefits() {
+		const { activePlugins } = this.props;
+		return [
+			{
+				title: __( 'Security', 'woocommerce-admin' ),
+				icon: <SecurityIcon />,
+				description: __(
+					'Jetpack automatically blocks brute force attacks to protect your store from unauthorized access.',
+					'woocommerce-admin'
+				),
+				visible: ! activePlugins.includes( 'jetpack' ),
+			},
+			{
+				title: __( 'Sales Tax', 'woocommerce-admin' ),
+				icon: <SalesTaxIcon />,
+				description: __(
+					'With WooCommerce Services we ensure that the correct rate of tax is charged on all of your orders.',
+					'woocommerce-admin'
+				),
+				visible: true,
+			},
+			{
+				title: __( 'Speed', 'woocommerce-admin' ),
+				icon: <SpeedIcon />,
+				description: __(
+					'Cache your images and static files on our own powerful global network of servers and speed up your site.',
+					'woocommerce-admin'
+				),
+				visible: ! activePlugins.includes( 'jetpack' ),
+			},
+			{
+				title: __( 'Mobile App', 'woocommerce-admin' ),
+				icon: <MobileAppIcon />,
+				description: __(
+					'Your store in your pocket. Manage orders, receive sales notifications, and more. Only with a Jetpack connection.',
+					'woocommerce-admin'
+				),
+				visible: ! activePlugins.includes( 'jetpack' ),
+			},
+			{
+				title: __( 'Print your own shipping labels', 'woocommerce-admin' ),
+				icon: <PrintIcon />,
+				description: __(
+					'Save time at the Post Office by printing USPS shipping labels at home.',
+					'woocommerce-admin'
+				),
+				visible:
+					activePlugins.includes( 'jetpack' ) && ! activePlugins.includes( 'woocommerce-services' ),
+			},
+			{
+				title: __( 'Simple payment setup', 'woocommerce-admin' ),
+				icon: <CardIcon />,
+				description: __(
+					'WooCommerce Services enables us to provision Stripe and Paypal accounts quickly and easily for you.',
+					'woocommerce-admin'
+				),
+				visible:
+					activePlugins.includes( 'jetpack' ) && ! activePlugins.includes( 'woocommerce-services' ),
+			},
+		];
+	}
+
 	renderBenefits() {
 		return (
 			<div className="woocommerce-profile-wizard__benefits">
-				{ filter( benefits, benefit => benefit.visible ).map( benefit =>
+				{ filter( this.getBenefits(), benefit => benefit.visible ).map( benefit =>
 					this.renderBenefit( benefit )
 				) }
 			</div>
@@ -185,7 +184,8 @@ class Start extends Component {
 
 	render() {
 		const { allowTracking } = this.state;
-		const pluginNames = activatedPlugins.includes( 'jetpack' )
+		const { activePlugins } = this.props;
+		const pluginNames = activePlugins.includes( 'jetpack' )
 			? __( 'WooCommerce Services', 'woocommerce-admin' )
 			: __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' );
 
@@ -264,15 +264,27 @@ class Start extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItemsError, getSettings, getSettingsError, isGetSettingsRequesting } = select(
-			'wc-api'
-		);
+		const {
+			getProfileItemsError,
+			getSettings,
+			getSettingsError,
+			isGetSettingsRequesting,
+			getActivePlugins,
+		} = select( 'wc-api' );
 
 		const isSettingsError = Boolean( getSettingsError( 'advanced' ) );
 		const isSettingsRequesting = isGetSettingsRequesting( 'advanced' );
 		const isProfileItemsError = Boolean( getProfileItemsError() );
 
-		return { getSettings, isSettingsError, isProfileItemsError, isSettingsRequesting };
+		const activePlugins = getActivePlugins();
+
+		return {
+			getSettings,
+			isSettingsError,
+			isProfileItemsError,
+			isSettingsRequesting,
+			activePlugins,
+		};
 	} ),
 	withDispatch( dispatch => {
 		const { updateProfileItems, updateSettings } = dispatch( 'wc-api' );

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -263,7 +263,7 @@
 .woocommerce-profile-wizard__plugins-card {
 	.woocommerce-profile-wizard__plugins-actions {
 		text-align: left;
-		margin-left: 64px;
+		margin-left: 44px;
 		min-height: 28px;
 
 		button.muriel-button {
@@ -271,6 +271,7 @@
 			height: 40px;
 			min-width: auto;
 			display: initial;
+			margin-right: $gap-small;
 		}
 	}
 }

--- a/client/wc-api/onboarding/operations.js
+++ b/client/wc-api/onboarding/operations.js
@@ -98,6 +98,43 @@ function profileItemToResource( items ) {
 	return resources;
 }
 
+function activatePlugins( resourceNames, data, fetch ) {
+	const resourceName = 'plugin-activate';
+	if ( resourceNames.includes( resourceName ) ) {
+		const plugins = data[ resourceName ];
+		const url = NAMESPACE + '/onboarding/plugins/activate';
+		return [
+			fetch( {
+				path: url,
+				method: 'POST',
+				data: {
+					plugins: plugins.join( ',' ),
+				},
+			} )
+				.then( activatePluginToResource.bind( null, data[ resourceName ] ) )
+				.catch( error => {
+					return { [ resourceName ]: { error } };
+				} ),
+		];
+	}
+
+	return [];
+}
+
+function activatePluginToResource( items ) {
+	const resourceName = 'plugin-activate';
+
+	const resources = {
+		[ resourceName ]: { data: items },
+	};
+	Object.keys( items ).forEach( key => {
+		const item = items[ key ];
+		resources[ getResourceName( resourceName, item ) ] = { data: item };
+	} );
+
+	return resources;
+}
+
 function readJetpackConnectUrl( resourceNames, fetch ) {
 	const resourceName = 'jetpack-connect-url';
 
@@ -121,33 +158,6 @@ function readJetpackConnectUrl( resourceNames, fetch ) {
 	return [];
 }
 
-function doPluginActions( fetch, action, plugins ) {
-	const resourceName = [ `plugin-${ action }` ];
-
-	return plugins.map( async plugin => {
-		return fetch( {
-			path: `${ NAMESPACE }/onboarding/plugins/${ action }`,
-			method: 'POST',
-			data: {
-				plugin,
-			},
-		} )
-			.then( response => {
-				return {
-					[ resourceName ]: { data: plugins },
-					[ getResourceName( resourceName, plugin ) ]: { data: response },
-				};
-			} )
-			.catch( error => {
-				error.message = getPluginErrorMessage( action, plugin );
-				return {
-					[ resourceName ]: { data: plugins },
-					[ getResourceName( resourceName, plugin ) ]: { error },
-				};
-			} );
-	} );
-}
-
 function getPluginErrorMessage( action, plugin ) {
 	const pluginName = pluginNames[ plugin ] || plugin;
 
@@ -156,29 +166,36 @@ function getPluginErrorMessage( action, plugin ) {
 				__( 'There was an error installing %s. Please try again.', 'woocommerce-admin' ),
 				pluginName
 			)
-		: sprintf(
-				__( 'There was an error activating %s. Please try again.', 'woocommerce-admin' ),
-				pluginName
-			);
+		: __( 'There was an error activating your plugins. Please try again.', 'woocommerce-admin' );
 }
 
 function installPlugins( resourceNames, data, fetch ) {
 	const resourceName = 'plugin-install';
-
 	if ( resourceNames.includes( resourceName ) ) {
 		const plugins = data[ resourceName ];
-		return doPluginActions( fetch, 'install', plugins );
-	}
 
-	return [];
-}
-
-function activatePlugins( resourceNames, data, fetch ) {
-	const resourceName = 'plugin-activate';
-
-	if ( resourceNames.includes( resourceName ) ) {
-		const plugins = data[ resourceName ];
-		return doPluginActions( fetch, 'activate', plugins );
+		return plugins.map( async plugin => {
+			return fetch( {
+				path: `${ NAMESPACE }/onboarding/plugins/install`,
+				method: 'POST',
+				data: {
+					plugin,
+				},
+			} )
+				.then( response => {
+					return {
+						[ resourceName ]: { data: plugins },
+						[ getResourceName( resourceName, plugin ) ]: { data: response },
+					};
+				} )
+				.catch( error => {
+					error.message = getPluginErrorMessage( 'install', plugin );
+					return {
+						[ resourceName ]: { data: plugins },
+						[ getResourceName( resourceName, plugin ) ]: { error },
+					};
+				} );
+		} );
 	}
 
 	return [];

--- a/client/wc-api/onboarding/selectors.js
+++ b/client/wc-api/onboarding/selectors.js
@@ -77,6 +77,32 @@ const getPluginInstallations = getResource => plugins => {
 	return installations;
 };
 
+const getActivePlugins = ( getResource, requireResource ) => (
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = 'active-plugins';
+	const data = requireResource( requirement, resourceName ).data || [];
+	if ( ! data.length ) {
+		return wcSettings.onboarding.activePlugins;
+	}
+
+	return data;
+};
+
+const getActivePluginsError = getResource => () => {
+	return getResource( 'active-plugins' ).error;
+};
+
+const isGetActivePluginsRequesting = getResource => () => {
+	const { lastReceived, lastRequested } = getResource( 'active-plugins' );
+
+	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
 const getPluginActivations = getResource => plugins => {
 	const resourceName = 'plugin-activate';
 
@@ -146,6 +172,9 @@ export default {
 	getJetpackConnectUrl,
 	getJetpackConnectUrlError,
 	isGetJetpackConnectUrlRequesting,
+	getActivePlugins,
+	getActivePluginsError,
+	isGetActivePluginsRequesting,
 	getPluginActivations,
 	getPluginInstallations,
 	getPluginInstallationErrors,

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -8,6 +8,7 @@
  */
 
 namespace Automattic\WooCommerce\Admin\API;
+use Automattic\WooCommerce\Admin\Features\Onboarding;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -116,27 +117,13 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Get an array of plugins that can be installed & activated via the endpoints.
-	 */
-	public function get_allowed_plugins() {
-		return apply_filters(
-			'woocommerce_onboarding_plugins_whitelist',
-			array(
-				'facebook-for-woocommerce' => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
-				'jetpack'                  => 'jetpack/jetpack.php',
-				'woocommerce-services'     => 'woocommerce-services/woocommerce-services.php',
-			)
-		);
-	}
-
-	/**
 	 * Installs the requested plugin.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array Plugin Status
 	 */
 	public function install_plugin( $request ) {
-		$allowed_plugins = $this->get_allowed_plugins();
+		$allowed_plugins = Onboarding::get_allowed_plugins();
 		$plugin          = sanitize_title_with_dashes( $request['plugin'] );
 		if ( ! in_array( $plugin, array_keys( $allowed_plugins ), true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'Invalid plugin.', 'woocommerce-admin' ), 404 );
@@ -197,7 +184,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	 * @return array Plugin Status
 	 */
 	public function activate_plugin( $request ) {
-		$allowed_plugins = $this->get_allowed_plugins();
+		$allowed_plugins = Onboarding::get_allowed_plugins();
 		$plugin          = sanitize_title_with_dashes( $request['plugin'] );
 		if ( ! in_array( $plugin, array_keys( $allowed_plugins ), true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugin', __( 'Invalid plugin.', 'woocommerce-admin' ), 404 );
@@ -231,7 +218,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	 * @return array Connection URL for Jetpack
 	 */
 	public function connect_jetpack() {
-		if ( ! class_exists( 'Jetpack' ) ) {
+		if ( ! class_exists( '\Jetpack' ) ) {
 			return new \WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce-admin' ), 404 );
 		}
 

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -52,6 +52,19 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/active',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'active_plugins' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/activate',
 			array(
 				array(
@@ -178,6 +191,19 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	}
 
 	/**
+	 * Returns a list of active plugins.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array Active plugins
+	 */
+	public function active_plugins( $request ) {
+		$plugins = Onboarding::get_active_plugins();
+		return( array(
+			'plugins' => array_values( $plugins ),
+		) );
+	}
+
+	/**
 	 * Activate the requested plugin.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
@@ -210,8 +236,9 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		}
 
 		return( array(
-			'plugins' => array_values( $plugins ),
-			'status'  => 'success',
+			'activatedPlugins' => array_values( $plugins ),
+			'active' => Onboarding::get_active_plugins(),
+			'status' => 'success',
 		) );
 	}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -347,12 +347,6 @@ class Onboarding {
 		$active_plugins = array();
 		foreach ( $active_plugin_files as $file ) {
 			$slug = $allowed_plugin_slugs[ $file ];
-			if ( 'jetpack' === $slug || 'woocommerce-services' === $slug ) {
-				// If Jetpack is installed but not connected, consider both WCS and Jetpack inactive for the purpose of onboarding.
-				if ( ! class_exists( 'Jetpack' ) || ! ( \Jetpack::is_active() || \Jetpack::is_development_mode() ) ) {
-					continue;
-				}
-			}
 			$active_plugins[] = $slug;
 		}
 		return $active_plugins;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -311,12 +311,49 @@ class Onboarding {
 
 		// Only fetch if the onboarding wizard is incomplete.
 		if ( $this->should_show_profiler() ) {
-			$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
-			$settings['onboarding']['themes']       = self::get_themes();
-			$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
+			$settings['onboarding']['productTypes']  = self::get_allowed_product_types();
+			$settings['onboarding']['themes']        = self::get_themes();
+			$settings['onboarding']['activeTheme']   = get_option( 'stylesheet' );
+			$settings['onboarding']['activePlugins'] = self::get_active_plugins();
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Gets an array of plugins that can be installed & activated via the onboarding wizard.
+	 */
+	public static function get_allowed_plugins() {
+		return apply_filters(
+			'woocommerce_onboarding_plugins_whitelist',
+			array(
+				'jetpack'              => 'jetpack/jetpack.php',
+				'woocommerce-services' => 'woocommerce-services/woocommerce-services.php',
+			)
+		);
+	}
+	/**
+	 * Get a list of active plugins, relevent to the onboarding wizard.
+	 *
+	 * @return array
+	 */
+	public static function get_active_plugins() {
+		$all_active_plugins   = get_option( 'active_plugins', array() );
+		$allowed_plugins      = self::get_allowed_plugins();
+		$active_plugin_files  = array_intersect( $all_active_plugins, $allowed_plugins );
+		$allowed_plugin_slugs = array_flip( $allowed_plugins );
+		$active_plugins = array();
+		foreach ( $active_plugin_files as $file ) {
+			$slug = $allowed_plugin_slugs[ $file ];
+			if ( 'jetpack' === $slug || 'woocommerce-services' === $slug ) {
+				// If Jetpack is installed but not connected, consider both WCS and Jetpack inactive for the purpose of onboarding.
+				if ( ! class_exists( 'Jetpack' ) || ! ( \Jetpack::is_active() || \Jetpack::is_development_mode() ) ) {
+					continue;
+				}
+			}
+			$active_plugins[] = $slug;
+		}
+		return $active_plugins;
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -322,6 +322,8 @@ class Onboarding {
 
 	/**
 	 * Gets an array of plugins that can be installed & activated via the onboarding wizard.
+	 *
+	 * @todo Handle edgecase of where installed plugins may have versioned folder names (i.e. `jetpack-master/jetpack.php`).
 	 */
 	public static function get_allowed_plugins() {
 		return apply_filters(


### PR DESCRIPTION
Fixes #2599.

This PR updates the main start page and the plugins install page to handle cases where Jetpack and/or WooCommerce Services are already installed or connected. This can happen with a hosting partner, for example.

This PR also updates the activate plugins endpoint. We were running into a race condition activating plugins in multiple requests so quickly. WP's active plugins are stored in a simple serialized array. In some cases, if both plugins were not active. WooCommerce Services would try to activate, and it would have a stale copy of the option, so Jetpack would get wiped out of the active plugins list. My solution for this is to allow activating multiple plugins in one request. Otherwise, we could artificially delay the requests or something else -- I'm open to ideas but think this will work the best.

### Screenshots

<img width="840" alt="Screen Shot 2019-08-21 at 12 20 32 PM" src="https://user-images.githubusercontent.com/689165/63449427-28867f00-c40e-11e9-9dd2-391842f1a19c.png">

### Detailed test instructions:

If Jetpack is in Development mode, it will be considered as connected in these steps. Disable development mode to disconnect.

---

* Deactivate and/or delete Jetpack & WooCommerce Services
* Run through the profile wizard, verify that benefits are shown for both products
* Continue and verify plugins install, activate, and take you to the connection screen

---

* Deactivate and/or delete WooCommerce Services
* Run through the profile wizard, verify that benefits are shown only for WooCommerce Services
* Continue and verify that WooCommerce Services installs and activates. You should be taken to the store details screen

---

* Activate both Jetpack & WooCommerce Services. Make sure Jetpack is connected or in development mode.
* Verify going to the main profiler redirects you to the store details page.