### PR TITLE
use wc-admin urls in devdocs

### DIFF
--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -12,7 +12,6 @@ import { find, get } from 'lodash';
 import ComponentExample from './example';
 import ComponentDocs from './docs';
 import { Card, Link } from '@woocommerce/components';
-import { getAdminLink } from '@woocommerce/navigation';
 import examples from './examples.json';
 import './style.scss';
 
@@ -63,15 +62,13 @@ export default class extends Component {
 								component ? (
 									componentName
 								) : (
-									<Link href={ getAdminLink( `?page=wc-admin&path=/devdocs/${ filePath }` ) }>
+									<Link href={ `admin.php?page=wc-admin&path=/devdocs/${ filePath }` }>
 										{ componentName }
 									</Link>
 								)
 							}
 							action={
-								component ? (
-									<Link href={ getAdminLink( '?page=wc-admin&path=/devdocs' ) }>Full list</Link>
-								) : null
+								component ? <Link href={ '?page=wc-admin&path=/devdocs' }>Full list</Link> : null
 							}
 						>
 							<ComponentExample

--- a/client/devdocs/index.js
+++ b/client/devdocs/index.js
@@ -62,13 +62,20 @@ export default class extends Component {
 								component ? (
 									componentName
 								) : (
-									<Link href={ `admin.php?page=wc-admin&path=/devdocs/${ filePath }` }>
+									<Link
+										href={ `admin.php?page=wc-admin&path=/devdocs/${ filePath }` }
+										type="wc-admin"
+									>
 										{ componentName }
 									</Link>
 								)
 							}
 							action={
-								component ? <Link href={ '?page=wc-admin&path=/devdocs' }>Full list</Link> : null
+								component ? (
+									<Link href={ '?page=wc-admin&path=/devdocs' } type="wc-admin">
+										Full list
+									</Link>
+								) : null
 							}
 						>
 							<ComponentExample


### PR DESCRIPTION
Fixes #2813

This PR changes the URLs used in the DevDocs page to use wc-admin URLs instead of fully qualified dashboard URLs.

### Detailed test instructions:

- Ensure navigation among regular dashboard pages, WC Admin, DevDocs main & component pages works without issue.

### Changelog Note:

Fix: Bug navigating from DevDoc component pages to WP dashboard pages.