### PR TITLE
use correct path for NAMESPACE import in task-list

### DIFF
--- a/client/dashboard/task-list/tasks/connect.js
+++ b/client/dashboard/task-list/tasks/connect.js
@@ -17,7 +17,7 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 /**
  * Internal depdencies
  */
-import { NAMESPACE } from 'wc-api/onboarding/constants';
+import { NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
 class Connect extends Component {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -417,7 +417,7 @@ class Onboarding {
 		}
 
 		$help_tabs = $screen->get_help_tabs();
-		
+
 		foreach ( $help_tabs as $help_tab ) {
 			if ( 'woocommerce_onboard_tab' !== $help_tab['id'] ) {
 				continue;


### PR DESCRIPTION
See #2718

This fixes a webpack warning 

```
[0] WARNING in ./client/dashboard/task-list/tasks/connect.js 96:34-43
[0] "export 'NAMESPACE' was not found in 'wc-api/onboarding/constants'
[0]  @ ./client/dashboard/task-list/index.js
[0]  @ ./client/dashboard/index.js
[0]  @ ./client/layout/controller.js
[0]  @ ./client/layout/index.js
[0]  @ ./client/index.js
[0] 
[0] WARNING in ./client/dashboard/task-list/tasks/connect.js 148:34-43
[0] "export 'NAMESPACE' was not found in 'wc-api/onboarding/constants'
[0]  @ ./client/dashboard/task-list/index.js
[0]  @ ./client/dashboard/index.js
[0]  @ ./client/layout/controller.js
[0]  @ ./client/layout/index.js
[0]  @ ./client/index.js
```


### Detailed test instructions:

- `npm run start`
- Check output that no warnings occur

### Changelog Note:

None needed.