### PR TITLE
Ignore filename rules for PSR-4 classes.

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,6 +33,10 @@
 		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
 	</rule>
 
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>src/*</exclude-pattern>
+	</rule>
+
 	<rule ref="Generic.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>


### PR DESCRIPTION
The linter started rejecting the PSR-4 classnames because they aren't lowercase.