### PR TITLE
Queue customer lookup updates.

### DIFF
--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -75,8 +75,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_new_customer', array( __CLASS__, 'update_registered_customer' ) );
-		add_action( 'woocommerce_update_customer', array( __CLASS__, 'update_registered_customer' ) );
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'update_registered_customer' ) );
 		add_action( 'updated_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
 	}

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -65,7 +65,12 @@ class ReportsSync {
 	const ORDERS_DELETE_BATCH_ACTION = 'wc-admin_delete_orders_batch';
 
 	/**
-	 * Action hook for importing a batch of orders.
+	 * Action hook for importing a single customer.
+	 */
+	const SINGLE_CUSTOMER_IMPORT_ACTION = 'wc-admin_import_customer';
+
+	/**
+	 * Action hook for importing a single order.
 	 */
 	const SINGLE_ORDER_IMPORT_ACTION = 'wc-admin_import_order';
 
@@ -116,6 +121,7 @@ class ReportsSync {
 		add_action( self::CUSTOMERS_IMPORT_BATCH_ACTION, array( __CLASS__, 'customer_lookup_import_batch' ), 10, 3 );
 		add_action( self::CUSTOMERS_DELETE_BATCH_INIT, array( __CLASS__, 'customer_lookup_delete_batch_init' ) );
 		add_action( self::CUSTOMERS_DELETE_BATCH_ACTION, array( __CLASS__, 'customer_lookup_delete_batch' ) );
+		add_action( self::SINGLE_CUSTOMER_IMPORT_ACTION, array( __CLASS__, 'customer_lookup_import_customer' ) );
 		add_action( self::ORDERS_IMPORT_BATCH_ACTION, array( __CLASS__, 'orders_lookup_import_batch' ), 10, 4 );
 		add_action( self::ORDERS_IMPORT_BATCH_INIT, array( __CLASS__, 'orders_lookup_import_batch_init' ), 10, 3 );
 		add_action( self::ORDERS_DELETE_BATCH_ACTION, array( __CLASS__, 'orders_lookup_delete_batch' ), 10, 4 );
@@ -714,7 +720,7 @@ class ReportsSync {
 
 		foreach ( $customer_ids as $customer_id ) {
 			// @todo Schedule single customer update if this fails?
-			CustomersDataStore::update_registered_customer( $customer_id );
+			self::customer_lookup_import_customer( $customer_id );
 		}
 
 		$imported_count = get_option( 'wc_admin_import_customers_count', 0 );
@@ -723,6 +729,44 @@ class ReportsSync {
 		$properties['imported_count'] = $imported_count;
 
 		wc_admin_record_tracks_event( 'import_job_complete', $properties );
+	}
+
+	/**
+	 * Schedule an action to import a single Customer.
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	public static function schedule_single_customer_import( $user_id ) {
+		// This can get called multiple times for a single customer, so we look
+		// for existing pending jobs for the same customer to avoid duplicating efforts.
+		$existing_jobs = self::queue()->search(
+			array(
+				'status'   => 'pending',
+				'per_page' => 1,
+				'claimed'  => false,
+				'hook'     => self::SINGLE_CUSTOMER_IMPORT_ACTION,
+				'args'     => array( $user_id ),
+				'group'    => self::QUEUE_GROUP,
+			)
+		);
+
+		if ( $existing_jobs ) {
+			// Bail out if there's a pending single customer action.
+			return;
+		}
+
+		self::queue()->schedule_single( time() + 5, self::SINGLE_CUSTOMER_IMPORT_ACTION, array( $user_id ), self::QUEUE_GROUP );
+	}
+
+	/**
+	 * Imports a single customer to update lookup tables for.
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	public static function customer_lookup_import_customer( $user_id ) {
+		CustomersDataStore::update_registered_customer( $user_id );
 	}
 
 	/**

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -113,6 +113,7 @@ class ReportsSync {
 	 */
 	public static function init() {
 		// Initialize syncing hooks.
+		add_action( 'wp_loaded', array( __CLASS__, 'customers_lookup_update_init' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'orders_lookup_update_init' ) );
 
 		// Initialize scheduled action handlers.
@@ -316,6 +317,16 @@ class ReportsSync {
 	}
 
 	/**
+	 * Attach customer lookup update hooks.
+	 */
+	public static function customers_lookup_update_init() {
+		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_single_customer_import' ) );
+		add_action( 'woocommerce_update_customer', array( __CLASS__, 'schedule_single_customer_import' ) );
+
+		CustomersDataStore::init();
+	}
+
+	/**
 	 * Attach order lookup update hooks.
 	 */
 	public static function orders_lookup_update_init() {
@@ -328,7 +339,6 @@ class ReportsSync {
 		add_action( 'woocommerce_refund_created', array( __CLASS__, 'schedule_single_order_import' ) );
 
 		OrdersStatsDataStore::init();
-		CustomersDataStore::init();
 		CouponsDataStore::init();
 		ProductsDataStore::init();
 		TaxesDataStore::init();

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -234,6 +234,7 @@ class ReportsSync {
 				self::ORDERS_IMPORT_BATCH_INIT,
 				self::ORDERS_DELETE_BATCH_INIT,
 				self::ORDERS_DELETE_BATCH_ACTION,
+				self::SINGLE_CUSTOMER_IMPORT_ACTION,
 				self::SINGLE_ORDER_IMPORT_ACTION,
 			);
 			$store->clear_pending_wcadmin_actions( $action_types );

--- a/tests/api/reports-customers.php
+++ b/tests/api/reports-customers.php
@@ -160,6 +160,8 @@ class WC_Tests_API_Reports_Customers extends WC_REST_Unit_Test_Case {
 		// Creating a customer should show up regardless of orders.
 		$customer = WC_Helper_Customer::create_customer( 'customer', 'password', 'customer@example.com' );
 
+		WC_Helper_Queue::run_all_pending();
+
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(

--- a/tests/api/reports-downloads-stats.php
+++ b/tests/api/reports-downloads-stats.php
@@ -152,6 +152,8 @@ class WC_Tests_API_Reports_Downloads_Stats extends WC_REST_Unit_Test_Case {
 		$order->save();
 		$order_1 = $order->get_id();
 
+		WC_Helper_Queue::run_all_pending();
+
 		$download = new WC_Customer_Download();
 		$download->set_user_id( 1 );
 		$download->set_order_id( $order->get_id() );

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -169,6 +169,8 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$object->set_timestamp( date( 'Y-m-d H:00:00', $time - ( 2 * DAY_IN_SECONDS ) ) );
 		$id = $object->save();
 
+		WC_Helper_Queue::run_all_pending();
+		
 		return array(
 			'time'      => $time,
 			'product_1' => $product_1,

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -119,9 +119,6 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $report['status'] );
 
-		// Run pending thrice to process batch and order.
-		WC_Helper_Queue::run_all_pending();
-		WC_Helper_Queue::run_all_pending();
 		WC_Helper_Queue::run_all_pending();
 
 		$request  = new WP_REST_Request( 'GET', '/wc/v4/reports/customers' );
@@ -164,9 +161,6 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $report['status'] );
 
-		// Run pending thrice to process batch and order.
-		WC_Helper_Queue::run_all_pending();
-		WC_Helper_Queue::run_all_pending();
 		WC_Helper_Queue::run_all_pending();
 
 		$request  = new WP_REST_Request( 'GET', '/wc/v4/reports/customers' );
@@ -267,9 +261,6 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $report['status'] );
 
-		// Run pending three times to process batches and dependent actions.
-		WC_Helper_Queue::run_all_pending();
-		WC_Helper_Queue::run_all_pending();
 		WC_Helper_Queue::run_all_pending();
 
 		// Check that stats have been deleted.
@@ -377,10 +368,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 0, $report['orders_count'] );
 		$this->assertEquals( 4, $report['orders_total'] );
 
-		// Run pending thrice to process batch and order.
-		WC_Helper_Queue::process_pending();
-		WC_Helper_Queue::process_pending();
-		WC_Helper_Queue::process_pending();
+		WC_Helper_Queue::run_all_pending();
 
 		// Test import status after processing.
 		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/status' );

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -206,7 +206,7 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		// Verify there are actions to cancel.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$this->assertCount( 1, $pending_actions );
+		$this->assertCount( 2, $pending_actions ); // 1 for the user, 1 for order.
 
 		// Cancel outstanding actions.
 		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/cancel' );

--- a/tests/framework/helpers/class-wc-helper-queue.php
+++ b/tests/framework/helpers/class-wc-helper-queue.php
@@ -34,24 +34,12 @@ class WC_Helper_Queue {
 	 * @return void
 	 */
 	public static function run_all_pending() {
-		$jobs = self::get_all_pending();
-
-		foreach ( $jobs as $job ) {
-			$job->execute();
-		}
-	}
-
-	/**
-	 * Run all pending queued actions.
-	 *
-	 * @return void
-	 */
-	public static function process_pending() {
-		$jobs = self::get_all_pending();
-
 		$queue_runner = new ActionScheduler_QueueRunner();
-		foreach ( $jobs as $job_id => $job ) {
-			$queue_runner->process_action( $job_id );
+
+		while ( $jobs = self::get_all_pending() ) {
+			foreach ( $jobs as $job_id => $job ) {
+				$queue_runner->process_action( $job_id );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #2702.

This PR introduces a `SINGLE_CUSTOMER_IMPORT_ACTION` to update the customer lookup table using Action Scheduler.

### Detailed test instructions:

- Use "Action Scheduler - Disable Default Queue Runner" plugin to see queued jobs before they're executed
- Place an order or create a WP user
- Verify a `wc-admin_import_customer` action is pending
- Verify that when run, the customer lookup table is updated

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: schedule customer lookup table updates instead of running during checkout.