### PR TITLE
Fix conflict with Blocks 2.4

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -519,6 +519,10 @@ class Loader {
 	 * @return array Array of component settings.
 	 */
 	public static function add_component_settings( $settings ) {
+		if ( ! is_admin() ) {
+			return $settings;
+		}
+		
 		if ( ! function_exists( 'wc_blocks_container' ) ) {
 			global $wp_locale;
 			// inject data not available via older versions of wc_blocks/woo.
@@ -536,6 +540,7 @@ class Loader {
 					: array_values( $wp_locale->weekday_abbrev )
 			];
 		}
+
 		$preload_data_endpoints = apply_filters( 'woocommerce_component_settings_preload_endpoints', array( '/wc/v3' ) );
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$preload_data = array_reduce(

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -347,7 +347,7 @@ class PageController {
 		}
 
 		// Disable embed on the block editor.
-		$current_screen = get_current_screen();
+		$current_screen = did_action( 'current_screen' ) ? get_current_screen() : false;
 		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
 			$is_connected_page = false;
 		}


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/916/files
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2938

WC-Admin calls `get_current_screen` on non-admin screens. These checks protect against that happening.

### Detailed test instructions:

You can test against Blocks 2.4. Before this patch, viewing the frontend of the store shows the following fatal:
![slack-imgs](https://user-images.githubusercontent.com/90977/63774879-1907aa00-c8d6-11e9-8049-1c5c062de1cc.png)
