### PR TITLE
Fix issue #2992 (order number in orders panel)

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -95,7 +95,7 @@ class OrdersPanel extends Component {
 		};
 
 		const orderCardTitle = order => {
-			const { extended_info, order_id } = order;
+			const { extended_info, order_id, order_number } = order;
 			const { customer } = extended_info || {};
 			const customerUrl = customer.customer_id
 				? getNewPath( {}, '/analytics/customers', {
@@ -113,7 +113,7 @@ class OrdersPanel extends Component {
 								'woocommerce-admin'
 							),
 							{
-								orderNumber: order_id,
+								orderNumber: order_number,
 								customerString: getCustomerString( order ),
 							}
 						),


### PR DESCRIPTION
Fixes #2992

Use order number instead of order ID

### Screenshots

### Detailed test instructions:

1. Activate Sequential Order Numbers (or Sequential Order Numbers Pro)
1. Configure SON with a prefix/suffix (to make it easier to differentiate order number from order ID)
1. Go to a WC admin page
1. Click on Orders on the top right bar
   - [ ] Verify the order number from SON is displayed, not the order ID
