### PR TITLE
Update order stats table status index length.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "files": [
       "includes/core-functions.php",
       "includes/feature-config.php",
-      "includes/page-controller-functions.php"
+      "includes/page-controller-functions.php",
+      "includes/wc-admin-update-functions.php"
     ],
     "psr-4": {
       "Automattic\\WooCommerce\\Admin\\": "src/"

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WooCommerce Admin Updates
+ *
+ * Functions for updating data, used by the background updater.
+ *
+ * @package WooCommerce/Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use \Automattic\WooCommerce\Admin\Install as Installer;
+
+/**
+ * Update order stats `status` index length.
+ * See: https://github.com/woocommerce/woocommerce-admin/issues/2969.
+ */
+function wc_admin_update_0201_order_status_index() {
+	global $wpdb;
+
+	// Max DB index length. See wp_get_db_schema().
+	$max_index_length = 191;
+
+	$index = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_order_stats WHERE key_name = 'status'" );
+
+	if ( property_exists( $index, 'Sub_part' ) ) {
+		// The index was created with the right length. Time to bail.
+		if ( $max_index_length === $index->Sub_part ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+			return;
+		}
+
+		// We need to drop the index so it can be recreated.
+		$wpdb->query( "DROP INDEX `status` ON {$wpdb->prefix}wc_order_stats" );
+	}
+
+	// Recreate the status index with a max length.
+	$wpdb->query( $wpdb->prepare( "ALTER TABLE {$wpdb->prefix}wc_order_stats ADD INDEX status (status(%d))", $max_index_length ) );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_0201_db_version() {
+	Installer::update_db_version( '0.20.1' );
+}


### PR DESCRIPTION
Fixes #2969.

This PR seeks to limit the `status` index length to `191` (WordPress' max, see: https://github.com/WordPress/WordPress/blob/a014bd21c15a7d9eb8622a1be91965700edaae06/wp-admin/includes/schema.php#L48-L52)

It introduces a version-based DB upgrade routine, lifted directly from core WC's `WC_Install` class. It directly uses the `woocommerce_run_update_callback` scheduled action to perform DB updates.

### Detailed test instructions:

There's a good chance your DB already has the `wc_order_stats` table with a `status` index that has no length.

- Update your `wc_admin_version` option to `0.18.0` to trigger updates
- Refresh the WP dashboard
- Verify the `status` key is now of length `191` (`Sub_part` column in index)
- `DROP` or rename the `wc_order_stats` table
- Update your `wc_admin_version` option to `0.18.0` to trigger updates
- Refresh the WP dashboard
- Verify the table is recreated and the `status` key has length `191`
- Remove the `status` key
- Add a `status` key with a length other than `191`
- Update your `wc_admin_version` option to `0.18.0` to trigger updates
- Refresh the WP dashboard
- Verify the `status` key is now of length `191` (`Sub_part` column in index)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: create table error during import.