### PR TITLE
Use upstream webpack-rtl-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "url-loader": "1.1.2",
     "webpack": "4.35.3",
     "webpack-cli": "3.3.4",
-    "webpack-rtl-plugin": "github:yoavf/webpack-rtl-plugin#develop"
+    "webpack-rtl-plugin": "2.0.0"
   },
   "engines": {
     "node": ">=8.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,7 +167,7 @@ const webpackConfig = {
 			},
 		} ),
 		new WebpackRTLPlugin( {
-			suffix: '-rtl',
+			filename: './dist/[name]/style-rtl.css',
 			minify: {
 				safe: true,
 			},


### PR DESCRIPTION
We were using a custom branch of `webpack-rtl-plugin` which added the `suffix` option. But the last upstream version adds the `filename` option, so there is no need to use the custom branch anymore.

### Detailed test instructions:

- Run `npm i && npm start`.
- Set your site language to a RTL locale (Arabic, for example).
- Verify everything still looks ok.