### PR TITLE
Add Square & Klarna to Payments Task

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -1,5 +1,10 @@
 /** @format */
 
+.woocommerce-page:not(.woocommerce-embed-page) #klarna-banner,
+#klarna-kp-banner {
+	display: none;
+}
+
 .woocommerce-dashboard__columns {
 	display: grid;
 	grid-template-columns: calc(50% - #{$gap-large/2}) calc(50% - #{$gap-large/2});

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { filter } from 'lodash';
+import { filter, get } from 'lodash';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -45,7 +45,7 @@ class TaskDashboard extends Component {
 	}
 
 	getTasks() {
-		const { profileItems, query } = this.props;
+		const { profileItems, query, paymentsCompleted } = this.props;
 
 		return [
 			{
@@ -130,6 +130,7 @@ class TaskDashboard extends Component {
 				after: <i className="material-icons-outlined">chevron_right</i>,
 				onClick: () => updateQueryString( { task: 'payments' } ),
 				container: <Payments />,
+				className: paymentsCompleted ? 'is-complete' : null,
 				visible: true,
 			},
 		];
@@ -175,8 +176,16 @@ class TaskDashboard extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItems } = select( 'wc-api' );
+		const { getProfileItems, getOptions } = select( 'wc-api' );
 		const profileItems = getProfileItems();
-		return { profileItems };
+
+		const options = getOptions( [ 'woocommerce_onboarding_payments' ] );
+		const paymentsCompleted = get(
+			options,
+			[ 'woocommerce_onboarding_payments', 'completed' ],
+			false
+		);
+
+		return { profileItems, paymentsCompleted };
 	} )
 )( TaskDashboard );

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -202,6 +202,16 @@
 		margin-top: $gap-large;
 	}
 
+	.woocommerce-list__item .woocommerce-list__item-before {
+		max-width: 96px;
+		background: $studio-gray-0;
+		padding: $gap-small;
+
+		img {
+			max-width: 72px;
+		}
+	}
+
 	.woocommerce-list__item-title {
 		border-top: 1px solid $studio-gray-5;
 		padding-top: $gap;

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -17,6 +17,7 @@ import { withDispatch } from '@wordpress/data';
 import { getCountryCode } from 'dashboard/utils';
 import { Form, Card, Stepper, List } from '@woocommerce/components';
 import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
+import { WC_ASSET_URL as wcAssetUrl } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ import Plugins from '../steps/plugins';
 import Stripe from './stripe';
 import Square from './square';
 import PayPal from './paypal';
+import Klarna from './klarna';
 
 class Payments extends Component {
 	constructor() {
@@ -85,7 +87,11 @@ class Payments extends Component {
 	}
 
 	completeTask() {
-		// @todo Mark as completed on the task list.
+		this.props.updateOptions( {
+			[ 'woocommerce_onboarding_payments' ]: {
+				completed: 1,
+			},
+		} );
 		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
 
@@ -121,8 +127,10 @@ class Payments extends Component {
 	}
 
 	completePluginInstall() {
+		const { completed } = this.props;
 		this.props.updateOptions( {
 			[ 'woocommerce_onboarding_payments' ]: {
+				completed: completed || false,
 				installed: 1,
 				methods: this.getMethodsToConfigure(),
 			},
@@ -200,7 +208,7 @@ class Payments extends Component {
 						{ this.renderWooCommerceServicesStripeConnect() }
 					</Fragment>
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/stripe.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'stripe' ) } />,
 				visible: true,
 			},
@@ -214,7 +222,7 @@ class Payments extends Component {
 						) }
 					</Fragment>
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/paypal.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'paypal' ) } />,
 				visible: true,
 			},
@@ -224,7 +232,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_checkout' ) } />,
 				visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
 			},
@@ -234,7 +242,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_payments' ) } />,
 				visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
 			},
@@ -245,7 +253,7 @@ class Payments extends Component {
 						'Sell online and in store and track sales and inventory in one place.',
 					'woocommerce-admin'
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/square-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'square' ) } />,
 				visible:
 					[ 'brick-mortar', 'brick-mortar-other' ].includes( profileItems.selling_venues ) &&
@@ -385,7 +393,32 @@ class Payments extends Component {
 				),
 				visible: showIndividualConfigs && methods.includes( 'square' ),
 			},
-			// @todo Klarna
+			{
+				key: 'klarna-checkout',
+				label: __( 'Klarna', 'woocommerce-admin' ),
+				description: '',
+				content: (
+					<Klarna
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+						plugin={ 'checkout' }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'klarna-checkout' ),
+			},
+			{
+				key: 'klarna-payments',
+				label: __( 'Klarna', 'woocommerce-admin' ),
+				description: '',
+				content: (
+					<Klarna
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+						plugin={ 'payments' }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'klarna-payments' ),
+			},
 		];
 
 		return filter( steps, step => step.visible );
@@ -443,6 +476,8 @@ export default compose(
 		const installed = get( options, [ 'woocommerce_onboarding_payments', 'installed' ], false );
 		const configured = get( options, [ 'woocommerce_onboarding_payments', 'configured' ], [] );
 
+		const completed = get( options, [ 'woocommerce_onboarding_payments', 'completed' ], false );
+
 		return {
 			countryCode,
 			isSettingsError,
@@ -455,6 +490,7 @@ export default compose(
 			methods,
 			installed,
 			configured,
+			completed,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -24,6 +24,7 @@ import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
 import withSelect from 'wc-api/with-select';
 import Plugins from '../steps/plugins';
 import Stripe from './stripe';
+import Square from './square';
 import PayPal from './paypal';
 
 class Payments extends Component {
@@ -372,8 +373,19 @@ class Payments extends Component {
 				),
 				visible: showIndividualConfigs && methods.includes( 'paypal' ),
 			},
+			{
+				key: 'square',
+				label: __( 'Enable Square', 'woocommerce-admin' ),
+				description: __( 'Connect your store to your Square account', 'woocommerce-admin' ),
+				content: (
+					<Square
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'square' ),
+			},
 			// @todo Klarna
-			// @todo Square
 		];
 
 		return filter( steps, step => step.visible );

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -200,7 +200,7 @@ class Payments extends Component {
 						{ this.renderWooCommerceServicesStripeConnect() }
 					</Fragment>
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/stripe.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'stripe' ) } />,
 				visible: true,
 			},
@@ -214,7 +214,7 @@ class Payments extends Component {
 						) }
 					</Fragment>
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/paypal.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'paypal' ) } />,
 				visible: true,
 			},
@@ -224,7 +224,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_checkout' ) } />,
 				visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
 			},
@@ -234,7 +234,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_payments' ) } />,
 				visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
 			},
@@ -245,7 +245,7 @@ class Payments extends Component {
 						'Sell online and in store and track sales and inventory in one place.',
 					'woocommerce-admin'
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'square' ) } />,
 				visible:
 					[ 'brick-mortar', 'brick-mortar-other' ].includes( profileItems.selling_venues ) &&

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -1,0 +1,69 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { Button } from 'newspack-components';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
+import { Link } from '@woocommerce/components';
+
+class Klarna extends Component {
+	constructor( props ) {
+		super( props );
+		this.continue = this.continue.bind( this );
+	}
+
+	continue() {
+		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		this.props.markConfigured( slug );
+		return;
+	}
+
+	render() {
+		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		const section = 'checkout' === this.props.plugin ? 'kco' : 'klarna_payments';
+
+		const link = (
+			<Link
+				href={ adminUrl + 'admin.php?page=wc-settings&tab=checkout&section=' + section }
+				target="_blank"
+				type="external"
+			/>
+		);
+
+		const helpLink = (
+			<Link
+				href={ 'https://docs.woocommerce.com/document/' + slug + '/#section-3' }
+				target="_blank"
+				type="external"
+			/>
+		);
+
+		const configureText = interpolateComponents( {
+			mixedString: __(
+				'Klarna can be configured under your {{link}}store settings{{/link}}. Figure out {{helpLink}}what you need{{/helpLink}}.',
+				'woocommerce-admin'
+			),
+			components: {
+				link,
+				helpLink,
+			},
+		} );
+		return (
+			<Fragment>
+				<p>{ configureText }</p>
+				<Button isPrimary isDefault onClick={ this.continue }>
+					{ __( 'Continue', 'woocommerce-admin' ) }
+				</Button>
+			</Fragment>
+		);
+	}
+}
+
+export default Klarna;

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -1,0 +1,144 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from 'newspack-components';
+import { getQuery } from '@woocommerce/navigation';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * WooCommerce dependencies
+ */
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
+import withSelect from 'wc-api/with-select';
+
+class Square extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showSkipButton: false,
+		};
+
+		this.connect = this.connect.bind( this );
+	}
+
+	componentDidMount() {
+		const query = getQuery();
+		// Handle redirect back from Square
+		if ( query[ 'square-connect' ] ) {
+			if ( '1' === query[ 'square-connect' ] ) {
+				this.props.markConfigured( 'square' );
+				this.props.createNotice(
+					'success',
+					__( 'Square connected successfully.', 'woocommerce-admin' )
+				);
+				return;
+			}
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( false === prevProps.optionsIsRequesting && true === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( true );
+		}
+
+		if ( true === prevProps.optionsIsRequesting && false === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( false );
+		}
+	}
+
+	renderConnectButton() {
+		return (
+			<Button isPrimary isDefault onClick={ this.connect }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
+	async connect() {
+		const { updateOptions } = this.props;
+		this.props.setRequestPending( true );
+
+		updateOptions( {
+			woocommerce_stripe_settings: {
+				...this.props.options.woocommerce_stripe_settings,
+				enabled: 'yes',
+			},
+		} );
+
+		const errorMessage = __(
+			'There was an error connecting to Square. Please try again or skip to connect later in store settings.',
+			'woocommerce-admin'
+		);
+
+		try {
+			const result = await apiFetch( {
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square2',
+				method: 'POST',
+			} );
+
+			if ( ! result || ! result.connectUrl ) {
+				this.props.setRequestPending( false );
+				this.setState( { showSkipButton: true } );
+				this.props.createNotice( 'error', errorMessage );
+				return;
+			}
+
+			this.props.setRequestPending( false );
+			window.location = result.connectUrl;
+		} catch ( error ) {
+			this.props.setRequestPending( false );
+			this.setState( { showSkipButton: true } );
+			this.props.createNotice( 'error', errorMessage );
+		}
+	}
+
+	render() {
+		const { showSkipButton } = this.state;
+
+		return (
+			<Fragment>
+				<Button isPrimary isDefault onClick={ this.connect }>
+					{ __( 'Connect', 'woocommerce-admin' ) }
+				</Button>
+				{ showSkipButton && (
+					<Button
+						onClick={ () => {
+							this.props.markConfigured( 'square' );
+						} }
+					>
+						{ __( 'Skip', 'woocommerce-admin' ) }
+					</Button>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default compose(
+	withSelect( select => {
+		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_stripe_settings' ] );
+		const optionsIsRequesting = Boolean(
+			isGetOptionsRequesting( [ 'woocommerce_stripe_settings' ] )
+		);
+
+		return {
+			options,
+			optionsIsRequesting,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( Square );

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -52,14 +52,6 @@ class Square extends Component {
 		}
 	}
 
-	renderConnectButton() {
-		return (
-			<Button isPrimary isDefault onClick={ this.connect }>
-				{ __( 'Connect', 'woocommerce-admin' ) }
-			</Button>
-		);
-	}
-
 	async connect() {
 		const { updateOptions } = this.props;
 		this.props.setRequestPending( true );
@@ -78,7 +70,7 @@ class Square extends Component {
 
 		try {
 			const result = await apiFetch( {
-				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square2',
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square',
 				method: 'POST',
 			} );
 


### PR DESCRIPTION
Closes #2684. This PR adds the remainder of the big pieces:

* Square connection logic (oauth flow only, no manual configuration mode)
* Klarna, where we just provide a configuration link. Setup can be pretty involved, involving multiple API keys even requires approval from Klarna to start selling -- so we'll just help them install the plugin. p1569430941016800-slack-wc-onboarding.
* Logos have been added to the main payment methods as well.
* The task is now marked as completed once you run through all the tasks. You can renter the task to run through the steps again (though perhaps it would make more sense to link to payment settings?)

Note: The way Klarna hooks into the header to output its setup banners messes with the display of WooCommerce Admin and I haven't fixed this yet. I'll do that in a follow up PR next week, and will probably also log some issues in those repos.

### Screenshots

<img width="750" alt="Screen Shot 2019-09-25 at 12 46 07 PM" src="https://user-images.githubusercontent.com/689165/65623629-3a6fba80-df96-11e9-9323-62e3ff6e4b7f.png">

<img width="734" alt="Screen Shot 2019-09-25 at 1 31 28 PM" src="https://user-images.githubusercontent.com/689165/65625274-7fe1b700-df99-11e9-9a5c-c887a7c6c0b0.png">

<img width="612" alt="Screen Shot 2019-09-25 at 4 21 03 PM" src="https://user-images.githubusercontent.com/689165/65636590-93e4e300-dfb0-11e9-93d0-418723e88d11.png">

### Detailed test instructions:

* Delete the `woocommerce_onboarding_payments` option if you have previously tested this branch, the Stripe/PayPal branch.

* For Square to display in the payments task, your country must be set to `'US', 'CA', 'JP', 'GB', 'AU'` and you must have said you have a brick and motor store during the profiler step.

* Go Under Settings > Square and make sure Square is disconnected.

* Run through the payments task and test the square payment method connection flow. You should get a success message. Check under Settings > Square and verify square is connected.

* For Klarna Payments to display, your country must be set as `'DK', 'DE', 'AT'`.
* For Klarna Checkout to display, your country must be `'SE', 'FI', 'NO', 'NL' `.