### PR TITLE
Onboarding: Update the product types to use IDs

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -119,19 +119,19 @@ class Onboarding {
 				),
 				'subscriptions' => array(
 					'label'   => __( 'Subscriptions', 'woocommerce-admin' ),
-					'product' => 'woocommerce-subscriptions',
+					'product' => 27147,
 				),
 				'memberships'   => array(
 					'label'   => __( 'Memberships', 'woocommerce-admin' ),
-					'product' => 'woocommerce-memberships',
+					'product' => 958589,
 				),
 				'composite'     => array(
 					'label'   => __( 'Composite Products', 'woocommerce-admin' ),
-					'product' => 'woocommerce-composite-products',
+					'product' => 216836,
 				),
 				'bookings'      => array(
 					'label'   => __( 'Bookings', 'woocommerce-admin' ),
-					'product' => 'WooCommerce Bookings',
+					'product' => 390890,
 				),
 			)
 		);
@@ -267,9 +267,9 @@ class Onboarding {
 		$product_data = json_decode( $woocommerce_products['body'] );
 		$products     = array();
 
-		// Map product data by slug.
+		// Map product data by ID.
 		foreach ( $product_data->products as $product_datum ) {
-			$products[ $product_datum->slug ] = $product_datum;
+			$products[ $product_datum->id ] = $product_datum;
 		}
 
 		// Loop over product types and append data.


### PR DESCRIPTION
Fixes #2666

Maps the product types to IDs instead of slugs in the profiler.

### Screenshots
<img width="517" alt="Screen Shot 2019-08-26 at 4 27 16 PM" src="https://user-images.githubusercontent.com/10561050/63676890-7dffc900-c81e-11e9-99d5-e405289a9f6c.png">

### Detailed test instructions:
1.  Visit the profiler product type step `/wp-admin/admin.php?page=wc-admin&step=product-types`
2.  Make sure information is still correctly mapped to products and prices show next to respective products.

Note that you don't need to delete the `wc_onboarding_product_data` transient to test this.