### PR TITLE
Hide shipping step for stores without physical products

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -26,9 +26,16 @@ import Tax from './tasks/tax';
 import Payments from './tasks/payments';
 import withSelect from 'wc-api/with-select';
 
-const { customLogo, hasHomepage, hasProducts, shippingZonesCount } = getSetting( 'onboarding', {
+const {
+	customLogo,
+	hasHomepage,
+	hasPhysicalProducts,
+	hasProducts,
+	shippingZonesCount,
+} = getSetting( 'onboarding', {
 	customLogo: '',
 	hasHomePage: false,
+	hasPhysicalProducts: false,
 	hasProducts: false,
 	shippingZonesCount: 0,
 } );
@@ -104,7 +111,7 @@ class TaskDashboard extends Component {
 				onClick: () => updateQueryString( { task: 'shipping' } ),
 				container: <Shipping />,
 				className: shippingZonesCount > 0 ? 'is-complete' : null,
-				visible: true,
+				visible: profileItems.product_types.includes( 'physical' ) || hasPhysicalProducts,
 			},
 			{
 				key: 'tax',

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -41,10 +41,10 @@ class OnboardingTasks {
 	 */
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_media_scripts' ) );
-		// old settings injection
+		// Old settings injection.
 		// Run after Onboarding.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 30 );
-		// new settings injection
+		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 30 );
 		add_action( 'admin_init', array( $this, 'set_active_task' ), 20 );
 		add_action( 'current_screen', array( $this, 'check_active_task_completion' ), 1000 );
@@ -70,6 +70,14 @@ class OnboardingTasks {
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
 		$settings['onboarding']['customLogo']                     = get_theme_mod( 'custom_logo', false );
 		$settings['onboarding']['hasHomepage']                    = self::check_task_completion( 'homepage' );
+		$settings['onboarding']['hasPhysicalProducts']            = count(
+			wc_get_products(
+				array(
+					'virtual' => false,
+					'limit'   => 1,
+				)
+			)
+		) > 0;
 		$settings['onboarding']['hasProducts']                    = self::check_task_completion( 'products' );
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
 
@@ -133,8 +141,8 @@ class OnboardingTasks {
 					return false;
 				}
 
-				$post        = get_post( $homepage_id );
-				$completed   = $post && 'publish' === $post->post_status;
+				$post      = get_post( $homepage_id );
+				$completed = $post && 'publish' === $post->post_status;
 				if ( $completed ) {
 					update_option( 'show_on_front', 'page' );
 					update_option( 'page_on_front', $homepage_id );


### PR DESCRIPTION
Fixes #2966

Hides the shipping task if the following 2 criteria aren't met:
* A store owner has selected "Physical products" as part of their products during the onboarding profiler.
* Any non-virtual (physical) products exist.

### Screenshots
<img width="573" alt="Screen Shot 2019-10-07 at 11 58 53 AM" src="https://user-images.githubusercontent.com/10561050/66284440-4c3c5080-e8fa-11e9-8340-d57587006d13.png">

### Detailed test instructions:

1. Enable the task list.
2. Remove all physical products or make them virtual.
3. Make sure you uncheck "Physical" during the onboarding profiler (or re-run the profiler from the "Help" tab if necessary).
4. Visit the dashboard `wp-admin/admin.php?page=wc-admin` and make sure the shipping step isn't displayed.
5. Add either a physical product or rerun the profiler and select "physical" products.
6. Check that the shipping task is once again shown.