### PR TITLE
Replace lodash isNaN() with native Number.isNaN()

### DIFF
--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Remove lodash dependency.
+
 # 1.1.3
 
 - Update dependencies.

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -22,8 +22,7 @@
   "react-native": "src/index",
   "dependencies": {
     "@babel/runtime-corejs2": "7.5.5",
-    "@woocommerce/number": "1.0.2",
-    "lodash": "4.17.15"
+    "@woocommerce/number": "1.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { isNaN } from 'lodash';
 import { sprintf } from '@wordpress/i18n';
 
 /**
@@ -46,7 +45,7 @@ export function getCurrencyFormatDecimal( number ) {
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
 	}
-	if ( isNaN( number ) ) {
+	if ( Number.isNaN( number ) ) {
 		return 0;
 	}
 	return Math.round( number * Math.pow( 10, precision ) ) / Math.pow( 10, precision );
@@ -64,7 +63,7 @@ export function getCurrencyFormatString( number ) {
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
 	}
-	if ( isNaN( number ) ) {
+	if ( Number.isNaN( number ) ) {
 		return '';
 	}
 	return number.toFixed( precision );


### PR DESCRIPTION
Similar to #2977.

Replaces calls to lodash `isNaN()` with browsers' native `Number.isNaN()`. Polyfills already take care of making it work on IE11 so there is no need to use lodash version. This way, `@woocommerce/currency` package will be [much](https://bundlephobia.com/result?p=@woocommerce/currency@1.1.3) smaller.

### Detailed test instructions:

- Open the _Coupons_ report and verify no JS errors appear.