### PR TITLE
Copy component READMEs to docs folder before GH page deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,13 @@ branches:
   only:
     - master
 
+before_deploy:
+  # Remove our unneeded symlink.
+  - rm docs/components/packages
+  # Copy each component README to the docs folder.
+  - find packages/components/src -type f -name 'README.md' | sed 's/\(packages\/components\/src\/\)\(.*\)README\.md/docs\/components\/packages\/\2/g' | xargs mkdir -p
+  - find packages/components/src -type f -name 'README.md' | sed 's/\(packages\/components\/src\/\)\(.*\)\(README\.md\)/\1\2\3 docs\/components\/packages\/\2/g' | xargs -n2 cp
+
 deploy:
   local_dir: docs
   provider: pages


### PR DESCRIPTION
Turns out the GH Pages Travis CI deploy does not follow symlinks when copying/pushing files.

This PR seeks to add a `before_deploy` script that:
* Removes the `docs/components/packages -> packages/components/src` symlink
* Copies all `README.md`s from the components src to `docs/components/packages/**`

### Detailed test instructions:

This really just needs to be tested in situ on Travis CI, but to approximate a test locally:

- Run each command of the `before_deploy` script in order from the root of the repo
- Verify that the `docs/components/packages` directory has been populated with component READMEs (nested)
