### PR TITLE
Followup: Refactor all client files to use new settings api

### DIFF
--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -13,6 +13,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { SectionHeader, useFilters, ScrollTo } from '@woocommerce/components';
+import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -116,14 +117,13 @@ class Settings extends Component {
 	 * @param {object} state - State
 	 */
 	persistChanges( state ) {
-		// @todo Should remove global state from the file. This creates
-		// potential hard to debug side-effects.
-		wcSettings.wcAdminSettings = wcSettings.wcAdminSettings || {};
+		const settings = getSetting( 'wcAdminSetting', {} );
 		analyticsSettings.forEach( setting => {
 			const updatedValue = state.settings[ setting.name ];
-			wcSettings.wcAdminSettings[ setting.name ] = updatedValue;
+			settings[ setting.name ] = updatedValue;
 			setting.initialValue = updatedValue;
 		} );
+		setSetting( 'wcAdminSetting', settings );
 	}
 
 	saveChanges = source => {

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -13,6 +13,7 @@ import CustomizableDashboard from './customizable';
 import DashboardCharts from './dashboard-charts';
 import Leaderboards from './leaderboards';
 import { ReportFilters } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import StorePerformance from './store-performance';
 import TaskList from './task-list';
 import ProfileWizard from './profile-wizard';
@@ -26,12 +27,10 @@ class Dashboard extends Component {
 			return <ProfileWizard query={ query } />;
 		}
 
+		const { taskListHidden } = getSetting( 'onboarding', {} );
+
 		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
-		if (
-			window.wcAdminFeatures.onboarding &&
-			wcSettings.onboarding &&
-			! wcSettings.onboarding.taskListHidden
-		) {
+		if ( window.wcAdminFeatures.onboarding && ! taskListHidden ) {
 			return <TaskList query={ query } />;
 		}
 

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { difference, get } from 'lodash';
+import { difference } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 
 /**
@@ -14,6 +14,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { H, Stepper, Card } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal depdencies
@@ -23,11 +24,9 @@ import withSelect from 'wc-api/with-select';
 import { pluginNames } from 'wc-api/onboarding/constants';
 
 const pluginsToInstall = [ 'jetpack', 'woocommerce-services' ];
+const { activePlugins = [] } = getSetting( 'onboarding', {} );
 // We want to use the cached version of activePlugins here, otherwise the list we are dealing with could update as plugins are activated.
-const plugins = difference(
-	pluginsToInstall,
-	get( wcSettings, [ 'onboarding', 'activePlugins' ], [] )
-);
+const plugins = difference( pluginsToInstall, activePlugins );
 
 class Plugins extends Component {
 	constructor() {

--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -14,6 +14,7 @@ import { withDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { H, Card, Link } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 
@@ -86,7 +87,7 @@ class ProductTypes extends Component {
 	}
 
 	render() {
-		const { productTypes } = wcSettings.onboarding;
+		const { productTypes = {} } = getSetting( 'onboarding', {} );
 		const { error, selected } = this.state;
 		return (
 			<Fragment>

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -15,6 +15,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Card, H } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal depdencies
@@ -117,7 +118,7 @@ class Theme extends Component {
 
 	getThemeStatus( theme ) {
 		const { is_installed, price, slug } = theme;
-		const { activeTheme } = wcSettings.onboarding;
+		const { activeTheme = '' } = getSetting( 'onboarding', {} );
 
 		if ( activeTheme === slug ) {
 			return __( 'Currently active theme', 'woocommerce-admin' );
@@ -142,7 +143,7 @@ class Theme extends Component {
 
 	getThemes() {
 		const { activeTab, uploadedThemes } = this.state;
-		const { themes } = wcSettings.onboarding;
+		const { themes = [] } = getSetting( 'onboarding', {} );
 		themes.concat( uploadedThemes );
 		const allThemes = [ ...themes, ...uploadedThemes ];
 

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -15,6 +15,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { Card, Stepper } from '@woocommerce/components';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -25,10 +26,11 @@ import withSelect from 'wc-api/with-select';
 class Appearance extends Component {
 	constructor( props ) {
 		super( props );
+		const { hasHomepage, hasProducts } = getSetting( 'onboarding', {} );
 
 		this.stepVisibility = {
-			homepage: ! wcSettings.onboarding.hasHomepage,
-			import: ! wcSettings.onboarding.hasProducts,
+			homepage: ! hasHomepage,
+			import: ! hasProducts,
 		};
 
 		this.state = {
@@ -71,7 +73,10 @@ class Appearance extends Component {
 		if ( 'logo' === step && isRequestSuccessful ) {
 			createNotice( 'success', __( 'Store logo updated sucessfully.', 'woocommerce-admin' ) );
 			this.completeStep();
-			wcSettings.onboarding.customLogo = themeMods.custom_logo ? true : false;
+			setSetting( 'onboarding', {
+				...getSetting( 'onboarding', {} ),
+				customLogo: !! themeMods.custom_logo,
+			} );
 		}
 
 		if ( 'notice' === step && isRequestSuccessful ) {
@@ -113,7 +118,10 @@ class Appearance extends Component {
 						'success',
 						__( 'All demo products have been imported.', 'woocommerce-admin' )
 					);
-					wcSettings.onboarding.hasProducts = true;
+					setSetting( 'onboarding', {
+						...getSetting( 'onboarding', {} ),
+						hasProducts: true,
+					} );
 				}
 
 				this.setState( { isPending: false } );

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -14,6 +14,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { Card, Stepper } from '@woocommerce/components';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -227,7 +228,7 @@ export default compose(
 
 		const countryCode = getCountryCode( settings.woocommerce_default_country );
 
-		const countries = ( wcSettings.dataEndpoints && wcSettings.dataEndpoints.countries ) || [];
+		const { countries = [] } = getSetting( 'dataEndpoints', {} );
 		const country = countryCode ? countries.find( c => c.code === countryCode ) : null;
 		const countryName = country ? country.name : null;
 

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
  */
 import { Flag, Form } from '@woocommerce/components';
 import { getCurrencyFormatString } from '@woocommerce/currency';
-import { CURRENCY } from '@woocommerce/wc-admin-settings';
+import { CURRENCY, getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 const { symbol, symbolPosition } = CURRENCY;
 
@@ -75,7 +75,10 @@ class ShippingRates extends Component {
 
 		// @todo This is a workaround to force the task to mark as complete.
 		// This should probably be updated to use wc-api so we can fetch shipping methods.
-		wcSettings.onboarding.shippingZonesCount = 1;
+		setSetting( 'onboarding', {
+			...getSetting( 'onboarding', {} ),
+			shippingZonesCount: 1,
+		} );
 
 		createNotice( 'success', __( 'Your shipping rates have been updated.', 'woocommerce-admin' ) );
 

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -16,6 +16,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { Card, H, Stepper } from '@woocommerce/components';
 import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -99,7 +100,7 @@ class Tax extends Component {
 
 	isSupportedCountry() {
 		const { countryCode } = this.props;
-		const { automatedTaxSupportedCountries } = wcSettings.onboarding;
+		const { automatedTaxSupportedCountries = [] } = getSetting( 'onboarding', {} );
 		return automatedTaxSupportedCountries.includes( countryCode );
 	}
 

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -17,6 +17,7 @@ import { keyBy, map, merge } from 'lodash';
 import { EmptyContent, Flag, Link, OrderStatus, Section } from '@woocommerce/components';
 import { formatCurrency } from '@woocommerce/currency';
 import { getAdminLink, getNewPath } from '@woocommerce/navigation';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -266,11 +267,9 @@ export default compose(
 			getReportItemsError,
 			isReportItemsRequesting,
 		} = select( 'wc-api' );
-		wcSettings.wcAdminSettings = wcSettings.wcAdminSettings || {};
-		const orderStatuses =
-			wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses ||
-			DEFAULT_ACTIONABLE_STATUSES;
-
+		const {
+			woocommerce_actionable_order_statuses: orderStatuses = DEFAULT_ACTIONABLE_STATUSES,
+		} = getSetting( 'wcAdminSettings', {} );
 		if ( ! orderStatuses.length ) {
 			return { orders: [], isError: true, isRequesting: false, orderStatuses };
 		}
@@ -319,7 +318,7 @@ export default compose(
 		}
 
 		// Get a count of all orders for messaging purposes.
-		// @todo Add a property to wcSettings for this?
+		// @todo Add a property to settings api for this?
 		const allOrdersQuery = {
 			page: 1,
 			per_page: 1,

--- a/client/header/activity-panel/panels/stock/card.js
+++ b/client/header/activity-panel/panels/stock/card.js
@@ -15,6 +15,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Link, ProductImage } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -132,7 +133,7 @@ class ProductStockCard extends Component {
 	render() {
 		const { product } = this.props;
 		const { edited, editing } = this.state;
-		const { notifyLowStockAmount } = wcSettings;
+		const notifyLowStockAmount = getSetting( 'notifyLowStockAmount', 0 );
 		const lowStockAmount = Number.isFinite( product.low_stock_amount )
 			? product.low_stock_amount
 			: notifyLowStockAmount;

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -4,6 +4,7 @@
  * Internal dependencies
  */
 import { DEFAULT_ACTIONABLE_STATUSES } from 'wc-api/constants';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 export function getUnreadNotes( select ) {
 	const { getCurrentUserData, getNotes, getNotesError, isGetNotesRequesting } = select( 'wc-api' );
@@ -36,9 +37,9 @@ export function getUnreadNotes( select ) {
 
 export function getUnreadOrders( select ) {
 	const { getItems, getItemsTotalCount, getItemsError, isGetItemsRequesting } = select( 'wc-api' );
-	wcSettings.wcAdminSettings = wcSettings.wcAdminSettings || {};
-	const orderStatuses =
-		wcSettings.wcAdminSettings.woocommerce_actionable_order_statuses || DEFAULT_ACTIONABLE_STATUSES;
+	const {
+		woocommerce_actionable_order_statuses: orderStatuses = DEFAULT_ACTIONABLE_STATUSES,
+	} = getSetting( 'wcAdminSettings', {} );
 
 	if ( ! orderStatuses.length ) {
 		return false;
@@ -65,7 +66,9 @@ export function getUnreadOrders( select ) {
 
 export function getUnapprovedReviews( select ) {
 	const { getReviewsTotalCount, getReviewsError, isGetReviewsRequesting } = select( 'wc-api' );
-	if ( 'yes' === wcSettings.reviewsEnabled && '1' === wcSettings.commentModeration ) {
+	const reviewsEnabled = getSetting( 'reviewsEnabled' );
+	const commentModeration = getSetting( 'commentModeration' );
+	if ( 'yes' === reviewsEnabled && '1' === commentModeration ) {
 		const actionableReviewsQuery = {
 			page: 1,
 			// @todo we are not using this review, so when the endpoint supports it,

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
  */
 import { getNewPath } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -79,7 +80,7 @@ class Header extends Component {
 			sprintf(
 				__( '%1$s &lsaquo; %2$s &#8212; WooCommerce', 'woocommerce-admin' ),
 				documentTitle,
-				wcSettings.siteTitle
+				getSetting( 'siteTitle', '' )
 			)
 		);
 

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -12,6 +12,7 @@ import { get, isFunction } from 'lodash';
  * WooCommerce dependencies
  */
 import { getHistory } from '@woocommerce/navigation';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -139,7 +140,7 @@ export class EmbedLayout extends Component {
 		return (
 			<Layout
 				page={ {
-					breadcrumbs: wcSettings.embedBreadcrumbs,
+					breadcrumbs: getSetting( 'embedBreadcrumbs', [] ),
 				} }
 				isEmbedded
 			/>

--- a/client/layout/store-alerts/index.js
+++ b/client/layout/store-alerts/index.js
@@ -15,6 +15,7 @@ import moment from 'moment';
  * WooCommerce dependencies
  */
 import { Card, DropdownButton } from '@woocommerce/components';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -174,7 +175,7 @@ class StoreAlerts extends Component {
 
 	render() {
 		const alerts = this.props.alerts || [];
-		const preloadAlertCount = wcSettings.alertCount && parseInt( wcSettings.alertCount );
+		const preloadAlertCount = getSetting( 'alertCount', 0, count => parseInt( count, 10 ) );
 
 		if ( preloadAlertCount > 0 && this.props.isLoading ) {
 			return <StoreAlertsPlaceholder hasMultipleAlerts={ preloadAlertCount > 1 } />;

--- a/client/wc-api/onboarding/selectors.js
+++ b/client/wc-api/onboarding/selectors.js
@@ -6,6 +6,11 @@
 import { isNil } from 'lodash';
 
 /**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+/**
  * Internal dependencies
  */
 import { DEFAULT_REQUIREMENT } from '../constants';
@@ -16,9 +21,10 @@ const getProfileItems = ( getResource, requireResource ) => (
 ) => {
 	const resourceName = 'onboarding-profile';
 	const ids = requireResource( requirement, resourceName ).data || [];
+	const { profile } = getSetting( 'onboarding', {} );
 
 	if ( ! ids.length ) {
-		return wcSettings.onboarding.profile;
+		return profile;
 	}
 
 	const items = {};
@@ -80,18 +86,21 @@ const getPluginInstallations = getResource => plugins => {
 const isJetpackConnected = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const activePluginsData = requireResource( requirement, 'active-plugins' ).data || undefined;
-	const activePlugins = ! activePluginsData
-		? wcSettings.onboarding.activePlugins
-		: activePluginsData;
+	const activePlugins = getSetting(
+		'onboarding',
+		{},
+		ob => requireResource( requirement, 'active-plugins' ).data || ob.activePlugins
+	);
 
 	// Avoid issuing API calls, since Jetpack is obviously not connected.
 	if ( ! activePlugins.includes( 'jetpack' ) ) {
 		return false;
 	}
-
-	const data =
-		requireResource( requirement, 'jetpack-status' ).data || wcSettings.dataEndpoints.jetpackStatus;
+	const data = getSetting(
+		'dataEndpoints',
+		{},
+		de => requireResource( requirement, 'jetpack-status' ) || de.jetpackStatus
+	);
 	return ( data && data.isActive ) || false;
 };
 
@@ -101,7 +110,7 @@ const getActivePlugins = ( getResource, requireResource ) => (
 	const resourceName = 'active-plugins';
 	const data = requireResource( requirement, resourceName ).data || [];
 	if ( ! data.length ) {
-		return wcSettings.onboarding.activePlugins;
+		return getSetting( 'onboarding', {}, ob => ob.activePlugins || [] );
 	}
 
 	return data;

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -6,6 +6,11 @@
 import { isNil } from 'lodash';
 
 /**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+/**
  * Internal dependencies
  */
 import { DEFAULT_REQUIREMENT } from '../constants';
@@ -21,8 +26,11 @@ const getOptions = ( getResource, requireResource ) => (
 	const names = requireResource( requirement, resourceName ).data || optionNames;
 
 	names.forEach( name => {
-		const data =
-			getResource( getResourceName( 'options', name ) ).data || wcSettings.preloadOptions[ name ];
+		const data = getSetting(
+			'preloadOptions',
+			{},
+			po => getResource( getResourceName( 'options', name ) ).data || po[ name ]
+		);
 		if ( data ) {
 			options[ name ] = data;
 		}

--- a/client/wc-api/user/selectors.js
+++ b/client/wc-api/user/selectors.js
@@ -5,11 +5,19 @@
  */
 import { DEFAULT_REQUIREMENT } from '../constants';
 
+/**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
 const getCurrentUserData = ( getResource, requireResource ) => (
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	const initialState = wcSettings.currentUserData;
-	return requireResource( requirement, 'current-user-data' ).data || initialState;
+	return getSetting(
+		'currentUserData',
+		{},
+		cud => requireResource( requirement, 'current-user-data' ).data || cud
+	);
 };
 
 export default {


### PR DESCRIPTION
This pull finishes off the refactor of the js to use the new settings api introduce in #2917.  In it all the `client` js files are updated.

## To test

* [ ] Smoke test all affected routes.

I visited all routes in the wc admin but this could use some testing verification by someone else as well.