### PR TITLE
Initiate report export from download button

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -176,6 +176,7 @@ class ReportTable extends Component {
 		const params = Object.assign( {}, query );
 		const { items, query: reportQuery } = tableData;
 		const { data, totalResults } = items;
+		let downloadType = 'browser';
 
 		// Delete unnecessary items from filename.
 		delete params.extended_info;
@@ -189,10 +190,15 @@ class ReportTable extends Component {
 				generateCSVDataFromTable( getHeadersContent(), getRowsContent( data ) )
 			);
 		} else {
+			downloadType = 'email';
 			initiateReportExport( endpoint, title, reportQuery );
 		}
 
-		recordEvent( 'analytics_table_download', { report: endpoint, rows: totalResults } );
+		recordEvent( 'analytics_table_download', {
+			report: endpoint,
+			rows: totalResults,
+			downloadType,
+		} );
 	}
 
 	onCompare() {

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -167,14 +167,15 @@ class ReportTable extends Component {
 			endpoint,
 			getHeadersContent,
 			getRowsContent,
+			initiateReportExport,
 			query,
 			searchBy,
 			tableData,
 			title,
-			totalRows,
 		} = this.props;
 		const params = Object.assign( {}, query );
-		const { items } = tableData;
+		const { items, query: reportQuery } = tableData;
+		const { data, totalResults } = items;
 
 		// Delete unnecessary items from filename.
 		delete params.extended_info;
@@ -182,14 +183,16 @@ class ReportTable extends Component {
 			delete params[ searchBy ];
 		}
 
-		if ( items.length === totalRows ) {
+		if ( data && data.length === totalResults ) {
 			downloadCSVFile(
 				generateCSVFileName( title, params ),
-				generateCSVDataFromTable( getHeadersContent(), getRowsContent( items.data ) )
+				generateCSVDataFromTable( getHeadersContent(), getRowsContent( data ) )
 			);
+		} else {
+			initiateReportExport( endpoint, title, reportQuery );
 		}
 
-		recordEvent( 'analytics_table_download', { report: endpoint, rows: totalRows } );
+		recordEvent( 'analytics_table_download', { report: endpoint, rows: totalResults } );
 	}
 
 	onCompare() {
@@ -589,9 +592,10 @@ export default compose(
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { updateCurrentUserData } = dispatch( 'wc-api' );
+		const { initiateReportExport, updateCurrentUserData } = dispatch( 'wc-api' );
 
 		return {
+			initiateReportExport,
 			updateCurrentUserData,
 		};
 	} )

--- a/client/wc-api/export/index.js
+++ b/client/wc-api/export/index.js
@@ -1,0 +1,11 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import mutations from './mutations';
+import operations from './operations';
+
+export default {
+	mutations,
+	operations,
+};

--- a/client/wc-api/export/mutations.js
+++ b/client/wc-api/export/mutations.js
@@ -1,0 +1,46 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { getResourceName } from '../utils';
+
+const initiateReportExport = operations => async ( reportType, reportTitle, reportArgs ) => {
+	const { createNotice } = dispatch( 'core/notices' );
+
+	const resourceName = getResourceName( `report-export-${ reportType }`, reportArgs );
+
+	const result = await operations.update( [ resourceName ], {
+		[ resourceName ]: reportArgs,
+	} );
+
+	const response = result[ 0 ][ resourceName ];
+
+	if ( response && response.success ) {
+		createNotice(
+			'success',
+			sprintf( __( 'Your %s Report will be emailed to you.', 'woocommerce-admin' ), reportTitle )
+		);
+	}
+	if ( response && response.error ) {
+		createNotice(
+			'error',
+			sprintf(
+				__(
+					'There was a problem exporting your %s Report. Please try again.',
+					'woocommerce-admin'
+				),
+				reportTitle
+			)
+		);
+	}
+};
+
+export default {
+	initiateReportExport,
+};

--- a/client/wc-api/export/operations.js
+++ b/client/wc-api/export/operations.js
@@ -1,0 +1,47 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { getResourcePrefix } from '../utils';
+import { NAMESPACE } from '../constants';
+
+function update( resourceNames, data, fetch = apiFetch ) {
+	return [ ...initiateExport( resourceNames, data, fetch ) ];
+}
+
+function initiateExport( resourceNames, data, fetch ) {
+	const filteredNames = resourceNames.filter( name => {
+		return name.startsWith( 'report-export-' );
+	} );
+
+	return filteredNames.map( async resourceName => {
+		const prefix = getResourcePrefix( resourceName );
+		const reportType = prefix.split( '-' ).pop();
+		const url = NAMESPACE + '/reports/' + reportType + '/export';
+
+		try {
+			const result = await fetch( {
+				path: url,
+				method: 'POST',
+				// @todo - add email param when PR #2899 is merged.
+				data: { report_args: data[ resourceName ] },
+			} );
+
+			return {
+				[ resourceName ]: { [ result.status ]: result.message },
+			};
+		} catch ( error ) {
+			return { [ resourceName ]: { error } };
+		}
+	} );
+}
+
+export default {
+	update,
+};

--- a/client/wc-api/wc-api-spec.js
+++ b/client/wc-api/wc-api-spec.js
@@ -3,6 +3,7 @@
 /**
  * Internal dependencies
  */
+import reportExport from './export';
 import items from './items';
 import imports from './imports';
 import notes from './notes';
@@ -18,6 +19,7 @@ function createWcApiSpec() {
 	return {
 		name: 'wcApi',
 		mutations: {
+			...reportExport.mutations,
 			...items.mutations,
 			...notes.mutations,
 			...onboarding.mutations,
@@ -59,6 +61,7 @@ function createWcApiSpec() {
 			},
 			update( resourceNames, data ) {
 				return [
+					...reportExport.operations.update( resourceNames, data ),
 					...items.operations.update( resourceNames, data ),
 					...notes.operations.update( resourceNames, data ),
 					...onboarding.operations.update( resourceNames, data ),


### PR DESCRIPTION
Fixes #311 in part.

This PR seeks to initiate background report exports from the report table download button, if the report is more than one page.

While the success notice says you'll receive an email - that won't be true until #2899 is merged.

### Screenshots

![Screen Shot 2019-09-24 at 2 07 33 PM](https://user-images.githubusercontent.com/63922/65550560-ae498e80-ded4-11e9-8759-cef394a84909.png)

### Detailed test instructions:

- Open a report with more only 1 page of results
- Click download
- Verify a .csv file is immediately downloaded
- Open a report with more only 1 page of results
- Click download
- Verify a notice is displayed stating you'll receive an email
- Check your `wp-content/uploads` dir for the .csv file


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

N/A - Changelog can wait until this is fully hooked up.