### PR TITLE
Add ability to receive an emailed download link to report export endpoint.

### DIFF
--- a/includes/emails/html-admin-report-export-download.php
+++ b/includes/emails/html-admin-report-export-download.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Admin report export download
+ *
+ * @package WooCommerce/Admin/Templates/Emails/HTML
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email );
+
+?>
+<a href="<?php echo esc_url( $download_url ); ?>">
+	<?php echo esc_html( sprintf( __( 'Download your %s Report', 'woocommerce-admin' ), $report_name ) ); ?>
+</a>
+<?php
+
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/includes/emails/plain-admin-report-export-download.php
+++ b/includes/emails/plain-admin-report-export-download.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Admin report export download email (plain text)
+ *
+ * @package WooCommerce/Admin/Templates/Emails/HTML
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n";
+echo esc_html( wp_strip_all_tags( $email_heading ) );
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+/* translators: %1$s: report name, %2$s: download URL */
+echo sprintf( __( 'Download your %1$s Report: %2$s', 'woocommerce-admin' ), $report_name, $download_url );
+
+echo "\n\n----------------------------------------\n\n";
+
+echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/src/API/Reports/Export/Controller.php
+++ b/src/API/Reports/Export/Controller.php
@@ -80,6 +80,11 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'type'              => 'object',
 			'validate_callback' => 'rest_validate_request_arg', // @todo: use each controller's schema?
 		);
+		$params['email']       = array(
+			'description'       => __( 'When true, email a link to download the export to the requesting user.', 'woocommerce-admin' ),
+			'type'              => 'boolean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 		return $params;
 	}
 
@@ -150,9 +155,10 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	public function export_items( $request ) {
 		$report_type = $request['type'];
 		$report_args = empty( $request['report_args'] ) ? array() : $request['report_args'];
+		$send_email  = isset( $request['email'] ) ? $request['email'] : false;
 		$export_id   = str_replace( '.', '', microtime( true ) );
 
-		$total_rows = ReportExporter::queue_report_export( $export_id, $report_type, $report_args );
+		$total_rows = ReportExporter::queue_report_export( $export_id, $report_type, $report_args, $send_email );
 
 		if ( 0 === $total_rows ) {
 			$response = rest_ensure_response(

--- a/src/ReportCSVEmail.php
+++ b/src/ReportCSVEmail.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Handles emailing users CSV Export download links.
+ *
+ * @package WooCommerce/Export
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Include dependencies.
+ */
+if ( ! class_exists( 'WC_Email', false ) ) {
+	include_once WC_ABSPATH . 'includes/emails/class-wc-email.php';
+}
+
+/**
+ * ReportCSVEmail Class.
+ */
+class ReportCSVEmail extends \WC_Email {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id             = 'admin_report_export_download';
+		$this->template_base  = dirname( __DIR__ ) . '/includes/emails/';
+		$this->template_html  = 'html-admin-report-export-download.php';
+		$this->template_plain = 'plain-admin-report-export-download.php';
+		$this->report_labels  = array(
+			'revenue'    => __( 'Revenue', 'woocommerce-admin' ),
+			'orders'     => __( 'Orders', 'woocommerce-admin' ),
+			'products'   => __( 'Products', 'woocommerce-admin' ),
+			'categories' => __( 'Categories', 'woocommerce-admin' ),
+			'coupons'    => __( 'Coupons', 'woocommerce-admin' ),
+			'taxes'      => __( 'Taxes', 'woocommerce-admin' ),
+			'downloads'  => __( 'Downloads', 'woocommerce-admin' ),
+			'stock'      => __( 'Stock', 'woocommerce-admin' ),
+			'customers'  => __( 'Customers', 'woocommerce-admin' ),
+		);
+
+		// Call parent constructor.
+		parent::__construct();
+	}
+
+	/**
+	 * This email has no user-facing settings.
+	 */
+	public function init_form_fields() {}
+
+	/**
+	 * This email has no user-facing settings.
+	 */
+	public function init_settings() {}
+
+	/**
+	 * Return email type.
+	 *
+	 * @return string
+	 */
+	public function get_email_type() {
+		return class_exists( 'DOMDocument' ) ? 'html' : 'plain';
+	}
+
+	/**
+	 * Get email heading.
+	 *
+	 * @return string
+	 */
+	public function get_default_heading() {
+		return __( 'Your Report Download', 'woocommerce-admin' );
+	}
+
+	/**
+	 * Get email subject.
+	 *
+	 * @return string
+	 */
+	public function get_default_subject() {
+		return __( '[{site_title}]: Your {report_name} Report download is ready', 'woocommerce-admin' );
+	}
+
+	/**
+	 * Get content html.
+	 *
+	 * @return string
+	 */
+	public function get_content_html() {
+		return wc_get_template_html(
+			$this->template_html,
+			array(
+				'report_name'   => $this->report_type,
+				'download_url'  => $this->download_url,
+				'email_heading' => $this->get_heading(),
+				'sent_to_admin' => true,
+				'plain_text'    => false,
+				'email'         => $this,
+			),
+			'',
+			$this->template_base
+		);
+	}
+
+	/**
+	 * Get content plain.
+	 *
+	 * @return string
+	 */
+	public function get_content_plain() {
+		return wc_get_template_html(
+			$this->template_plain,
+			array(
+				'report_name'   => $this->report_type,
+				'download_url'  => $this->download_url,
+				'email_heading' => $this->get_heading(),
+				'sent_to_admin' => true,
+				'plain_text'    => true,
+				'email'         => $this,
+			),
+			'',
+			$this->template_base
+		);
+	}
+
+	/**
+	 * Trigger the sending of this email.
+	 *
+	 * @param int            $order_id The order ID.
+	 * @param WC_Order|false $order Order object.
+	 */
+	public function trigger( $user_id, $report_type, $download_url ) {
+		$user               = new \WP_User( $user_id );
+		$this->recipient    = $user->user_email;
+		$this->download_url = $download_url;
+
+		if ( isset( $this->report_labels[ $report_type ] ) ) {
+			$this->report_type = $this->report_labels[ $report_type ];
+			$this->placeholders['{report_name}'] = $this->report_type;
+		}
+
+		$this->send(
+			$this->get_recipient(),
+			$this->get_subject(),
+			$this->get_content(),
+			$this->get_headers(),
+			$this->get_attachments()
+		);
+	}
+}

--- a/src/ReportExporter.php
+++ b/src/ReportExporter.php
@@ -36,6 +36,11 @@ class ReportExporter {
 	const DOWNLOAD_EXPORT_ACTION = 'woocommerce_admin_download_report_csv';
 
 	/**
+	 * Email export file download link action.
+	 */
+	const REPORT_EXPORT_EMAIL_ACTION = 'woocommerce_admin_email_report_download_link';
+
+	/**
 	 * Queue instance.
 	 *
 	 * @var WC_Queue_Interface
@@ -70,6 +75,8 @@ class ReportExporter {
 	public static function init() {
 		// Initialize scheduled action handlers.
 		add_action( self::REPORT_EXPORT_ACTION, array( __CLASS__, 'report_export_action' ), 10, 4 );
+		add_action( self::REPORT_EXPORT_EMAIL_ACTION, array( __CLASS__, 'report_export_email_action' ), 10, 3 );
+		
 		// Report download handler.
 		add_action( 'admin_init', array( __CLASS__, 'download_export_file' ) );
 	}
@@ -80,9 +87,10 @@ class ReportExporter {
 	 * @param string $export_id Unique ID for report (timestamp expected).
 	 * @param string $report_type Report type. E.g. 'customers'.
 	 * @param array  $report_args Report parameters, passed to data query.
+	 * @param bool   $send_email Optional. Send an email when the export is complete.
 	 * @return int Number of items to export.
 	 */
-	public static function queue_report_export( $export_id, $report_type, $report_args = array() ) {
+	public static function queue_report_export( $export_id, $report_type, $report_args = array(), $send_email = false ) {
 		$exporter = new ReportCSVExporter( $report_type, $report_args );
 		$exporter->prepare_data_to_export();
 
@@ -96,6 +104,12 @@ class ReportExporter {
 
 		if ( 0 < $num_batches ) {
 			ReportsSync::queue_batches( 1, $num_batches, self::REPORT_EXPORT_ACTION, $report_batch_args );
+
+			if ( $send_email ) {
+				$email_action_args = array( get_current_user_id(), $export_id, $report_type );
+
+				ReportsSync::queue_dependent_action( self::REPORT_EXPORT_EMAIL_ACTION, $email_action_args, self::REPORT_EXPORT_ACTION );
+			}
 		}
 
 		return $total_rows;
@@ -180,6 +194,38 @@ class ReportExporter {
 			$exporter = new ReportCSVExporter();
 			$exporter->set_filename( wp_unslash( $_GET['filename'] ) ); // WPCS: input var ok, sanitization ok.
 			$exporter->export();
+		}
+	}
+
+	/**
+	 * Process a report export email action.
+	 *
+	 * @param int    $user_id User ID that requested the email.
+	 * @param string $export_id Unique ID for report (timestamp expected).
+	 * @param string $report_type Report type. E.g. 'customers'.
+	 * @return void
+	 */
+	public static function report_export_email_action( $user_id, $export_id, $report_type ) {
+		$percent_complete = self::get_export_percentage_complete( $report_type, $export_id );
+
+		if ( 100 === $percent_complete ) {
+			$query_args   = array(
+				'action'   => self::DOWNLOAD_EXPORT_ACTION,
+				'filename' => "wc-{$report_type}-report-export-{$export_id}",
+			);
+			$download_url = add_query_arg( $query_args, admin_url() );
+			$user         = new \WP_User( $user_id );
+			$recipient    = $user->display_name . '<' . $user->user_email . '>';
+			$subject      = __( 'WooCommerce Admin: Your analytics export is ready.', 'woocommerce-admin' );
+			$message      = sprintf( __( 'Download your analytics export here: %s', 'woocommerce-admin' ), $download_url );
+
+			wp_mail(
+				apply_filters( 'woocommerce_admin_export_email_recipient', $recipient, $user_id, $export_id, $report_type ),
+				apply_filters( 'woocommerce_admin_export_email_subject', $subject, $user_id, $export_id, $report_type ),
+				apply_filters( 'woocommerce_admin_export_email_content', $message, $user_id, $export_id, $report_type ),
+				apply_filters( 'woocommerce_admin_export_email_headers', '', $user_id, $export_id, $report_type ),
+				apply_filters( 'woocommerce_admin_export_email_attachments', array(), $user_id, $export_id, $report_type )
+			);
 		}
 	}
 }

--- a/src/ReportExporter.php
+++ b/src/ReportExporter.php
@@ -214,18 +214,9 @@ class ReportExporter {
 				'filename' => "wc-{$report_type}-report-export-{$export_id}",
 			);
 			$download_url = add_query_arg( $query_args, admin_url() );
-			$user         = new \WP_User( $user_id );
-			$recipient    = $user->display_name . '<' . $user->user_email . '>';
-			$subject      = __( 'WooCommerce Admin: Your analytics export is ready.', 'woocommerce-admin' );
-			$message      = sprintf( __( 'Download your analytics export here: %s', 'woocommerce-admin' ), $download_url );
 
-			wp_mail(
-				apply_filters( 'woocommerce_admin_export_email_recipient', $recipient, $user_id, $export_id, $report_type ),
-				apply_filters( 'woocommerce_admin_export_email_subject', $subject, $user_id, $export_id, $report_type ),
-				apply_filters( 'woocommerce_admin_export_email_content', $message, $user_id, $export_id, $report_type ),
-				apply_filters( 'woocommerce_admin_export_email_headers', '', $user_id, $export_id, $report_type ),
-				apply_filters( 'woocommerce_admin_export_email_attachments', array(), $user_id, $export_id, $report_type )
-			);
+			$email = new ReportCSVEmail();
+			$email->trigger( $user_id, $report_type, $download_url );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #311.

This PR seeks to introduce an `email` parameter to the Report Export REST endpoint. When a boolean `true` is passed to the endpoint, an action is scheduled to email a link to download the report to the requesting user.

### Screenshots:

![Screen Shot 2019-09-06 at 10 28 00 AM](https://user-images.githubusercontent.com/63922/64448316-47ce0f00-d092-11e9-9c6e-155c5c0906b8.png)

### Detailed test instructions:

- `POST /wc/v4/reports/products/export` with body: `{ "email": true }`
- Verify a `woocommerce_admin_email_report_download_link` scheduled action exists (Tools > Scheduled Actions)
- When 100%, verify the email associated with your user account has received an email with a link to download the export
- Verify the download link in the email works

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add option to email a download link when exporting reports.