### PR TITLE
Remove unnecessary duplicate logic

### DIFF
--- a/client/settings/fallbacks.js
+++ b/client/settings/fallbacks.js
@@ -87,6 +87,5 @@ export function getSetting( name, fallback = false, filter = val => val ) {
  *                                               ensure it's a number)
  */
 export function setSetting( name, value, filter = val => val ) {
-	value = filter( value );
 	allSettings[ name ] = filter( value );
 }


### PR DESCRIPTION
While writing documentation for the recent `wcSettings` refactor I noticed that there was some unnecessary logic in the `setSetting` fallback function.  This pull fixes that.