### PR TITLE
Add Payments Task Track Events

### DIFF
--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -74,10 +74,13 @@ class Start extends Component {
 	}
 
 	async startWizard() {
-		const { createNotice, isSettingsError } = this.props;
+		const { updateOptions, createNotice, isSettingsError } = this.props;
 
 		recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
 
+		await updateOptions( {
+			woocommerce_setup_jetpack_opted_in: true,
+		} );
 		await this.updateTracking();
 
 		if ( ! isSettingsError ) {
@@ -250,6 +253,26 @@ class Start extends Component {
 					>
 						{ __( 'Get started', 'woocommerce-admin' ) }
 					</Button>
+
+					<p>
+						{ interpolateComponents( {
+							mixedString: __(
+								'By connecting your site you agree to our fascinating {{tosLink}}Terms of Service{{/tosLink}} and ' +
+									'to {{jetpackLink}}share details{{/jetpackLink}} with WordPress.com.',
+								'woocommerce-admin'
+							),
+							components: {
+								tosLink: <Link href="https://wordpress.com/tos" target="_blank" type="external" />,
+								jetpackLink: (
+									<Link
+										href="https://jetpack.com/support/what-data-does-jetpack-sync"
+										target="_blank"
+										type="external"
+									/>
+								),
+							},
+						} ) }
+					</p>
 				</Card>
 
 				<p>
@@ -287,12 +310,13 @@ export default compose(
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { updateProfileItems, updateSettings } = dispatch( 'wc-api' );
+		const { updateProfileItems, updateOptions, updateSettings } = dispatch( 'wc-api' );
 		const { createNotice } = dispatch( 'core/notices' );
 
 		return {
 			createNotice,
 			updateProfileItems,
+			updateOptions,
 			updateSettings,
 		};
 	} )

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -1,5 +1,10 @@
 /** @format */
 
+.woocommerce-page:not(.woocommerce-embed-page) #klarna-banner,
+#klarna-kp-banner {
+	display: none;
+}
+
 .woocommerce-dashboard__columns {
 	display: grid;
 	grid-template-columns: calc(50% - #{$gap-large/2}) calc(50% - #{$gap-large/2});

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { filter } from 'lodash';
+import { filter, get } from 'lodash';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -45,7 +45,7 @@ class TaskDashboard extends Component {
 	}
 
 	getTasks() {
-		const { profileItems, query } = this.props;
+		const { profileItems, query, paymentsCompleted } = this.props;
 
 		return [
 			{
@@ -130,6 +130,7 @@ class TaskDashboard extends Component {
 				after: <i className="material-icons-outlined">chevron_right</i>,
 				onClick: () => updateQueryString( { task: 'payments' } ),
 				container: <Payments />,
+				className: paymentsCompleted ? 'is-complete' : null,
 				visible: true,
 			},
 		];
@@ -175,8 +176,16 @@ class TaskDashboard extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItems } = select( 'wc-api' );
+		const { getProfileItems, getOptions } = select( 'wc-api' );
 		const profileItems = getProfileItems();
-		return { profileItems };
+
+		const options = getOptions( [ 'woocommerce_onboarding_payments' ] );
+		const paymentsCompleted = get(
+			options,
+			[ 'woocommerce_onboarding_payments', 'completed' ],
+			false
+		);
+
+		return { profileItems, paymentsCompleted };
 	} )
 )( TaskDashboard );

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -202,6 +202,16 @@
 		margin-top: $gap-large;
 	}
 
+	.woocommerce-list__item .woocommerce-list__item-before {
+		max-width: 96px;
+		background: $studio-gray-0;
+		padding: $gap-small;
+
+		img {
+			max-width: 72px;
+		}
+	}
+
 	.woocommerce-list__item-title {
 		border-top: 1px solid $studio-gray-5;
 		padding-top: $gap;

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -226,6 +226,20 @@
 	}
 }
 
+.components-modal__frame.woocommerce-task-payments__stripe-error-modal {
+	.components-modal__header {
+		border-bottom: 0;
+		margin-bottom: 0;
+	}
+
+	.woocommerce-task-payments__stripe-error-wrapper {
+		align-items: flex-end;
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+	}
+}
+
 .woocommerce-task-appearance {
 	.muriel-image-upload {
 		margin-bottom: $gap-smallest;

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -17,6 +17,7 @@ import { withDispatch } from '@wordpress/data';
 import { getCountryCode } from 'dashboard/utils';
 import { Form, Card, Stepper, List } from '@woocommerce/components';
 import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
+import { WC_ASSET_URL as wcAssetUrl } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ import Plugins from '../steps/plugins';
 import Stripe from './stripe';
 import Square from './square';
 import PayPal from './paypal';
+import Klarna from './klarna';
 
 class Payments extends Component {
 	constructor() {
@@ -85,7 +87,11 @@ class Payments extends Component {
 	}
 
 	completeTask() {
-		// @todo Mark as completed on the task list.
+		this.props.updateOptions( {
+			[ 'woocommerce_onboarding_payments' ]: {
+				completed: 1,
+			},
+		} );
 		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
 
@@ -121,8 +127,10 @@ class Payments extends Component {
 	}
 
 	completePluginInstall() {
+		const { completed } = this.props;
 		this.props.updateOptions( {
 			[ 'woocommerce_onboarding_payments' ]: {
+				completed: completed || false,
 				installed: 1,
 				methods: this.getMethodsToConfigure(),
 			},
@@ -200,7 +208,7 @@ class Payments extends Component {
 						{ this.renderWooCommerceServicesStripeConnect() }
 					</Fragment>
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/stripe.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'stripe' ) } />,
 				visible: true,
 			},
@@ -214,7 +222,7 @@ class Payments extends Component {
 						) }
 					</Fragment>
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/paypal.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'paypal' ) } />,
 				visible: true,
 			},
@@ -224,7 +232,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_checkout' ) } />,
 				visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
 			},
@@ -234,7 +242,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_payments' ) } />,
 				visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
 			},
@@ -245,7 +253,7 @@ class Payments extends Component {
 						'Sell online and in store and track sales and inventory in one place.',
 					'woocommerce-admin'
 				),
-				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
+				before: <img src={ wcAssetUrl + 'images/square-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'square' ) } />,
 				visible:
 					[ 'brick-mortar', 'brick-mortar-other' ].includes( profileItems.selling_venues ) &&
@@ -385,7 +393,32 @@ class Payments extends Component {
 				),
 				visible: showIndividualConfigs && methods.includes( 'square' ),
 			},
-			// @todo Klarna
+			{
+				key: 'klarna-checkout',
+				label: __( 'Klarna', 'woocommerce-admin' ),
+				description: '',
+				content: (
+					<Klarna
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+						plugin={ 'checkout' }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'klarna-checkout' ),
+			},
+			{
+				key: 'klarna-payments',
+				label: __( 'Klarna', 'woocommerce-admin' ),
+				description: '',
+				content: (
+					<Klarna
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+						plugin={ 'payments' }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'klarna-payments' ),
+			},
 		];
 
 		return filter( steps, step => step.visible );
@@ -443,6 +476,8 @@ export default compose(
 		const installed = get( options, [ 'woocommerce_onboarding_payments', 'installed' ], false );
 		const configured = get( options, [ 'woocommerce_onboarding_payments', 'configured' ], [] );
 
+		const completed = get( options, [ 'woocommerce_onboarding_payments', 'completed' ], false );
+
 		return {
 			countryCode,
 			isSettingsError,
@@ -455,6 +490,7 @@ export default compose(
 			methods,
 			installed,
 			configured,
+			completed,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -24,6 +24,7 @@ import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
 import withSelect from 'wc-api/with-select';
 import Plugins from '../steps/plugins';
 import Stripe from './stripe';
+import Square from './square';
 import PayPal from './paypal';
 
 class Payments extends Component {
@@ -372,8 +373,19 @@ class Payments extends Component {
 				),
 				visible: showIndividualConfigs && methods.includes( 'paypal' ),
 			},
+			{
+				key: 'square',
+				label: __( 'Enable Square', 'woocommerce-admin' ),
+				description: __( 'Connect your store to your Square account', 'woocommerce-admin' ),
+				content: (
+					<Square
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'square' ),
+			},
 			// @todo Klarna
-			// @todo Square
 		];
 
 		return filter( steps, step => step.visible );

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -200,7 +200,7 @@ class Payments extends Component {
 						{ this.renderWooCommerceServicesStripeConnect() }
 					</Fragment>
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/stripe.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'stripe' ) } />,
 				visible: true,
 			},
@@ -214,7 +214,7 @@ class Payments extends Component {
 						) }
 					</Fragment>
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/paypal.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'paypal' ) } />,
 				visible: true,
 			},
@@ -224,7 +224,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_checkout' ) } />,
 				visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
 			},
@@ -234,7 +234,7 @@ class Payments extends Component {
 					'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
 					'woocommerce-admin'
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'klarna_payments' ) } />,
 				visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
 			},
@@ -245,7 +245,7 @@ class Payments extends Component {
 						'Sell online and in store and track sales and inventory in one place.',
 					'woocommerce-admin'
 				),
-				before: <div />, // @todo Logo
+				before: <img src={ wcSettings.wcAssetUrl + 'images/klarna-black.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'square' ) } />,
 				visible:
 					[ 'brick-mortar', 'brick-mortar-other' ].includes( profileItems.selling_venues ) &&

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -13,6 +13,11 @@ import interpolateComponents from 'interpolate-components';
 import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
 import { Link } from '@woocommerce/components';
 
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
 class Klarna extends Component {
 	constructor( props ) {
 		super( props );
@@ -21,6 +26,7 @@ class Klarna extends Component {
 
 	continue() {
 		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		recordEvent( 'tasklist_payment_connect_method', { payment_method: slug } );
 		this.props.markConfigured( slug );
 		return;
 	}

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -1,0 +1,69 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { Button } from 'newspack-components';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
+import { Link } from '@woocommerce/components';
+
+class Klarna extends Component {
+	constructor( props ) {
+		super( props );
+		this.continue = this.continue.bind( this );
+	}
+
+	continue() {
+		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		this.props.markConfigured( slug );
+		return;
+	}
+
+	render() {
+		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		const section = 'checkout' === this.props.plugin ? 'kco' : 'klarna_payments';
+
+		const link = (
+			<Link
+				href={ adminUrl + 'admin.php?page=wc-settings&tab=checkout&section=' + section }
+				target="_blank"
+				type="external"
+			/>
+		);
+
+		const helpLink = (
+			<Link
+				href={ 'https://docs.woocommerce.com/document/' + slug + '/#section-3' }
+				target="_blank"
+				type="external"
+			/>
+		);
+
+		const configureText = interpolateComponents( {
+			mixedString: __(
+				'Klarna can be configured under your {{link}}store settings{{/link}}. Figure out {{helpLink}}what you need{{/helpLink}}.',
+				'woocommerce-admin'
+			),
+			components: {
+				link,
+				helpLink,
+			},
+		} );
+		return (
+			<Fragment>
+				<p>{ configureText }</p>
+				<Button isPrimary isDefault onClick={ this.continue }>
+					{ __( 'Continue', 'woocommerce-admin' ) }
+				</Button>
+			</Fragment>
+		);
+	}
+}
+
+export default Klarna;

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -14,9 +14,14 @@ import interpolateComponents from 'interpolate-components';
 /**
  * WooCommerce dependencies
  */
-import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import { Form, Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class PayPal extends Component {
 	constructor( props ) {
@@ -37,6 +42,7 @@ class PayPal extends Component {
 		// Handle redirect back from PayPal
 		if ( query[ 'paypal-connect' ] ) {
 			if ( '1' === query[ 'paypal-connect' ] ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'paypal' } );
 				this.props.markConfigured( 'paypal' );
 				this.props.createNotice(
 					'success',
@@ -124,6 +130,7 @@ class PayPal extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
+			recordEvent( 'tasklist_payment_connect_method', { payment_method: 'paypal' } );
 			this.props.setRequestPending( false );
 			markConfigured( 'paypal' );
 		} else {

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -2,16 +2,255 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button, TextControl } from 'newspack-components';
+import { getQuery } from '@woocommerce/navigation';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import interpolateComponents from 'interpolate-components';
 
 /**
  * WooCommerce dependencies
  */
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
+import { Form, Link } from '@woocommerce/components';
+import withSelect from 'wc-api/with-select';
 
 class PayPal extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			connectURL: '',
+			showManualConfiguration: props.manualConfig,
+		};
+
+		this.updateSettings = this.updateSettings.bind( this );
+	}
+
+	componentDidMount() {
+		const { showManualConfiguration } = this.state;
+
+		const query = getQuery();
+		// Handle redirect back from PayPal
+		if ( query[ 'paypal-connect' ] ) {
+			if ( '1' === query[ 'paypal-connect' ] ) {
+				this.props.markConfigured( 'paypal' );
+				this.props.createNotice(
+					'success',
+					__( 'PayPal connected successfully.', 'woocommerce-admin' )
+				);
+				return;
+			}
+
+			/* eslint-disable react/no-did-mount-set-state */
+			this.setState( {
+				showManualConfiguration: true,
+			} );
+			/* eslint-enable react/no-did-mount-set-state */
+			return;
+		}
+
+		if ( ! showManualConfiguration ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if (
+			true === prevState.showManualConfiguration &&
+			false === this.state.showManualConfiguration
+		) {
+			this.fetchOAuthConnectURL();
+		}
+
+		if ( false === prevProps.optionsIsRequesting && true === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( true );
+		}
+
+		if ( true === prevProps.optionsIsRequesting && false === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( false );
+		}
+	}
+
+	async fetchOAuthConnectURL() {
+		this.props.setRequestPending( true );
+		try {
+			const result = await apiFetch( {
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-paypal',
+				method: 'POST',
+			} );
+			if ( ! result || ! result.connectUrl ) {
+				this.props.setRequestPending( false );
+				this.setState( {
+					showManualConfiguration: true,
+				} );
+				return;
+			}
+			this.props.setRequestPending( false );
+			this.setState( {
+				connectURL: result.connectUrl,
+			} );
+		} catch ( error ) {
+			this.props.setRequestPending( false );
+			this.setState( {
+				showManualConfiguration: true,
+			} );
+		}
+	}
+
+	renderConnectButton() {
+		const { connectURL } = this.state;
+		return (
+			<Button isPrimary isDefault href={ connectURL }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
+	async updateSettings( values ) {
+		const { createNotice, isSettingsError, updateOptions, markConfigured } = this.props;
+
+		this.props.setRequestPending( true );
+		await updateOptions( {
+			woocommerce_ppec_paypal_settings: {
+				...this.props.options.woocommerce_ppec_paypal_settings,
+				api_username: values.api_username,
+				api_password: values.api_password,
+			},
+		} );
+
+		if ( ! isSettingsError ) {
+			this.props.setRequestPending( false );
+			markConfigured( 'paypal' );
+		} else {
+			this.props.setRequestPending( false );
+			createNotice(
+				'error',
+				__( 'There was a problem saving your payment settings.', 'woocommerce-admin' )
+			);
+		}
+	}
+
+	getInitialConfigValues() {
+		return {
+			api_username: '',
+			api_password: '',
+		};
+	}
+
+	validate( values ) {
+		const errors = {};
+
+		if ( ! values.api_username ) {
+			errors.api_username = __( 'Please enter your API username', 'woocommerce-admin' );
+		}
+		if ( ! values.api_password ) {
+			errors.api_password = __( 'Please enter your API password', 'woocommerce-admin' );
+		}
+
+		return errors;
+	}
+
+	renderManualConfig() {
+		const { optionsIsRequesting } = this.props;
+		const link = (
+			<Link
+				href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-8"
+				target="_blank"
+				type="external"
+			/>
+		);
+		const help = interpolateComponents( {
+			mixedString: __(
+				'Your API details can be obtained from your {{link}}PayPal account{{/link}}',
+				'woocommerce-admin'
+			),
+			components: {
+				link,
+			},
+		} );
+
+		return (
+			<Form
+				initialValues={ this.getInitialConfigValues() }
+				onSubmitCallback={ this.updateSettings }
+				validate={ this.validate }
+			>
+				{ ( { getInputProps, handleSubmit } ) => {
+					return (
+						<Fragment>
+							<TextControl
+								label={ __( 'API Username', 'woocommerce-admin' ) }
+								required
+								{ ...getInputProps( 'api_username' ) }
+							/>
+							<TextControl
+								label={ __( 'API Password', 'woocommerce-admin' ) }
+								required
+								{ ...getInputProps( 'api_password' ) }
+							/>
+
+							<Button onClick={ handleSubmit } isPrimary disabled={ optionsIsRequesting }>
+								{ __( 'Proceed', 'woocommerce-admin' ) }
+							</Button>
+
+							<Button
+								onClick={ () => {
+									this.props.markConfigured( 'paypal' );
+								} }
+							>
+								{ __( 'Skip', 'woocommerce-admin' ) }
+							</Button>
+
+							<p>{ help }</p>
+						</Fragment>
+					);
+				} }
+			</Form>
+		);
+	}
+
 	render() {
+		const { connectURL, showManualConfiguration } = this.state;
+
+		if ( connectURL && ! showManualConfiguration ) {
+			return this.renderConnectButton();
+		}
+
+		if ( showManualConfiguration ) {
+			return this.renderManualConfig();
+		}
+
 		return null;
 	}
 }
 
-export default PayPal;
+PayPal.defaultProps = {
+	manualConfig: false, // WCS is not required for the PayPal OAuth flow, so we can default to smooth connection.
+};
+
+export default compose(
+	withSelect( select => {
+		const { getOptions, isOptionsRequesting } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_ppec_paypal_settings' ] );
+		const optionsIsRequesting = Boolean(
+			isOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
+		);
+
+		return {
+			options,
+			optionsIsRequesting,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( PayPal );

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -119,6 +119,7 @@ class PayPal extends Component {
 				...this.props.options.woocommerce_ppec_paypal_settings,
 				api_username: values.api_username,
 				api_password: values.api_password,
+				enabled: 'yes',
 			},
 		} );
 
@@ -234,10 +235,10 @@ PayPal.defaultProps = {
 
 export default compose(
 	withSelect( select => {
-		const { getOptions, isOptionsRequesting } = select( 'wc-api' );
+		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
 		const options = getOptions( [ 'woocommerce_ppec_paypal_settings' ] );
 		const optionsIsRequesting = Boolean(
-			isOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
+			isGetOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
 		);
 
 		return {

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+
+class PayPal extends Component {
+	render() {
+		return null;
+	}
+}
+
+export default PayPal;

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -1,0 +1,144 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from 'newspack-components';
+import { getQuery } from '@woocommerce/navigation';
+import { withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+
+/**
+ * WooCommerce dependencies
+ */
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
+import withSelect from 'wc-api/with-select';
+
+class Square extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showSkipButton: false,
+		};
+
+		this.connect = this.connect.bind( this );
+	}
+
+	componentDidMount() {
+		const query = getQuery();
+		// Handle redirect back from Square
+		if ( query[ 'square-connect' ] ) {
+			if ( '1' === query[ 'square-connect' ] ) {
+				this.props.markConfigured( 'square' );
+				this.props.createNotice(
+					'success',
+					__( 'Square connected successfully.', 'woocommerce-admin' )
+				);
+				return;
+			}
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( false === prevProps.optionsIsRequesting && true === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( true );
+		}
+
+		if ( true === prevProps.optionsIsRequesting && false === this.props.optionsIsRequesting ) {
+			this.props.setRequestPending( false );
+		}
+	}
+
+	renderConnectButton() {
+		return (
+			<Button isPrimary isDefault onClick={ this.connect }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
+	async connect() {
+		const { updateOptions } = this.props;
+		this.props.setRequestPending( true );
+
+		updateOptions( {
+			woocommerce_stripe_settings: {
+				...this.props.options.woocommerce_stripe_settings,
+				enabled: 'yes',
+			},
+		} );
+
+		const errorMessage = __(
+			'There was an error connecting to Square. Please try again or skip to connect later in store settings.',
+			'woocommerce-admin'
+		);
+
+		try {
+			const result = await apiFetch( {
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square2',
+				method: 'POST',
+			} );
+
+			if ( ! result || ! result.connectUrl ) {
+				this.props.setRequestPending( false );
+				this.setState( { showSkipButton: true } );
+				this.props.createNotice( 'error', errorMessage );
+				return;
+			}
+
+			this.props.setRequestPending( false );
+			window.location = result.connectUrl;
+		} catch ( error ) {
+			this.props.setRequestPending( false );
+			this.setState( { showSkipButton: true } );
+			this.props.createNotice( 'error', errorMessage );
+		}
+	}
+
+	render() {
+		const { showSkipButton } = this.state;
+
+		return (
+			<Fragment>
+				<Button isPrimary isDefault onClick={ this.connect }>
+					{ __( 'Connect', 'woocommerce-admin' ) }
+				</Button>
+				{ showSkipButton && (
+					<Button
+						onClick={ () => {
+							this.props.markConfigured( 'square' );
+						} }
+					>
+						{ __( 'Skip', 'woocommerce-admin' ) }
+					</Button>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default compose(
+	withSelect( select => {
+		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_stripe_settings' ] );
+		const optionsIsRequesting = Boolean(
+			isGetOptionsRequesting( [ 'woocommerce_stripe_settings' ] )
+		);
+
+		return {
+			options,
+			optionsIsRequesting,
+		};
+	} ),
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+		return {
+			createNotice,
+			updateOptions,
+		};
+	} )
+)( Square );

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -52,14 +52,6 @@ class Square extends Component {
 		}
 	}
 
-	renderConnectButton() {
-		return (
-			<Button isPrimary isDefault onClick={ this.connect }>
-				{ __( 'Connect', 'woocommerce-admin' ) }
-			</Button>
-		);
-	}
-
 	async connect() {
 		const { updateOptions } = this.props;
 		this.props.setRequestPending( true );
@@ -78,7 +70,7 @@ class Square extends Component {
 
 		try {
 			const result = await apiFetch( {
-				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square2',
+				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square',
 				method: 'POST',
 			} );
 

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -11,10 +11,11 @@ import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
- * WooCommerce dependencies
+ * Internal dependencies
  */
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class Square extends Component {
 	constructor( props ) {
@@ -32,6 +33,7 @@ class Square extends Component {
 		// Handle redirect back from Square
 		if ( query[ 'square-connect' ] ) {
 			if ( '1' === query[ 'square-connect' ] ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'square' } );
 				this.props.markConfigured( 'square' );
 				this.props.createNotice(
 					'success',

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -17,8 +17,13 @@ import { get } from 'lodash';
  * WooCommerce dependencies
  */
 import { Form, Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
 import withSelect from 'wc-api/with-select';
 import { WCS_NAMESPACE } from 'wc-api/constants';
+import { recordEvent } from 'lib/tracks';
 
 class Stripe extends Component {
 	constructor( props ) {
@@ -44,6 +49,8 @@ class Stripe extends Component {
 		if ( query[ 'stripe-connect' ] && '1' === query[ 'stripe-connect' ] ) {
 			const stripeSettings = get( options, [ 'woocommerce_stripe_settings' ], [] );
 			const isStripeConnected = stripeSettings.publishable_key && stripeSettings.secret_key;
+
+			recordEvent( 'tasklist_payment_connect_method', { payment_method: 'stripe' } );
 
 			if ( isStripeConnected ) {
 				this.props.markConfigured( 'stripe' );
@@ -125,6 +132,7 @@ class Stripe extends Component {
 			} );
 
 			if ( result ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'stripe' } );
 				this.props.setRequestPending( false );
 				this.props.markConfigured( 'stripe' );
 				this.props.createNotice(
@@ -223,6 +231,7 @@ class Stripe extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
+			recordEvent( 'tasklist_payment_connect_method', { payment_method: 'stripe' } );
 			this.props.setRequestPending( false );
 			markConfigured( 'stripe' );
 		} else {

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -1,0 +1,17 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * WooCommerce dependencies
+ */
+
+class Stripe extends Component {
+	render() {
+		return null;
+	}
+}
+
+export default Stripe;

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -2,16 +2,194 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import apiFetch from '@wordpress/api-fetch';
+import { withDispatch } from '@wordpress/data';
+import interpolateComponents from 'interpolate-components';
+import { Modal } from '@wordpress/components';
+import { Button } from 'newspack-components';
 
 /**
  * WooCommerce dependencies
  */
 
 class Stripe extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			showErrorModal: false,
+			errorMessage: '',
+			connectURL: '',
+			showConnectionButtons: ! props.manualConfig && ! props.createAccount,
+			showManualConfiguration: props.manualConfig,
+		};
+	}
+
+	componentDidMount() {
+		const { createAccount } = this.props;
+		const { showConnectionButtons } = this.state;
+
+		if ( createAccount ) {
+			this.autoCreateAccount();
+		}
+
+		if ( showConnectionButtons ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	componentDidUpdate( prevProps, prevState ) {
+		if ( false === prevState.showConnectionButtons && this.state.showConnectionButtons ) {
+			this.fetchOAuthConnectURL();
+		}
+	}
+
+	async fetchOAuthConnectURL() {
+		const { returnUrl } = this.props;
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v1/connect/stripe/oauth/init', // @todo namespace
+				method: 'POST',
+				data: {
+					returnUrl,
+				},
+			} );
+			if ( ! result || ! result.oauthUrl ) {
+				this.setState( {
+					showConnectionButtons: false,
+					showManualConfiguration: true,
+				} );
+				return;
+			}
+			this.setState( {
+				connectURL: result.oauthUrl,
+			} );
+		} catch ( error ) {
+			// Fallback to manual configuration if the OAuth URL cannot be grabbed.
+			this.setState( {
+				showConnectionButtons: false,
+				showManualConfiguration: true,
+			} );
+		}
+	}
+
+	async autoCreateAccount() {
+		const { email, countryCode, returnUrl } = this.props;
+		try {
+			const result = await apiFetch( {
+				path: '/wc/v1/connect/stripe/account', // @todo namespace
+				method: 'POST',
+				data: {
+					email,
+					country: countryCode,
+				},
+			} );
+
+			if ( result ) {
+				window.location = returnUrl;
+				return;
+			}
+		} catch ( error ) {
+			let errorTitle, errorMessage;
+			// This seems to be the best way to handle this.
+			// github.com/Automattic/woocommerce-services/blob/cfb6173deb3c72897ee1d35b8fdcf29c5a93dea2/woocommerce-services.php#L563-L570
+			if ( -1 === error.message.indexOf( 'Account already exists for the provided email' ) ) {
+				errorTitle = __( 'Stripe', 'woocommerce-admin' );
+				errorMessage = interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but an error occured. ' +
+								'Please try connecting manually to continue.',
+							'woocommerce-admin'
+						),
+						email
+					),
+					components: {
+						strong: <strong />,
+					},
+				} );
+			} else {
+				errorTitle = __( 'You already have a Stripe account', 'woocommerce-admin' );
+				errorMessage = interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but one already exists. ' +
+								'Please sign in and connect to continue.',
+							'woocommerce-admin'
+						),
+						email
+					),
+					components: {
+						strong: <strong />,
+					},
+				} );
+			}
+
+			this.setState( {
+				showErrorModal: true,
+				showConnectionButtons: true,
+				errorTitle,
+				errorMessage,
+			} );
+		}
+	}
+
+	/*
+	<Button isDefault onClick={ () => setState( { isOpen: false } ) }>
+					My custom close button
+				</Button>
+				*/
+
+	renderErrorModal() {
+		const { errorTitle, errorMessage } = this.state;
+		return (
+			<Modal
+				title={ errorTitle }
+				onRequestClose={ () => this.setState( { showErrorModal: false } ) }
+				className="woocommerce-task-payments__stripe-error-modal"
+			>
+				<div className="woocommerce-task-payments__stripe-error-wrapper">
+					<div className="woocommerce-task-payments__stripe-error-message">{ errorMessage }</div>
+					<Button isPrimary isDefault onClick={ () => this.setState( { showErrorModal: false } ) }>
+						{ __( 'OK', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+
+	renderConnectButton() {
+		const { connectURL } = this.state;
+		return (
+			<Button isPrimary isDefault href={ connectURL }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
+		);
+	}
+
 	render() {
+		const { showErrorModal, showConnectionButtons, connectURL } = this.state;
+
+		if ( showErrorModal ) {
+			return this.renderErrorModal();
+		}
+
+		if ( showConnectionButtons && connectURL ) {
+			return this.renderConnectButton();
+		}
+
 		return null;
 	}
 }
 
-export default Stripe;
+export default compose(
+	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
+		return {
+			createNotice,
+		};
+	} )
+)( Stripe );

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -25,7 +25,6 @@ class Stripe extends Component {
 		super( props );
 
 		this.state = {
-			showErrorModal: false,
 			errorMessage: '',
 			connectURL: '',
 			showConnectionButtons: ! props.manualConfig && ! props.createAccount,
@@ -172,7 +171,6 @@ class Stripe extends Component {
 			}
 
 			this.setState( {
-				showErrorModal: true,
 				showConnectionButtons: true,
 				errorTitle,
 				errorMessage,
@@ -185,12 +183,16 @@ class Stripe extends Component {
 		return (
 			<Modal
 				title={ errorTitle }
-				onRequestClose={ () => this.setState( { showErrorModal: false } ) }
+				onRequestClose={ () => this.setState( { errorMessage: '', errorTitle: '' } ) }
 				className="woocommerce-task-payments__stripe-error-modal"
 			>
 				<div className="woocommerce-task-payments__stripe-error-wrapper">
 					<div className="woocommerce-task-payments__stripe-error-message">{ errorMessage }</div>
-					<Button isPrimary isDefault onClick={ () => this.setState( { showErrorModal: false } ) }>
+					<Button
+						isPrimary
+						isDefault
+						onClick={ () => this.setState( { errorMessage: '', errorTitle: '' } ) }
+					>
 						{ __( 'OK', 'woocommerce-admin' ) }
 					</Button>
 				</div>
@@ -216,6 +218,7 @@ class Stripe extends Component {
 				...this.props.options.woocommerce_stripe_settings,
 				publishable_key: values.publishable_key,
 				secret_key: values.secret_key,
+				enabled: 'yes',
 			},
 		} );
 
@@ -303,14 +306,9 @@ class Stripe extends Component {
 	}
 
 	render() {
-		const {
-			showErrorModal,
-			showConnectionButtons,
-			connectURL,
-			showManualConfiguration,
-		} = this.state;
+		const { errorMessage, showConnectionButtons, connectURL, showManualConfiguration } = this.state;
 
-		if ( showErrorModal ) {
+		if ( errorMessage ) {
 			return this.renderErrorModal();
 		}
 

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -7,6 +7,7 @@ import { MINUTE } from '@fresh-data/framework';
 export const JETPACK_NAMESPACE = '/jetpack/v4';
 export const NAMESPACE = '/wc/v4';
 export const WC_ADMIN_NAMESPACE = '/wc-admin/v1';
+export const WCS_NAMESPACE = '/wc/v1'; // WCS endpoints like Stripe are not avaiable on later /wc versions
 
 export const DEFAULT_REQUIREMENT = {
 	timeout: 1 * MINUTE,

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -18,12 +18,15 @@ const getOptions = ( getResource, requireResource ) => (
 	const resourceName = getResourceName( 'options', optionNames );
 	const options = {};
 
-	const names = requireResource( requirement, resourceName ).data || [];
+	const names = requireResource( requirement, resourceName ).data || optionNames;
 
 	names.forEach( name => {
-		options[ name ] = getResource( getResourceName( 'options', name ) ).data;
+		const data =
+			getResource( getResourceName( 'options', name ) ).data || wcSettings.preloadOptions[ name ];
+		if ( data ) {
+			options[ name ] = data;
+		}
 	} );
-
 	return options;
 };
 

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -114,6 +114,19 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 				'schema' => array( $this, 'get_connect_schema' ),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/connect-paypal',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'connect_paypal' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_connect_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -400,6 +413,38 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		return array(
 			'success' => true,
 		);
+	}
+
+	/**
+	 * Returns a URL that can be used to connect to PayPal.
+	 *
+	 * @param  object $rest_request Request details.
+	 * @return array Connect URL.
+	 */
+	public function connect_paypal() {
+		if ( ! function_exists( 'wc_gateway_ppec' ) ) {
+			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to PayPal.', 'woocommerce-admin' ), 500 );
+		}
+
+		$redirect_url = add_query_arg(
+			array(
+				'env'                     => 'live',
+				'wc_ppec_ips_admin_nonce' => wp_create_nonce( 'wc_ppec_ips' ),
+			),
+			wc_admin_url( '&task=payments&paypal-connect-finish=1' )
+		);
+
+		// https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/b6df13ba035038aac5024d501e8099a37e13d6cf/includes/class-wc-gateway-ppec-ips-handler.php#L79-L93
+		$query_args = array(
+			'redirect'    => urlencode( $redirect_url ),
+			'countryCode' => WC()->countries->get_base_country(),
+			'merchantId'  => md5( site_url( '/' ) . time() ),
+		);
+		$connect_url = add_query_arg( $query_args, wc_gateway_ppec()->ips->get_middleware_login_url( 'live' ) );
+
+		return( array(
+			'connectUrl' => $connect_url,
+		) );
 	}
 
 	/**

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -418,7 +418,6 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	/**
 	 * Returns a URL that can be used to connect to PayPal.
 	 *
-	 * @param  object $rest_request Request details.
 	 * @return array Connect URL.
 	 */
 	public function connect_paypal() {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -63,6 +63,7 @@ class Onboarding {
 		// new settings injection
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
@@ -340,6 +341,15 @@ class Onboarding {
 		}
 
 		return $settings;
+	}
+
+	public function preload_options( $options ) {
+		if ( ! $this->should_show_tasks() ) {
+			return $options;
+		}
+		$options[] = 'woocommerce_onboarding_payments';
+		$options[] = 'woocommerce_stripe_settings';
+		return $options;
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -544,6 +544,13 @@ class Loader {
 			);
 		}
 
+		$preload_options = apply_filters( 'woocommerce_admin_preload_options', array() );
+		if ( ! empty( $preload_options ) ) {
+			foreach ( $preload_options as $option ) {
+				$settings['preloadOptions'][ $option ] = get_option( $option );
+			}
+		}
+
 		$current_user_data = array();
 		foreach ( self::get_user_data_fields() as $user_field ) {
 			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true ) );


### PR DESCRIPTION
This PR builds upon/depends on #2960 and #2897.
See #2671.

It implements all of the `wcadmin_tasklist_payment_*`  track events listed in the events spreadsheet.

### Testing Directions:

* Either clear out the  `woocommerce_onboarding_payments` option, or complete running through the payments task so that you can restart from the beginning.
* * In your debug console, enter `localStorage.setItem( 'debug', 'wc-admin:*' )`.
* Walk through the payment method flows outlined in #2960 and #2897 to make sure the events in the spreadsheet are fired. `wcadmin_tasklist_payment_choose_method`, `wcadmin_tasklist_payment_install_method`, and `wcadmin_tasklist_payment_connect_method`.