### PR TITLE
Fix DevDocs example render.

### DIFF
--- a/client/devdocs/example.js
+++ b/client/devdocs/example.js
@@ -18,7 +18,9 @@ class Example extends Component {
 		let exampleComponent;
 
 		try {
-			exampleComponent = require( `components/src/${ this.props.filePath }/docs/example` );
+			exampleComponent = require( `../../packages/components/src/${
+				this.props.filePath
+			}/docs/example` );
 		} catch ( e ) {
 			// eslint-disable-next-line no-console
 			console.error( e );

--- a/packages/components/src/advanced-filters/docs/example.js
+++ b/packages/components/src/advanced-filters/docs/example.js
@@ -3,7 +3,7 @@
  * Internal dependencies
  */
 import { AdvancedFilters } from '@woocommerce/components';
-const { ORDER_STATUSES } = '@woocommerce/wc-admin-settings';
+import { ORDER_STATUSES } from '@woocommerce/wc-admin-settings';
 
 const path = ( new URL( document.location ) ).searchParams.get( 'path' ) || '/devdocs';
 const query = {


### PR DESCRIPTION
Fixes some incorrect changes chosen in a merge conflict resolution.

### Detailed test instructions:

- Go to WooCommerce > DevDocs
- Verify the examples (including `AdvancedFilters`) render

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A
