### PR TITLE
Add tax stats where filters

### DIFF
--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -1039,7 +1039,8 @@ class DataStore {
 		 * Allows filtering of the objects included or excluded from reports.
 		 *
 		 * @param array $ids List of object Ids.
-		 * @param array $query_args        The original arguments for the request.
+		 * @param array $query_args The original arguments for the request.
+		 * @param array $field      The field in the query arguments being filtered.
 		 */
 		$ids = apply_filters( 'wc_admin_reports_ ' . $field, $ids, $query_args, $field );
 

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -440,7 +440,15 @@ class DataStore {
 	 * @return string
 	 */
 	protected function selected_columns( $query_args ) {
-		$selections = $this->report_columns;
+		/**
+		 * Filter the report columns before retrieving data.
+		 *
+		 * Allows filtering of the report columns included in reports.
+		 *
+		 * @param array $report_columns Associative list of columns.
+		 * @param array $query_args     The original arguments for the request.
+		 */
+		$selections = apply_filters( 'wc_admin_reports_selected_columns', $this->report_columns, $query_args );
 
 		if ( isset( $query_args['fields'] ) && is_array( $query_args['fields'] ) ) {
 			$keep = array();

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -76,8 +76,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$sql_query_params = array_merge( $sql_query_params, $this->get_limit_sql_params( $query_args ) );
 		$sql_query_params = array_merge( $sql_query_params, $this->get_order_by_sql_params( $query_args ) );
 
-		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
-			$allowed_taxes                     = implode( ',', $query_args['taxes'] );
+		$allowed_taxes = $this->get_filtered_ids( $query_args, 'taxes' );
+		if ( ! empty( $allowed_taxes ) ) {
 			$sql_query_params['where_clause'] .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
 		}
 
@@ -104,8 +104,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$order_tax_lookup_table = $wpdb->prefix . self::TABLE_NAME;
 
-		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
-			$allowed_taxes       = implode( ',', $query_args['taxes'] );
+		$allowed_taxes = $this->get_filtered_ids( $query_args, 'taxes' );
+		if ( ! empty( $allowed_taxes ) ) {
 			$taxes_where_clause .= " AND {$order_tax_lookup_table}.tax_rate_id IN ({$allowed_taxes})";
 		}
 


### PR DESCRIPTION
See #2714 
Dependant on #2891 

- Add filters to downloads data store

### Detailed test instructions:

- Load Analytics Taxes without PR
- Clear transients
- Switch to PR
- Load Taxes in second tab to compare results

### Changelog Note:

Dev: Add filter to tax stats datastore tax codes.
