### PR TITLE
use category lookup id instead of term taxonomy id

### DIFF
--- a/src/API/Reports/Products/Stats/Segmenter.php
+++ b/src/API/Reports/Products/Stats/Segmenter.php
@@ -104,7 +104,7 @@ class Segmenter extends ReportsSegmenter {
 		$orig_offset      = intval( $limit_parts[1] );
 		$orig_rowcount    = intval( $limit_parts[2] );
 		$segmenting_limit = $wpdb->prepare( 'LIMIT %d, %d', $orig_offset * $segment_count, $orig_rowcount * $segment_count );
-		
+
 		// Can't get all the numbers from one query, so split it into one query for product-level numbers and one for order-level numbers (which first need to have orders uniqued).
 		// Product-level numbers.
 		$segments_products = $wpdb->get_results(
@@ -191,8 +191,8 @@ class Segmenter extends ReportsSegmenter {
 
 			// Restrict our search space for category comparisons.
 			if ( isset( $this->query_args['categories'] ) ) {
-				$category_ids = implode( ',', $this->get_all_segments() );
-				$segmenting_where .= " AND wp_term_taxonomy.term_taxonomy_id IN ( $category_ids )";
+				$category_ids      = implode( ',', $this->get_all_segments() );
+				$segmenting_where .= " AND {$wpdb->wc_category_lookup}.category_id IN ( $category_ids )";
 			}
 
 			$segments = $this->get_product_related_segments( $type, $segmenting_selections, $segmenting_from, $segmenting_where, $segmenting_groupby, $segmenting_dimension_name, $table_name, $query_params, $unique_orders_table );


### PR DESCRIPTION
Fixes #3024

This PR updates on missed `term_taxonomy_id` -> `category_id` in #2253. I searched the code base and all remaining references to `term_taxonomy_id` are in JOIN expressions.

### Detailed test instructions:

- Checkout v0.19.0
- Change to YTD (multiple pages of segments)
- Compare top 2 categories
- Load this PR in a separate tab
- Repeat & compare categories charts

### Changelog Note:

Fix: Error in category comparison chart.