### PR TITLE
Add variations where filters

### DIFF
--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -1039,7 +1039,8 @@ class DataStore {
 		 * Allows filtering of the objects included or excluded from reports.
 		 *
 		 * @param array $ids List of object Ids.
-		 * @param array $query_args        The original arguments for the request.
+		 * @param array $query_args The original arguments for the request.
+		 * @param array $field      The field in the query arguments being filtered.
 		 */
 		$ids = apply_filters( 'wc_admin_reports_ ' . $field, $ids, $query_args, $field );
 

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -440,7 +440,15 @@ class DataStore {
 	 * @return string
 	 */
 	protected function selected_columns( $query_args ) {
-		$selections = $this->report_columns;
+		/**
+		 * Filter the report columns before retrieving data.
+		 *
+		 * Allows filtering of the report columns included in reports.
+		 *
+		 * @param array $report_columns Associative list of columns.
+		 * @param array $query_args     The original arguments for the request.
+		 */
+		$selections = apply_filters( 'wc_admin_reports_selected_columns', $this->report_columns, $query_args );
 
 		if ( isset( $query_args['fields'] ) && is_array( $query_args['fields'] ) ) {
 			$keep = array();

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -129,9 +129,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.product_id IN ({$included_products})";
 		}
 
-		if ( count( $query_args['variations'] ) > 0 ) {
-			$allowed_variations_str            = implode( ',', $query_args['variations'] );
-			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.variation_id IN ({$allowed_variations_str})";
+		$allowed_variations = $this->get_filtered_ids( $query_args, 'variations' );
+		if ( ! empty( $allowed_variations ) ) {
+			$sql_query_params['where_clause'] .= " AND {$order_product_lookup_table}.variation_id IN ({$allowed_variations})";
 		}
 
 		$order_status_filter = $this->get_status_subquery( $query_args );


### PR DESCRIPTION
See #2714 
Dependant on #2891 

- Add filters to variations data store

### Detailed test instructions:

- Load a variable product with sales of multiple variations without PR
- Clear transients
- Switch to PR
- Load same screen in second tab to compare results

### Changelog Note:

Dev: Add filter to variation ids in variations datastore.
