### PR TITLE
Product in dropdown clickable in FF/Safari

### DIFF
--- a/packages/components/src/search/autocomplete.js
+++ b/packages/components/src/search/autocomplete.js
@@ -324,6 +324,12 @@ export class Autocomplete extends Component {
 									className={ classnames( 'woocommerce-search__autocomplete-result', className, {
 										'is-selected': index === selectedIndex,
 									} ) }
+									/*
+									 * On FF and Safari, if <Button> contains interior DOM nodes (i.e., <span>)
+									 * `handleFocusOutside` will be triggered before `onClick` and close the autocomplete.
+									 * Prevent focus from shifting to these nodes with onMouseDown.
+									 */
+									onMouseDown={ ( e ) => e.preventDefault() }
 									onClick={ () => this.select( option ) }
 								>
 									{ option.label }


### PR DESCRIPTION
Fixes #2729

The issue can be [recreated outside of woocommerce-admin](https://codesandbox.io/s/vigilant-wood-yuu2b) in FF and Safari, and impacts all `Autocomplete` components that have a `<Button>` with DOM nodes for `children` (i.e., Products, Categories, etc). 

Adding the `preventDefault` within `onMouseDown` seems to prevent focus from shifting to the `children` of a `<Button>`, and prevents triggering the `handleFocusOutside` by the `withFocusOutside` HOC.

_To recreate issue in CodeSandbox:_

**In FF or Safari: Clicking on button contents**
- Click the red area
- Click the blue area in the button
- In the console, you'll see the following logging: _focus_, _blur_, **outside**, _click_ 

**IN FF or Safari: Clicking on button**
- Click the red area
- Click the button (not the blue area)
- You'll see `handleFocusOutside` is not called
- In the console, you'll see the following logging: _focus_, _blur_, _click_


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [X] I've tested using only a keyboard (no mouse)

### Detailed test instructions:

- In FF or Safari, open Products view and select Show: Single Product
- Type in a product name
- Once the search results are shown, click directly on the underlined text
- The product should be selected
