### PR TITLE
Add Task List Completed Functionality

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -5,7 +5,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { partial } from 'lodash';
+import { partial, filter, get } from 'lodash';
 import { IconButton, Icon, Dropdown, Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
@@ -22,6 +22,8 @@ import defaultSections from './default-sections';
 import Section from './section';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
+import TaskList from './task-list';
+import { getTasks } from './task-list/tasks';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -189,14 +191,28 @@ class CustomizableDashboard extends Component {
 	}
 
 	render() {
-		const { query, path } = this.props;
+		const { query, path, taskListHidden, taskListCompleted } = this.props;
 		const { sections } = this.state;
 		const visibleSectionKeys = sections
 			.filter( section => section.isVisible )
 			.map( section => section.key );
 
+		if (
+			window.wcAdminFeatures.onboarding &&
+			wcSettings.onboarding &&
+			! taskListHidden &&
+			( query.task || ! taskListCompleted )
+		) {
+			return <TaskList query={ query } />;
+		}
+
 		return (
 			<Fragment>
+				{ window.wcAdminFeatures.onboarding &&
+					wcSettings.onboarding &&
+					! taskListHidden &&
+					taskListCompleted && <TaskList query={ query } inline /> }
+
 				<ReportFilters query={ query } path={ path } />
 				{ sections.map( ( section, index ) => {
 					if ( section.isVisible ) {
@@ -226,11 +242,32 @@ class CustomizableDashboard extends Component {
 }
 
 export default compose(
-	withSelect( select => {
-		const { getCurrentUserData } = select( 'wc-api' );
+	withSelect( ( select, props ) => {
+		const { getCurrentUserData, getProfileItems, getOptions } = select( 'wc-api' );
 		const userData = getCurrentUserData();
 
+		const profileItems = getProfileItems();
+		const taskListHidden =
+			'yes' ===
+			get(
+				getOptions( [ 'woocommerce_task_list_hidden' ] ),
+				[ 'woocommerce_task_list_hidden' ],
+				'no'
+			);
+
+		const tasks = getTasks( {
+			profileItems,
+			options: getOptions( [ 'woocommerce_onboarding_payments' ] ),
+			query: props.query,
+		} );
+
+		const visibleTasks = filter( tasks, task => task.visible );
+		const completedTasks = filter( tasks, task => task.completed );
+		const taskListCompleted = visibleTasks.length === completedTasks.length;
+
 		return {
+			taskListHidden,
+			taskListCompleted,
 			userPrefSections: userData.dashboard_sections,
 		};
 	} ),

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -262,7 +262,7 @@ export default compose(
 		} );
 
 		const visibleTasks = filter( tasks, task => task.visible );
-		const completedTasks = filter( tasks, task => task.completed );
+		const completedTasks = filter( tasks, task => task.visible && task.completed );
 		const taskListCompleted = visibleTasks.length === completedTasks.length;
 
 		return {

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 
 /**
@@ -10,12 +10,6 @@ import { compose } from '@wordpress/compose';
  */
 import './style.scss';
 import CustomizableDashboard from './customizable';
-import DashboardCharts from './dashboard-charts';
-import Leaderboards from './leaderboards';
-import { ReportFilters } from '@woocommerce/components';
-import { getSetting } from '@woocommerce/wc-admin-settings';
-import StorePerformance from './store-performance';
-import TaskList from './task-list';
 import ProfileWizard from './profile-wizard';
 import withSelect from 'wc-api/with-select';
 
@@ -27,27 +21,11 @@ class Dashboard extends Component {
 			return <ProfileWizard query={ query } />;
 		}
 
-		const { taskListHidden } = getSetting( 'onboarding', {} );
-
-		// @todo This should be replaced by a check of tasks from the REST API response from #1897.
-		if ( window.wcAdminFeatures.onboarding && ! taskListHidden ) {
-			return <TaskList query={ query } />;
-		}
-
-		// @todo When the customizable dashboard is ready to be launched, we can pull `CustomizableDashboard`'s render
-		// method into `index.js`, and replace both this feature check, and the existing dashboard below.
 		if ( window.wcAdminFeatures[ 'analytics-dashboard/customizable' ] ) {
 			return <CustomizableDashboard query={ query } path={ path } />;
 		}
 
-		return (
-			<Fragment>
-				<ReportFilters query={ query } path={ path } />
-				<StorePerformance query={ query } hiddenBlocks={ [] } />
-				<DashboardCharts query={ query } path={ path } hiddenBlocks={ [] } />
-				<Leaderboards query={ query } hiddenBlocks={ [] } />
-			</Fragment>
-		);
+		return null;
 	}
 }
 

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -6,40 +6,22 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { filter, get } from 'lodash';
 import { compose } from '@wordpress/compose';
+import classNames from 'classnames';
+import { Snackbar, Icon, Button } from '@wordpress/components';
 
 /**
  * WooCommerce dependencies
  */
-import { Card, List } from '@woocommerce/components';
+import { Card, List, MenuItem, EllipsisMenu } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
-import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal depdencies
  */
 import './style.scss';
-import Appearance from './tasks/appearance';
-import Connect from './tasks/connect';
-import Products from './tasks/products';
-import Shipping from './tasks/shipping';
-import Tax from './tasks/tax';
-import Payments from './tasks/payments';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
-
-const {
-	customLogo,
-	hasHomepage,
-	hasPhysicalProducts,
-	hasProducts,
-	shippingZonesCount,
-} = getSetting( 'onboarding', {
-	customLogo: '',
-	hasHomePage: false,
-	hasPhysicalProducts: false,
-	hasProducts: false,
-	shippingZonesCount: 0,
-} );
+import { getTasks } from './tasks';
 
 class TaskDashboard extends Component {
 	componentDidMount() {
@@ -59,108 +41,16 @@ class TaskDashboard extends Component {
 			return;
 		}
 		const { profileItems } = this.props;
-		const tasks = filter( this.getTasks(), task => task.visible );
+		const tasks = filter( this.props.tasks, task => task.visible );
 		recordEvent( 'tasklist_view', {
 			number_tasks: tasks.length,
 			store_connected: profileItems.wccom_connected,
 		} );
 	}
 
-	getTasks() {
-		const { profileItems, query, paymentsCompleted } = this.props;
-
-		return [
-			{
-				key: 'connect',
-				title: __( 'Connect your store to WooCommerce.com', 'woocommerce-admin' ),
-				content: __(
-					'Install and manage your extensions directly from your Dashboard',
-					'wooocommerce-admin'
-				),
-				before: <i className="material-icons-outlined">extension</i>,
-				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: () => updateQueryString( { task: 'connect' } ),
-				container: <Connect query={ query } />,
-				visible: profileItems.items_purchased && ! profileItems.wccom_connected,
-			},
-			{
-				key: 'products',
-				title: __( 'Add your first product', 'woocommerce-admin' ),
-				content: __(
-					'Add products manually, import from a sheet or migrate from another platform',
-					'wooocommerce-admin'
-				),
-				before: hasProducts ? (
-					<i className="material-icons-outlined">check_circle</i>
-				) : (
-					<i className="material-icons-outlined">add_box</i>
-				),
-				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: () => updateQueryString( { task: 'products' } ),
-				container: <Products />,
-				className: hasProducts ? 'is-complete' : null,
-				visible: true,
-			},
-			{
-				key: 'appearance',
-				title: __( 'Personalize your store', 'woocommerce-admin' ),
-				content: __( 'Create a custom homepage and upload your logo', 'wooocommerce-admin' ),
-				before: <i className="material-icons-outlined">palette</i>,
-				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: () => updateQueryString( { task: 'appearance' } ),
-				container: <Appearance />,
-				className: customLogo && hasHomepage ? 'is-complete' : null,
-				visible: true,
-			},
-			{
-				key: 'shipping',
-				title: __( 'Set up shipping', 'woocommerce-admin' ),
-				content: __( 'Configure some basic shipping rates to get started', 'wooocommerce-admin' ),
-				before:
-					shippingZonesCount > 0 ? (
-						<i className="material-icons-outlined">check_circle</i>
-					) : (
-						<i className="material-icons-outlined">local_shipping</i>
-					),
-				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: () => updateQueryString( { task: 'shipping' } ),
-				container: <Shipping />,
-				className: shippingZonesCount > 0 ? 'is-complete' : null,
-				visible: profileItems.product_types.includes( 'physical' ) || hasPhysicalProducts,
-			},
-			{
-				key: 'tax',
-				title: __( 'Set up tax', 'woocommerce-admin' ),
-				content: __(
-					'Choose how to configure tax rates - manually or automatically',
-					'wooocommerce-admin'
-				),
-				before: <i className="material-icons-outlined">account_balance</i>,
-				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: () => updateQueryString( { task: 'tax' } ),
-				container: <Tax />,
-				visible: true,
-			},
-			{
-				key: 'payments',
-				title: __( 'Set up payments', 'woocommerce-admin' ),
-				content: __(
-					'Select which payment providers you’d like to use and configure them',
-					'wooocommerce-admin'
-				),
-				before: <i className="material-icons-outlined">payment</i>,
-				after: <i className="material-icons-outlined">chevron_right</i>,
-				onClick: () => updateQueryString( { task: 'payments' } ),
-				container: <Payments />,
-				className: paymentsCompleted ? 'is-complete' : null,
-				visible: true,
-			},
-		];
-	}
-
 	getCurrentTask() {
 		const { task } = this.props.query;
-		const currentTask = this.getTasks().find( s => s.key === task );
+		const currentTask = this.props.tasks.find( s => s.key === task );
 
 		if ( ! currentTask ) {
 			return null;
@@ -169,9 +59,55 @@ class TaskDashboard extends Component {
 		return currentTask;
 	}
 
+	renderPrompt() {
+		if ( this.props.promptShown ) {
+			return null;
+		}
+
+		return (
+			<Snackbar className="woocommerce-task-card__prompt">
+				<span>{ __( 'Is this card useful?', 'woocommerce-admin' ) }</span>
+
+				<div className="woocommerce-task-card__prompt-actions">
+					<Button isLink onClick={ this.clearQuery }>
+						{ __( 'No, hide it', 'woocommerce-admin' ) }
+					</Button>
+
+					<Button isLink onClick={ this.clearQuery }>
+						{ __( 'Yes, keep it', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Snackbar>
+		);
+	}
+
+	renderMenu() {
+		return (
+			<EllipsisMenu
+				label={ __( 'Task List Options', 'woocommerce-admin' ) }
+				renderContent={ ( { onToggle } ) => (
+					<MenuItem isClickable onInvoke={ onToggle }>
+						<Icon icon={ 'trash' } label={ __( 'Remove block' ) } />
+						{ __( 'Remove section', 'woocommerce-admin' ) }
+					</MenuItem>
+				) }
+			/>
+		);
+	}
+
 	render() {
 		const currentTask = this.getCurrentTask();
-		const tasks = filter( this.getTasks(), task => task.visible );
+		const tasks = filter( this.props.tasks, task => task.visible ).map( task => {
+			task.className = classNames( task.completed ? 'is-complete' : null, task.className );
+			task.before = task.completed ? (
+				<i className="material-icons-outlined">check_circle</i>
+			) : (
+				<i className="material-icons-outlined">{ task.icon }</i>
+			);
+			task.after = <i className="material-icons-outlined">chevron_right</i>;
+			task.onClick = () => updateQueryString( { task: task.key } );
+			return task;
+		} );
 
 		return (
 			<Fragment>
@@ -179,16 +115,20 @@ class TaskDashboard extends Component {
 					{ currentTask ? (
 						currentTask.container
 					) : (
-						<Card
-							className="woocommerce-task-card"
-							title={ __( 'Set up your store and start selling', 'woocommerce-admin' ) }
-							description={ __(
-								'Below you’ll find a list of the most important steps to get your store up and running.',
-								'woocommerce-admin'
-							) }
-						>
-							<List items={ tasks } />
-						</Card>
+						<Fragment>
+							<Card
+								className="woocommerce-task-card"
+								title={ __( 'Set up your store and start selling', 'woocommerce-admin' ) }
+								description={ __(
+									'Below you’ll find a list of the most important steps to get your store up and running.',
+									'woocommerce-admin'
+								) }
+								menu={ this.props.inline && this.renderMenu() }
+							>
+								<List items={ tasks } />
+							</Card>
+							{ this.props.inline && this.renderPrompt() }
+						</Fragment>
 					) }
 				</div>
 			</Fragment>
@@ -197,17 +137,26 @@ class TaskDashboard extends Component {
 }
 
 export default compose(
-	withSelect( select => {
+	withSelect( ( select, props ) => {
 		const { getProfileItems, getOptions } = select( 'wc-api' );
 		const profileItems = getProfileItems();
 
-		const options = getOptions( [ 'woocommerce_onboarding_payments' ] );
-		const paymentsCompleted = get(
-			options,
-			[ 'woocommerce_onboarding_payments', 'completed' ],
+		const promptShown = get(
+			getOptions( [ 'woocommerce_task_list_prompt_shown' ] ),
+			[ 'woocommerce_task_list_prompt_shown' ],
 			false
 		);
 
-		return { profileItems, paymentsCompleted };
+		const tasks = getTasks( {
+			profileItems,
+			options: getOptions( [ 'woocommerce_onboarding_payments' ] ),
+			query: props.query,
+		} );
+
+		return {
+			profileItems,
+			promptShown,
+			tasks,
+		};
 	} )
 )( TaskDashboard );

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -25,22 +25,11 @@ import { recordEvent } from 'lib/tracks';
 import { getTasks } from './tasks';
 
 class TaskDashboard extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			promptShown: props.promptShown,
-		};
-	}
-
 	componentDidMount() {
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
 
 		this.recordEvent();
-
-		if ( ! this.state.promptShown ) {
-			this.markPromptShown();
-		}
 	}
 
 	componentWillUnmount() {
@@ -65,7 +54,9 @@ class TaskDashboard extends Component {
 			action: 'keep_card',
 		} );
 
-		this.setState( { promptShown: true } );
+		this.props.updateOptions( {
+			woocommerce_task_list_prompt_shown: true,
+		} );
 	}
 
 	hideTaskCard( action ) {
@@ -73,13 +64,8 @@ class TaskDashboard extends Component {
 			action,
 		} );
 		this.props.updateOptions( {
-			[ 'woocommerce_task_list_hidden' ]: 'yes',
-		} );
-	}
-
-	markPromptShown() {
-		this.props.updateOptions( {
-			[ 'woocommerce_task_list_prompt_shown' ]: true,
+			woocommerce_task_list_hidden: 'yes',
+			woocommerce_task_list_prompt_shown: true,
 		} );
 	}
 
@@ -95,14 +81,16 @@ class TaskDashboard extends Component {
 	}
 
 	renderPrompt() {
-		if ( this.state.promptShown ) {
+		if ( this.props.promptShown ) {
 			return null;
 		}
 
 		return (
 			<Snackbar className="woocommerce-task-card__prompt">
-				<span>{ __( 'Is this card useful?', 'woocommerce-admin' ) }</span>
-
+				<div>
+					<div className="woocommerce-task-card__prompt-pointer" />
+					<span>{ __( 'Is this card useful?', 'woocommerce-admin' ) }</span>
+				</div>
 				<div className="woocommerce-task-card__prompt-actions">
 					<Button isLink onClick={ () => this.hideTaskCard( 'hide_card' ) }>
 						{ __( 'No, hide it', 'woocommerce-admin' ) }

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -259,4 +259,32 @@
 .woocommerce-task-card__prompt {
 	width: 100%;
 	min-width: 100%;
+	margin-bottom: $gap-large;
+	margin-top: -$gap;
+	cursor: default;
+
+	.woocommerce-task-card__prompt-actions {
+		button.is-link,
+		button.is-link:active,
+		button.is-link:focus {
+			color: $studio-white;
+			margin-left: $gap-large;
+			background: transparent;
+		}
+
+		button.is-link:hover {
+			color: $studio-white;
+		}
+	}
+}
+
+.woocommerce-task-card__section-controls {
+	.dashicon {
+		margin: 0 $gap-smaller 0 0;
+		vertical-align: bottom;
+	}
+
+	.woocommerce-ellipsis-menu__item {
+		padding-bottom: 10px;
+	}
 }

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -255,3 +255,8 @@
 		margin-bottom: $gap-smallest;
 	}
 }
+
+.woocommerce-task-card__prompt {
+	width: 100%;
+	min-width: 100%;
+}

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -260,8 +260,12 @@
 	width: 100%;
 	min-width: 100%;
 	margin-bottom: $gap-large;
-	margin-top: -$gap;
+	margin-top: -$gap-smallest;
 	cursor: default;
+
+	.components-snackbar__content span {
+		margin-left: -$gap-large;
+	}
 
 	.woocommerce-task-card__prompt-actions {
 		button.is-link,
@@ -274,6 +278,23 @@
 
 		button.is-link:hover {
 			color: $studio-white;
+		}
+	}
+
+	.woocommerce-task-card__prompt-pointer {
+		border-bottom: 10px solid $core-grey-dark-700; /* Snackbar color */
+		border-left: 10px solid transparent;
+		border-right: 10px solid transparent;
+		position: relative;
+		width: 0;
+		height: 0;
+		display: inline-block;
+		top: -30px;
+	}
+
+	&:hover {
+		.woocommerce-task-card__prompt-pointer {
+			border-bottom-color: $core-grey-dark-900; /* Snackbar hover */
 		}
 	}
 }

--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -28,12 +28,14 @@ export function getTasks( { profileItems, options, query } ) {
 		hasHomepage,
 		hasPhysicalProducts,
 		hasProducts,
+		isTaxComplete,
 		shippingZonesCount,
 	} = getSetting( 'onboarding', {
 		customLogo: '',
 		hasHomePage: false,
 		hasPhysicalProducts: false,
 		hasProducts: false,
+		isTaxComplete: false,
 		shippingZonesCount: 0,
 	} );
 
@@ -95,8 +97,8 @@ export function getTasks( { profileItems, options, query } ) {
 			),
 			icon: 'account_balance',
 			container: <Tax />,
+			completed: isTaxComplete,
 			visible: true,
-			completed: true, // @todo completed logic
 		},
 		{
 			key: 'payments',

--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import { __ } from '@wordpress/i18n';
+import { get } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+/**
+ * Internal dependencies
+ */
+import Appearance from './tasks/appearance';
+import Connect from './tasks/connect';
+import Products from './tasks/products';
+import Shipping from './tasks/shipping';
+import Tax from './tasks/tax';
+import Payments from './tasks/payments';
+
+export function getTasks( { profileItems, options, query } ) {
+	const {
+		customLogo,
+		hasHomepage,
+		hasPhysicalProducts,
+		hasProducts,
+		shippingZonesCount,
+	} = getSetting( 'onboarding', {
+		customLogo: '',
+		hasHomePage: false,
+		hasPhysicalProducts: false,
+		hasProducts: false,
+		shippingZonesCount: 0,
+	} );
+
+	const paymentsCompleted = get(
+		options,
+		[ 'woocommerce_onboarding_payments', 'completed' ],
+		false
+	);
+
+	return [
+		{
+			key: 'connect',
+			title: __( 'Connect your store to WooCommerce.com', 'woocommerce-admin' ),
+			content: __(
+				'Install and manage your extensions directly from your Dashboard',
+				'wooocommerce-admin'
+			),
+			icon: 'extension',
+			container: <Connect query={ query } />,
+			visible: profileItems.items_purchased && ! profileItems.wccom_connected,
+			completed: true, //profileItems.wccom_connected,
+		},
+		{
+			key: 'products',
+			title: __( 'Add your first product', 'woocommerce-admin' ),
+			content: __(
+				'Add products manually, import from a sheet or migrate from another platform',
+				'wooocommerce-admin'
+			),
+			icon: 'add_box',
+			container: <Products />,
+			completed: hasProducts,
+			visible: true,
+		},
+		{
+			key: 'appearance',
+			title: __( 'Personalize your store', 'woocommerce-admin' ),
+			content: __( 'Create a custom homepage and upload your logo', 'wooocommerce-admin' ),
+			icon: 'palette',
+			container: <Appearance />,
+			completed: customLogo && hasHomepage,
+			visible: true,
+		},
+		{
+			key: 'shipping',
+			title: __( 'Set up shipping', 'woocommerce-admin' ),
+			content: __( 'Configure some basic shipping rates to get started', 'wooocommerce-admin' ),
+			icon: 'local_shipping',
+			container: <Shipping />,
+			completed: shippingZonesCount > 0,
+			visible: profileItems.product_types.includes( 'physical' ) || hasPhysicalProducts,
+		},
+		{
+			key: 'tax',
+			title: __( 'Set up tax', 'woocommerce-admin' ),
+			content: __(
+				'Choose how to configure tax rates - manually or automatically',
+				'wooocommerce-admin'
+			),
+			icon: 'account_balance',
+			container: <Tax />,
+			visible: true,
+			completed: true, // @todo completed logic
+		},
+		{
+			key: 'payments',
+			title: __( 'Set up payments', 'woocommerce-admin' ),
+			content: __(
+				'Select which payment providers you’d like to use and configure them',
+				'wooocommerce-admin'
+			),
+			icon: 'payment',
+			container: <Payments />,
+			completed: paymentsCompleted,
+			visible: true,
+		},
+	];
+}

--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -56,7 +56,7 @@ export function getTasks( { profileItems, options, query } ) {
 			icon: 'extension',
 			container: <Connect query={ query } />,
 			visible: profileItems.items_purchased && ! profileItems.wccom_connected,
-			completed: true, //profileItems.wccom_connected,
+			completed: profileItems.wccom_connected,
 		},
 		{
 			key: 'products',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -325,9 +325,8 @@ class Onboarding {
 		$profile['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
 		$settings['onboarding'] = array(
-			'industries'     => self::get_allowed_industries(),
-			'profile'        => $profile,
-			'taskListHidden' => ! $this->should_show_tasks(),
+			'industries' => self::get_allowed_industries(),
+			'profile'    => $profile,
 		);
 
 		// Only fetch if the onboarding wizard is incomplete.
@@ -355,6 +354,8 @@ class Onboarding {
 		if ( ! $this->should_show_tasks() && ! $this->should_show_profiler() ) {
 			return $options;
 		}
+		$options[] = 'woocommerce_task_list_hidden';
+		$options[] = 'woocommerce_task_list_prompt_shown';
 		$options[] = 'woocommerce_onboarding_payments';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -351,10 +351,12 @@ class Onboarding {
 	 * @return array
 	 */
 	public function preload_options( $options ) {
+		$options[] = 'woocommerce_task_list_hidden';
+
 		if ( ! $this->should_show_tasks() && ! $this->should_show_profiler() ) {
 			return $options;
 		}
-		$options[] = 'woocommerce_task_list_hidden';
+
 		$options[] = 'woocommerce_task_list_prompt_shown';
 		$options[] = 'woocommerce_onboarding_payments';
 		$options[] = 'woocommerce_allow_tracking';

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore;
+
 /**
  * Contains the logic for completing onboarding tasks.
  */
@@ -79,6 +81,7 @@ class OnboardingTasks {
 			)
 		) > 0;
 		$settings['onboarding']['hasProducts']                    = self::check_task_completion( 'products' );
+		$settings['onboarding']['isTaxComplete']                  = 'yes' === get_option( 'wc_connect_taxes_enabled' ) || count( DataStore::get_taxes( array() ) ) > 0;
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
 
 		return $settings;


### PR DESCRIPTION
Closes #2685.

This PR implements functionality necessary to complete the task list, and allows for dismissing it.
A banner prompt will show the first time you view the dashboard after completing all tasks.
There is now an "inline" mode  so that the task list will display above the dashboard when all tasks are completed. The `wcadmin_tasklist_completed` event is also implemented.

### Screenshots

<img width="997" alt="Screen Shot 2019-10-10 at 10 35 20 AM" src="https://user-images.githubusercontent.com/689165/66579636-1e9a1600-eb4b-11e9-8ff3-d2a189bf6e7f.png">

### Detailed test instructions:

* Delete the `woocommerce_task_list_prompt_shown` option if it happens to be set.
* Make sure the task list is being displayed by either using the `Help` menu, or by deleting  the `woocommerce_task_list_hidden` option.
* Go to the task list. If you have any remaining tasks to complete, complete them.
* When you return to the dashboard with all tasks completed, you should see the the task list as a card above the rest of the dashboard widgets. A banner should also be displayed.
* Test dismissing and/or keeping the banner. You will have to clear out the prompt option to get it to show again.