### PR TITLE
Improve Autocomplete accessibility

### DIFF
--- a/packages/components/src/autocomplete/index.js
+++ b/packages/components/src/autocomplete/index.js
@@ -123,7 +123,7 @@ export class Autocomplete extends Component {
 		const filtered = [];
 
 		// Create a regular expression to filter the options.
-		const expression = getSearchExpression( escapeRegExp( query.trim() ) );
+		const expression = getSearchExpression( escapeRegExp( query ? query.trim() : '' ) );
 		const search = expression ? new RegExp( expression, 'i' ) : /^$/;
 
 		for ( let i = 0; i < options.length; i++ ) {

--- a/packages/components/src/autocomplete/list.js
+++ b/packages/components/src/autocomplete/list.js
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component, createRef } from '@wordpress/element';
 import { isEqual } from 'lodash';
-import { ENTER, ESCAPE, UP, DOWN, LEFT, TAB, RIGHT } from '@wordpress/keycodes';
+import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import PropTypes from 'prop-types';
 
 /**
@@ -82,7 +82,6 @@ class List extends Component {
 				event.stopPropagation();
 				break;
 
-			case TAB:
 			case DOWN:
 				nextSelectedIndex = null !== selectedIndex
 					? ( selectedIndex + 1 ) % filteredOptions.length
@@ -153,6 +152,7 @@ class List extends Component {
 								'is-selected': index === selectedIndex,
 							} ) }
 							onClick={ () => this.select( option ) }
+							tabIndex="-1"
 						>
 							{ option.label }
 						</Button>

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -55,6 +55,11 @@
 			width: 24px;
 		}
 
+		&.is-active {
+			box-shadow: 0 0 0 1px $new-muriel-primary-500;
+			border-color: $new-muriel-primary-500;
+		}
+
 		&.with-value .components-base-control__label,
 		&.is-active .components-base-control__label,
 		&.has-tags .components-base-control__label {
@@ -96,7 +101,7 @@
 		position: absolute;
 		left: 0;
 		right: 0;
-		top: 56px;
+		top: 57px;
 		z-index: 10;
 		overflow: scroll;
 		max-height: 350px;


### PR DESCRIPTION
Fixes #2833

Fixes keyboard events for the `Autocomplete` component and adds a focus outline using Muriel's primary color.

### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Screenshots
<img width="721" alt="Screen Shot 2019-08-26 at 3 38 22 PM" src="https://user-images.githubusercontent.com/10561050/63673782-a801bd00-c817-11e9-97ca-4db7d920562b.png">


### Detailed test instructions:
1. Go to the devdocs and navigate to the `Autocomplete` component.
2. On the inline tags example, click it to open the options list and hit "escape."  Make sure that no error is thrown.
3. Make sure focusing the input adds a blue outline with the muriel primary color.
4. Make sure "tab" navigates to the next element and not through the list options.