### PR TITLE
Match server-side CSV export format to client-side

### DIFF
--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -186,7 +186,11 @@ export default class OrdersReportTable extends Component {
 							href: product.href,
 						} ) )
 					),
-					value: formattedProducts.map( product => product.label ).join( ' ' ),
+					value: formattedProducts
+						.map( ( { quantity, label } ) =>
+							sprintf( __( '%s× %s', 'woocommerce-admin' ), quantity, label )
+						)
+						.join( ', ' ),
 				},
 				{
 					display: numberFormat( num_items_sold ),

--- a/packages/csv-export/CHANGELOG.md
+++ b/packages/csv-export/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.2.0 (Unreleased)
+
+- Properly escape values with double quotes.
+- Prevent CSV injection.
+
 # 1.1.2
 
 - Update dependencies.

--- a/packages/csv-export/src/__mocks__/mock-csv-data.js
+++ b/packages/csv-export/src/__mocks__/mock-csv-data.js
@@ -1,4 +1,4 @@
 /** @format */
 
 export default `Date,Orders,Description,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
-2018-04-29T00:00:00,30,lorem ipsum,200,19,19,100,19,200`;
+2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200`;

--- a/packages/csv-export/src/__mocks__/mock-csv-data.js
+++ b/packages/csv-export/src/__mocks__/mock-csv-data.js
@@ -1,4 +1,4 @@
 /** @format */
 
-export default `Date,Orders,Description,"Gross Revenue",Refunds,Coupons,Taxes,Shipping,"Net Revenue"
-2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200`;
+export default `Date,Orders,Description,"Gross Revenue",Refunds,Coupons,Taxes,Shipping,"Net Revenue","Negative Number"
+2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200,'-123`;

--- a/packages/csv-export/src/__mocks__/mock-csv-data.js
+++ b/packages/csv-export/src/__mocks__/mock-csv-data.js
@@ -1,4 +1,4 @@
 /** @format */
 
-export default `Date,Orders,Description,Gross Revenue,Refunds,Coupons,Taxes,Shipping,Net Revenue
+export default `Date,Orders,Description,"Gross Revenue",Refunds,Coupons,Taxes,Shipping,"Net Revenue"
 2018-04-29T00:00:00,30,"Lorem, ""ipsum""",200,19,19,100,19,200`;

--- a/packages/csv-export/src/__mocks__/mock-headers.js
+++ b/packages/csv-export/src/__mocks__/mock-headers.js
@@ -37,4 +37,8 @@ export default [
 		label: 'Net Revenue',
 		key: 'net_revenue',
 	},
+	{
+		label: 'Negative Number',
+		key: 'neg_num',
+	},
 ];

--- a/packages/csv-export/src/__mocks__/mock-rows.js
+++ b/packages/csv-export/src/__mocks__/mock-rows.js
@@ -11,8 +11,8 @@ export default [
 			value: '30',
 		},
 		{
-			display: 'Lorem, ipsum',
-			value: 'lorem, ipsum',
+			display: 'Lorem, "ipsum"',
+			value: 'Lorem, "ipsum"',
 		},
 		{
 			display: '€200.00',

--- a/packages/csv-export/src/__mocks__/mock-rows.js
+++ b/packages/csv-export/src/__mocks__/mock-rows.js
@@ -38,5 +38,9 @@ export default [
 			display: '€200.00',
 			value: 200,
 		},
+		{
+			display: '-123',
+			value: -123,
+		},
 	],
 ];

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -5,8 +5,22 @@
 import moment from 'moment';
 import { saveAs } from 'browser-filesaver';
 
+function escapeCSVValue( value ) {
+	let stringValue = value.toString();
+
+	if ( stringValue.match( /[,"\s]/ ) ) {
+		stringValue = '"' + stringValue.replace( /"/g, '""' ) + '"';
+	}
+
+	return stringValue;
+}
+
 function getCSVHeaders( headers ) {
-	return Array.isArray( headers ) ? headers.map( header => header.label ).join( ',' ) : [];
+	return Array.isArray( headers )
+		? headers
+			.map( header => escapeCSVValue( header.label ) )
+			.join( ',' )
+		: [];
 }
 
 function getCSVRows( rows ) {
@@ -18,13 +32,7 @@ function getCSVRows( rows ) {
 							return '';
 						}
 
-						let stringValue = rowItem.value.toString();
-
-						if ( stringValue.includes( ',' ) || stringValue.includes( '"' ) ) {
-							stringValue = '"' + stringValue.replace( /"/g, '""' ) + '"';
-						}
-
-						return stringValue;
+						return escapeCSVValue( rowItem.value );
 					} ).join( ',' )
 				)
 				.join( '\n' )

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -13,9 +13,19 @@ function getCSVRows( rows ) {
 	return Array.isArray( rows )
 		? rows
 				.map( row =>
-					row.map( rowItem =>
-						rowItem.value !== undefined && rowItem.value !== null ? rowItem.value.toString().replace( /,/g, ''
-					) : '' ).join( ',' )
+					row.map( rowItem => {
+						if ( undefined === rowItem.value || null === rowItem.value ) {
+							return '';
+						}
+
+						let stringValue = rowItem.value.toString();
+
+						if ( stringValue.includes( ',' ) || stringValue.includes( '"' ) ) {
+							stringValue = '"' + stringValue.replace( /"/g, '""' ) + '"';
+						}
+
+						return stringValue;
+					} ).join( ',' )
 				)
 				.join( '\n' )
 		: [];

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -8,7 +8,12 @@ import { saveAs } from 'browser-filesaver';
 function escapeCSVValue( value ) {
 	let stringValue = value.toString();
 
-	if ( stringValue.match( /[,"\s]/ ) ) {
+	// Prevent CSV injection.
+	// See: http://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
+	// See: WC_CSV_Exporter::escape_data()
+	if ( [ '=', '+', '-', '@' ].includes( stringValue.charAt( 0 ) ) ) {
+		stringValue = "'" + stringValue;
+	} else if ( stringValue.match( /[,"\s]/ ) ) {
 		stringValue = '"' + stringValue.replace( /"/g, '""' ) + '"';
 	}
 

--- a/src/API/Reports/Categories/Controller.php
+++ b/src/API/Reports/Categories/Controller.php
@@ -11,13 +11,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Categories;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+
 /**
  * REST API Reports categories controller class.
  *
  * @package WooCommerce/API
  * @extends \Automattic\WooCommerce\Admin\API\Reports\Controller
  */
-class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
+class Controller extends ReportsController implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -317,5 +320,36 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'category'       => __( 'Category', 'woocommerce-admin' ),
+			'items_sold'     => __( 'Items Sold', 'woocommerce-admin' ),
+			'net_revenue'    => __( 'Net Revenue', 'woocommerce-admin' ),
+			'products_count' => __( 'Products', 'woocommerce-admin' ),
+			'orders_count'   => __( 'Orders', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		return array(
+			'category'       => $item['extended_info']['name'],
+			'items_sold'     => $item['items_sold'],
+			'net_revenue'    => $item['net_revenue'],
+			'products_count' => $item['products_count'],
+			'orders_count'   => $item['orders_count'],
+		);
 	}
 }

--- a/src/API/Reports/Controller.php
+++ b/src/API/Reports/Controller.php
@@ -294,10 +294,20 @@ class Controller extends \WC_REST_Reports_Controller {
 	 * @return array
 	 */
 	public function get_order_statuses() {
+		return array_keys( $this->get_order_status_labels() );
+	}
+
+	/**
+	 * Get order statuses (and labels) without prefixes.
+	 *
+	 * @return array
+	 */
+	public function get_order_status_labels() {
 		$order_statuses = array();
 
-		foreach ( array_keys( wc_get_order_statuses() ) as $status ) {
-			$order_statuses[] = str_replace( 'wc-', '', $status );
+		foreach ( wc_get_order_statuses() as $key => $label ) {
+			$new_key                    = str_replace( 'wc-', '', $key );
+			$order_statuses[ $new_key ] = $label;
 		}
 
 		return $order_statuses;

--- a/src/API/Reports/Coupons/Controller.php
+++ b/src/API/Reports/Coupons/Controller.php
@@ -11,13 +11,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Coupons;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+
 /**
  * REST API Reports coupons controller class.
  *
  * @package WooCommerce/API
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -288,5 +290,42 @@ class Controller extends \WC_REST_Reports_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'code'         => __( 'Coupon Code', 'woocommerce-admin' ),
+			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
+			'amount'       => __( 'Amount Discounted', 'woocommerce-admin' ),
+			'created'      => __( 'Created', 'woocommerce-admin' ),
+			'expires'      => __( 'Expires', 'woocommerce-admin' ),
+			'type'         => __( 'Type', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		$date_expires = empty( $item['extended_info']['date_expires'] )
+			? __( 'N/A', 'woocommerce-admin' )
+			: $item['extended_info']['date_expires'];
+
+		return array(
+			'code'         => $item['extended_info']['code'],
+			'orders_count' => $item['orders_count'],
+			'amount'       => $item['amount'],
+			'created'      => $item['extended_info']['date_created'],
+			'expires'      => $date_expires,
+			'type'         => $item['extended_info']['discount_type'],
+		);
 	}
 }

--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Customers;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 
 /**
@@ -19,7 +20,7 @@ use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
  * @package WooCommerce/API
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -221,7 +222,7 @@ class Controller extends \WC_REST_Reports_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'state'                 => array(
+				'state'                => array(
 					'description' => __( 'Region.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -524,5 +525,52 @@ class Controller extends \WC_REST_Reports_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'name'            => __( 'Name', 'woocommerce-admin' ),
+			'username'        => __( 'Username', 'woocommerce-admin' ),
+			'last_active'     => __( 'Last Active', 'woocommerce-admin' ),
+			'registered'      => __( 'Sign Up', 'woocommerce-admin' ),
+			'email'           => __( 'Email', 'woocommerce-admin' ),
+			'orders_count'    => __( 'Orders', 'woocommerce-admin' ),
+			'total_spend'     => __( 'Total Spend', 'woocommerce-admin' ),
+			'avg_order_value' => __( 'AOV', 'woocommerce-admin' ),
+			'country'         => __( 'Country', 'woocommerce-admin' ),
+			'city'            => __( 'City', 'woocommerce-admin' ),
+			'region'          => __( 'Region', 'woocommerce-admin' ),
+			'postcode'        => __( 'Postal Code', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		$decimals = wc_get_price_decimals();
+
+		return array(
+			'name'            => $item['name'],
+			'username'        => $item['username'],
+			'last_active'     => $item['date_last_active'],
+			'registered'      => $item['date_registered'],
+			'email'           => $item['email'],
+			'orders_count'    => $item['orders_count'],
+			'total_spend'     => number_format( $item['total_spend'], $decimals, '.', '' ), // See: getCurrencyFormatDecimal().
+			'avg_order_value' => number_format( $item['avg_order_value'], $decimals, '.', '' ), // See: getCurrencyFormatDecimal().
+			'country'         => $item['country'],
+			'city'            => $item['city'],
+			'region'          => $item['state'],
+			'postcode'        => $item['postcode'],
+		);
 	}
 }

--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Customers;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
 use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
 
@@ -21,6 +22,10 @@ use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
  * @extends WC_REST_Reports_Controller
  */
 class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+	/**
+	 * Exportable traits.
+	 */
+	use ExportableTraits;
 
 	/**
 	 * Endpoint namespace.
@@ -556,8 +561,6 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return array Key value pair of Column ID => Row Value.
 	 */
 	public function prepare_item_for_export( $item ) {
-		$decimals = wc_get_price_decimals();
-
 		return array(
 			'name'            => $item['name'],
 			'username'        => $item['username'],
@@ -565,8 +568,8 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'registered'      => $item['date_registered'],
 			'email'           => $item['email'],
 			'orders_count'    => $item['orders_count'],
-			'total_spend'     => number_format( $item['total_spend'], $decimals, '.', '' ), // See: getCurrencyFormatDecimal().
-			'avg_order_value' => number_format( $item['avg_order_value'], $decimals, '.', '' ), // See: getCurrencyFormatDecimal().
+			'total_spend'     => self::csv_number_format( $item['total_spend'] ),
+			'avg_order_value' => self::csv_number_format( $item['avg_order_value'] ),
 			'country'         => $item['country'],
 			'city'            => $item['city'],
 			'region'          => $item['state'],

--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -11,13 +11,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Downloads;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+
 /**
  * REST API Reports downloads controller class.
  *
  * @package WooCommerce/API
  * @extends Automattic\WooCommerce\Admin\API\Reports\Controller
  */
-class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
+class Controller extends ReportsController implements ExportableInterface {
 	/**
 	 * Endpoint namespace.
 	 *
@@ -377,5 +380,38 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'date'         => __( 'Date', 'woocommerce-admin' ),
+			'product'      => __( 'Product Title', 'woocommerce-admin' ),
+			'file_name'    => __( 'File Name', 'woocommerce-admin' ),
+			'order_number' => __( 'Order #', 'woocommerce-admin' ),
+			'user_id'      => __( 'User Name', 'woocommerce-admin' ),
+			'ip_address'   => __( 'IP', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		return array(
+			'date'         => $item['date'],
+			'product'      => $item['_embedded']['product'][0]['name'],
+			'file_name'    => $item['file_name'],
+			'order_number' => $item['order_number'],
+			'user_id'      => $item['username'],
+			'ip_address'   => $item['ip_address'],
+		);
 	}
 }

--- a/src/API/Reports/ExportableInterface.php
+++ b/src/API/Reports/ExportableInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Reports Exportable Controller Interface
+ *
+ * @package  WooCommerce Admin/Interface
+ */
+
+namespace Automattic\WooCommerce\Admin\API\Reports;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WooCommerce Reports exportable controller interface.
+ *
+ * @since 3.5.0
+ */
+interface ExportableInterface {
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns();
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Value.
+	 */
+	public function prepare_item_for_export( $item );
+}

--- a/src/API/Reports/ExportableTraits.php
+++ b/src/API/Reports/ExportableTraits.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * REST API Reports exportable traits
+ *
+ * Collection of utility methods for exportable reports.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+namespace Automattic\WooCommerce\Admin\API\Reports;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ExportableTraits class.
+ */
+trait ExportableTraits {
+	/**
+	 * Format numbers for CSV using store precision setting.
+	 *
+	 * @param string|float $value Numeric value.
+	 * @return string Formatted value.
+	 */
+	public static function csv_number_format( $value ) {
+		$decimals = wc_get_price_decimals();
+		// See: @woocommerce/currency: getCurrencyFormatDecimal().
+		return number_format( $value, $decimals, '.', '' );
+	}
+}

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -415,35 +415,6 @@ class Controller extends ReportsController implements ExportableInterface {
 	}
 
 	/**
-	 * Get order status column export value.
-	 *
-	 * @param array $status Order status from report row.
-	 * @return string
-	 */
-	protected function _get_order_status( $status ) {
-		$statuses = $this->get_order_status_labels();
-
-		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : '';
-	}
-
-	/**
-	 * Get customer type column export value.
-	 *
-	 * @param array $type Customer type from report row.
-	 * @return string
-	 */
-	protected function _get_customer_type( $type ) {
-		switch ( $type ) {
-			case 'new':
-				return _x( 'New', 'customer type', 'woocommerce-admin' );
-			case 'returning':
-				return _x( 'Returning', 'customer type', 'woocommerce-admin' );
-			default:
-				return _x( 'N/A', 'customer type', 'woocommerce-admin' );
-		}
-	}
-
-	/**
 	 * Get products column export value.
 	 *
 	 * @param array $products Products from report row.
@@ -502,8 +473,8 @@ class Controller extends ReportsController implements ExportableInterface {
 		return array(
 			'date_created'   => $item['date_created'],
 			'order_number'   => $item['order_number'],
-			'status'         => $this->_get_order_status( $item['status'] ),
-			'customer_type'  => $this->_get_customer_type( $item['customer_type'] ),
+			'status'         => $item['status'],
+			'customer_type'  => $item['customer_type'],
 			'products'       => $this->_get_products( $item['extended_info']['products'] ),
 			'num_items_sold' => $item['num_items_sold'],
 			'coupons'        => $this->_get_coupons( $item['extended_info']['coupons'] ),

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -11,13 +11,16 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Orders;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Controller as ReportsController;
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+
 /**
  * REST API Reports orders controller class.
  *
  * @package WooCommerce/API
  * @extends \Automattic\WooCommerce\Admin\API\Reports\Controller
  */
-class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
+class Controller extends ReportsController implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -409,5 +412,102 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get order status column export value.
+	 *
+	 * @param array $status Order status from report row.
+	 * @return string
+	 */
+	protected function _get_order_status( $status ) {
+		$statuses = $this->get_order_status_labels();
+
+		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : '';
+	}
+
+	/**
+	 * Get customer type column export value.
+	 *
+	 * @param array $type Customer type from report row.
+	 * @return string
+	 */
+	protected function _get_customer_type( $type ) {
+		switch ( $type ) {
+			case 'new':
+				return _x( 'New', 'customer type', 'woocommerce-admin' );
+			case 'returning':
+				return _x( 'Returning', 'customer type', 'woocommerce-admin' );
+			default:
+				return _x( 'N/A', 'customer type', 'woocommerce-admin' );
+		}
+	}
+
+	/**
+	 * Get products column export value.
+	 *
+	 * @param array $products Products from report row.
+	 * @return string
+	 */
+	protected function _get_products( $products ) {
+		$products_list = array();
+
+		foreach ( $products as $product ) {
+			$products_list[] = sprintf(
+				/* translators: 1: numeric product quantity, 2: name of product */
+				__( '%1$s× %2$s', 'woocommerce-admin' ),
+				$product['quantity'],
+				$product['name']
+			);
+		}
+
+		return implode( ', ', $products_list );
+	}
+
+	/**
+	 * Get coupons column export value.
+	 *
+	 * @param array $coupons Coupons from report row.
+	 * @return string
+	 */
+	protected function _get_coupons( $coupons ) {
+		return implode( ', ', wp_list_pluck( $coupons, 'code' ) );
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'date_created'   => __( 'Date', 'woocommerce-admin' ),
+			'order_number'   => __( 'Order #', 'woocommerce-admin' ),
+			'status'         => __( 'Status', 'woocommerce-admin' ),
+			'customer_type'  => __( 'Customer', 'woocommerce-admin' ),
+			'products'       => __( 'Product(s)', 'woocommerce-admin' ),
+			'num_items_sold' => __( 'Items Sold', 'woocommerce-admin' ),
+			'coupons'        => __( 'Coupon(s)', 'woocommerce-admin' ),
+			'net_total'      => __( 'N. Revenue', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		return array(
+			'date_created'   => $item['date_created'],
+			'order_number'   => $item['order_number'],
+			'status'         => $this->_get_order_status( $item['status'] ),
+			'customer_type'  => $this->_get_customer_type( $item['customer_type'] ),
+			'products'       => $this->_get_products( $item['extended_info']['products'] ),
+			'num_items_sold' => $item['num_items_sold'],
+			'coupons'        => $this->_get_coupons( $item['extended_info']['coupons'] ),
+			'net_total'      => $item['net_total'],
+		);
 	}
 }

--- a/src/API/Reports/Products/Controller.php
+++ b/src/API/Reports/Products/Controller.php
@@ -418,8 +418,14 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		);
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
-			$export_item['stock_status'] = $this->_get_stock_status( $item['extended_info']['stock_status'] );
-			$export_item['stock']        = $item['extended_info']['stock_quantity'];
+			if ( $item['extended_info']['manage_stock'] ) {
+				$export_item['stock_status'] = $this->_get_stock_status( $item['extended_info']['stock_status'] );
+				$export_item['stock']        = $item['extended_info']['stock_quantity'];
+			} else {
+				$export_item['stock_status'] = __( 'N/A', 'woocommerce-admin' );
+				$export_item['stock']        = __( 'N/A', 'woocommerce-admin' );
+			}
+			
 		}
 
 		return $export_item;

--- a/src/API/Reports/Products/Controller.php
+++ b/src/API/Reports/Products/Controller.php
@@ -11,13 +11,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Products;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+
 /**
  * REST API Reports products controller class.
  *
  * @package WooCommerce/API
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -342,5 +344,84 @@ class Controller extends \WC_REST_Reports_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get stock status column export value.
+	 *
+	 * @param array $status Stock status from report row.
+	 * @return string
+	 */
+	protected function _get_stock_status( $status ) {
+		$statuses = wc_get_product_stock_status_options();
+
+		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : '';
+	}
+
+	/**
+	 * Get categories column export value.
+	 *
+	 * @param array $category_ids Category IDs from report row.
+	 * @return string
+	 */
+	protected function _get_categories( $category_ids ) {
+		$category_names = get_terms(
+			array(
+				'taxonomy' => 'product_cat',
+				'include'  => $category_ids,
+				'fields'   => 'names',
+			)
+		);
+
+		return implode( ', ', $category_names );
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		$export_columns = array(
+			'product_name' => __( 'Product Title', 'woocommerce-admin' ),
+			'sku'          => __( 'SKU', 'woocommerce-admin' ),
+			'items_sold'   => __( 'Items Sold', 'woocommerce-admin' ),
+			'net_revenue'  => __( 'N. Revenue', 'woocommerce-admin' ),
+			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
+			'product_cat'  => __( 'Category', 'woocommerce-admin' ),
+			'variations'   => __( 'Variations', 'woocommerce-admin' ),
+		);
+
+		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
+			$export_columns['stock_status'] = __( 'Status', 'woocommerce-admin' );
+			$export_columns['stock']        = __( 'Stock', 'woocommerce-admin' );
+		}
+
+		return $export_columns;
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		$export_item = array(
+			'product_name' => $item['extended_info']['name'],
+			'sku'          => $item['extended_info']['sku'],
+			'items_sold'   => $item['items_sold'],
+			'net_revenue'  => $item['net_revenue'],
+			'orders_count' => $item['orders_count'],
+			'product_cat'  => $this->_get_categories( $item['extended_info']['category_ids'] ),
+			'variations'   => isset( $item['extended_info']['variations'] ) ? count( $item['extended_info']['variations'] ) : 0,
+		);
+
+		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
+			$export_item['stock_status'] = $this->_get_stock_status( $item['extended_info']['stock_status'] );
+			$export_item['stock']        = $item['extended_info']['stock_quantity'];
+		}
+
+		return $export_item;
 	}
 }

--- a/src/API/Reports/Stock/Controller.php
+++ b/src/API/Reports/Stock/Controller.php
@@ -11,13 +11,15 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Stock;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+
 /**
  * REST API Reports stock controller class.
  *
  * @package WooCommerce/API
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
 
 	/**
 	 * Endpoint namespace.
@@ -513,5 +515,34 @@ class Controller extends \WC_REST_Reports_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'title'          => __( 'Product / Variation', 'woocommerce-admin' ),
+			'sku'            => __( 'SKU', 'woocommerce-admin' ),
+			'stock_status'   => __( 'Status', 'woocommerce-admin' ),
+			'stock_quantity' => __( 'Stock', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		return array(
+			'title'          => $item['name'],
+			'sku'            => $item['sku'],
+			'stock_status'   => $item['stock_status'],
+			'stock_quantity' => $item['stock_quantity'],
+		);
 	}
 }

--- a/src/API/Reports/Taxes/Controller.php
+++ b/src/API/Reports/Taxes/Controller.php
@@ -11,13 +11,20 @@ namespace Automattic\WooCommerce\Admin\API\Reports\Taxes;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableInterface;
+use \Automattic\WooCommerce\Admin\API\Reports\ExportableTraits;
+
 /**
  * REST API Reports taxes controller class.
  *
  * @package WooCommerce/API
  * @extends WC_REST_Reports_Controller
  */
-class Controller extends \WC_REST_Reports_Controller {
+class Controller extends \WC_REST_Reports_Controller implements ExportableInterface {
+	/**
+	 * Exportable traits.
+	 */
+	use ExportableTraits;
 
 	/**
 	 * Endpoint namespace.
@@ -286,5 +293,38 @@ class Controller extends \WC_REST_Reports_Controller {
 		);
 
 		return $params;
+	}
+
+	/**
+	 * Get the column names for export.
+	 *
+	 * @return array Key value pair of Column ID => Label.
+	 */
+	public function get_export_columns() {
+		return array(
+			'tax_code'     => __( 'Tax Code', 'woocommerce-admin' ),
+			'rate'         => __( 'Rate', 'woocommerce-admin' ),
+			'total_tax'    => __( 'Total Tax', 'woocommerce-admin' ),
+			'order_tax'    => __( 'Order Tax', 'woocommerce-admin' ),
+			'shipping_tax' => __( 'Shipping Tax', 'woocommerce-admin' ),
+			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
+		);
+	}
+
+	/**
+	 * Get the column values for export.
+	 *
+	 * @param array $item Single report item/row.
+	 * @return array Key value pair of Column ID => Row Value.
+	 */
+	public function prepare_item_for_export( $item ) {
+		return array(
+			'tax_code'     => \WC_Tax::get_rate_code( $item['tax_rate_id'] ),
+			'rate'         => $item['tax_rate'],
+			'total_tax'    => self::csv_number_format( $item['total_tax'] ),
+			'order_tax'    => self::csv_number_format( $item['order_tax'] ),
+			'shipping_tax' => self::csv_number_format( $item['shipping_tax'] ),
+			'orders_count' => $item['orders_count'],
+		);
 	}
 }

--- a/src/ReportCSVExporter.php
+++ b/src/ReportCSVExporter.php
@@ -199,9 +199,14 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 		$request->set_default_params( $defaults );
 		$request->set_query_params( $this->report_args );
 
-		$response         = $this->controller->get_items( $request );
-		$report_meta      = $response->get_headers();
-		$report_data      = $response->get_data();
+		$response    = $this->controller->get_items( $request );
+		$report_meta = $response->get_headers();
+		// Use WP_REST_Server::response_to_data() to embed links in data.
+		add_filter( 'woocommerce_rest_check_permissions', '__return_true' );
+		$rest_server = rest_get_server();
+		$report_data = $rest_server->response_to_data( $response, true );
+		remove_filter( 'woocommerce_rest_check_permissions', '__return_true' );
+
 		$this->total_rows = $report_meta['X-WP-Total'];
 		$this->row_data   = array_map( array( $this, 'generate_row_data' ), $report_data );
 	}

--- a/src/ReportCSVExporter.php
+++ b/src/ReportCSVExporter.php
@@ -270,7 +270,7 @@ class ReportCSVExporter extends \WC_CSV_Batch_Exporter {
 	protected function generate_row_data( $item ) {
 		// Default to the report's export method.
 		if ( $this->controller instanceof ExportableInterface ) {
-			return $this->controller->prepare_item_for_export( $item );
+			$row = $this->controller->prepare_item_for_export( $item );
 		} else {
 			// Fallback to raw report data.
 			$row = $this->get_raw_row_data( $item );

--- a/tests/reports/class-wc-tests-reports-coupons.php
+++ b/tests/reports/class-wc-tests-reports-coupons.php
@@ -274,40 +274,31 @@ class WC_Tests_Reports_Coupons extends WC_Unit_Test_Case {
 
 		// Test the CSV export.
 		$expected_csv_columns = array(
-			'coupon_id',
-			'amount',
-			'orders_count',
-			'code',
-			'date_created',
-			'date_created_gmt',
-			'date_expires',
-			'date_expires_gmt',
-			'discount_type',
+			'"Coupon Code"',
+			'Orders',
+			'"Amount Discounted"',
+			'Created',
+			'Expires',
+			'Type',
 		);
 
 		// Expected CSV for Coupon 2.
 		$coupon_2_csv = array(
-			$coupon_2_response['coupon_id'],
-			$coupon_2_response['amount'],
-			$coupon_2_response['orders_count'],
 			$coupon_2_response['extended_info']['code'],
+			$coupon_2_response['orders_count'],
+			$coupon_2_response['amount'],
 			$coupon_2_response['extended_info']['date_created'],
-			$coupon_2_response['extended_info']['date_created_gmt'],
-			$coupon_2_response['extended_info']['date_expires'],
-			$coupon_2_response['extended_info']['date_expires_gmt'],
+			$coupon_2_response['extended_info']['date_expires'] ? : 'N/A',
 			$coupon_2_response['extended_info']['discount_type'],
 		);
 
 		// Expected CSV for Coupon 1.
 		$coupon_1_csv = array(
-			$coupon_1_response['coupon_id'],
-			$coupon_1_response['amount'],
-			$coupon_1_response['orders_count'],
 			$coupon_1_response['extended_info']['code'],
+			$coupon_1_response['orders_count'],
+			$coupon_1_response['amount'],
 			$coupon_1_response['extended_info']['date_created'],
-			$coupon_1_response['extended_info']['date_created_gmt'],
-			$coupon_1_response['extended_info']['date_expires'],
-			$coupon_1_response['extended_info']['date_expires_gmt'],
+			$coupon_1_response['extended_info']['date_expires'] ? : 'N/A',
 			$coupon_1_response['extended_info']['discount_type'],
 		);
 


### PR DESCRIPTION
Fixes #2980.
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3023

This PR seeks to align the server-side and client-side report export formats by:

* Introducing a `ExportableInterface` which requires `get_export_columns()` and `prepare_item_for_export()` methods to be defined on Controllers
* Allows and escapes commas and double quotes in CSV values
* Uses `WP_REST_Server::response_to_data()` to include embedded objects in responses

One kludge I'm not fond of is the `get_export_items()` check - it's there so we can shape the response of `/revenue/stats` into a single array of values. I'm open to ideas on how to better implement that.

### Detailed test instructions:

For each report:

- Use date range and filters to get a single-page result set
- Download the report (should be in-browser)
- Use date range and filters to get a multi-page result set
- Download the report (should be server-side, emailed)
- Compare CSV files, they should match

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: report export format when generated server-side.