### PR TITLE
Fix: persist date_last_active for customer reports

### DIFF
--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -517,6 +517,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			'%s',
 			'%s',
 			'%s',
+			'%s',
 		);
 
 		// Add registered customer data.
@@ -649,6 +650,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		);
 		$format      = array(
 			'%d',
+			'%s',
 			'%s',
 			'%s',
 			'%s',


### PR DESCRIPTION
[State](https://github.com/woocommerce/woocommerce-admin/commit/0d5def5fcc3136885bbcd18148ecb2ea0606ecfe) was added as a data point for customer reports but the SQL formatting wasn't updated to account for it. This means `date_last_active` is not always being persisted correctly to customer reports, which seems like it might be the reason for the empty spots in #2815.

### Detailed test instructions:

- Register an account
- Add a product to the cart
- Check out
- `Last Active` and `Date Registered` should both have dates for the created customer

### Changelog Note:

Fix: persist date_last_active for customer reports 👏 @cojennin 
