### PR TITLE
Fix vendor scripts not autoloading

### DIFF
--- a/bin/travis.sh
+++ b/bin/travis.sh
@@ -3,10 +3,10 @@
 
 if [ $1 == 'before' ]; then
 	cd "$WP_CORE_DIR/wp-content/plugins/woocommerce-admin/"
+	npm run build:feature-config
 	if [[ ${RUN_PHPCS} == 1 ]]; then
 		composer install
 	else
-		npm run build:feature-config
 		composer install --no-dev
 	fi
 

--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -7,8 +7,6 @@
  * @package WC_Admin\Functions
  */
 
-defined( 'ABSPATH' ) || exit;
-
 use \Automattic\WooCommerce\Admin\Loader;
 
 /**

--- a/tests/api/reports-downloads.php
+++ b/tests/api/reports-downloads.php
@@ -92,7 +92,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $this->user, $download_report['user_id'] );
 		$this->assertEquals( '1.2.3.4', $download_report['ip_address'] );
 		$this->assertEquals( 'help.png', $download_report['file_name'] );
-		$this->assertEquals( plugin_dir_url( __FILE__ ) . 'assets/images/help.png', $download_report['file_path'] );
+		$this->assertEquals( esc_url( plugin_dir_url( __FILE__ ) . 'assets/images/help.png' ), $download_report['file_path'] );
 	}
 
 	/**
@@ -170,7 +170,7 @@ class WC_Tests_API_Reports_Downloads extends WC_REST_Unit_Test_Case {
 		$id = $object->save();
 
 		WC_Helper_Queue::run_all_pending();
-		
+
 		return array(
 			'time'      => $time,
 			'product_1' => $product_1,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -111,10 +111,9 @@ require_once dirname( __FILE__ ) . '/framework/helpers/class-wc-test-action-queu
 require_once dirname( __FILE__ ) . '/framework/helpers/class-wc-helper-queue.php';
 
 /**
- * Set the environment and feature flags to 'develop' when running tests, instead of what is set in the generated `config/feature-flags.php`.
- * This matches how we mock the flags in jest.
+ * Use the `development` features for testing.
  */
-function wc_admin_get_feature_config() {
+function wc_admin_add_development_features() {
 	$config = json_decode( file_get_contents( dirname( dirname( __FILE__ ) ) . '/config/development.json' ) ); // @codingStandardsIgnoreLine.
 	$flags  = array();
 	foreach ( $config->features as $feature => $bool ) {
@@ -122,3 +121,4 @@ function wc_admin_get_feature_config() {
 	}
 	return $flags;
 }
+tests_add_filter( 'wc_admin_get_feature_config', 'wc_admin_add_development_features' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,9 +40,6 @@ function wc_admin_install() {
 	\Automattic\WooCommerce\Admin\Install::create_tables();
 	\Automattic\WooCommerce\Admin\Install::create_events();
 
-	// Generate feature config file in case it hasn't yet been.
-	include_once dirname( dirname( __FILE__ ) ) . '/bin/generate-feature-config.php';
-
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
 	wp_roles();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -40,6 +40,9 @@ function wc_admin_install() {
 	\Automattic\WooCommerce\Admin\Install::create_tables();
 	\Automattic\WooCommerce\Admin\Install::create_events();
 
+	// Generate feature config file in case it hasn't yet been.
+	include_once dirname( dirname( __FILE__ ) ) . '/bin/generate-feature-config.php';
+
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
 	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
 	wp_roles();


### PR DESCRIPTION
Fixes #2901

The autoloading included a file `core-functions.php` which exited before any scripts could be run.  This PR fixes that and a small discrepancy in special characters for the downloads API test.

### Screenshots

<img width="535" alt="Screen Shot 2019-09-09 at 7 51 02 AM" src="https://user-images.githubusercontent.com/10561050/64528481-9bc93580-d2d6-11e9-888c-4ba4efe17ab4.png">


### Detailed test instructions:

#### Vendor scripts

1. Navigate to your wc-admin folder in a terminal.
2. Try running tests, `composer test` and/or accessing vendor bin files to make sure they work `./vendor/bin/phpunit --version`, `./vendor/bin/phpcs`

#### Downloads API

1. Add a space or special character (like a space) in your file path to your WP install.
2. Run tests and make sure they all pass.