### PR TITLE
Update README.md and CONTRIBUTING.md (moving and adding)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,35 @@ After you've made your updates, you're ready to commit:
 3. Create your commit. Write a descriptive, but short first line (e.g. "Reports: Reticulate the splines"), and add more details below. If your commit addresses a github issue, reference it by number here (e.g. "This commit fixes issue #123 by reticulating all the splines.")
 4. Push the branch up to your local fork, then create a PR via the GitHub web interface.
 
+## Helper Scripts
+
+There are a number of helper scripts exposed via our `package.json` (below list is not exhaustive, you can view the [`package.json` file directly to see all](https://github.com/woocommerce/woocommerce-admin/blob/master/package.json)):
+
+ - `npm run lint` : Run eslint over the javascript files
+ - `npm run i18n` : A multi-step process, used to create a pot file from both the JS and PHP gettext calls. First it runs `i18n:js`, which creates a temporary `.pot` file from the JS files. Next it runs `i18n:php`, which converts that `.pot` file to a PHP file. Lastly, it runs `i18n:pot`, which creates the final `.pot` file from all the PHP files in the plugin (including the generated one with the JS strings).
+ - `npm test` : Run the JS test suite
+ - `npm run docs`: Runs the script for generating/updating docs.
+
+## Debugging
+
+### Debugging synced lookup information:
+
+To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_disable_order_scheduling` hook.
+
+```php
+add_filter( 'woocommerce_disable_order_scheduling', '__return_true' );
+```
+
+### Using `debug` package.
+
+Currently, the [debug package](https://github.com/visionmedia/debug) is utilized to provide additional debugging for various systems. This tool outputs additional debugging information in the browser console when it is activated.
+
+To activate, open up your browser console and add this:
+
+```js
+localStorage.setItem( 'debug', 'wc-admin:*' );
+```
+
 ## License
 
 WooCommerce Admin is licensed under [GNU General Public License v3 (or later)](/license.txt).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', tru
 ## Development
 
 After cloning the repo, install dependencies:
- 
+
  - `npm install` to install JavaScript dependencies.
  - `composer install` to gather PHP dependencies.
 
@@ -28,15 +28,9 @@ Now you can build the files using one of these commands:
  - `npm start` : Build a development version, watch files for changes
  - `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
 
-There are also some helper scripts:
+For more helper scripts [see here](./CONTRIBUTING.md#helper-scripts)
 
- - `npm run lint` : Run eslint over the javascript files
- - `npm run i18n` : A multi-step process, used to create a pot file from both the JS and PHP gettext calls. First it runs `i18n:js`, which creates a temporary `.pot` file from the JS files. Next it runs `i18n:php`, which converts that `.pot` file to a PHP file. Lastly, it runs `i18n:pot`, which creates the final `.pot` file from all the PHP files in the plugin (including the generated one with the JS strings).
- - `npm test` : Run the JS test suite
-
- To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_disable_order_scheduling` hook.
-
-`add_filter( 'woocommerce_disable_order_scheduling', '__return_true' );`
+For some debugging tools/help [see here](./CONTRIBUTING.md#debugging)
 
 ## Privacy
 


### PR DESCRIPTION
In this pull:

- I moved the helper scripts section to `CONTRIBUTING.md` (linked from README.md).  This helps with extra surfacing of the contributor doc.
- I added `npm run docs` script to this section and also included a link to package.json for all scripts.
- I moved debug section to `CONTRIBUTING.md` and added information about the `debug` package.