### PR TITLE
Add Stripe & PayPal Connection Flows

### DIFF
--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -246,24 +246,16 @@ class Start extends Component {
 						/>
 					</div>
 
-					<Button
-						isPrimary
-						onClick={ this.startWizard }
-						className="woocommerce-profile-wizard__continue"
-					>
-						{ __( 'Get started', 'woocommerce-admin' ) }
-					</Button>
-
-					<p>
+					<p className="woocommerce-profile-wizard__tos">
 						{ interpolateComponents( {
 							mixedString: __(
-								'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and ' +
-									'to {{jetpackLink}}share details{{/jetpackLink}} with WordPress.com.',
+								'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and to ' +
+									'{{detailsLink}}share details{{/detailsLink}} with WordPress.com. ',
 								'woocommerce-admin'
 							),
 							components: {
 								tosLink: <Link href="https://wordpress.com/tos" target="_blank" type="external" />,
-								jetpackLink: (
+								detailsLink: (
 									<Link
 										href="https://jetpack.com/support/what-data-does-jetpack-sync"
 										target="_blank"
@@ -273,6 +265,14 @@ class Start extends Component {
 							},
 						} ) }
 					</p>
+
+					<Button
+						isPrimary
+						onClick={ this.startWizard }
+						className="woocommerce-profile-wizard__continue"
+					>
+						{ __( 'Get started', 'woocommerce-admin' ) }
+					</Button>
 				</Card>
 
 				<p>

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -74,10 +74,13 @@ class Start extends Component {
 	}
 
 	async startWizard() {
-		const { createNotice, isSettingsError } = this.props;
+		const { updateOptions, createNotice, isSettingsError } = this.props;
 
 		recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
 
+		await updateOptions( {
+			woocommerce_setup_jetpack_opted_in: true,
+		} );
 		await this.updateTracking();
 
 		if ( ! isSettingsError ) {
@@ -250,6 +253,26 @@ class Start extends Component {
 					>
 						{ __( 'Get started', 'woocommerce-admin' ) }
 					</Button>
+
+					<p>
+						{ interpolateComponents( {
+							mixedString: __(
+								'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and ' +
+									'to {{jetpackLink}}share details{{/jetpackLink}} with WordPress.com.',
+								'woocommerce-admin'
+							),
+							components: {
+								tosLink: <Link href="https://wordpress.com/tos" target="_blank" type="external" />,
+								jetpackLink: (
+									<Link
+										href="https://jetpack.com/support/what-data-does-jetpack-sync"
+										target="_blank"
+										type="external"
+									/>
+								),
+							},
+						} ) }
+					</p>
 				</Card>
 
 				<p>
@@ -287,12 +310,13 @@ export default compose(
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { updateProfileItems, updateSettings } = dispatch( 'wc-api' );
+		const { updateProfileItems, updateOptions, updateSettings } = dispatch( 'wc-api' );
 		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
 			createNotice,
 			updateProfileItems,
+			updateOptions,
 			updateSettings,
 		};
 	} )

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -36,6 +36,19 @@
 		}
 	}
 
+	.woocommerce-profile-wizard__container {
+		.woocommerce-profile-wizard__tos {
+			font-size: 12px;
+			margin-top: 0;
+			margin-bottom: $gap-large;
+			padding: $gap-smaller;
+
+			a {
+				color: $studio-gray-60;
+			}
+		}
+	}
+
 	.woocommerce-profile-wizard__header {
 		height: 56px;
 		border-bottom: 1px solid $studio-gray-5;

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -1,5 +1,10 @@
 /** @format */
 
+.woocommerce-page:not(.woocommerce-embed-page) #klarna-banner,
+#klarna-kp-banner {
+	display: none;
+}
+
 .woocommerce-dashboard__columns {
 	display: grid;
 	grid-template-columns: calc(50% - #{$gap-large/2}) calc(50% - #{$gap-large/2});

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { filter } from 'lodash';
+import { filter, get } from 'lodash';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -45,7 +45,7 @@ class TaskDashboard extends Component {
 	}
 
 	getTasks() {
-		const { profileItems, query } = this.props;
+		const { profileItems, query, paymentsCompleted } = this.props;
 
 		return [
 			{
@@ -130,6 +130,7 @@ class TaskDashboard extends Component {
 				after: <i className="material-icons-outlined">chevron_right</i>,
 				onClick: () => updateQueryString( { task: 'payments' } ),
 				container: <Payments />,
+				className: paymentsCompleted ? 'is-complete' : null,
 				visible: true,
 			},
 		];
@@ -175,8 +176,16 @@ class TaskDashboard extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItems } = select( 'wc-api' );
+		const { getProfileItems, getOptions } = select( 'wc-api' );
 		const profileItems = getProfileItems();
-		return { profileItems };
+
+		const options = getOptions( [ 'woocommerce_onboarding_payments' ] );
+		const paymentsCompleted = get(
+			options,
+			[ 'woocommerce_onboarding_payments', 'completed' ],
+			false
+		);
+
+		return { profileItems, paymentsCompleted };
 	} )
 )( TaskDashboard );

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -202,6 +202,16 @@
 		margin-top: $gap-large;
 	}
 
+	.woocommerce-list__item .woocommerce-list__item-before {
+		max-width: 96px;
+		background: $studio-gray-0;
+		padding: $gap-small;
+
+		img {
+			max-width: 72px;
+		}
+	}
+
 	.woocommerce-list__item-title {
 		border-top: 1px solid $studio-gray-5;
 		padding-top: $gap;

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -226,6 +226,20 @@
 	}
 }
 
+.components-modal__frame.woocommerce-task-payments__stripe-error-modal {
+	.components-modal__header {
+		border-bottom: 0;
+		margin-bottom: 0;
+	}
+
+	.woocommerce-task-payments__stripe-error-wrapper {
+		align-items: flex-end;
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+	}
+}
+
 .woocommerce-task-appearance {
 	.muriel-image-upload {
 		margin-bottom: $gap-smallest;

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -1,0 +1,69 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { Button } from 'newspack-components';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
+import { Link } from '@woocommerce/components';
+
+class Klarna extends Component {
+	constructor( props ) {
+		super( props );
+		this.continue = this.continue.bind( this );
+	}
+
+	continue() {
+		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		this.props.markConfigured( slug );
+		return;
+	}
+
+	render() {
+		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		const section = 'checkout' === this.props.plugin ? 'kco' : 'klarna_payments';
+
+		const link = (
+			<Link
+				href={ adminUrl + 'admin.php?page=wc-settings&tab=checkout&section=' + section }
+				target="_blank"
+				type="external"
+			/>
+		);
+
+		const helpLink = (
+			<Link
+				href={ 'https://docs.woocommerce.com/document/' + slug + '/#section-3' }
+				target="_blank"
+				type="external"
+			/>
+		);
+
+		const configureText = interpolateComponents( {
+			mixedString: __(
+				'Klarna can be configured under your {{link}}store settings{{/link}}. Figure out {{helpLink}}what you need{{/helpLink}}.',
+				'woocommerce-admin'
+			),
+			components: {
+				link,
+				helpLink,
+			},
+		} );
+		return (
+			<Fragment>
+				<p>{ configureText }</p>
+				<Button isPrimary isDefault onClick={ this.continue }>
+					{ __( 'Continue', 'woocommerce-admin' ) }
+				</Button>
+			</Fragment>
+		);
+	}
+}
+
+export default Klarna;

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -2,16 +2,255 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, TextControl } from 'newspack-components';
+import { getQuery } from '@woocommerce/navigation';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import interpolateComponents from 'interpolate-components';
 
 /**
  * WooCommerce dependencies
  */
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
+import { Form, Link } from '@woocommerce/components';
+import withSelect from 'wc-api/with-select';
 
 class PayPal extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			connectURL: '',
+			showManualConfiguration: props.manualConfig,
+		};
+
+		this.updateSettings = this.updateSettings.bind( this );
+	}
+
+	componentDidMount() {
+		const { showManualConfiguration } = this.state;
+
+		const query = getQuery();
+		// Handle redirect back from PayPal
+		if ( query[ 'paypal-connect' ] ) {
+			if ( '1' === query[ 'paypal-connect' ] ) {
+				this.props.markConfigured( 'paypal' );
+				this.props.createNotice(
+					'success',
+					__( 'PayPal connected successfully.', 'woocommerce-admin' )
+				);
+				return;
+			}
+
+			/* eslint-disable react/no-did-mount-set-state */
+			this.setState( {
+				showManualConfiguration: true,
+			} );
+			/* eslint-enable react/no-did-mount-set-state */
+			return;
+		}
+
+		if ( ! showManualConfiguration ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if (
+			true === prevState.showManualConfiguration &&
+			false === this.state.showManualConfiguration
+		) {
+			this.fetchOAuthConnectURL();
+		}
+
+		if ( false === prevProps.optionsIsRequesting && true === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( true );
+		}
+
+		if ( true === prevProps.optionsIsRequesting && false === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( false );
+		}
+	}
+
+	async fetchOAuthConnectURL() {
+		this.props.setRequestPending( true );
+		try {
+			const result = await apiFetch( {
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-paypal',
+				method: 'POST',
+			} );
+			if ( ! result || ! result.connectUrl ) {
+				this.props.setRequestPending( false );
+				this.setState( {
+					showManualConfiguration: true,
+				} );
+				return;
+			}
+			this.props.setRequestPending( false );
+			this.setState( {
+				connectURL: result.connectUrl,
+			} );
+		} catch ( error ) {
+			this.props.setRequestPending( false );
+			this.setState( {
+				showManualConfiguration: true,
+			} );
+		}
+	}
+
+	renderConnectButton() {
+		const { connectURL } = this.state;
+		return (
+			<Button isPrimary isDefault href={ connectURL }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
+	async updateSettings( values ) {
+		const { createNotice, isSettingsError, updateOptions, markConfigured } = this.props;
+
+		this.props.setRequestPending( true );
+		await updateOptions( {
+			woocommerce_ppec_paypal_settings: {
+				...this.props.options.woocommerce_ppec_paypal_settings,
+				api_username: values.api_username,
+				api_password: values.api_password,
+			},
+		} );
+
+		if ( ! isSettingsError ) {
+			this.props.setRequestPending( false );
+			markConfigured( 'paypal' );
+		} else {
+			this.props.setRequestPending( false );
+			createNotice(
+				'error',
+				__( 'There was a problem saving your payment settings.', 'woocommerce-admin' )
+			);
+		}
+	}
+
+	getInitialConfigValues() {
+		return {
+			api_username: '',
+			api_password: '',
+		};
+	}
+
+	validate( values ) {
+		const errors = {};
+
+		if ( ! values.api_username ) {
+			errors.api_username = __( 'Please enter your API username', 'woocommerce-admin' );
+		}
+		if ( ! values.api_password ) {
+			errors.api_password = __( 'Please enter your API password', 'woocommerce-admin' );
+		}
+
+		return errors;
+	}
+
+	renderManualConfig() {
+		const { optionsIsRequesting } = this.props;
+		const link = (
+			<Link
+				href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-8"
+				target="_blank"
+				type="external"
+			/>
+		);
+		const help = interpolateComponents( {
+			mixedString: __(
+				'Your API details can be obtained from your {{link}}PayPal account{{/link}}',
+				'woocommerce-admin'
+			),
+			components: {
+				link,
+			},
+		} );
+
+		return (
+			<Form
+				initialValues={ this.getInitialConfigValues() }
+				onSubmitCallback={ this.updateSettings }
+				validate={ this.validate }
+			>
+				{ ( { getInputProps, handleSubmit } ) => {
+					return (
+						<Fragment>
+							<TextControl
+								label={ __( 'API Username', 'woocommerce-admin' ) }
+								required
+								{ ...getInputProps( 'api_username' ) }
+							/>
+							<TextControl
+								label={ __( 'API Password', 'woocommerce-admin' ) }
+								required
+								{ ...getInputProps( 'api_password' ) }
+							/>
+
+							<Button onClick={ handleSubmit } isPrimary disabled={ optionsIsRequesting }>
+								{ __( 'Proceed', 'woocommerce-admin' ) }
+							</Button>
+
+							<Button
+								onClick={ () => {
+									this.props.markConfigured( 'paypal' );
+								} }
+							>
+								{ __( 'Skip', 'woocommerce-admin' ) }
+							</Button>
+
+							<p>{ help }</p>
+						</Fragment>
+					);
+				} }
+			</Form>
+		);
+	}
+
 	render() {
+		const { connectURL, showManualConfiguration } = this.state;
+
+		if ( connectURL && ! showManualConfiguration ) {
+			return this.renderConnectButton();
+		}
+
+		if ( showManualConfiguration ) {
+			return this.renderManualConfig();
+		}
+
 		return null;
 	}
 }
 
-export default PayPal;
+PayPal.defaultProps = {
+	manualConfig: false, // WCS is not required for the PayPal OAuth flow, so we can default to smooth connection.
+};
+
+export default compose(
+	withSelect( select => {
+		const { getOptions, isOptionsRequesting } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_ppec_paypal_settings' ] );
+		const optionsIsRequesting = Boolean(
+			isOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
+		);
+
+		return {
+			options,
+			optionsIsRequesting,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( PayPal );

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -119,6 +119,7 @@ class PayPal extends Component {
 				...this.props.options.woocommerce_ppec_paypal_settings,
 				api_username: values.api_username,
 				api_password: values.api_password,
+				enabled: 'yes',
 			},
 		} );
 
@@ -234,10 +235,10 @@ PayPal.defaultProps = {
 
 export default compose(
 	withSelect( select => {
-		const { getOptions, isOptionsRequesting } = select( 'wc-api' );
+		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
 		const options = getOptions( [ 'woocommerce_ppec_paypal_settings' ] );
 		const optionsIsRequesting = Boolean(
-			isOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
+			isGetOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
 		);
 
 		return {

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -126,6 +126,10 @@ class PayPal extends Component {
 		if ( ! isSettingsError ) {
 			this.props.setRequestPending( false );
 			markConfigured( 'paypal' );
+			this.props.createNotice(
+				'success',
+				__( 'PayPal connected successfully.', 'woocommerce-admin' )
+			);
 		} else {
 			this.props.setRequestPending( false );
 			createNotice(

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+
+class PayPal extends Component {
+	render() {
+		return null;
+	}
+}
+
+export default PayPal;

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -1,0 +1,136 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from 'newspack-components';
+import { getQuery } from '@woocommerce/navigation';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * WooCommerce dependencies
+ */
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
+import withSelect from 'wc-api/with-select';
+
+class Square extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showSkipButton: false,
+		};
+
+		this.connect = this.connect.bind( this );
+	}
+
+	componentDidMount() {
+		const query = getQuery();
+		// Handle redirect back from Square
+		if ( query[ 'square-connect' ] ) {
+			if ( '1' === query[ 'square-connect' ] ) {
+				this.props.markConfigured( 'square' );
+				this.props.createNotice(
+					'success',
+					__( 'Square connected successfully.', 'woocommerce-admin' )
+				);
+				return;
+			}
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( false === prevProps.optionsIsRequesting && true === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( true );
+		}
+
+		if ( true === prevProps.optionsIsRequesting && false === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( false );
+		}
+	}
+
+	async connect() {
+		const { updateOptions } = this.props;
+		this.props.setRequestPending( true );
+
+		updateOptions( {
+			woocommerce_stripe_settings: {
+				...this.props.options.woocommerce_stripe_settings,
+				enabled: 'yes',
+			},
+		} );
+
+		const errorMessage = __(
+			'There was an error connecting to Square. Please try again or skip to connect later in store settings.',
+			'woocommerce-admin'
+		);
+
+		try {
+			const result = await apiFetch( {
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square',
+				method: 'POST',
+			} );
+
+			if ( ! result || ! result.connectUrl ) {
+				this.props.setRequestPending( false );
+				this.setState( { showSkipButton: true } );
+				this.props.createNotice( 'error', errorMessage );
+				return;
+			}
+
+			this.props.setRequestPending( false );
+			window.location = result.connectUrl;
+		} catch ( error ) {
+			this.props.setRequestPending( false );
+			this.setState( { showSkipButton: true } );
+			this.props.createNotice( 'error', errorMessage );
+		}
+	}
+
+	render() {
+		const { showSkipButton } = this.state;
+
+		return (
+			<Fragment>
+				<Button isPrimary isDefault onClick={ this.connect }>
+					{ __( 'Connect', 'woocommerce-admin' ) }
+				</Button>
+				{ showSkipButton && (
+					<Button
+						onClick={ () => {
+							this.props.markConfigured( 'square' );
+						} }
+					>
+						{ __( 'Skip', 'woocommerce-admin' ) }
+					</Button>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default compose(
+	withSelect( select => {
+		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_stripe_settings' ] );
+		const optionsIsRequesting = Boolean(
+			isGetOptionsRequesting( [ 'woocommerce_stripe_settings' ] )
+		);
+
+		return {
+			options,
+			optionsIsRequesting,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( Square );

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+
+class Stripe extends Component {
+	render() {
+		return null;
+	}
+}
+
+export default Stripe;

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -2,16 +2,194 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import apiFetch from '@wordpress/api-fetch';
+import { withDispatch } from '@wordpress/data';
+import interpolateComponents from 'interpolate-components';
+import { Modal } from '@wordpress/components';
+import { Button } from 'newspack-components';
 
 /**
  * WooCommerce dependencies
  */
 
 class Stripe extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showErrorModal: false,
+			errorMessage: '',
+			connectURL: '',
+			showConnectionButtons: ! props.manualConfig && ! props.createAccount,
+			showManualConfiguration: props.manualConfig,
+		};
+	}
+
+	componentDidMount() {
+		const { createAccount } = this.props;
+		const { showConnectionButtons } = this.state;
+
+		if ( createAccount ) {
+			this.autoCreateAccount();
+		}
+
+		if ( showConnectionButtons ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( false === prevState.showConnectionButtons && this.state.showConnectionButtons ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	async fetchOAuthConnectURL() {
+		const { returnUrl } = this.props;
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v1/connect/stripe/oauth/init', // @todo namespace
+				method: 'POST',
+				data: {
+					returnUrl,
+				},
+			} );
+			if ( ! result || ! result.oauthUrl ) {
+				this.setState( {
+					showConnectionButtons: false,
+					showManualConfiguration: true,
+				} );
+				return;
+			}
+			this.setState( {
+				connectURL: result.oauthUrl,
+			} );
+		} catch ( error ) {
+			// Fallback to manual configuration if the OAuth URL cannot be grabbed.
+			this.setState( {
+				showConnectionButtons: false,
+				showManualConfiguration: true,
+			} );
+		}
+	}
+
+	async autoCreateAccount() {
+		const { email, countryCode, returnUrl } = this.props;
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v1/connect/stripe/account', // @todo namespace
+				method: 'POST',
+				data: {
+					email,
+					country: countryCode,
+				},
+			} );
+
+			if ( result ) {
+				window.location = returnUrl;
+				return;
+			}
+		} catch ( error ) {
+			let errorTitle, errorMessage;
+			// This seems to be the best way to handle this.
+			// github.com/Automattic/woocommerce-services/blob/cfb6173deb3c72897ee1d35b8fdcf29c5a93dea2/woocommerce-services.php#L563-L570
+			if ( -1 === error.message.indexOf( 'Account already exists for the provided email' ) ) {
+				errorTitle = __( 'Stripe', 'woocommerce-admin' );
+				errorMessage = interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but an error occured. ' +
+								'Please try connecting manually to continue.',
+							'woocommerce-admin'
+						),
+						email
+					),
+					components: {
+						strong: <strong />,
+					},
+				} );
+			} else {
+				errorTitle = __( 'You already have a Stripe account', 'woocommerce-admin' );
+				errorMessage = interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but one already exists. ' +
+								'Please sign in and connect to continue.',
+							'woocommerce-admin'
+						),
+						email
+					),
+					components: {
+						strong: <strong />,
+					},
+				} );
+			}
+
+			this.setState( {
+				showErrorModal: true,
+				showConnectionButtons: true,
+				errorTitle,
+				errorMessage,
+			} );
+		}
+	}
+
+	/*
+	<Button isDefault onClick={ () => setState( { isOpen: false } ) }>
+					My custom close button
+				</Button>
+				*/
+
+	renderErrorModal() {
+		const { errorTitle, errorMessage } = this.state;
+		return (
+			<Modal
+				title={ errorTitle }
+				onRequestClose={ () => this.setState( { showErrorModal: false } ) }
+				className="woocommerce-task-payments__stripe-error-modal"
+			>
+				<div className="woocommerce-task-payments__stripe-error-wrapper">
+					<div className="woocommerce-task-payments__stripe-error-message">{ errorMessage }</div>
+					<Button isPrimary isDefault onClick={ () => this.setState( { showErrorModal: false } ) }>
+						{ __( 'OK', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+
+	renderConnectButton() {
+		const { connectURL } = this.state;
+		return (
+			<Button isPrimary isDefault href={ connectURL }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
 	render() {
+		const { showErrorModal, showConnectionButtons, connectURL } = this.state;
+
+		if ( showErrorModal ) {
+			return this.renderErrorModal();
+		}
+
+		if ( showConnectionButtons && connectURL ) {
+			return this.renderConnectButton();
+		}
+
 		return null;
 	}
 }
 
-export default Stripe;
+export default compose(
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		return {
+			createNotice,
+		};
+	} )
+)( Stripe );

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -225,6 +225,10 @@ class Stripe extends Component {
 		if ( ! isSettingsError ) {
 			this.props.setRequestPending( false );
 			markConfigured( 'stripe' );
+			this.props.createNotice(
+				'success',
+				__( 'Stripe connected successfully.', 'woocommerce-admin' )
+			);
 		} else {
 			this.props.setRequestPending( false );
 			createNotice(

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -25,7 +25,6 @@ class Stripe extends Component {
 		super( props );
 
 		this.state = {
-			showErrorModal: false,
 			errorMessage: '',
 			connectURL: '',
 			showConnectionButtons: ! props.manualConfig && ! props.createAccount,
@@ -172,7 +171,6 @@ class Stripe extends Component {
 			}
 
 			this.setState( {
-				showErrorModal: true,
 				showConnectionButtons: true,
 				errorTitle,
 				errorMessage,
@@ -185,12 +183,16 @@ class Stripe extends Component {
 		return (
 			<Modal
 				title={ errorTitle }
-				onRequestClose={ () => this.setState( { showErrorModal: false } ) }
+				onRequestClose={ () => this.setState( { errorMessage: '', errorTitle: '' } ) }
 				className="woocommerce-task-payments__stripe-error-modal"
 			>
 				<div className="woocommerce-task-payments__stripe-error-wrapper">
 					<div className="woocommerce-task-payments__stripe-error-message">{ errorMessage }</div>
-					<Button isPrimary isDefault onClick={ () => this.setState( { showErrorModal: false } ) }>
+					<Button
+						isPrimary
+						isDefault
+						onClick={ () => this.setState( { errorMessage: '', errorTitle: '' } ) }
+					>
 						{ __( 'OK', 'woocommerce-admin' ) }
 					</Button>
 				</div>
@@ -216,6 +218,7 @@ class Stripe extends Component {
 				...this.props.options.woocommerce_stripe_settings,
 				publishable_key: values.publishable_key,
 				secret_key: values.secret_key,
+				enabled: 'yes',
 			},
 		} );
 
@@ -303,14 +306,9 @@ class Stripe extends Component {
 	}
 
 	render() {
-		const {
-			showErrorModal,
-			showConnectionButtons,
-			connectURL,
-			showManualConfiguration,
-		} = this.state;
+		const { errorMessage, showConnectionButtons, connectURL, showManualConfiguration } = this.state;
 
-		if ( showErrorModal ) {
+		if ( errorMessage ) {
 			return this.renderErrorModal();
 		}
 

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -7,6 +7,7 @@ import { MINUTE } from '@fresh-data/framework';
 export const JETPACK_NAMESPACE = '/jetpack/v4';
 export const NAMESPACE = '/wc/v4';
 export const WC_ADMIN_NAMESPACE = '/wc-admin/v1';
+export const WCS_NAMESPACE = '/wc/v1'; // WCS endpoints like Stripe are not avaiable on later /wc versions
 
 export const DEFAULT_REQUIREMENT = {
 	timeout: 1 * MINUTE,

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -18,12 +18,15 @@ const getOptions = ( getResource, requireResource ) => (
 	const resourceName = getResourceName( 'options', optionNames );
 	const options = {};
 
-	const names = requireResource( requirement, resourceName ).data || [];
+	const names = requireResource( requirement, resourceName ).data || optionNames;
 
 	names.forEach( name => {
-		options[ name ] = getResource( getResourceName( 'options', name ) ).data;
+		const data =
+			getResource( getResourceName( 'options', name ) ).data || wcSettings.preloadOptions[ name ];
+		if ( data ) {
+			options[ name ] = data;
+		}
 	} );
-
 	return options;
 };
 

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -114,6 +114,19 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 				'schema' => array( $this, 'get_connect_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/connect-paypal',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'connect_paypal' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_connect_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -400,6 +413,38 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		return array(
 			'success' => true,
 		);
+	}
+
+	/**
+	 * Returns a URL that can be used to connect to PayPal.
+	 *
+	 * @param  object $rest_request Request details.
+	 * @return array Connect URL.
+	 */
+	public function connect_paypal() {
+		if ( ! function_exists( 'wc_gateway_ppec' ) ) {
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to PayPal.', 'woocommerce-admin' ), 500 );
+		}
+
+		$redirect_url = add_query_arg(
+			array(
+				'env'                     => 'live',
+				'wc_ppec_ips_admin_nonce' => wp_create_nonce( 'wc_ppec_ips' ),
+			),
+			wc_admin_url( '&task=payments&paypal-connect-finish=1' )
+		);
+
+		// https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/b6df13ba035038aac5024d501e8099a37e13d6cf/includes/class-wc-gateway-ppec-ips-handler.php#L79-L93
+		$query_args = array(
+			'redirect'    => urlencode( $redirect_url ),
+			'countryCode' => WC()->countries->get_base_country(),
+			'merchantId'  => md5( site_url( '/' ) . time() ),
+		);
+		$connect_url = add_query_arg( $query_args, wc_gateway_ppec()->ips->get_middleware_login_url( 'live' ) );
+
+		return( array(
+			'connectUrl' => $connect_url,
+		) );
 	}
 
 	/**

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -418,7 +418,6 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	/**
 	 * Returns a URL that can be used to connect to PayPal.
 	 *
-	 * @param  object $rest_request Request details.
 	 * @return array Connect URL.
 	 */
 	public function connect_paypal() {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -63,6 +63,7 @@ class Onboarding {
 		// new settings injection
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
@@ -340,6 +341,15 @@ class Onboarding {
 		}
 
 		return $settings;
+	}
+
+	public function preload_options( $options ) {
+		if ( ! $this->should_show_tasks() ) {
+			return $options;
+		}
+		$options[] = 'woocommerce_onboarding_payments';
+		$options[] = 'woocommerce_stripe_settings';
+		return $options;
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -544,6 +544,13 @@ class Loader {
 			);
 		}
 
+		$preload_options = apply_filters( 'woocommerce_admin_preload_options', array() );
+		if ( ! empty( $preload_options ) ) {
+			foreach ( $preload_options as $option ) {
+				$settings['preloadOptions'][ $option ] = get_option( $option );
+			}
+		}
+
 		$current_user_data = array();
 		foreach ( self::get_user_data_fields() as $user_field ) {
 			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true ) );


### PR DESCRIPTION
Part of #2684. 

This PR adds the Stripe & PayPal connection flows to the payments task list. 

PayPal does not require WCS for the OAuth flow, so two modes are supported here. OAuth connection, or manual key entry if the OAuth connection fails.

Stripe does require WCS. There is an auto-create account mode, a Oauth flow, and manual configuration.

<img width="747" alt="Screen Shot 2019-09-04 at 4 33 03 PM" src="https://user-images.githubusercontent.com/689165/64290472-29520180-cf34-11e9-855f-f64b75dc713b.png">

<img width="731" alt="Screen Shot 2019-09-04 at 4 33 25 PM" src="https://user-images.githubusercontent.com/689165/64290491-32db6980-cf34-11e9-86bc-059f321bf79f.png">

<img width="706" alt="Screen Shot 2019-09-04 at 4 51 25 PM" src="https://user-images.githubusercontent.com/689165/64290533-3ff85880-cf34-11e9-9cd4-c0a59b04982f.png">

### Screenshots

<img width="737" alt="Screen Shot 2019-09-05 at 3 31 13 PM" src="https://user-images.githubusercontent.com/689165/64374664-5238cc00-cff2-11e9-9426-3dc4239dcab5.png">

<img width="722" alt="Screen Shot 2019-09-05 at 3 31 54 PM" src="https://user-images.githubusercontent.com/689165/64374675-57961680-cff2-11e9-8ee4-8cf23c3fb43c.png">

### Detailed test instructions:

* Delete the `woocommerce_onboarding_payments` option if you have previously tested this branch, the Stripe branch, or want to run through the steps again. We will clear this automatically in the future.

PayPal:

* Go under your payment settings and make sure `API Username` and `API Password` are blank for PayPal Checkout.
* Go to the payments task, and make sure PayPal is selected. Attempt to connect through the OAuth flow. You will need a PayPal Business account.
* Test the manual mode by clearing the above onboarding option, and trying again. Instead of clicking the connect button, manually set your URL to `/wp-admin/admin.php?page=wc-admin&task=payments&paypal-connect=0`.

Stripe:

* Go under your payment settings and make sure `Live Publishable Key` and `Live Secret Key` are blank for Stripe.

See testing directions on https://github.com/woocommerce/woocommerce-admin/pull/2887.
