### PR TITLE
Only build pushes to master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,7 @@ script:
   - bash bin/js_lint_test.sh
   - bash bin/phpunit.sh
   - bash bin/phpcs.sh
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
Following the steps here to enable Travis Builds for pushes to `master` in addition to PRs: https://stackoverflow.com/a/31882307

This is in support of fixing the GH-pages after merging https://github.com/woocommerce/woocommerce-admin/pull/2872 - the Docsify docs now need a build step (since a symlink is involved instead of copying files)

Another PR will be opened to incorporate: https://github.com/woocommerce/woocommerce-admin/tree/add/gh-pages-build-step. Then we can change the GH pages branch to `gh-pages`.