### PR TITLE
Onboarding: Add task list toggle option

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -27,8 +27,11 @@ class Dashboard extends Component {
 		}
 
 		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
-		const requiredTasksComplete = true;
-		if ( window.wcAdminFeatures.onboarding && ! requiredTasksComplete ) {
+		if (
+			window.wcAdminFeatures.onboarding &&
+			wcSettings.onboarding &&
+			! wcSettings.onboarding.taskListHidden
+		) {
 			return <TaskList query={ query } />;
 		}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -54,14 +54,17 @@ class Onboarding {
 		}
 
 		// Include WC Admin Onboarding classes.
-		OnboardingTasks::get_instance();
+		if ( $this->should_show_tasks() ) {
+			OnboardingTasks::get_instance();
+		}
 
 		add_action( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 ); // Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
-		add_action( 'current_screen', array( $this, 'reset_onboarding' ) );
+		add_action( 'current_screen', array( $this, 'reset_profiler' ) );
+		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
 	}
@@ -88,8 +91,7 @@ class Onboarding {
 	 * @return bool
 	 */
 	public function should_show_tasks() {
-		// @todo Implement logic for this.
-		return true;
+		return 'no' === get_option( 'woocommerce_task_list_hidden', 'no' );
 	}
 
 	/**
@@ -316,8 +318,9 @@ class Onboarding {
 		$profile['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
 		$settings['onboarding'] = array(
-			'industries' => self::get_allowed_industries(),
-			'profile'    => $profile,
+			'industries'     => self::get_allowed_industries(),
+			'profile'        => $profile,
+			'taskListHidden' => ! $this->should_show_tasks(),
 		);
 
 		// Only fetch if the onboarding wizard is incomplete.
@@ -408,7 +411,7 @@ class Onboarding {
 		}
 
 		$help_tabs = $screen->get_help_tabs();
-
+		
 		foreach ( $help_tabs as $help_tab ) {
 			if ( 'woocommerce_onboard_tab' !== $help_tab['id'] ) {
 				continue;
@@ -417,19 +420,32 @@ class Onboarding {
 			$screen->remove_help_tab( 'woocommerce_onboard_tab' );
 			$help_tab['content'] = '<h2>' . __( 'Setup wizard', 'woocommerce-admin' ) . '</h2>' .
 				'<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-				'<p><a href="' . wc_admin_url( '&reset_onboarding=1' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
+				'<p><a href="' . wc_admin_url( '&reset_profiler=1' ) . '" class="button button-primary">' . __( 'Setup wizard', 'woocommerce-admin' ) . '</a></p>';
 			$screen->add_help_tab( $help_tab );
 		}
+
+		$task_list_hidden = get_option( 'woocommerce_task_list_hidden', 'no' );
+		$task_list_tab    = array(
+			'id'      => 'woocommerce_task_list_tab',
+			'title'   => __( 'Task list', 'woocommerce-admin' ),
+			'content' => '<h2>' . __( 'Task list', 'woocommerce-admin' ) . '</h2>' .
+				'<p>' . __( 'If you need to enable or disable the task list, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
+				( 'yes' === $task_list_hidden
+					? '<p><a href="' . wc_admin_url( '&reset_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
+					: '<p><a href="' . wc_admin_url( '&reset_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
+				),
+		);
+		$screen->add_help_tab( $task_list_tab );
 	}
 
 	/**
 	 * Reset the onboarding profiler and redirect to the profiler.
 	 */
-	public static function reset_onboarding() {
+	public static function reset_profiler() {
 		if (
 			! Loader::is_admin_page() ||
-			! isset( $_GET['reset_onboarding'] ) || // WPCS: CSRF ok.
-			1 !== absint( $_GET['reset_onboarding'] ) // WPCS: CSRF ok.
+			! isset( $_GET['reset_profiler'] ) || // WPCS: CSRF ok.
+			1 !== absint( $_GET['reset_profiler'] ) // WPCS: CSRF ok.
 		) {
 			return;
 		}
@@ -445,5 +461,22 @@ class Onboarding {
 			)
 		);
 		$response = rest_do_request( $request );
+	}
+
+	/**
+	 * Reset the onboarding task list and redirect to the dashboard.
+	 */
+	public static function reset_task_list() {
+		if (
+			! Loader::is_admin_page() ||
+			! isset( $_GET['reset_task_list'] ) // WPCS: CSRF ok.
+		) {
+			return;
+		}
+
+		$new_value = 1 === absint( $_GET['reset_task_list'] ) ? 'no' : 'yes'; // WPCS: CSRF ok.
+		update_option( 'woocommerce_task_list_hidden', $new_value );
+		wp_safe_redirect( wc_admin_url() );
+		exit;
 	}
 }

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -461,6 +461,8 @@ class Onboarding {
 			)
 		);
 		$response = rest_do_request( $request );
+		wp_safe_redirect( wc_admin_url() );
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2861 

Adds a temporary method to toggle on/off the task list.

### Screenshots
<img width="674" alt="Screen Shot 2019-08-30 at 12 17 34 PM" src="https://user-images.githubusercontent.com/10561050/63992816-4f386a00-cb20-11e9-92cd-53f36d229557.png">

### Detailed test instructions:
1. Go to the Products page.
2. Click on the "Help" tab in the upper-right corner.
3.  Navigate to "Task List."
4.  Enable/Disable the task list and make sure you're redirected to the dashboard and the task list is toggled on/off depending on previous state.