### PR TITLE
Activity Panel: Catch notices earlier than priority 10

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -49,12 +49,12 @@ class Loader {
 	 */
 	public function __construct() {
 		add_action( 'init', array( __CLASS__, 'load_features' ) );
-;		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_scripts' ), 15 );
-		// old settings injection
+		// Old settings injection.
 		add_filter( 'woocommerce_components_settings', array( __CLASS__, 'add_component_settings' ) );
-		// new settings injection
+		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'add_component_settings' ) );
 		add_filter( 'admin_body_class', array( __CLASS__, 'add_admin_body_classes' ) );
 		add_action( 'admin_menu', array( __CLASS__, 'register_page_handler' ) );
@@ -64,7 +64,7 @@ class Loader {
 		add_filter( 'woocommerce_settings_groups', array( __CLASS__, 'add_settings_group' ) );
 		add_filter( 'woocommerce_settings-wc_admin', array( __CLASS__, 'add_settings' ) );
 		add_action( 'admin_head', array( __CLASS__, 'remove_notices' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_after_notices' ), PHP_INT_MAX );
 
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
@@ -141,7 +141,7 @@ class Loader {
 			$feature = 'Automattic\\WooCommerce\\Admin\\Features\\' . $feature;
 
 			if ( class_exists( $feature ) ) {
-				new $feature;
+				new $feature();
 			}
 		}
 	}
@@ -298,7 +298,7 @@ class Loader {
 			WC_ADMIN_APP,
 			self::get_url( 'app/style.css' ),
 			array( 'wc-components' ),
-			self::get_file_version('app/style.css' )
+			self::get_file_version( 'app/style.css' )
 		);
 		wp_style_add_data( WC_ADMIN_APP, 'rtl', 'replace' );
 
@@ -522,22 +522,22 @@ class Loader {
 		if ( ! is_admin() ) {
 			return $settings;
 		}
-		
+
 		if ( ! function_exists( 'wc_blocks_container' ) ) {
 			global $wp_locale;
 			// inject data not available via older versions of wc_blocks/woo.
-			$settings['orderStatuses']        = self::get_order_statuses( wc_get_order_statuses() );
-			$settings['currency']             = self::get_currency_settings();
-			$settings['locale'] = [
-				'siteLocale' => isset( $settings['siteLocale'] )
+			$settings['orderStatuses'] = self::get_order_statuses( wc_get_order_statuses() );
+			$settings['currency']      = self::get_currency_settings();
+			$settings['locale']        = [
+				'siteLocale'    => isset( $settings['siteLocale'] )
 					? $settings['siteLocale']
 					: get_locale(),
-				'userLocale' => isset( $settings['l10n']['userLocale'] )
+				'userLocale'    => isset( $settings['l10n']['userLocale'] )
 					? $settings['l10n']['userLocale']
 					: get_user_locale(),
 				'weekdaysShort' => isset( $settings['l10n']['weekdaysShort'] )
 					? $settings['l10n']['weekdaysShort']
-					: array_values( $wp_locale->weekday_abbrev )
+					: array_values( $wp_locale->weekday_abbrev ),
 			];
 		}
 
@@ -772,7 +772,7 @@ class Loader {
 				'wc-date',
 				'wc-components',
 			];
-			foreach( $handles_for_injection as $handle ) {
+			foreach ( $handles_for_injection as $handle ) {
 				$script = wp_scripts()->query( $handle, 'registered' );
 				if ( $script instanceof _WP_Dependency ) {
 					$script->deps[] = 'wc-settings';


### PR DESCRIPTION
The way we are catching notices for the activity panel only catches notices between `priority 11` and `PHP_INT_MAX`. This means notices hooked on the default priority of 10 are not caught, and anything hooked earlier than that isn't caught. This PR hooks into a lower priority. 

### Detailed test instructions:

Before applying this PR, add the following code to your install:

```
add_action( 'admin_notices', function() {
	echo 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed lectus orci, interdum id risus ut, rhoncus lacinia dolor. Integer condimentum enim dapibus tellus suscipit, sed porta dui eleifend. Suspendisse vel porta risus, at tempor dui. Aliquam pellentesque consectetur tincidunt. Vestibulum non posuere felis. Phasellus sagittis sit amet risus at laoreet. Vestibulum malesuada, lacus eu malesuada porttitor, ante turpis laoreet ex, et dignissim enim est sed purus. Sed bibendum faucibus justo, in sodales ligula cursus sit amet. Fusce sed vestibulum diam, et aliquam mauris.
	Etiam auctor metus eros. Aliquam qui';
}, 10 );
```

* Load a WooCommerce Admin page
* See that the text flashes on first load, and does not show up under the notices panel
* Apply this PR.
* See that the notice is now under the notice panel.

### Changelog Note:

Fix: Catch notices that are hooked earlier than priority 10.
