### PR TITLE
Replace lodash isFinite() with native Number.isFinite()

### DIFF
--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -8,7 +8,7 @@ import { Component } from '@wordpress/element';
 import { IconButton, SelectControl } from '@wordpress/components';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { isFinite, noop, uniqueId } from 'lodash';
+import { noop, uniqueId } from 'lodash';
 
 const PER_PAGE_OPTIONS = [ 25, 50, 75, 100 ];
 
@@ -70,7 +70,7 @@ class Pagination extends Component {
 		const { onPageChange, page } = this.props;
 		const newPage = parseInt( event.target.value, 10 );
 
-		if ( newPage !== page && isFinite( newPage ) && newPage > 0 && this.pageCount && this.pageCount >= newPage ) {
+		if ( newPage !== page && Number.isFinite( newPage ) && newPage > 0 && this.pageCount && this.pageCount >= newPage ) {
 			onPageChange( newPage, 'goto' );
 		}
 	}

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,3 +1,6 @@
+# (unreleased)
+- Remove lodash dependency.
+
 # 1.0.4
 
 - Update dependencies.

--- a/packages/number/package.json
+++ b/packages/number/package.json
@@ -21,8 +21,7 @@
 	"react-native": "src/index",
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.5.5",
-		"locutus": "2.0.11",
-		"lodash": "4.17.15"
+		"locutus": "2.0.11"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/number/src/index.js
+++ b/packages/number/src/index.js
@@ -1,8 +1,5 @@
 /** @format */
-/**
- * External dependencies
- */
-import { isFinite } from 'lodash';
+/* eslint-disable wpcalypso/import-docblock */
 
 /**
  * WooCommerce dependencies
@@ -50,7 +47,7 @@ export function numberFormat( number, precision = null ) {
  * @returns {?String} A formatted string.
  */
 export function formatValue( type, value ) {
-	if ( ! isFinite( value ) ) {
+	if ( ! Number.isFinite( value ) ) {
 		return null;
 	}
 
@@ -70,7 +67,7 @@ export function formatValue( type, value ) {
  * @returns {?int} Percent change between the primaryValue from the secondaryValue.
  */
 export function calculateDelta( primaryValue, secondaryValue ) {
-	if ( ! isFinite( primaryValue ) || ! isFinite( secondaryValue ) ) {
+	if ( ! Number.isFinite( primaryValue ) || ! Number.isFinite( secondaryValue ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Replaces calls to lodash `isFinite()` with browsers' native `Number.isFinite()`. Polyfills already take care of making it work on IE11 so there is no need to use lodash version. This way, `@woocommerce/number` package will be [much](https://bundlephobia.com/result?p=@woocommerce/number@1.0.4) smaller.

### Detailed test instructions:

- Open the _Orders_ report and verify no JS errors appear.