### PR TITLE
Add Task List Tracks Events

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -25,6 +25,7 @@ import Shipping from './tasks/shipping';
 import Tax from './tasks/tax';
 import Payments from './tasks/payments';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 const { customLogo, hasHomepage, hasProducts, shippingZonesCount } = getSetting( 'onboarding', {
 	customLogo: '',
@@ -37,11 +38,25 @@ class TaskDashboard extends Component {
 	componentDidMount() {
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
+
+		this.recordEvent();
 	}
 
 	componentWillUnmount() {
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-task-dashboard__body' );
+	}
+
+	recordEvent() {
+		if ( this.getCurrentTask() ) {
+			return;
+		}
+		const { profileItems } = this.props;
+		const tasks = filter( this.getTasks(), task => task.visible );
+		recordEvent( 'tasklist_view', {
+			number_tasks: tasks.length,
+			store_connected: profileItems.wccom_connected,
+		} );
 	}
 
 	getTasks() {

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -211,7 +211,7 @@ class Appearance extends Component {
 						</Button>
 						<Button
 							onClick={ () => {
-								recordEvent( 'tasklist_appearance_create_homepage', { skipped: true } );
+								recordEvent( 'tasklist_appearance_create_homepage', { create_homepage: false } );
 								this.completeStep();
 							} }
 						>

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -21,6 +21,7 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
  */
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class Appearance extends Component {
 	constructor( props ) {
@@ -129,6 +130,8 @@ class Appearance extends Component {
 		const { createNotice } = this.props;
 		this.setState( { isPending: true } );
 
+		recordEvent( 'tasklist_appearance_create_homepage', { create_homepage: true } );
+
 		apiFetch( { path: '/wc-admin/v1/onboarding/tasks/create_homepage', method: 'POST' } )
 			.then( response => {
 				createNotice( response.status, response.message );
@@ -149,6 +152,8 @@ class Appearance extends Component {
 		const { logo } = this.state;
 		const updateThemeMods = logo ? { ...themeMods, custom_logo: logo.id } : themeMods;
 
+		recordEvent( 'tasklist_appearance_upload_logo' );
+
 		updateOptions( {
 			[ `theme_mods_${ options.stylesheet }` ]: updateThemeMods,
 		} );
@@ -157,6 +162,10 @@ class Appearance extends Component {
 	updateNotice() {
 		const { updateOptions } = this.props;
 		const { storeNoticeText } = this.state;
+
+		recordEvent( 'tasklist_appearance_set_store_notice', {
+			added_text: Boolean( storeNoticeText.length ),
+		} );
 
 		updateOptions( {
 			woocommerce_demo_store: storeNoticeText.length ? 'yes' : 'no',
@@ -200,7 +209,12 @@ class Appearance extends Component {
 						<Button isPrimary onClick={ this.createHomepage }>
 							{ __( 'Create homepage', 'woocommerce-admin' ) }
 						</Button>
-						<Button onClick={ () => this.completeStep() }>
+						<Button
+							onClick={ () => {
+								recordEvent( 'tasklist_appearance_create_homepage', { skipped: true } );
+								this.completeStep();
+							} }
+						>
 							{ __( 'Skip', 'woocommerce-admin' ) }
 						</Button>
 					</Fragment>

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -13,6 +13,11 @@ import interpolateComponents from 'interpolate-components';
 import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
 import { Link } from '@woocommerce/components';
 
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
 class Klarna extends Component {
 	constructor( props ) {
 		super( props );
@@ -21,6 +26,7 @@ class Klarna extends Component {
 
 	continue() {
 		const slug = 'checkout' === this.props.plugin ? 'klarna-checkout' : 'klarna-payments';
+		recordEvent( 'tasklist_payment_connect_method', { payment_method: slug } );
 		this.props.markConfigured( slug );
 		return;
 	}

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -17,6 +17,7 @@ import interpolateComponents from 'interpolate-components';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import { Form, Link } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class PayPal extends Component {
 	constructor( props ) {
@@ -37,6 +38,7 @@ class PayPal extends Component {
 		// Handle redirect back from PayPal
 		if ( query[ 'paypal-connect' ] ) {
 			if ( '1' === query[ 'paypal-connect' ] ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'paypal' } );
 				this.props.markConfigured( 'paypal' );
 				this.props.createNotice(
 					'success',
@@ -124,6 +126,7 @@ class PayPal extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
+			recordEvent( 'tasklist_payment_connect_method', { payment_method: 'paypal' } );
 			this.props.setRequestPending( false );
 			markConfigured( 'paypal' );
 			this.props.createNotice(

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -15,6 +15,7 @@ import { compose } from '@wordpress/compose';
  */
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class Square extends Component {
 	constructor( props ) {
@@ -32,6 +33,7 @@ class Square extends Component {
 		// Handle redirect back from Square
 		if ( query[ 'square-connect' ] ) {
 			if ( '1' === query[ 'square-connect' ] ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'square' } );
 				this.props.markConfigured( 'square' );
 				this.props.createNotice(
 					'success',

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -19,6 +19,7 @@ import { get } from 'lodash';
 import { Form, Link } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import { WCS_NAMESPACE } from 'wc-api/constants';
+import { recordEvent } from 'lib/tracks';
 
 class Stripe extends Component {
 	constructor( props ) {
@@ -46,6 +47,7 @@ class Stripe extends Component {
 			const isStripeConnected = stripeSettings.publishable_key && stripeSettings.secret_key;
 
 			if ( isStripeConnected ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'stripe' } );
 				this.props.markConfigured( 'stripe' );
 				this.props.createNotice(
 					'success',
@@ -125,6 +127,7 @@ class Stripe extends Component {
 			} );
 
 			if ( result ) {
+				recordEvent( 'tasklist_payment_connect_method', { payment_method: 'stripe' } );
 				this.props.setRequestPending( false );
 				this.props.markConfigured( 'stripe' );
 				this.props.createNotice(
@@ -223,6 +226,7 @@ class Stripe extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
+			recordEvent( 'tasklist_payment_connect_method', { payment_method: 'stripe' } );
 			this.props.setRequestPending( false );
 			markConfigured( 'stripe' );
 			this.props.createNotice(

--- a/client/dashboard/task-list/tasks/products.js
+++ b/client/dashboard/task-list/tasks/products.js
@@ -11,12 +11,18 @@ import { Component, Fragment } from '@wordpress/element';
 import { Card, List } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/navigation';
 
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
 const subTasks = [
 	{
 		title: __( 'Add manually (recommended)', 'woocommerce-admin' ),
 		content: __( 'For small stores we recommend adding products manually', 'woocommerce-admin' ),
 		before: <i className="material-icons-outlined">add_box</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
+		onClick: () => recordEvent( 'tasklist_add_product', { method: 'manually' } ),
 		href: getAdminLink( 'post-new.php?post_type=product&wc_onboarding_active_task=products' ),
 	},
 	{
@@ -27,6 +33,7 @@ const subTasks = [
 		),
 		before: <i className="material-icons-outlined">import_export</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
+		onClick: () => recordEvent( 'tasklist_add_product', { method: 'import' } ),
 		href: getAdminLink(
 			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
 		),
@@ -39,6 +46,7 @@ const subTasks = [
 		),
 		before: <i className="material-icons-outlined">cloud_download</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
+		onClick: () => recordEvent( 'tasklist_add_product', { method: 'migrate' } ),
 		// @todo This should be replaced with the in-app purchase iframe when ready.
 		href: 'https://woocommerce.com/products/cart2cart/',
 		target: '_blank',

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -191,7 +191,7 @@ class Shipping extends Component {
 							this.completeStep();
 						} }
 						onSkip={ () => {
-							recordEvent( 'tasklist_shipping_label_printing', { skip: true } );
+							recordEvent( 'tasklist_shipping_label_printing', { install: false } );
 							getHistory().push( getNewPath( {}, '/', {} ) );
 						} }
 						{ ...this.props }

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -24,6 +24,7 @@ import Plugins from '../steps/plugins';
 import StoreLocation from '../steps/location';
 import ShippingRates from './rates';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class Shipping extends Component {
 	constructor() {
@@ -38,6 +39,7 @@ class Shipping extends Component {
 		this.state = this.initialState;
 
 		this.completeStep = this.completeStep.bind( this );
+		this.completeLocationStep = this.completeLocationStep.bind( this );
 	}
 
 	componentDidMount() {
@@ -126,6 +128,12 @@ class Shipping extends Component {
 		}
 	}
 
+	completeLocationStep() {
+		const { countryCode } = this.props;
+		recordEvent( 'tasklist_shipping_set_location', { country: countryCode } );
+		this.completeStep();
+	}
+
 	completeStep() {
 		const { step } = this.state;
 		const steps = this.getSteps();
@@ -147,7 +155,7 @@ class Shipping extends Component {
 				key: 'store_location',
 				label: __( 'Set store location', 'woocommerce-admin' ),
 				description: __( 'The address from which your business operates', 'woocommerce-admin' ),
-				content: <StoreLocation onComplete={ this.completeStep } { ...this.props } />,
+				content: <StoreLocation onComplete={ this.completeLocationStep } { ...this.props } />,
 				visible: true,
 			},
 			{

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -17,6 +17,11 @@ import { Flag, Form } from '@woocommerce/components';
 import { getCurrencyFormatString } from '@woocommerce/currency';
 import { CURRENCY } from '@woocommerce/wc-admin-settings';
 
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
 const { symbol, symbolPosition } = CURRENCY;
 
 class ShippingRates extends Component {
@@ -29,7 +34,17 @@ class ShippingRates extends Component {
 	async updateShippingZones( values ) {
 		const { createNotice, shippingZones } = this.props;
 
+		let restOfTheWorld = false;
+		let shippingCost = false;
 		shippingZones.map( zone => {
+			if ( 0 === zone.id ) {
+				restOfTheWorld = zone.toggleEnabled && values[ `${ zone.id }_enabled` ];
+			} else {
+				shippingCost =
+					'' !== values[ `${ zone.id }_rate` ] &&
+					parseFloat( values[ `${ zone.id }_rate` ] ) !== parseFloat( 0 );
+			}
+
 			const flatRateMethods = zone.methods
 				? zone.methods.filter( method => 'flat_rate' === method.method_id )
 				: [];
@@ -71,6 +86,11 @@ class ShippingRates extends Component {
 					},
 				} );
 			}
+		} );
+
+		recordEvent( 'tasklist_shipping_set_costs', {
+			shipping_cost: shippingCost,
+			rest_world: restOfTheWorld,
 		} );
 
 		// @todo This is a workaround to force the task to mark as complete.

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -29,7 +29,10 @@ class Connect extends Component {
 	}
 
 	async connectJetpack() {
-		const { jetpackConnectUrl } = this.props;
+		const { jetpackConnectUrl, onConnect } = this.props;
+		if ( onConnect ) {
+			onConnect();
+		}
 		window.location = jetpackConnectUrl;
 	}
 

--- a/client/dashboard/task-list/tasks/steps/location.js
+++ b/client/dashboard/task-list/tasks/steps/location.js
@@ -39,7 +39,7 @@ export default class StoreLocation extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
-			onComplete();
+			onComplete( values );
 		} else {
 			createNotice(
 				'error',

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -216,7 +216,7 @@ class Tax extends Component {
 							this.completeStep();
 						} }
 						onSkip={ () => {
-							recordEvent( 'tasklist_tax_install_extensions', { skip: true } );
+							recordEvent( 'tasklist_tax_install_extensions', { install_extensions: false } );
 							window.location.href = getAdminLink(
 								'admin.php?page=wc-settings&tab=tax&section=standard'
 							);
@@ -329,7 +329,9 @@ class Tax extends Component {
 							</Button>
 							<Button
 								onClick={ () => {
-									recordEvent( 'tasklist_tax_setup_automated_simple', { skip: true } );
+									recordEvent( 'tasklist_tax_setup_automated_simple', {
+										setup_automatically: false,
+									} );
 									this.setState( { automatedTaxEnabled: false }, this.updateAutomatedTax );
 								} }
 							>


### PR DESCRIPTION
Closes #2671.

This PR implements all of the `wcadmin_tasklist_*`  events outlined in the onboarding events spreadsheet, with the exception of the following:

* `wcadmin_tasklist_completed`, which will be handled as part of the acceptance criteria for https://github.com/woocommerce/woocommerce-admin/issues/2685.

### Testing Directions:

* In your debug console, enter `localStorage.setItem( 'debug', 'wc-admin:*' )`
* Walk through the add product, appearance, shipping, payment, tax tasks to make sure the events outlined in the spreadsheet are fired. I would duplicate them here, but the spreadsheet does a good job of outlining what should be fired.
	* When testing the tax task, you may need to change some hard coded variables and/or force certain steps to show. See https://github.com/woocommerce/woocommerce-admin/issues/2988.