### PR TITLE
Escape spaces in package file watch paths

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -12,7 +12,7 @@ const watch = require( 'node-watch' );
  */
 const getPackages = require( './get-packages' );
 
-const BUILD_CMD = `node ${ path.resolve( __dirname, './build.js' ) }`;
+const BUILD_CMD = `node ${ path.resolve( __dirname, './build.js' ).replace( /(\s+)/g, '\\$1' ) }`;
 
 let filesToBuild = new Map();
 
@@ -68,7 +68,7 @@ setInterval( () => {
 	if ( files.length ) {
 		filesToBuild = new Map();
 		try {
-			execSync( `${ BUILD_CMD } ${ files.join( ' ' ) }`, { stdio: [ 0, 1, 2 ] } );
+			execSync( `${ BUILD_CMD } ${ files.map( file => file.replace( /(\s+)/g, '\\$1' ) ).join( ' ' ) }`, { stdio: [ 0, 1, 2 ] } );
 		} catch ( e ) {}
 	}
 }, 100 );


### PR DESCRIPTION
Fixes #3034 

Escapes spaces in file paths for package files.

### Detailed test instructions:

1. Add a space somewhere in your local system file path or wc-admin plugin absolute path.
2. Run `npm start`.
3. Update a file.
4. Make sure that the updates are built and reflected.