### PR TITLE
Change usage tracking prompt to modal

### DIFF
--- a/client/dashboard/profile-wizard/steps/usage-modal.js
+++ b/client/dashboard/profile-wizard/steps/usage-modal.js
@@ -1,0 +1,143 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, CheckboxControl } from 'newspack-components';
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
+import { get } from 'lodash';
+import interpolateComponents from 'interpolate-components';
+import { FormToggle, Modal } from '@wordpress/components';
+
+/**
+ * Internal depdencies
+ */
+import { Link } from '@woocommerce/components';
+import withSelect from 'wc-api/with-select';
+
+class UsageModal extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			allowTracking: props.allowTracking,
+		};
+
+		this.onTrackingChange = this.onTrackingChange.bind( this );
+	}
+
+	onTrackingChange() {
+		this.setState( {
+			allowTracking: ! this.state.allowTracking,
+		} );
+	}
+
+	async componentDidUpdate( prevProps ) {
+		const { hasErrors, isRequesting } = this.props;
+		const isRequestSuccessful = ! isRequesting && prevProps.isRequesting && ! hasErrors;
+		const isRequestError = ! isRequesting && prevProps.isRequesting && hasErrors;
+
+		if ( isRequestSuccessful ) {
+			this.props.onClose();
+			this.props.onContinue();
+		}
+
+		if ( isRequestError ) {
+			this.props.createNotice(
+				'error',
+				__( 'There was a problem updating your preferences.', 'woocommerce-admin' )
+			);
+			this.props.onClose();
+		}
+	}
+
+	updateTracking() {
+		const { updateOptions } = this.props;
+		const allowTracking = this.state.allowTracking ? 'yes' : 'no';
+		updateOptions( {
+			[ 'woocommerce_allow_tracking' ]: allowTracking,
+		} );
+	}
+
+	render() {
+		const { allowTracking } = this.state;
+		const { isRequesting } = this.props;
+		const trackingMessage = interpolateComponents( {
+			mixedString: __(
+				"Learn more about how usage tracking works, and how you'll be helping {{link}}here{{/link}}.",
+				'woocommerce-admin'
+			),
+			components: {
+				link: (
+					<Link href="https://woocommerce.com/usage-tracking" target="_blank" type="external" />
+				),
+			},
+		} );
+
+		return (
+			<Modal
+				title={ __( 'Help improve WooCommerce with usage tracking', 'woocommerce-admin' ) }
+				onRequestClose={ () => this.props.onClose() }
+				className="woocommerce-profile-wizard__usage-modal"
+			>
+				<div className="woocommerce-profile-wizard__usage-wrapper">
+					<div className="woocommerce-profile-wizard__usage-modal-message">{ trackingMessage }</div>
+					<div className="woocommerce-profile-wizard__tracking">
+						<CheckboxControl
+							className="woocommerce-profile-wizard__tracking-checkbox"
+							checked={ allowTracking }
+							label={ __(
+								'Enable usage tracking and help improve WooCommerce',
+								'woocommerce-admin'
+							) }
+							onChange={ this.onTrackingChange }
+						/>
+
+						<FormToggle
+							aria-hidden="true"
+							checked={ allowTracking }
+							onChange={ this.onTrackingChange }
+							onClick={ e => e.stopPropagation() }
+							tabIndex="-1"
+						/>
+					</div>
+					<Button
+						isPrimary
+						isDefault
+						isBusy={ isRequesting }
+						onClick={ () => this.updateTracking() }
+					>
+						{ __( 'Continue', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+}
+
+export default compose(
+	withSelect( select => {
+		const { getOptions, getOptionsError, isUpdateOptionsRequesting } = select( 'wc-api' );
+
+		const options = getOptions( [ 'woocommerce_allow_tracking' ] );
+		const allowTracking = 'yes' === get( options, [ 'woocommerce_allow_tracking' ], false );
+		const isRequesting = Boolean( isUpdateOptionsRequesting( [ 'woocommerce_allow_tracking' ] ) );
+		const hasErrors = Boolean( getOptionsError( [ 'woocommerce_allow_tracking' ] ) );
+
+		return {
+			allowTracking,
+			isRequesting,
+			hasErrors,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( UsageModal );

--- a/client/dashboard/profile-wizard/steps/usage-modal.js
+++ b/client/dashboard/profile-wizard/steps/usage-modal.js
@@ -34,21 +34,21 @@ class UsageModal extends Component {
 	}
 
 	async componentDidUpdate( prevProps ) {
-		const { hasErrors, isRequesting } = this.props;
+		const { hasErrors, isRequesting, onClose, onContinue, createNotice } = this.props;
 		const isRequestSuccessful = ! isRequesting && prevProps.isRequesting && ! hasErrors;
 		const isRequestError = ! isRequesting && prevProps.isRequesting && hasErrors;
 
 		if ( isRequestSuccessful ) {
-			this.props.onClose();
-			this.props.onContinue();
+			onClose();
+			onContinue();
 		}
 
 		if ( isRequestError ) {
-			this.props.createNotice(
+			createNotice(
 				'error',
 				__( 'There was a problem updating your preferences.', 'woocommerce-admin' )
 			);
-			this.props.onClose();
+			onClose();
 		}
 	}
 
@@ -56,7 +56,7 @@ class UsageModal extends Component {
 		const { updateOptions } = this.props;
 		const allowTracking = this.state.allowTracking ? 'yes' : 'no';
 		updateOptions( {
-			[ 'woocommerce_allow_tracking' ]: allowTracking,
+			woocommerce_allow_tracking: allowTracking,
 		} );
 	}
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -311,3 +311,31 @@
 		margin: 0;
 	}
 }
+
+.components-modal__frame.woocommerce-profile-wizard__usage-modal {
+	min-width: 600px;
+
+	.components-modal__header {
+		border-bottom: 0;
+		margin-bottom: 0;
+	}
+
+	.woocommerce-profile-wizard__usage-wrapper {
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+
+		a {
+			color: $studio-gray-60;
+		}
+
+		button.is-primary {
+			min-width: 160px;
+			align-self: flex-end;
+		}
+
+		.muriel-checkbox label.components-checkbox-control__label {
+			font-size: 13px;
+		}
+	}
+}

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -336,6 +336,7 @@
 		button.is-primary {
 			min-width: 160px;
 			align-self: flex-end;
+			margin-bottom: 0;
 		}
 
 		.muriel-checkbox label.components-checkbox-control__label {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -12,6 +12,10 @@
 		font-weight: normal;
 	}
 
+	.woocommerce-profile-wizard__continue {
+		line-height: 32px;
+	}
+
 	.woocommerce-card {
 		margin-top: $gap;
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,6 +27,12 @@
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 
+	<rule ref="PHPCompatibility.FunctionUse.NewFunctionParameters.ucwords_delimitersFound">
+		<exclude-pattern>src/*</exclude-pattern>
+		<exclude-pattern>tests/*</exclude-pattern>
+		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
+	</rule>
+
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>src/*</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,12 +27,6 @@
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>
 
-	<rule ref="PHPCompatibility.FunctionUse.NewFunctionParameters.ucwords_delimitersFound">
-		<exclude-pattern>src/*</exclude-pattern>
-		<exclude-pattern>tests/*</exclude-pattern>
-		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
-	</rule>
-
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>src/*</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -216,6 +216,18 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
+			'wcs_jetpack'         => array(
+				'type'              => 'string',
+				'description'       => __( 'How the Jetpack/WooCommerce Services step was handled.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => array(
+					'skipped',
+					'already-installed',
+					'wizard',
+				),
+			),
 			'account_type'        => array(
 				'type'              => 'string',
 				'description'       => __( 'Account type used for Jetpack.', 'woocommerce-admin' ),
@@ -278,7 +290,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'brick-mortar-other',
 				),
 			),
-			'revenue'      => array(
+			'revenue'             => array(
 				'type'              => 'string',
 				'description'       => __( 'Current annual revenue of the store.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -346,30 +346,17 @@ class Onboarding {
 	}
 
 	/**
-	 * Preload options to prime WooCommerce Admin.
-	 *
-	 * @param array $options Array of preloaded options.
-	 * @return array
-	 */
-	public function preload_options( $options ) {
-		if ( ! $this->should_show_profiler() ) {
-			return $options;
-		}
-		$options[] = 'woocommerce_allow_tracking';
-		return $options;
-	}
-
-	/**
 	 * Preload options to prime state of the application.
 	 *
 	 * @param array $options Array of options to preload.
 	 * @return array
 	 */
 	public function preload_options( $options ) {
-		if ( ! $this->should_show_tasks() ) {
+		if ( ! $this->should_show_tasks() && ! $this->should_show_profiler() ) {
 			return $options;
 		}
 		$options[] = 'woocommerce_onboarding_payments';
+		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
 		return $options;
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -57,10 +57,10 @@ class Onboarding {
 		if ( $this->should_show_tasks() ) {
 			OnboardingTasks::get_instance();
 		}
-		// old settings injection.
+		// Old settings injection.
 		// Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
-		// new settings injection.
+		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
@@ -345,6 +345,12 @@ class Onboarding {
 		return $settings;
 	}
 
+	/**
+	 * Preload options to prime WooCommerce Admin.
+	 *
+	 * @param array $options Array of preloaded options.
+	 * @return array
+	 */
 	public function preload_options( $options ) {
 		if ( ! $this->should_show_profiler() ) {
 			return $options;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -345,6 +345,14 @@ class Onboarding {
 		return $settings;
 	}
 
+	public function preload_options( $options ) {
+		if ( ! $this->should_show_profiler() ) {
+			return $options;
+		}
+		$options[] = 'woocommerce_allow_tracking';
+		return $options;
+	}
+
 	/**
 	 * Preload options to prime state of the application.
 	 *

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -99,7 +99,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 14, $properties );
+		$this->assertCount( 15, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
 		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
@@ -113,6 +113,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'theme', $properties );
 		$this->assertArrayHasKey( 'wccom_connected', $properties );
 		$this->assertArrayHasKey( 'items_purchased', $properties );
+		$this->assertArrayHasKey( 'wcs_jetpack', $properties );
 		$this->assertArrayHasKey( 'setup_client', $properties );
 	}
 


### PR DESCRIPTION
Closes #2965.

This PR changes the usage tracking checkbox to a modal per the designs in #2934. It also makes it opted-out by default (though if you have run through the wizard before, it is defaulted to your previous selection).

It also detects if the Jetpack/WCS were skipped (because the extensions were already installed), and instead shows the modal on the store details page instead. See p1565365006096800-slack-wc-onboarding

I was getting some linter errors unrelated to this PR, so I've fixed a few of those up here to get tests to pass.

### Screenshots

<img width="869" alt="Screen Shot 2019-09-26 at 2 17 34 PM" src="https://user-images.githubusercontent.com/689165/65714518-3bbde780-e069-11e9-8209-3996cf96345f.png">

<img width="703" alt="Screen Shot 2019-09-26 at 2 29 18 PM" src="https://user-images.githubusercontent.com/689165/65717012-534b9f00-e06e-11e9-9e64-bedb3acd79f2.png">

### Detailed test instructions:

* Clear out the `woocommerce_allow_tracking` option from your database.
* Testing with Jetpack or WooCommerce Services disabled so that you see the start screen.
* Click `Get Started` on the start screen. The usage tracking dialog should display. It should default to off.
* Try selecting the box and hitting continue. Verify the option updates in the database.
* Go to store settings and verify the continue button there goes to the industry step.
* Test again with the "Skip WooCommerce Services/Jetpack" link. You should still see the dialog. It should default to your previous selection.
* Enable WooCommerce Services AND Jetpack, enable the profile wizard, and go back to test. You should automatically end up on the store details page. Fill out your details, and click continue. You should see the auth dialog here instead. Verify your address updates, and the option updates in the database.