### PR TITLE
Add Stripe Connection Flows

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -226,6 +226,20 @@
 	}
 }
 
+.components-modal__frame.woocommerce-task-payments__stripe-error-modal {
+	.components-modal__header {
+		border-bottom: 0;
+		margin-bottom: 0;
+	}
+
+	.woocommerce-task-payments__stripe-error-wrapper {
+		align-items: flex-end;
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+	}
+}
+
 .woocommerce-task-appearance {
 	.muriel-image-upload {
 		margin-bottom: $gap-smallest;

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+
+class PayPal extends Component {
+	render() {
+		return null;
+	}
+}
+
+export default PayPal;

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+
+class Stripe extends Component {
+	render() {
+		return null;
+	}
+}
+
+export default Stripe;

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -2,16 +2,194 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import apiFetch from '@wordpress/api-fetch';
+import { withDispatch } from '@wordpress/data';
+import interpolateComponents from 'interpolate-components';
+import { Modal } from '@wordpress/components';
+import { Button } from 'newspack-components';
 
 /**
  * WooCommerce dependencies
  */
 
 class Stripe extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showErrorModal: false,
+			errorMessage: '',
+			connectURL: '',
+			showConnectionButtons: ! props.manualConfig && ! props.createAccount,
+			showManualConfiguration: props.manualConfig,
+		};
+	}
+
+	componentDidMount() {
+		const { createAccount } = this.props;
+		const { showConnectionButtons } = this.state;
+
+		if ( createAccount ) {
+			this.autoCreateAccount();
+		}
+
+		if ( showConnectionButtons ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( false === prevState.showConnectionButtons && this.state.showConnectionButtons ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	async fetchOAuthConnectURL() {
+		const { returnUrl } = this.props;
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v1/connect/stripe/oauth/init', // @todo namespace
+				method: 'POST',
+				data: {
+					returnUrl,
+				},
+			} );
+			if ( ! result || ! result.oauthUrl ) {
+				this.setState( {
+					showConnectionButtons: false,
+					showManualConfiguration: true,
+				} );
+				return;
+			}
+			this.setState( {
+				connectURL: result.oauthUrl,
+			} );
+		} catch ( error ) {
+			// Fallback to manual configuration if the OAuth URL cannot be grabbed.
+			this.setState( {
+				showConnectionButtons: false,
+				showManualConfiguration: true,
+			} );
+		}
+	}
+
+	async autoCreateAccount() {
+		const { email, countryCode, returnUrl } = this.props;
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v1/connect/stripe/account', // @todo namespace
+				method: 'POST',
+				data: {
+					email,
+					country: countryCode,
+				},
+			} );
+
+			if ( result ) {
+				window.location = returnUrl;
+				return;
+			}
+		} catch ( error ) {
+			let errorTitle, errorMessage;
+			// This seems to be the best way to handle this.
+			// github.com/Automattic/woocommerce-services/blob/cfb6173deb3c72897ee1d35b8fdcf29c5a93dea2/woocommerce-services.php#L563-L570
+			if ( -1 === error.message.indexOf( 'Account already exists for the provided email' ) ) {
+				errorTitle = __( 'Stripe', 'woocommerce-admin' );
+				errorMessage = interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but an error occured. ' +
+								'Please try connecting manually to continue.',
+							'woocommerce-admin'
+						),
+						email
+					),
+					components: {
+						strong: <strong />,
+					},
+				} );
+			} else {
+				errorTitle = __( 'You already have a Stripe account', 'woocommerce-admin' );
+				errorMessage = interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but one already exists. ' +
+								'Please sign in and connect to continue.',
+							'woocommerce-admin'
+						),
+						email
+					),
+					components: {
+						strong: <strong />,
+					},
+				} );
+			}
+
+			this.setState( {
+				showErrorModal: true,
+				showConnectionButtons: true,
+				errorTitle,
+				errorMessage,
+			} );
+		}
+	}
+
+	/*
+	<Button isDefault onClick={ () => setState( { isOpen: false } ) }>
+					My custom close button
+				</Button>
+				*/
+
+	renderErrorModal() {
+		const { errorTitle, errorMessage } = this.state;
+		return (
+			<Modal
+				title={ errorTitle }
+				onRequestClose={ () => this.setState( { showErrorModal: false } ) }
+				className="woocommerce-task-payments__stripe-error-modal"
+			>
+				<div className="woocommerce-task-payments__stripe-error-wrapper">
+					<div className="woocommerce-task-payments__stripe-error-message">{ errorMessage }</div>
+					<Button isPrimary isDefault onClick={ () => this.setState( { showErrorModal: false } ) }>
+						{ __( 'OK', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+
+	renderConnectButton() {
+		const { connectURL } = this.state;
+		return (
+			<Button isPrimary isDefault href={ connectURL }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
 	render() {
+		const { showErrorModal, showConnectionButtons, connectURL } = this.state;
+
+		if ( showErrorModal ) {
+			return this.renderErrorModal();
+		}
+
+		if ( showConnectionButtons && connectURL ) {
+			return this.renderConnectButton();
+		}
+
 		return null;
 	}
 }
 
-export default Stripe;
+export default compose(
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		return {
+			createNotice,
+		};
+	} )
+)( Stripe );

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -7,6 +7,7 @@ import { MINUTE } from '@fresh-data/framework';
 export const JETPACK_NAMESPACE = '/jetpack/v4';
 export const NAMESPACE = '/wc/v4';
 export const WC_ADMIN_NAMESPACE = '/wc-admin/v1';
+export const WCS_NAMESPACE = '/wc/v1'; // WCS endpoints like Stripe are not avaiable on later /wc versions
 
 export const DEFAULT_REQUIREMENT = {
 	timeout: 1 * MINUTE,

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -18,12 +18,15 @@ const getOptions = ( getResource, requireResource ) => (
 	const resourceName = getResourceName( 'options', optionNames );
 	const options = {};
 
-	const names = requireResource( requirement, resourceName ).data || [];
+	const names = requireResource( requirement, resourceName ).data || optionNames;
 
 	names.forEach( name => {
-		options[ name ] = getResource( getResourceName( 'options', name ) ).data;
+		const data =
+			getResource( getResourceName( 'options', name ) ).data || wcSettings.preloadOptions[ name ];
+		if ( data ) {
+			options[ name ] = data;
+		}
 	} );
-
 	return options;
 };
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -60,6 +60,7 @@ class Onboarding {
 
 		add_action( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 ); // Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
@@ -336,6 +337,15 @@ class Onboarding {
 		}
 
 		return $settings;
+	}
+
+	public function preload_options( $options ) {
+		if ( ! $this->should_show_tasks() ) {
+			return $options;
+		}
+		$options[] = 'woocommerce_onboarding_payments';
+		$options[] = 'woocommerce_stripe_settings';
+		return $options;
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -526,6 +526,13 @@ class Loader {
 			);
 		}
 
+		$preload_options = apply_filters( 'woocommerce_admin_preload_options', array() );
+		if ( ! empty( $preload_options ) ) {
+			foreach ( $preload_options as $option ) {
+				$settings['preloadOptions'][ $option ] = get_option( $option );
+			}
+		}
+
 		$current_user_data = array();
 		foreach ( self::get_user_data_fields() as $user_field ) {
 			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true ) );


### PR DESCRIPTION
Part of #2684.

This PR adds the Stripe connection and configuration logic to the payment task.

It took me a bit to work through the logic and flows, but this handles all three possible ways to connect: auto-provisioning, OAuth Connection, and manual setting entry.

I wasn’t sure the best way to persist progress in the task, since the user will possibly get redirected off-site to Stripe (or PayPal in a follow up PR). I thought about just trying to pass back data via query parameters in the redirect URL, but that seemed prone to breakage. I eventually settled on storing progress in a custom option that is preloaded.

<img width="747" alt="Screen Shot 2019-09-04 at 4 33 03 PM" src="https://user-images.githubusercontent.com/689165/64290472-29520180-cf34-11e9-855f-f64b75dc713b.png">

<img width="731" alt="Screen Shot 2019-09-04 at 4 33 25 PM" src="https://user-images.githubusercontent.com/689165/64290491-32db6980-cf34-11e9-86bc-059f321bf79f.png">

<img width="706" alt="Screen Shot 2019-09-04 at 4 51 25 PM" src="https://user-images.githubusercontent.com/689165/64290533-3ff85880-cf34-11e9-9cd4-c0a59b04982f.png">

#### Testing Directions

* Go under your payment settings and make sure `Live Publishable Key` and `Live Secret Key` are blank for Stripe.

* Delete the `woocommerce_onboarding_payments` option if you have previously tested this branch, or want to run through the steps again.

To Test automatic account creation:

* Run through the payment task, and select Stripe. Select the checkbox and enter an email address that does not already have a Stripe account.
* You should get a success notice that the account created.
* Verify the secret and publishable keys are set under `WooCommerce > Settings > Payments > Stripe`.

* Try again using the same email address. You should get an error message that the account already exists, and are offered a connect button instead.

To Test the OAuth flow (https required):

* You will need a stripe account. I asked at p1567621185174900-slack-woo-partners-hydra if there was a test account to use, but it doesn't sound like it.
*  Run through the payment task, and select Stripe.  Do not select the checkbox.
* Click the Connect button.
* Test both the deny and approve flows from he Stripe OAuth screens.
* Verify the secret and publishable keys are set under `WooCommerce > Settings > Payments > Stripe` after approval.

To test manual configuration:

* Run through the payment task without Jetpack / WCS enabled. If your site doesn’t support SSL, you should also see the manual configuration option.
* Make sure you can fill in the settings. Verify they are set under `WooCommerce > Settings > Payments > Stripe`.

