### PR TITLE
Fix Report Column and Indicator Labels

### DIFF
--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -47,7 +47,7 @@ const headers = [
 		label: 'Items Sold',
 	},
 	{
-		label: 'Orders Count',
+		label: 'Orders',
 	},
 	{
 		label: 'Net Revenue',

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -32,7 +32,7 @@ export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders Count', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -39,7 +39,7 @@ class CategoriesReportTable extends Component {
 				isLeftAligned: true,
 			},
 			{
-				label: __( 'Items sold', 'woocommerce-admin' ),
+				label: __( 'Items Sold', 'woocommerce-admin' ),
 				key: 'items_sold',
 				required: true,
 				defaultSort: true,

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -19,7 +19,7 @@ const ORDERS_REPORT_ADVANCED_FILTERS_FILTER = 'woocommerce_admin_orders_report_a
 export const charts = applyFilters( ORDERS_REPORT_CHARTS_FILTER, [
 	{
 		key: 'orders_count',
-		label: __( 'Orders Count', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce-admin' ),
 		type: 'number',
 	},
 	{

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -32,7 +32,7 @@ export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders Count', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -40,7 +40,7 @@ export const charts = applyFilters( TAXES_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'orders_count',
-		label: __( 'Orders Count', 'woocommerce-admin' ),
+		label: __( 'Orders', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'orders_count',
 		type: 'number',

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -84,7 +84,7 @@ class DashboardCharts extends Component {
 										} );
 									} }
 								>
-									{ __( `${ chart.label }`, 'woocommerce-admin' ) }
+									{ chart.label }
 								</MenuItem>
 							);
 						} ) }

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
@@ -74,7 +74,7 @@ class StorePerformance extends Component {
 										} );
 									} }
 								>
-									{ sprintf( __( 'Show %s', 'woocommerce-admin' ), indicator.label ) }
+									{ indicator.label }
 								</MenuItem>
 							);
 						} ) }

--- a/src/API/Reports/Coupons/Stats/Controller.php
+++ b/src/API/Reports/Coupons/Stats/Controller.php
@@ -157,6 +157,7 @@ class Controller extends \WC_REST_Reports_Controller {
 				'readonly'    => true,
 			),
 			'orders_count'  => array(
+				'title'       => __( 'Discounted Orders', 'woocommerce-admin' ),
 				'description' => __( 'Number of discounted orders.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),

--- a/src/API/Reports/Downloads/Stats/Controller.php
+++ b/src/API/Reports/Downloads/Stats/Controller.php
@@ -143,6 +143,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$totals = array(
 			'download_count' => array(
+				'title'       => __( 'Downloads', 'woocommerce-admin' ),
 				'description' => __( 'Number of downloads.', 'woocommerce-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -159,6 +159,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 				'format'      => 'currency',
 			),
 			'orders_count'            => array(
+				'title'       => __( 'Orders', 'woocommerce-admin' ),
 				'description' => __( 'Number of orders', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -157,8 +157,9 @@ class Controller extends \WC_REST_Reports_Controller {
 
 					$stat            = $prefix . '/' . $property_key;
 					$allowed_stats[] = $stat;
+					$stat_label      = empty( $schema_info['title'] ) ? $schema_info['description'] : $schema_info['title'];
 
-					$this->labels[ $stat ]  = trim( preg_replace( '/\W+/', ' ', $schema_info['description'] ) );
+					$this->labels[ $stat ]  = trim( preg_replace( '/\W+/', ' ', $stat_label ) );
 					$this->formats[ $stat ] = isset( $schema_info['format'] ) ? $schema_info['format'] : 'number';
 				}
 

--- a/src/API/Reports/Products/Stats/Controller.php
+++ b/src/API/Reports/Products/Stats/Controller.php
@@ -157,6 +157,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
+				'title'       => __( 'Items Sold', 'woocommerce-admin' ),
 				'description' => __( 'Number of items sold.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),

--- a/src/API/Reports/Revenue/Stats/Controller.php
+++ b/src/API/Reports/Revenue/Stats/Controller.php
@@ -171,6 +171,7 @@ class Controller extends \WC_REST_Reports_Controller {
 				'format'      => 'currency',
 			),
 			'shipping'       => array(
+				'title'       => __( 'Shipping', 'woocommerce-admin' ),
 				'description' => __( 'Total of shipping.', 'woocommerce-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
@@ -186,6 +187,7 @@ class Controller extends \WC_REST_Reports_Controller {
 				'format'      => 'currency',
 			),
 			'refunds'        => array(
+				'title'       => __( 'Refunds', 'woocommerce-admin' ),
 				'description' => __( 'Total of refunds.', 'woocommerce-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -102,13 +102,13 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 		$this->assertEquals( 2, count( $reports ) );
 
 		$this->assertEquals( 'orders/orders_count', $reports[0]['stat'] );
-		$this->assertEquals( 'Number of orders', $reports[0]['label'] );
+		$this->assertEquals( 'Orders', $reports[0]['label'] );
 		$this->assertEquals( 1, $reports[0]['value'] );
 		$this->assertEquals( 'orders_count', $reports[0]['chart'] );
 		$this->assertEquals( '/analytics/orders', $response->data[0]['_links']['report'][0]['href'] );
 
 		$this->assertEquals( 'downloads/download_count', $reports[1]['stat'] );
-		$this->assertEquals( 'Number of downloads', $reports[1]['label'] );
+		$this->assertEquals( 'Downloads', $reports[1]['label'] );
 		$this->assertEquals( 2, $reports[1]['value'] );
 		$this->assertEquals( 'download_count', $reports[1]['chart'] );
 		$this->assertEquals( '/analytics/downloads', $response->data[1]['_links']['report'][0]['href'] );


### PR DESCRIPTION
Fixes #1677.

This PR cleans up some old terminology on the Dashboard and in some Reports.

### Detailed test instructions:

- Check the dashboard and report labels

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: consistent naming for report columns.