### PR TITLE
wcSettings: fix countries getSettings

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -5,7 +5,9 @@
 import { __, _x } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { applyFilters } from '@wordpress/hooks';
-import { COUNTRIES as countries } from '@woocommerce/wc-admin-settings';
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
 
 /**
  * Internal dependencies

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -13,7 +13,9 @@ import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
 import { Date, Link } from '@woocommerce/components';
 import { numberFormat } from '@woocommerce/number';
-import { COUNTRIES as countries } from '@woocommerce/wc-admin-settings';
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
 
 /**
  * Internal dependencies

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -6,8 +6,9 @@ import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { SelectControl, TextControl } from 'newspack-components';
 import { useMemo } from 'react';
-import { COUNTRIES as countries } from '@woocommerce/wc-admin-settings';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
+const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
 /**
  * Form validation.
  *

--- a/client/settings/fallbacks.js
+++ b/client/settings/fallbacks.js
@@ -2,7 +2,6 @@
 
 const defaults = {
 	adminUrl: '',
-	countries: [],
 	currency: {
 		code: 'USD',
 		precision: 2,
@@ -11,6 +10,13 @@ const defaults = {
 		decimalSeparator: '.',
 		priceFormat: '%1$s%2$s',
 		thousandSeparator: ',',
+	},
+	dataEndpoints: {
+		0: {},
+		countries: [],
+		jetpackStatus: {},
+		leaderboards: [],
+		performanceIndicators: [],
 	},
 	defaultDateRange: 'period=month&compare=previous_year',
 	locale: {
@@ -36,6 +42,11 @@ allSettings.currency = {
 	...allSettings.currency,
 };
 
+allSettings.dataEndpoints = {
+	...defaults.dataEndpoints,
+	...allSettings.dataEndpoints,
+};
+
 allSettings.locale = {
 	...defaults.locale,
 	...allSettings.locale,
@@ -45,7 +56,7 @@ allSettings.locale = {
 // import the constant. Otherwise use getSetting/setSetting for the value
 // reference.
 export const ADMIN_URL = allSettings.adminUrl;
-export const COUNTRIES = allSettings.countries;
+export const COUNTRIES = allSettings.dataEndpoints.countries;
 export const CURRENCY = allSettings.currency;
 export const LOCALE = allSettings.locale;
 export const ORDER_STATUSES = allSettings.orderStatuses;

--- a/client/settings/fallbacks.js
+++ b/client/settings/fallbacks.js
@@ -2,6 +2,7 @@
 
 const defaults = {
 	adminUrl: '',
+	countries: [],
 	currency: {
 		code: 'USD',
 		precision: 2,
@@ -10,13 +11,6 @@ const defaults = {
 		decimalSeparator: '.',
 		priceFormat: '%1$s%2$s',
 		thousandSeparator: ',',
-	},
-	dataEndpoints: {
-		0: {},
-		countries: [],
-		jetpackStatus: {},
-		leaderboards: [],
-		performanceIndicators: [],
 	},
 	defaultDateRange: 'period=month&compare=previous_year',
 	locale: {
@@ -42,11 +36,6 @@ allSettings.currency = {
 	...allSettings.currency,
 };
 
-allSettings.dataEndpoints = {
-	...defaults.dataEndpoints,
-	...allSettings.dataEndpoints,
-};
-
 allSettings.locale = {
 	...defaults.locale,
 	...allSettings.locale,
@@ -56,7 +45,7 @@ allSettings.locale = {
 // import the constant. Otherwise use getSetting/setSetting for the value
 // reference.
 export const ADMIN_URL = allSettings.adminUrl;
-export const COUNTRIES = allSettings.dataEndpoints.countries;
+export const COUNTRIES = allSettings.countries;
 export const CURRENCY = allSettings.currency;
 export const LOCALE = allSettings.locale;
 export const ORDER_STATUSES = allSettings.orderStatuses;


### PR DESCRIPTION
`countries` setting was being improperly gathered from the top level of `wcSettings` instead of from the property `dataEndpoints`. This PR fixes that and adds defaults for `dataEndpoints`.

### Before

![Screen Shot 2019-09-27 at 11 11 28 AM](https://user-images.githubusercontent.com/1922453/65730920-b9d8c780-e117-11e9-8caf-1cee8e59e7d4.png)

### After

The countries dropdown populates with options.

@nerrad Does the blocks repo require a similar change?
