### PR TITLE
wcSettings refactor: fix camel case for currencies in PHP

### DIFF
--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -20,8 +20,8 @@ function wc_admin_number_format( $number ) {
 	return number_format(
 		$number,
 		0,
-		$currency_settings['decimal_separator'],
-		$currency_settings['thousand_separator']
+		$currency_settings['decimalSeparator'],
+		$currency_settings['thousandSeparator']
 	);
 }
 


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/2917 introduced changes to property names in currency settings, causing the following PHP error logs:

<img width="1093" alt="Screen Shot 2019-09-30 at 2 37 06 PM" src="https://user-images.githubusercontent.com/1922453/65843749-ce26f980-e38f-11e9-869b-564ae8493db4.png">

core function `wc_admin_number_format` needed to be updated. I searched the codebase for instances of the snake case and these changes should be the only ones.

### Test

1. Load the dashboard.
2. Ensure no PHP error occur.