### PR TITLE
Onboarding: Add "Import products" step

### DIFF
--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -82,6 +82,7 @@ class Init {
 					'Automattic\WooCommerce\Admin\API\OnboardingLevels',
 					'Automattic\WooCommerce\Admin\API\OnboardingProfile',
 					'Automattic\WooCommerce\Admin\API\OnboardingPlugins',
+					'Automattic\WooCommerce\Admin\API\OnboardingTasks',
 				)
 			);
 		}

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -59,7 +59,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 */
 	public function import_products_permission_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( 'product', 'create' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * REST API Onboarding Tasks Controller
+ *
+ * Handles requests to complete various onboarding tasks.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+use Automattic\WooCommerce\Admin\Features\Onboarding;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Onboarding Tasks Controller.
+ *
+ * @package WooCommerce Admin/API
+ * @extends WC_REST_Data_Controller
+ */
+class OnboardingTasks extends \WC_REST_Data_Controller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-admin/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'onboarding/tasks';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/import_sample_products',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'import_sample_products' ),
+					'permission_callback' => array( $this, 'import_products_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to create a product.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function import_products_permission_check( $request ) {
+		if ( ! wc_rest_check_post_permissions( 'product', 'create' ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Import sample products from WooCommerce sample CSV.
+	 *
+	 * @return WP_Error|WP_REST_Response	 * 
+	 */
+	public static function import_sample_products() {
+		include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
+		$file = WC_ABSPATH . 'sample-data/sample_products.csv';
+
+		if ( file_exists( $file ) && class_exists( 'WC_Product_CSV_Importer' ) ) {
+			// Override locale so we can return mappings from WooCommerce in English language stores.
+			global $locale;
+			$locale = false;
+			$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
+			$args           = array( 'parse' => true, 'mapping' => self::get_header_mappings( $file ) );
+			$args           = apply_filters( 'woocommerce_product_csv_importer_args', $args, $importer_class );
+
+			$importer = new $importer_class( $file, $args );
+			$import   = $importer->import();
+			return rest_ensure_response( $import );
+		} else {
+			return new \WP_Error( 'woocommerce_rest_import_error', __( 'Sorry, the sample products data file was not found.', 'woocommerce-admin' ) );
+		}
+	}
+
+	/**
+	 * Get header mappings from CSV columns.
+	 *
+	 * @param string File path.
+	 * @return array Mapped headers.
+	 */
+	public static function get_header_mappings( $file ) {
+		include_once WC_ABSPATH . 'includes/admin/importers/mappings/mappings.php';
+
+		$importer_class  = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
+		$importer        = new $importer_class( $file, array() );
+		$raw_headers     = $importer->get_raw_keys();
+		$default_columns = wc_importer_default_english_mappings( array() );
+		$special_columns = wc_importer_default_special_english_mappings( array() );
+
+		$headers = array();
+		foreach ( $raw_headers as $key => $field ) {
+			$index             = $field;
+			$headers[ $index ] = $field;
+
+			if ( isset( $default_columns[ $field ] ) ) {
+				$headers[ $index ] = $default_columns[ $field ];
+			} else {
+				foreach ( $special_columns as $regex => $special_key ) {
+					if ( preg_match( self::sanitize_special_column_name_regex( $regex ), $field, $matches ) ) {
+						$headers[ $index ] = $special_key . $matches[1];
+						break;
+					}
+				}
+			}
+		}
+
+		return $headers;
+	}
+
+	/**
+	 * Sanitize special column name regex.
+	 *
+	 * @param  string $value Raw special column name.
+	 * @return string
+	 */
+	public static function sanitize_special_column_name_regex( $value ) {
+		return '/' . str_replace( array( '%d', '%s' ), '(.*)', trim( quotemeta( $value ) ) ) . '/';
+	}
+}

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -27,26 +27,6 @@ class Products extends \WC_REST_Products_Controller {
 	protected $namespace = 'wc/v4';
 
 	/**
-	 * Register routes.
-	 */
-	public function register_routes() {
-		parent::register_routes();
-
-		register_rest_route(
-			$this->namespace,
-			'/' . $this->rest_base . '/import_sample_data',
-			array(
-				array(
-					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'import_sample_data' ),
-					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				),
-				'schema' => array( $this, 'get_public_item_schema' ),
-			)
-		);
-	}
-
-	/**
 	 * Adds properties that can be embed via ?_embed=1.
 	 *
 	 * @return array
@@ -261,75 +241,4 @@ class Products extends \WC_REST_Products_Controller {
 		}
 		return $groupby;
 	}
-
-	/**
-	 * Import sample products from WooCommerce sample CSV.
-	 *
-	 * @return WP_Error|WP_REST_Response	 * 
-	 */
-	public static function import_sample_data() {
-		include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
-		$file = WC_ABSPATH . 'sample-data/sample_products.csv';
-
-		if ( file_exists( $file ) && class_exists( 'WC_Product_CSV_Importer' ) ) {
-			// Override locale so we can return mappings from WooCommerce in English language stores.
-			global $locale;
-			$locale = false;
-			$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
-			$args           = array( 'parse' => true, 'mapping' => self::get_header_mappings( $file ) );
-			$args           = apply_filters( 'woocommerce_product_csv_importer_args', $args, $importer_class );
-
-			$importer = new $importer_class( $file, $args );
-			$import   = $importer->import();
-			return rest_ensure_response( $import );
-		} else {
-			return new \WP_Error( 'woocommerce_rest_import_error', __( 'Sorry, the sample products data file was not found.', 'woocommerce-admin' ) );
-		}
-	}
-
-	/**
-	 * Get header mappings from CSV columns.
-	 *
-	 * @param string File path.
-	 * @return array Mapped headers.
-	 */
-	public static function get_header_mappings( $file ) {
-		include_once WC_ABSPATH . 'includes/admin/importers/mappings/default.php';
-
-		$importer_class  = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
-		$importer        = new $importer_class( $file, array() );
-		$raw_headers     = $importer->get_raw_keys();
-		$default_columns = wc_importer_default_english_mappings( array() );
-		$special_columns = wc_importer_default_special_english_mappings( array() );
-
-		$headers = array();
-		foreach ( $raw_headers as $key => $field ) {
-			$index             = $field;
-			$headers[ $index ] = $field;
-
-			if ( isset( $default_columns[ $field ] ) ) {
-				$headers[ $index ] = $default_columns[ $field ];
-			} else {
-				foreach ( $special_columns as $regex => $special_key ) {
-					if ( preg_match( self::sanitize_special_column_name_regex( $regex ), $field, $matches ) ) {
-						$headers[ $index ] = $special_key . $matches[1];
-						break;
-					}
-				}
-			}
-		}
-
-		return $headers;
-	}
-
-	/**
-	 * Sanitize special column name regex.
-	 *
-	 * @param  string $value Raw special column name.
-	 * @return string
-	 */
-	public static function sanitize_special_column_name_regex( $value ) {
-		return '/' . str_replace( array( '%d', '%s' ), '(.*)', trim( quotemeta( $value ) ) ) . '/';
-	}
-
 }

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -66,7 +66,8 @@ class OnboardingTasks {
 	 * @param array $settings Component settings.
 	 */
 	public function component_settings( $settings ) {
-		$tasks = get_transient( self::TASKS_TRANSIENT );
+		$tasks    = get_transient( self::TASKS_TRANSIENT );
+		$products = wp_count_posts( 'product' );
 
 		if ( ! $tasks ) {
 			$tasks     = array();
@@ -79,8 +80,11 @@ class OnboardingTasks {
 			set_transient( self::TASKS_TRANSIENT, $tasks, DAY_IN_SECONDS );
 		}
 
+		// @todo We may want to consider caching some of these and use to check against
+		// task completion along with cache busting for active tasks.
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
 		$settings['onboarding']['customLogo']                     = get_theme_mod( 'custom_logo', false );
+		$settings['onboarding']['hasProducts']                    = (int) $products->publish > 0 || (int) $products->draft > 0;
 		$settings['onboarding']['tasks']                          = $tasks;
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
 

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Onboarding Tasks REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+use \Automattic\WooCommerce\Admin\API\OnboardingTasks;
+
+/**
+ * WC Tests API Onboarding Tasks
+ */
+class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-admin/v1/onboarding/tasks';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that Tasks data is returned by the endpoint.
+	 */
+	public function test_import_sample_products() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/import_sample_products' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertArrayHasKey( 'failed', $data );
+		$this->assertArrayHasKey( 'imported', $data );
+		$this->assertArrayHasKey( 'skipped', $data );
+		$this->assertArrayHasKey( 'updated', $data );
+	}
+}

--- a/tests/api/onboarding-tasks.php
+++ b/tests/api/onboarding-tasks.php
@@ -33,7 +33,7 @@ class WC_Tests_API_Onboarding_Tasks extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that Tasks data is returned by the endpoint.
+	 * Test that sample product data is imported.
 	 */
 	public function test_import_sample_products() {
 		wp_set_current_user( $this->user );


### PR DESCRIPTION
Fixes #2859

Adds the product import step to customize appearance if 

### Screenshots

<img width="424" alt="Screen Shot 2019-09-03 at 11 38 32 AM" src="https://user-images.githubusercontent.com/10561050/64142877-72c12480-ce40-11e9-984b-5ac0b42acb46.png">
<img width="702" alt="Screen Shot 2019-09-03 at 11 36 12 AM" src="https://user-images.githubusercontent.com/10561050/64142878-72c12480-ce40-11e9-8da8-b76cff8a0c3e.png">

### Detailed test instructions:

1. Start with a fresh WP install without products.
2. Enable the task list and visit the "Customize Appearance" task from the dashboard.
3. Click "Import products."
4. Check that products were imported.
5. Check that revisiting the step with any products does not give the option to import.