### PR TITLE
Onboarding: Add "Customize Appearance" task

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -17,6 +17,7 @@ import { updateQueryString } from '@woocommerce/navigation';
  * Internal depdencies
  */
 import './style.scss';
+import Appearance from './tasks/appearance';
 import Connect from './tasks/connect';
 import Products from './tasks/products';
 import Shipping from './tasks/shipping';
@@ -72,12 +73,13 @@ class TaskDashboard extends Component {
 				visible: true,
 			},
 			{
-				key: 'personalize-store',
+				key: 'appearance',
 				title: __( 'Personalize your store', 'woocommerce-admin' ),
 				content: __( 'Create a custom homepage and upload your logo', 'wooocommerce-admin' ),
 				before: <i className="material-icons-outlined">palette</i>,
 				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: noop,
+				onClick: () => updateQueryString( { task: 'appearance' } ),
+				container: <Appearance />,
 				visible: true,
 			},
 			{

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { filter, noop } from 'lodash';
+import { filter } from 'lodash';
 import { compose } from '@wordpress/compose';
 
 /**

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -225,3 +225,9 @@
 		}
 	}
 }
+
+.woocommerce-task-appearance {
+	.muriel-image-upload {
+		margin-bottom: $gap-smallest;
+	}
+}

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -1,0 +1,133 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from 'newspack-components';
+import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { filter } from 'lodash';
+import { withDispatch } from '@wordpress/data';
+
+/**
+ * WooCommerce dependencies
+ */
+import { Card, Stepper } from '@woocommerce/components';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
+
+class Appearance extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			stepIndex: 0,
+		};
+
+		this.completeStep = this.completeStep.bind( this );
+	}
+
+	completeStep() {
+		const { stepIndex } = this.state;
+		const nextStep = this.getSteps()[ stepIndex + 1 ];
+
+		if ( nextStep ) {
+			this.setState( { stepIndex: stepIndex + 1 } );
+		} else {
+			getHistory().push( getNewPath( {}, '/', {} ) );
+		}
+	}
+
+	getSteps() {
+		const steps = [
+			{
+				key: 'import',
+				label: __( 'Import demo products', 'woocommerce-admin' ),
+				description: __(
+					'We’ll add some products that it will make it easier to see what your store looks like.',
+					'woocommerce-admin'
+				),
+				content: (
+					<Fragment>
+						<Button isPrimary>{ __( 'Import products', 'woocommerce-admin' ) }</Button>
+						<Button onClick={ () => this.completeStep() }>
+							{ __( 'Skip', 'woocommerce-admin' ) }
+						</Button>
+					</Fragment>
+				),
+				visible: true,
+			},
+			{
+				key: 'homepage',
+				label: __( 'Create a custom homepage', 'woocommerce-admin' ),
+				description: __(
+					'Create a new homepage and customize it to suit your needs',
+					'woocommerce-admin'
+				),
+				content: (
+					<Fragment>
+						<Button isPrimary>{ __( 'Create homepage', 'woocommerce-admin' ) }</Button>
+						<Button onClick={ () => this.completeStep() }>
+							{ __( 'Skip', 'woocommerce-admin' ) }
+						</Button>
+					</Fragment>
+				),
+				visible: true,
+			},
+			{
+				key: 'logo',
+				label: __( 'Upload a logo', 'woocommerce-admin' ),
+				description: __( 'Ensure your store is on-brand by adding your logo', 'woocommerce-admin' ),
+				content: (
+					<Fragment>
+						<Button isPrimary>{ __( 'Proceed', 'woocommerce-admin' ) }</Button>
+						<Button onClick={ () => this.completeStep() }>
+							{ __( 'Skip', 'woocommerce-admin' ) }
+						</Button>
+					</Fragment>
+				),
+				visible: true,
+			},
+			{
+				key: 'notice',
+				label: __( 'Set a store notice', 'woocommerce-admin' ),
+				description: __(
+					'Optionally display a prominent notice across all pages of your store',
+					'woocommerce-admin'
+				),
+				content: (
+					<Fragment>
+						<Button isPrimary>{ __( 'Complete task', 'woocommerce-admin' ) }</Button>
+					</Fragment>
+				),
+				visible: true,
+			},
+		];
+
+		return filter( steps, step => step.visible );
+	}
+
+	render() {
+		const { stepIndex } = this.state;
+
+		return (
+			<div className="woocommerce-task-tax">
+				<Card className="is-narrow">
+					<Stepper
+						isVertical={ true }
+						currentStep={ this.getSteps()[ stepIndex ].key }
+						steps={ this.getSteps() }
+					/>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default compose(
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		return {
+			createNotice,
+		};
+	} )
+)( Appearance );

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -190,7 +190,7 @@ class Appearance extends Component {
 		const { isRequesting, hasErrors } = this.props;
 
 		return (
-			<div className="woocommerce-task-tax">
+			<div className="woocommerce-task-appearance">
 				<Card className="is-narrow">
 					<Stepper
 						isPending={ isRequesting && ! hasErrors }

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -59,12 +59,12 @@ class Appearance extends Component {
 		}
 
 		if ( 'logo' === step && isRequestSuccessful ) {
-			createNotice( 'success', __( 'Store logo updated sucessfully.' ) );
+			createNotice( 'success', __( 'Store logo updated sucessfully.', 'woocommerce-admin' ) );
 			this.completeStep();
 		}
 
 		if ( 'notice' === step && isRequestSuccessful ) {
-			createNotice( 'success', __( 'Store notice updated sucessfully.' ) );
+			createNotice( 'success', __( 'Store notice updated sucessfully.', 'woocommerce-admin' ) );
 			this.completeStep();
 		}
 

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -4,7 +4,9 @@
  */
 import { MINUTE } from '@fresh-data/framework';
 
+export const JETPACK_NAMESPACE = '/jetpack/v4';
 export const NAMESPACE = '/wc/v4';
+export const WC_ADMIN_NAMESPACE = '/wc-admin/v1';
 
 export const DEFAULT_REQUIREMENT = {
 	timeout: 1 * MINUTE,

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -5,12 +5,6 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Onboarding namespace.
- */
-export const NAMESPACE = '/wc-admin/v1';
-export const JETPACK_NAMESPACE = '/jetpack/v4';
-
-/**
  * Plugin slugs and names as key/value pairs.
  */
 export const pluginNames = {

--- a/client/wc-api/onboarding/operations.js
+++ b/client/wc-api/onboarding/operations.js
@@ -10,7 +10,8 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { getResourceName } from '../utils';
-import { JETPACK_NAMESPACE, NAMESPACE, pluginNames } from './constants';
+import { JETPACK_NAMESPACE, WC_ADMIN_NAMESPACE } from '../constants';
+import { pluginNames } from './constants';
 
 function read( resourceNames, fetch = apiFetch ) {
 	return [
@@ -33,7 +34,7 @@ function readProfileItems( resourceNames, fetch ) {
 	const resourceName = 'onboarding-profile';
 
 	if ( resourceNames.includes( resourceName ) ) {
-		const url = NAMESPACE + '/onboarding/profile';
+		const url = WC_ADMIN_NAMESPACE + '/onboarding/profile';
 
 		return [
 			fetch( { path: url } )
@@ -51,7 +52,7 @@ function updateProfileItems( resourceNames, data, fetch ) {
 	const resourceName = 'onboarding-profile';
 
 	if ( resourceNames.includes( resourceName ) ) {
-		const url = NAMESPACE + '/onboarding/profile';
+		const url = WC_ADMIN_NAMESPACE + '/onboarding/profile';
 
 		return [
 			fetch( {
@@ -103,7 +104,7 @@ function profileItemToResource( items ) {
 function readActivePlugins( resourceNames, fetch ) {
 	const resourceName = 'active-plugins';
 	if ( resourceNames.includes( resourceName ) ) {
-		const url = NAMESPACE + '/onboarding/plugins/active';
+		const url = WC_ADMIN_NAMESPACE + '/onboarding/plugins/active';
 
 		return [
 			fetch( { path: url } )
@@ -131,7 +132,7 @@ function activatePlugins( resourceNames, data, fetch ) {
 	const resourceName = 'plugin-activate';
 	if ( resourceNames.includes( resourceName ) ) {
 		const plugins = data[ resourceName ];
-		const url = NAMESPACE + '/onboarding/plugins/activate';
+		const url = WC_ADMIN_NAMESPACE + '/onboarding/plugins/activate';
 		return [
 			fetch( {
 				path: url,
@@ -197,7 +198,7 @@ function readJetpackConnectUrl( resourceNames, fetch ) {
 	const resourceName = 'jetpack-connect-url';
 
 	if ( resourceNames.includes( resourceName ) ) {
-		const url = NAMESPACE + '/onboarding/plugins/connect-jetpack';
+		const url = WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-jetpack';
 
 		return [
 			fetch( {
@@ -245,7 +246,7 @@ function installPlugins( resourceNames, data, fetch ) {
 
 		return plugins.map( async plugin => {
 			return fetch( {
-				path: `${ NAMESPACE }/onboarding/plugins/install`,
+				path: `${ WC_ADMIN_NAMESPACE }/onboarding/plugins/install`,
 				method: 'POST',
 				data: {
 					plugin,

--- a/client/wc-api/options/index.js
+++ b/client/wc-api/options/index.js
@@ -1,0 +1,13 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import operations from './operations';
+import selectors from './selectors';
+import mutations from './mutations';
+
+export default {
+	operations,
+	selectors,
+	mutations,
+};

--- a/client/wc-api/options/mutations.js
+++ b/client/wc-api/options/mutations.js
@@ -1,0 +1,10 @@
+/** @format */
+
+const updateOptions = operations => options => {
+	const resourceKey = 'options';
+	operations.update( [ resourceKey ], { [ resourceKey ]: options } );
+};
+
+export default {
+	updateOptions,
+};

--- a/client/wc-api/options/mutations.js
+++ b/client/wc-api/options/mutations.js
@@ -1,8 +1,13 @@
 /** @format */
 
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../utils';
+
 const updateOptions = operations => options => {
-	const resourceKey = 'options';
-	operations.update( [ resourceKey ], { [ resourceKey ]: options } );
+	const resourceName = getResourceName( 'options', Object.keys( options ) );
+	operations.update( [ resourceName ], { [ resourceName ]: options } );
 };
 
 export default {

--- a/client/wc-api/options/operations.js
+++ b/client/wc-api/options/operations.js
@@ -44,10 +44,10 @@ function updateOptions( resourceNames, data, fetch ) {
 	} );
 
 	return filteredNames.map( async resourceName => {
-		return fetch( { path: url, method: 'POST', data: data.options } )
-			.then( () => optionsToResource( data ) )
+		return fetch( { path: url, method: 'POST', data: data[ resourceName ] } )
+			.then( () => optionsToResource( data[ resourceName ] ) )
 			.catch( error => {
-				return { [ resourceName ]: { error: String( error.message ) } };
+				return { [ resourceName ]: { error } };
 			} );
 	} );
 }

--- a/client/wc-api/options/operations.js
+++ b/client/wc-api/options/operations.js
@@ -9,7 +9,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { getResourceIdentifier, getResourceName } from '../utils';
-import { NAMESPACE } from '../constants';
+import { WC_ADMIN_NAMESPACE } from '../constants';
 
 function read( resourceNames, fetch = apiFetch ) {
 	return [ ...readOptions( resourceNames, fetch ) ];
@@ -26,7 +26,7 @@ function readOptions( resourceNames, fetch ) {
 
 	return filteredNames.map( async resourceName => {
 		const optionNames = getResourceIdentifier( resourceName );
-		const url = NAMESPACE + '/options?options=' + optionNames.join( ',' );
+		const url = WC_ADMIN_NAMESPACE + '/options?options=' + optionNames.join( ',' );
 
 		return fetch( { path: url } )
 			.then( optionsToResource )
@@ -37,7 +37,7 @@ function readOptions( resourceNames, fetch ) {
 }
 
 function updateOptions( resourceNames, data, fetch ) {
-	const url = NAMESPACE + '/options';
+	const url = WC_ADMIN_NAMESPACE + '/options';
 
 	const filteredNames = resourceNames.filter( name => {
 		return name.startsWith( 'options' );

--- a/client/wc-api/options/operations.js
+++ b/client/wc-api/options/operations.js
@@ -1,0 +1,76 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceIdentifier, getResourceName } from '../utils';
+import { NAMESPACE } from '../constants';
+
+function read( resourceNames, fetch = apiFetch ) {
+	return [ ...readOptions( resourceNames, fetch ) ];
+}
+
+function update( resourceNames, data, fetch = apiFetch ) {
+	return [ ...updateOptions( resourceNames, data, fetch ) ];
+}
+
+function readOptions( resourceNames, fetch ) {
+	const filteredNames = resourceNames.filter( name => {
+		return name.startsWith( 'options' );
+	} );
+
+	return filteredNames.map( async resourceName => {
+		const optionNames = getResourceIdentifier( resourceName );
+		const url = NAMESPACE + '/options?options=' + optionNames.join( ',' );
+
+		return fetch( { path: url } )
+			.then( optionsToResource )
+			.catch( error => {
+				return { [ resourceName ]: { error: String( error.message ) } };
+			} );
+	} );
+}
+
+function updateOptions( resourceNames, data, fetch ) {
+	const url = NAMESPACE + '/options';
+
+	const filteredNames = resourceNames.filter( name => {
+		return name.startsWith( 'options' );
+	} );
+
+	return filteredNames.map( async resourceName => {
+		return fetch( { path: url, method: 'POST', data: data.options } )
+			.then( () => optionsToResource( data ) )
+			.catch( error => {
+				return { [ resourceName ]: { error: String( error.message ) } };
+			} );
+	} );
+}
+
+function optionsToResource( options ) {
+	const optionNames = Object.keys( options );
+	const resourceName = getResourceName( 'options', optionNames );
+	const resources = {};
+
+	optionNames.forEach(
+		optionName =>
+			( resources[ getResourceName( 'options', optionName ) ] = { data: options[ optionName ] } )
+	);
+
+	return {
+		[ resourceName ]: {
+			data: optionNames,
+		},
+		...resources,
+	};
+}
+
+export default {
+	read,
+	update,
+};

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -1,0 +1,48 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { isNil } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_REQUIREMENT } from '../constants';
+import { getResourceName } from '../utils';
+
+const getOptions = ( getResource, requireResource ) => (
+	optionNames,
+	requirement = DEFAULT_REQUIREMENT
+) => {
+	const resourceName = getResourceName( 'options', optionNames );
+	const options = {};
+
+	const names = requireResource( requirement, resourceName ).data || [];
+
+	names.forEach( name => {
+		options[ name ] = getResource( getResourceName( 'options', name ) ).data;
+	} );
+
+	return options;
+};
+
+const getOptionError = getResource => name => {
+	return getResource( getResourceName( 'options', name ) ).error;
+};
+
+const isGetOptionsRequesting = getResource => name => {
+	const { lastReceived, lastRequested } = getResource( getResourceName( 'options', name ) );
+
+	if ( ! isNil( lastRequested ) && isNil( lastReceived ) ) {
+		return true;
+	}
+
+	return lastRequested > lastReceived;
+};
+
+export default {
+	getOptions,
+	getOptionError,
+	isGetOptionsRequesting,
+};

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -27,12 +27,12 @@ const getOptions = ( getResource, requireResource ) => (
 	return options;
 };
 
-const getOptionError = getResource => name => {
-	return getResource( getResourceName( 'options', name ) ).error;
+const getOptionsError = getResource => optionNames => {
+	return getResource( getResourceName( 'options', optionNames ) ).error;
 };
 
-const isGetOptionsRequesting = getResource => name => {
-	const { lastReceived, lastRequested } = getResource( getResourceName( 'options', name ) );
+const isOptionsRequesting = getResource => optionNames => {
+	const { lastReceived, lastRequested } = getResource( getResourceName( 'options', optionNames ) );
 
 	if ( ! isNil( lastRequested ) && isNil( lastReceived ) ) {
 		return true;
@@ -43,6 +43,6 @@ const isGetOptionsRequesting = getResource => name => {
 
 export default {
 	getOptions,
-	getOptionError,
-	isGetOptionsRequesting,
+	getOptionsError,
+	isOptionsRequesting,
 };

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -7,6 +7,7 @@ import items from './items';
 import imports from './imports';
 import notes from './notes';
 import onboarding from './onboarding';
+import options from './options';
 import reportItems from './reports/items';
 import reportStats from './reports/stats';
 import reviews from './reviews';
@@ -20,6 +21,7 @@ function createWcApiSpec() {
 			...items.mutations,
 			...notes.mutations,
 			...onboarding.mutations,
+			...options.mutations,
 			...settings.mutations,
 			...user.mutations,
 		},
@@ -28,6 +30,7 @@ function createWcApiSpec() {
 			...items.selectors,
 			...notes.selectors,
 			...onboarding.selectors,
+			...options.selectors,
 			...reportItems.selectors,
 			...reportStats.selectors,
 			...reviews.selectors,
@@ -46,6 +49,7 @@ function createWcApiSpec() {
 					...items.operations.read( resourceNames ),
 					...notes.operations.read( resourceNames ),
 					...onboarding.operations.read( resourceNames ),
+					...options.operations.read( resourceNames ),
 					...reportItems.operations.read( resourceNames ),
 					...reportStats.operations.read( resourceNames ),
 					...reviews.operations.read( resourceNames ),
@@ -58,6 +62,7 @@ function createWcApiSpec() {
 					...items.operations.update( resourceNames, data ),
 					...notes.operations.update( resourceNames, data ),
 					...onboarding.operations.update( resourceNames, data ),
+					...options.operations.update( resourceNames, data ),
 					...settings.operations.update( resourceNames, data ),
 					...user.operations.update( resourceNames, data ),
 				];

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -43,6 +43,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\DataCountries',
 			'Automattic\WooCommerce\Admin\API\DataDownloadIPs',
 			'Automattic\WooCommerce\Admin\API\Leaderboards',
+			'Automattic\WooCommerce\Admin\API\Options',
 			'Automattic\WooCommerce\Admin\API\Orders',
 			'Automattic\WooCommerce\Admin\API\Products',
 			'Automattic\WooCommerce\Admin\API\ProductCategories',

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -23,7 +23,7 @@ class Options extends \WC_REST_Data_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc/v4';
+	protected $namespace = 'wc-admin/v1';
 
 	/**
 	 * Route base.
@@ -64,7 +64,7 @@ class Options extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to manage plugins.
+	 * Check if a given request has access to manage options.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * REST API Options Controller
+ *
+ * Handles requests to get and update options in the wp_options table.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Options Controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class Options extends \WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v4';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'options';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_options' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_options' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to manage plugins.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage options.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Gets an array of options and respective values.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array Options object with option values.
+	 */
+	public function get_options( $request ) {
+		$params = explode( ',', $request[ 'options' ] );
+		$options  = array();
+
+		if ( ! is_array( $params ) ) {
+			return array();
+		}
+
+		foreach ( $params as $option ) {
+			$options[ $option ] = get_option( $option );
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Updates an array of objects.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array Options object with a boolean if the option was updated.
+	 */
+	public function update_options( $request ) {
+		$params = $request->get_json_params();
+		$updated = array();
+
+		if ( ! is_array( $params ) ) {
+			return array();
+		}
+
+		foreach ( $params as $key => $value ) {
+			$updated[ $key ] = update_option( $key, $value );
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Get the schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'options',
+			'type'       => 'object',
+			'properties' => array(
+				'options' => array(
+					'type'        => 'array',
+					'description' => __( 'Array of options with associated values.', 'woocommerce-admin' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -54,6 +54,7 @@ class Onboarding {
 		}
 
 		// Include WC Admin Onboarding classes.
+		// @todo We should return early if should_show_profiler and a new method should_show_tasks are both false.
 		OnboardingTasks::get_instance();
 
 		add_action( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 ); // Run after Automattic\WooCommerce\Admin\Loader.

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -47,9 +47,17 @@ class OnboardingTasks {
 	 * Constructor
 	 */
 	public function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_media_scripts' ) );
 		add_action( 'woocommerce_components_settings', array( $this, 'component_settings' ), 30 ); // Run after Onboarding.
 		add_action( 'admin_init', array( $this, 'set_active_task' ), 20 );
 		add_action( 'admin_init', array( $this, 'check_active_task_completion' ), 1 );
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	public function add_media_scripts() {
+		wp_enqueue_media();
 	}
 
 	/**
@@ -72,6 +80,7 @@ class OnboardingTasks {
 		}
 
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
+		$settings['onboarding']['customLogo']                     = get_theme_mod( 'custom_logo', false );
 		$settings['onboarding']['tasks']                          = $tasks;
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
 


### PR DESCRIPTION
Fixes #2480 

Adds the base task for "Customize Appearance", including the logo uploading step and the store notice step.

The homepage template and product import steps will occur in a follow-up.

### Questions/Thoughts

* The options REST API is very open-ended and probably needs more thought.  Should we consider whitelisting specific options (possibly with more specific capabilities and a filter for extensibility)?  Or should we scrap this and create individual APIs for theme mods and store settings?
* The image uploader component is not what's used in the design, but it's a component available in newspack that offers the added benefit of showing the actual logo.  Does this need tweaking or should we build out per design specs with a text input instead? /cc @LevinMedia @jameskoster 

### Screenshots
<img width="704" alt="Screen Shot 2019-08-29 at 5 45 18 PM" src="https://user-images.githubusercontent.com/10561050/63930049-2a42e900-ca85-11e9-9a0c-b13aa487d824.png">
<img width="708" alt="Screen Shot 2019-08-29 at 5 36 05 PM" src="https://user-images.githubusercontent.com/10561050/63930052-2a42e900-ca85-11e9-91d6-3c6742bd0676.png">

### Detailed test instructions:

1. Activate a theme that has declared support for `custom_logo`.
2. Remove the custom logo in the Customizer under Site Identity.
3. Visit the "Customize Appearance" task from the task list.
4. Skip the first 2 steps.
5. Select a logo and continue.
6. Enter a store notice or remove a store notice to disable the notice.
7. Make sure both of the above inputs were updated correctly and reflected in the site.