### PR TITLE
Render a "manage" link on review inbox items.

### DIFF
--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -95,7 +95,6 @@ class ReviewsPanel extends Component {
 
 		const manageReviewEvent = {
 			date: review.date_created_gmt,
-			review: review.id,
 			status: review.status,
 		};
 

--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -8,7 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import Gridicon from 'gridicons';
 import interpolateComponents from 'interpolate-components';
-import { get, noop, isNull } from 'lodash';
+import { get, isNull } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -21,7 +21,6 @@ import {
 	ProductImage,
 	ReviewRating,
 	Section,
-	SplitButton,
 } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/navigation';
 
@@ -33,6 +32,7 @@ import ActivityHeader from '../activity-header';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import sanitizeHTML from 'lib/sanitize-html';
 import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
 
 class ReviewsPanel extends Component {
 	constructor() {
@@ -93,33 +93,21 @@ class ReviewsPanel extends Component {
 			</div>
 		);
 
-		const cardActions = () => {
-			const mainLabel =
-				'approved' === review.status
-					? __( 'Unapprove', 'woocommerce-admin' )
-					: __( 'Approve', 'woocommerce-admin' );
-			return (
-				<SplitButton
-					mainLabel={ mainLabel }
-					menuLabel={ __( 'Select an action', 'woocommerce-admin' ) }
-					onClick={ noop }
-					controls={ [
-						{
-							label: __( 'Reply', 'woocommerce-admin' ),
-							onClick: noop,
-						},
-						{
-							label: __( 'Spam', 'woocommerce-admin' ),
-							onClick: noop,
-						},
-						{
-							label: __( 'Trash', 'woocommerce-admin' ),
-							onClick: noop,
-						},
-					] }
-				/>
-			);
+		const manageReviewEvent = {
+			date: review.date_created_gmt,
+			review: review.id,
+			status: review.status,
 		};
+
+		const cardActions = (
+			<Button
+				isDefault
+				onClick={ () => recordEvent( 'review_manage_click', manageReviewEvent ) }
+				href={ getAdminLink( 'comment.php?action=editcomment&c=' + review.id ) }
+			>
+				{ __( 'Manage', 'woocommerce-admin' ) }
+			</Button>
+		);
 
 		return (
 			<ActivityCard
@@ -129,7 +117,7 @@ class ReviewsPanel extends Component {
 				subtitle={ subtitle }
 				date={ review.date_created_gmt }
 				icon={ icon }
-				actions={ cardActions() }
+				actions={ cardActions }
 				unread={
 					review.status === 'hold' ||
 					! lastRead ||


### PR DESCRIPTION
Instead of the SplitButton with multiple actions.

Fixes #206 (comment https://github.com/woocommerce/woocommerce-admin/issues/206#issuecomment-539287069)

This PR:
- Replaces the `<SplitButton>` component on Review cards with a single "manage" link button
- Adds a Tracks event for monitoring usage

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Screen Shot 2019-10-08 at 1 44 11 PM](https://user-images.githubusercontent.com/63922/66431893-c4c21080-e9d1-11e9-99e7-9caf8a8c9242.png)


### Detailed test instructions:

- Open any wc-admin page
- Open the Reviews panel
- Verify the "manage" button is rendered
- Verify it leads to the review (comment) edit page
- Verify a tracks event is fired on click (preserving log in console helps)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: add management link to Reviews panel.