### PR TITLE
Add GitHub pages deploy step to Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,15 @@ script:
 branches:
   only:
     - master
+
+deploy:
+  local_dir: docs
+  provider: pages
+  skip_cleanup: true
+  github_token: $GH_PAGES_TOKEN
+  keep_history: true
+  on:
+    condition: $RUN_JS == 1 # only deploy on the PHP 7.2/JS build
+    branch: master
+  target_branch: gh-pages
+  verbose: true


### PR DESCRIPTION
This PR seeks to introduce a deploy step on Travis that pushes the built `docs/` folder to the `gh-pages` branch, since it now relies on a symlink to the `packages/components/src` directory.

The deploy should only occur on commits to `master` and on the PHP 7.2 / JS build.

Once this is merged and the first deploy occurs, we can switch the repo settings to build GH pages from the `gh-pages` branch.

Since https://github.com/travis-ci/dpl/pull/989, this _should_ copy the files symlinked. If that doesn't actually occur, this approach will need to be revisited - but we need to commit this to see if it works.