### PR TITLE
Add options REST API permission checks

### DIFF
--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -43,7 +43,7 @@ class Options extends \WC_REST_Data_Controller {
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_options' ),
-					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
 			)
@@ -64,16 +64,69 @@ class Options extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Check if a given request has access to manage options.
+	 * Check if a given request has access to get options.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		$params      = explode( ',', $request['options'] );
+		$permissions = $this->get_option_permissions( $request );
+
+		if ( ! is_array( $params ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'You must supply an array of options.', 'woocommerce-admin' ), 500 );
+		}
+
+		foreach ( $params as $option ) {
+			if ( ! isset( $permissions[ $option ] ) || ! $permissions[ $option ] ) {
+				return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage these options.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to update options.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
 	public function update_item_permissions_check( $request ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage options.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+		$params      = $request->get_json_params();
+		$permissions = $this->get_option_permissions( $request );
+
+		if ( ! is_array( $params ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'You must supply an array of options and values.', 'woocommerce-admin' ), 500 );
 		}
+
+		foreach ( $params as $option_name => $option_value ) {
+			if ( ! isset( $permissions[ $option_name ] ) || ! $permissions[ $option_name ] ) {
+				return new \WP_Error( 'woocommerce_rest_cannot_update', __( 'Sorry, you cannot manage these options.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			}
+		}
+
 		return true;
+	}
+
+	/**
+	 * Get an array of options and respective permissions for the current user.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	public function get_option_permissions( $request ) {
+		$permissions = array(
+			'theme_mods_' . get_stylesheet()     => current_user_can( 'edit_theme_options' ),
+			'woocommerce_setup_jetpack_opted_in' => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_stripe_settings'        => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_ppec_paypal_settings'   => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_onboarding_payments'    => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_demo_store'             => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_demo_store_notice'      => current_user_can( 'manage_woocommerce' ),
+		);
+
+		return apply_filters( 'woocommerce_rest_api_option_permissions', $permissions, $request );
 	}
 
 	/**
@@ -83,8 +136,8 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return array Options object with option values.
 	 */
 	public function get_options( $request ) {
-		$params = explode( ',', $request[ 'options' ] );
-		$options  = array();
+		$params  = explode( ',', $request['options'] );
+		$options = array();
 
 		if ( ! is_array( $params ) ) {
 			return array();
@@ -104,7 +157,7 @@ class Options extends \WC_REST_Data_Controller {
 	 * @return array Options object with a boolean if the option was updated.
 	 */
 	public function update_options( $request ) {
-		$params = $request->get_json_params();
+		$params  = $request->get_json_params();
 		$updated = array();
 
 		if ( ! is_array( $params ) ) {

--- a/tests/api/options.php
+++ b/tests/api/options.php
@@ -34,14 +34,28 @@ class WC_Tests_API_Options extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Test getting options without valid permissions.
-	 *
-	 * @since 3.5.0
 	 */
 	public function test_get_options_without_permission() {
 		wp_set_current_user( 0 );
+
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params( array( 'options' => 'woocommerce_demo_store_notice' ) );
 		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test updating options without valid permissions.
+	 */
+	public function test_update_options_without_permission() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'woocommerce_demo_store_notice' => 'Store notice updated.' ) ) );
+		$response = $this->server->dispatch( $request );
+
 		$this->assertEquals( 401, $response->get_status() );
 	}
 

--- a/tests/api/options.php
+++ b/tests/api/options.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Options REST API Test
+ *
+ * @package WooCommerce Admin\Tests\API
+ */
+
+use \Automattic\WooCommerce\Admin\API\Options;
+
+/**
+ * WC Tests API Options
+ */
+class WC_Tests_API_Options extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-admin/v1/options';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test getting options without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_options_without_permission() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'options' => 'woocommerce_demo_store_notice' ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test that options can be retrieved.
+	 */
+	public function test_get_options() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( array( 'options' => 'woocommerce_demo_store_notice' ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( get_option( 'woocommerce_demo_store_notice' ), $data['woocommerce_demo_store_notice'] );
+	}
+
+	/**
+	 * Test that options can be updated.
+	 */
+	public function test_update_options() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->set_headers( array( 'content-type' => 'application/json' ) );
+		$request->set_body( wp_json_encode( array( 'woocommerce_demo_store_notice' => 'Store notice updated.' ) ) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Store notice updated.', get_option( 'woocommerce_demo_store_notice' ) );
+	}
+}


### PR DESCRIPTION
Fixes #2865

Adds permission checks to individual options the REST API.

**Question** - should we allow a default with permission `manage_options` for options without defined permissions?

### Detailed test instructions:

1.  Hit the options API `wp-json/wc-admin/v1/options` with an admin who can `manage_woocommerce` and valid options as params (e.g., `woocommerce_demo_store_notice`).
2. Make sure that options are retrieved/updated for GET/POST requests respectively.  Note that POSTing should be done in JSON via the body.
3. Hit the same API with a user that does not have permissions to `manage_woocommerce`.
4. Make sure a forbidden error is returned.
5. Make sure all tests pass.