### PR TITLE
Fix API namespace for the WooCommerce.com Connect Task

### DIFF
--- a/client/dashboard/task-list/tasks/connect.js
+++ b/client/dashboard/task-list/tasks/connect.js
@@ -17,7 +17,7 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 /**
  * Internal depdencies
  */
-import { NAMESPACE } from 'wc-api/constants';
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
 class Connect extends Component {
@@ -67,7 +67,7 @@ class Connect extends Component {
 	async request() {
 		try {
 			const connectResponse = await apiFetch( {
-				path: `${ NAMESPACE }/onboarding/plugins/request-wccom-connect`,
+				path: `${ WC_ADMIN_NAMESPACE }/onboarding/plugins/request-wccom-connect`,
 				method: 'POST',
 			} );
 			if ( connectResponse && connectResponse.connectAction ) {
@@ -84,7 +84,7 @@ class Connect extends Component {
 		const { query } = this.props;
 		try {
 			const connectResponse = await apiFetch( {
-				path: `${ NAMESPACE }/onboarding/plugins/finish-wccom-connect`,
+				path: `${ WC_ADMIN_NAMESPACE }/onboarding/plugins/finish-wccom-connect`,
 				method: 'POST',
 				data: {
 					request_token: query.request_token,


### PR DESCRIPTION
The `Connect your store to WooCommerce.com` task was using the wrong API namespace, so the calls were failing. This PR fixes that.

#### Testing Directions

* Under `WooCommerce > Extensions`, make sure you are disconnected from WooCommerce.com.
* Go to `WooCommerce > Orders` and click `Help`. Under `Setup Wizard` make sure the `Task List` is *enabled*.
* Make the following `POST` request to make sure that the profile wizard has been skipped, but that a purchase has been made:
<img width="966" alt="Screen Shot 2019-09-30 at 1 08 34 PM" src="https://user-images.githubusercontent.com/689165/65900707-98304800-e384-11e9-8142-4312cbc218c1.png">

* Open your developer console.
* Go to `WooCommerce > Dashhboard` and you should see the task list, including a `Connect your store to WooCommerce.com` task. Click it.
* Verify that the API calls succeed you are redirected to WooCommerce.com.