### PR TITLE
Leaderboards: fix rename from getSettings

### DIFF
--- a/client/dashboard/leaderboards/index.js
+++ b/client/dashboard/leaderboards/index.js
@@ -162,7 +162,7 @@ export default compose(
 			'wc-api'
 		);
 		const userData = getCurrentUserData();
-		const { allLeaderboards } = getSetting( 'dataEndpoints', { leaderboards: {} } );
+		const { leaderboards: allLeaderboards } = getSetting( 'dataEndpoints', { leaderboards: [] } );
 
 		return {
 			allLeaderboards,


### PR DESCRIPTION
The leaderboards portion of the dashboard was incorrectly destructuring the `wcSettings` property `leaderboards` by getting `allLeaderboards`, which does not exist.

This fixes that.