### PR TITLE
Use version number for cache invalidation

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,6 +33,10 @@
 		<exclude-pattern>woocommerce-admin.php</exclude-pattern>
 	</rule>
 
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>src/*</exclude-pattern>
+	</rule>
+
 	<rule ref="Generic.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>

--- a/src/API/Reports/Cache.php
+++ b/src/API/Reports/Cache.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * REST API Reports Cache.
+ *
+ * Handles report data object caching.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+namespace Automattic\WooCommerce\Admin\API\Reports;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Reports Cache class.
+ *
+ * @package WooCommerce Admin/API
+ */
+class Cache {
+	/**
+	 * Cache version. Used to invalidate all cached values.
+	 */
+	const VERSION_OPTION = 'woocommerce_reports_cache_version';
+
+	/**
+	 * Increase cache version number.
+	 *
+	 * @return bool
+	 */
+	public static function bump_version() {
+		$version = self::get_version();
+		$version++; // @todo - reset this after a certain value? E.g. 9999?
+
+		return update_option( self::VERSION_OPTION, $version );
+	}
+
+	/**
+	 * Get cache version number.
+	 *
+	 * @return int
+	 */
+	public static function get_version() {
+		$version = (int) get_option( self::VERSION_OPTION, 1 );
+
+		return $version;
+	}
+
+	/**
+	 * Get cached value.
+	 *
+	 * @param string $key Cache key.
+	 * @return mixed
+	 */
+	public static function get( $key ) {
+		$version = self::get_version();
+		$value   = get_transient( $key . ':' . $version );
+
+		return $value;
+	}
+
+	/**
+	 * Update cached value.
+	 *
+	 * @param string $key   Cache key.
+	 * @param mixed  $value New value.
+	 * @return bool
+	 */
+	public static function set( $key, $value ) {
+		$version = self::get_version();
+		$result  = set_transient( $key . ':' . $version, $value );
+
+		return $result;
+	}
+}

--- a/src/API/Reports/Cache.php
+++ b/src/API/Reports/Cache.php
@@ -67,7 +67,8 @@ class Cache {
 	 */
 	public static function set( $key, $value ) {
 		$version = self::get_version();
-		$result  = set_transient( $key . ':' . $version, $value );
+		// @todo - set an expiration? No other way to clean these up.
+		$result = set_transient( $key . ':' . $version, $value );
 
 		return $result;
 	}

--- a/src/API/Reports/Cache.php
+++ b/src/API/Reports/Cache.php
@@ -23,13 +23,24 @@ class Cache {
 	const VERSION_OPTION = 'woocommerce_reports_cache_version';
 
 	/**
+	 * Default version number rollover threshold.
+	 */
+	const DEFAULT_VERSION_LIMIT = 99999;
+
+	/**
 	 * Increase cache version number.
 	 *
 	 * @return bool
 	 */
 	public static function bump_version() {
-		$version = self::get_version();
-		$version++; // @todo - reset this after a certain value? E.g. 9999?
+		/**
+		 * Upper limit to roll cache version back to zero.
+		 *
+		 * @param int $limit Limit.
+		 */
+		$limit   = apply_filters( 'woocommerce_reports_cache_version_limit', self::DEFAULT_VERSION_LIMIT );
+		$limit   = is_numeric( $limit ) ? (int) $limit : self::DEFAULT_VERSION_LIMIT;
+		$version = ( self::get_version() + 1 ) % $limit;
 
 		return update_option( self::VERSION_OPTION, $version );
 	}
@@ -67,8 +78,7 @@ class Cache {
 	 */
 	public static function set( $key, $value ) {
 		$version = self::get_version();
-		// @todo - set an expiration? No other way to clean these up.
-		$result = set_transient( $key . ':' . $version, $value );
+		$result  = set_transient( $key . ':' . $version, $value, DAY_IN_SECONDS );
 
 		return $result;
 	}

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -253,8 +253,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -326,7 +330,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_product_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'categories';
+
+	/**
 	 * Order by setting used for sorting categories data.
 	 *
 	 * @var string
@@ -323,15 +330,5 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStore as ReportsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 
 /**
  * API\Reports\Coupons\DataStore.
@@ -441,6 +442,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $order_id  Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_coupon', 0, $order_id );
+
+		ReportsCache::bump_version();
 	}
 
 	/**
@@ -460,6 +463,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$wpdb->prefix . self::TABLE_NAME,
 			array( 'coupon_id' => $post_id )
 		);
+
+		ReportsCache::bump_version();
 	}
 
 	/**

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -443,7 +443,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 */
 		do_action( 'woocommerce_reports_delete_coupon', 0, $order_id );
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 	}
 
 	/**
@@ -464,7 +464,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			array( 'coupon_id' => $post_id )
 		);
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 	}
 
 	/**

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_coupon_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'coupons';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -340,16 +347,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -251,8 +251,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -343,7 +347,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Coupons/Stats/DataStore.php
+++ b/src/API/Reports/Coupons/Stats/DataStore.php
@@ -121,8 +121,12 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -227,7 +231,7 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 			$segmenter->add_intervals_segments( $data, $intervals_query, $table_name );
 			$this->create_interval_subtotals( $data->intervals );
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Coupons/Stats/DataStore.php
+++ b/src/API/Reports/Coupons/Stats/DataStore.php
@@ -43,6 +43,13 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 	);
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'coupons_stats';
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -224,15 +231,5 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -689,7 +689,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 */
 		do_action( 'woocommerce_reports_update_customer', $customer_id );
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 
 		return $results;
 	}

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -365,8 +365,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -436,7 +440,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_customer_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'customers';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -723,15 +730,5 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $order_id Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_customer', $customer_id );
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStore as ReportsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 
 /**
  * Admin\API\Reports\Customers\DataStore.
@@ -687,6 +688,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $customer_id Customer ID.
 		 */
 		do_action( 'woocommerce_reports_update_customer', $customer_id );
+
+		ReportsCache::bump_version();
+
 		return $results;
 	}
 

--- a/src/API/Reports/Customers/Stats/DataStore.php
+++ b/src/API/Reports/Customers/Stats/DataStore.php
@@ -76,8 +76,12 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -124,7 +128,7 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 
 			$data = (object) $this->cast_numbers( $report_data[0] );
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Customers/Stats/DataStore.php
+++ b/src/API/Reports/Customers/Stats/DataStore.php
@@ -41,6 +41,13 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 	);
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'customers_stats';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -121,15 +128,5 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -85,6 +85,27 @@ class DataStore {
 	}
 
 	/**
+	 * Wrapper around Cache::get().
+	 *
+	 * @param string $cache_key Cache key.
+	 * @return mixed
+	 */
+	protected function get_cached_data( $cache_key ) {
+		return Cache::get( $cache_key );
+	}
+
+	/**
+	 * Wrapper around Cache::set().
+	 *
+	 * @param string $cache_key Cache key.
+	 * @param mixed  $value     New value.
+	 * @return bool
+	 */
+	protected function set_cached_data( $cache_key, $value ) {
+		return Cache::set( $cache_key, $value );
+	}
+
+	/**
 	 * Compares two report data objects by pre-defined object property and ASC/DESC ordering.
 	 *
 	 * @param stdClass $a Object a.
@@ -401,6 +422,7 @@ class DataStore {
 					$new_start_date->setTimestamp( $new_start_date_timestamp );
 				}
 			}
+			// @todo - Do this without modifying $query_args?
 			$query_args['adj_after']               = $new_start_date;
 			$query_args['adj_before']              = $new_end_date;
 			$adj_after                             = $new_start_date->format( TimeInterval::$sql_datetime_format );
@@ -422,6 +444,7 @@ class DataStore {
 				$intervals_query['limit'] = 'LIMIT ' . $offset . ',' . $count;
 			}
 			// Otherwise no change in limit clause.
+			// @todo - Do this without modifying $query_args?
 			$query_args['adj_after']  = $query_args['after'];
 			$query_args['adj_before'] = $query_args['before'];
 		}

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -68,6 +68,23 @@ class DataStore {
 	private $order = '';
 
 	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return implode(
+			'_',
+			array(
+				'wc_report',
+				$this->cache_key,
+				md5( wp_json_encode( $params ) ),
+			)
+		);
+	}
+
+	/**
 	 * Compares two report data objects by pre-defined object property and ASC/DESC ordering.
 	 *
 	 * @param stdClass $a Object a.

--- a/src/API/Reports/Downloads/DataStore.php
+++ b/src/API/Reports/Downloads/DataStore.php
@@ -332,8 +332,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -398,7 +402,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Downloads/DataStore.php
+++ b/src/API/Reports/Downloads/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_download_log';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'downloads';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -395,16 +402,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -37,6 +37,13 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 	);
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'downloads_stats';
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -177,16 +184,6 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -76,8 +76,12 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$selections       = $this->selected_columns( $query_args );
@@ -180,7 +184,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			}
 			$this->create_interval_subtotals( $data->intervals );
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -190,8 +190,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -265,7 +269,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -25,6 +25,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_stats';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'orders';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -421,15 +428,5 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 		return $coupons;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -234,8 +234,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -366,7 +370,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$segmenter->add_intervals_segments( $data, $intervals_query, $table_name );
 			$this->create_interval_subtotals( $data->intervals );
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStore as ReportsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 
 /**
  * API\Reports\Orders\Stats\DataStore.
@@ -540,6 +541,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $order_id Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_order_stats', $order_id );
+
+		ReportsCache::bump_version();
 	}
 
 

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -542,7 +542,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 */
 		do_action( 'woocommerce_reports_delete_order_stats', $order_id );
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 	}
 
 

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -31,6 +31,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const CRON_EVENT = 'wc_order_stats_update';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'orders_stats';
+
+	/**
 	 * Type for each column to cast values correctly later.
 	 *
 	 * @var array
@@ -276,7 +283,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$unique_products            = $this->get_unique_product_count( $totals_query['from_clause'], $totals_query['where_time_clause'], $totals_query['where_clause'] );
 			$totals[0]['products']      = $unique_products;
-			$segmenter                   = new Segmenter( $query_args, $this->report_columns );
+			$segmenter                  = new Segmenter( $query_args, $this->report_columns );
 			$unique_coupons             = $this->get_unique_coupon_count( $totals_query['from_clause'], $totals_query['where_time_clause'], $totals_query['where_clause'] );
 			$totals[0]['coupons_count'] = $unique_coupons;
 			$totals[0]['segments']      = $segmenter->get_totals_segments( $totals_query, $table_name );
@@ -629,15 +636,5 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$customer_id
 			)
 		);
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -502,6 +502,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 */
 		do_action( 'woocommerce_reports_delete_product', 0, $order_id );
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 	}
 }

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -278,8 +278,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -374,7 +378,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStore as ReportsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 
 /**
  * API\Reports\Products\DataStore.
@@ -500,5 +501,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $order_id   Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_product', 0, $order_id );
+
+		ReportsCache::bump_version();
 	}
 }

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_product_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'products';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -371,16 +378,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -125,10 +125,14 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
-		$cache_key    = $this->get_cache_key( $query_args );
-		$product_data = wp_cache_get( $cache_key, $this->cache_group );
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
+		$cache_key = $this->get_cache_key( $query_args );
+		$data      = $this->get_cached_data( $cache_key );
 
-		if ( false === $product_data ) {
+		if ( false === $data ) {
 			$selections      = $this->selected_columns( $query_args );
 			$totals_query    = array();
 			$intervals_query = array();

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -389,6 +389,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 */
 		do_action( 'woocommerce_reports_delete_tax', 0, $order_id );
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 	}
 }

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStore as ReportsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\DataStoreInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 
 /**
  * API\Reports\Taxes\DataStore.
@@ -387,5 +388,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $order_id    Order ID.
 		 */
 		do_action( 'woocommerce_reports_delete_tax', 0, $order_id );
+
+		ReportsCache::bump_version();
 	}
 }

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -188,8 +188,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -282,7 +286,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_tax_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'taxes';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -279,16 +286,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -172,8 +172,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -286,7 +290,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$segmenter->add_intervals_segments( $data, $intervals_query, $table_name );
 			$this->create_interval_subtotals( $data->intervals );
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_tax_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'taxes_stats';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -283,15 +290,5 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_stats_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -26,6 +26,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	const TABLE_NAME = 'wc_order_product_lookup';
 
 	/**
+	 * Cache identifier.
+	 *
+	 * @var string
+	 */
+	protected $cache_key = 'variations';
+
+	/**
 	 * Mapping columns to data type to return correct response types.
 	 *
 	 * @var array
@@ -352,16 +359,5 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 *
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . self::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 }

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -255,8 +255,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$query_args = wp_parse_args( $query_args, $defaults );
 		$this->normalize_timezones( $query_args, $defaults );
 
+		/*
+		 * We need to get the cache key here because
+		 * parent::update_intervals_sql_params() modifies $query_args.
+		 */
 		$cache_key = $this->get_cache_key( $query_args );
-		$data      = wp_cache_get( $cache_key, $this->cache_group );
+		$data      = $this->get_cached_data( $cache_key );
 
 		if ( false === $data ) {
 			$data = (object) array(
@@ -355,7 +359,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => (int) $query_args['page'],
 			);
 
-			wp_cache_set( $cache_key, $data, $this->cache_group );
+			$this->set_cached_data( $cache_key, $data );
 		}
 
 		return $data;

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -14,6 +14,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDa
 use \Automattic\WooCommerce\Admin\API\Reports\Orders\Stats\DataStore as OrdersStatsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
 use \Automattic\WooCommerce\Admin\API\Reports\Taxes\DataStore as TaxesDataStore;
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 
 /**
  * ReportsSync Class.
@@ -488,6 +489,8 @@ class ReportsSync {
 			)
 		);
 
+		ReportsCache::bump_version();
+
 		// If all updates were either skipped or successful, we're done.
 		// The update methods return -1 for skip, or a boolean success indicator.
 		if ( 4 === absint( $result ) ) {
@@ -817,6 +820,8 @@ class ReportsSync {
 			CustomersDataStore::delete_customer( $customer_id );
 		}
 
+		ReportsCache::bump_version();
+
 		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'customer' ) );
 	}
 
@@ -858,6 +863,8 @@ class ReportsSync {
 		foreach ( $order_ids as $order_id ) {
 			OrdersStatsDataStore::delete_order( $order_id );
 		}
+
+		ReportsCache::bump_version();
 
 		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'order' ) );
 	}

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -489,7 +489,7 @@ class ReportsSync {
 			)
 		);
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 
 		// If all updates were either skipped or successful, we're done.
 		// The update methods return -1 for skip, or a boolean success indicator.
@@ -820,7 +820,7 @@ class ReportsSync {
 			CustomersDataStore::delete_customer( $customer_id );
 		}
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 
 		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'customer' ) );
 	}
@@ -864,7 +864,7 @@ class ReportsSync {
 			OrdersStatsDataStore::delete_order( $order_id );
 		}
 
-		ReportsCache::bump_version();
+		ReportsCache::invalidate();
 
 		wc_admin_record_tracks_event( 'delete_import_data_job_complete', array( 'type' => 'order' ) );
 	}


### PR DESCRIPTION
Fixes #2020.

This PR seeks to do the following:
- Use transients to cache report data store queries
- Invalidate caches using a version number (incremented when data changes)

### Question:

Are there other places we need to invalidate cache?

### Detailed test instructions:

- Disable any persistent object cache plugins (makes testing easier)
- Open any Report
- Verify a transient containing `wc_report_[report name]` exists with a version number at the end (`:1`)
- Modify a user, order, or coupon
- Verify the `woocommerce_reports_cache_version` option value changes
- Reload the report
- Verify a new transient is created with the new version number appended

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Performance: add caching layer to analytics.