### PR TITLE
Fix Facebook extension install from inbox

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -383,6 +383,7 @@ class Onboarding {
 		return apply_filters(
 			'woocommerce_onboarding_plugins_whitelist',
 			array(
+				'facebook-for-woocommerce'        => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
 				'jetpack'                         => 'jetpack/jetpack.php',
 				'woocommerce-services'            => 'woocommerce-services/woocommerce-services.php',
 				'woocommerce-gateway-stripe'      => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',

--- a/src/Notes/WC_Admin_Notes_Facebook_Extension.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Extension.php
@@ -81,19 +81,22 @@ class WC_Admin_Notes_Facebook_Extension {
 
 	/**
 	 * Install Facebook extension when note is actioned.
+	 *
+	 * @param WC_Admin_Note $note Note being acted upon.
 	 */
 	public function install_facebook_extension( $note ) {
 		if ( self::NOTE_NAME === $note->get_name() ) {
-			$plugin    = array( 'plugin' => 'facebook-for-woocommerce' );
-			$installer = new \Automattic\WooCommerce\Admin\API\OnboardingPlugins();
-			$result    = $installer->install_plugin( $plugin );
+			$install_request = array( 'plugin' => 'facebook-for-woocommerce' );
+			$installer       = new \Automattic\WooCommerce\Admin\API\OnboardingPlugins();
+			$result          = $installer->install_plugin( $install_request );
 
 			if ( is_wp_error( $result ) ) {
 				// @todo Reset note actioned status?
 				return;
 			}
 
-			$installer->activate_plugin( $plugin );
+			$activate_request = array( 'plugins' => 'facebook-for-woocommerce' );
+			$installer->activate_plugins( $activate_request );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3008.

This PR:
- Restores the FB extension to the install whitelist (errantly removed in 76a94176f1040a3b61641822904a74fe5935a45e)
- Fix API usage - `activate_plugin` was renamed to `activate_plugins` in 76a94176f1040a3b61641822904a74fe5935a45e.

### Detailed test instructions:

1. Store must have one published product
2. Delete note `wc-admin-facebook-extension` from the `wp_wc_admin_notes` table, if it exists.
3. Use this plugin run the wc_admin_daily job: https://wordpress.org/plugins/wp-crontrol/
4. Refresh dashboard
5. Open inbox panel, click `install now` in the Facebook notice
6. Confirm in the plugins page that the extension was installed and activated

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Facebook extension installation.