### PR TITLE
Onboarding: Skip tax steps if complete and mark task complete

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from 'newspack-components';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { difference, filter } from 'lodash';
+import { difference, filter, get } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch } from '@wordpress/data';
 
@@ -100,12 +100,11 @@ class Tax extends Component {
 	}
 
 	isTaxJarSupported() {
-		const { countryCode, options } = this.props;
+		const { countryCode, wc_connect_options } = this.props;
 		const { automatedTaxSupportedCountries = [] } = getSetting( 'onboarding', {} );
 
 		return (
-			'1' === options.woocommerce_setup_jetpack_opted_in &&
-			automatedTaxSupportedCountries.includes( countryCode )
+			wc_connect_options.tos_accepted && automatedTaxSupportedCountries.includes( countryCode )
 		);
 	}
 
@@ -248,15 +247,16 @@ class Tax extends Component {
 	render() {
 		const { isPending, stepIndex } = this.state;
 		const { isGeneralSettingsRequesting, isTaxSettingsRequesting } = this.props;
+		const step = this.getSteps()[ stepIndex ];
 
 		return (
 			<div className="woocommerce-task-tax">
 				<Card className="is-narrow">
-					{ null !== stepIndex ? (
+					{ step ? (
 						<Stepper
 							isPending={ isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting }
 							isVertical={ true }
-							currentStep={ this.getSteps()[ stepIndex ].key }
+							currentStep={ step.key }
 							steps={ this.getSteps() }
 						/>
 					) : (
@@ -332,7 +332,11 @@ export default compose(
 		const countryCode = getCountryCode( generalSettings.woocommerce_default_country );
 		const activePlugins = getActivePlugins();
 		const pluginsToActivate = difference( [ 'jetpack', 'woocommerce-services' ], activePlugins );
-		const options = getOptions( [ 'woocommerce_setup_jetpack_opted_in' ] );
+		const wc_connect_options = get(
+			getOptions( [ 'wc_connect_options' ] ),
+			'wc_connect_options',
+			{}
+		);
 
 		return {
 			countryCode,
@@ -344,7 +348,7 @@ export default compose(
 			taxSettings,
 			isJetpackConnected: isJetpackConnected(),
 			pluginsToActivate,
-			options,
+			wc_connect_options,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -16,7 +16,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { Card, H, Stepper } from '@woocommerce/components';
 import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
-import { getSetting } from '@woocommerce/wc-admin-settings';
+import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -129,6 +129,12 @@ class Tax extends Component {
 		} );
 
 		if ( ! isTaxSettingsError ) {
+			// @todo This is a workaround to force the task to mark as complete.
+			// This should probably be updated to use wc-api so we can fetch tax rates.
+			setSetting( 'onboarding', {
+				...getSetting( 'onboarding', {} ),
+				isTaxComplete: true,
+			} );
 			createNotice( 'success', __( 'Your tax settings have been updated.', 'woocommerce-admin' ) );
 			if ( automatedTaxEnabled ) {
 				getHistory().push( getNewPath( {}, '/', {} ) );

--- a/client/wc-api/onboarding/selectors.js
+++ b/client/wc-api/onboarding/selectors.js
@@ -99,8 +99,9 @@ const isJetpackConnected = ( getResource, requireResource ) => (
 	const data = getSetting(
 		'dataEndpoints',
 		{},
-		de => requireResource( requirement, 'jetpack-status' ) || de.jetpackStatus
+		de => requireResource( requirement, 'jetpack-status' ).data || de.jetpackStatus
 	);
+
 	return ( data && data.isActive ) || false;
 };
 


### PR DESCRIPTION
Fixes #2988

Skips the plugin installation steps if plugins are already installed, skips Jetpack connection if connected, and marks the task complete if a tax rate exists or automatic tax rates are enabled.

>Clicking into the tax task shows you the Good News! message.
This means you never end up making it to these screens in the tax list of steps after connecting: https://www.figma.com/file/xyKPRZ73kKhDyNjwbFvBJR/Task-List?node-id=976%3A8566.

@justinshreve This is referring to this step that allows enabling automatic sales tax pictured below, right?  I'm wondering if it's better just to show the "Good news" screen since these do the same thing and reduce the amount of logic in this code.  Also the "Good news" screen has an option for manually setting taxes.

<img width="503" alt="Screen Shot 2019-10-08 at 12 50 36 PM" src="https://user-images.githubusercontent.com/10561050/66368334-72c9bc80-e9ca-11e9-973b-da651dce54be.png">

### Screenshots
<img width="580" alt="Screen Shot 2019-10-08 at 12 41 15 PM" src="https://user-images.githubusercontent.com/10561050/66368029-5711e680-e9c9-11e9-8036-424d45f24950.png">


### Detailed test instructions:

1. Delete all tax rates and set the option `wc_connect_taxes_enabled` to `no` if it exists.
2. Disconnect jetpack and deactive WCS or Jetpack.
3. Walk through the tax task and leave after the plugin installation step.
4. Return to the task and the plugins step should be skipped (not visible).
5. Do the same for the Jetpack connection step.
6. After re-entering this screen, you should see a "Good news" screen if the store is in a country that supports automatic tax calculation.  Complete it, either via manually adding tax rates or enabling automatic rates.
7. Make sure the task is marked complete in the task list.