### PR TITLE
Update proceed without Jetpack/WCS to go to store details step

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -17,7 +17,7 @@ class Dashboard extends Component {
 	render() {
 		const { path, profileItems, query } = this.props;
 
-		if ( window.wcAdminFeatures.onboarding && ! profileItems.skipped && ! profileItems.completed ) {
+		if ( window.wcAdminFeatures.onboarding && ! profileItems.completed ) {
 			return <ProfileWizard query={ query } />;
 		}
 

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -41,20 +41,26 @@ class Start extends Component {
 	}
 
 	componentDidMount() {
-		const { updateProfileItems } = this.props;
+		const { updateProfileItems, profileItems } = this.props;
 		if (
 			this.props.activePlugins.includes( 'jetpack' ) &&
 			this.props.activePlugins.includes( 'woocommerce-services' )
 		) {
-			updateProfileItems( { wcs_jetpack: 'already-installed' } );
+			// Don't track event again if they revisit the start page.
+			if ( 'already-installed' !== profileItems.plugins ) {
+				recordEvent( 'wcadmin_storeprofiler_already_installed_plugins', {} );
+			}
+
+			updateProfileItems( { plugins: 'already-installed' } );
 			return updateQueryString( { step: 'store-details' } );
 		}
 	}
 
 	async skipWizard() {
-		const { createNotice, isProfileItemsError, updateProfileItems } = this.props;
+		const { createNotice, isProfileItemsError, updateProfileItems, activePlugins } = this.props;
 
-		await updateProfileItems( { wcs_jetpack: 'skipped' } );
+		const plugins = activePlugins.includes( 'jetpack' ) ? 'skipped-wcs' : 'skipped';
+		await updateProfileItems( { plugins } );
 
 		if ( isProfileItemsError ) {
 			createNotice(
@@ -62,7 +68,7 @@ class Start extends Component {
 				__( 'There was a problem updating your preferences.', 'woocommerce-admin' )
 			);
 		} else {
-			recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
+			recordEvent( 'storeprofiler_welcome_clicked', { get_started: true, plugins } );
 			return updateQueryString( { step: 'store-details' } );
 		}
 	}
@@ -74,15 +80,18 @@ class Start extends Component {
 			updateProfileItems,
 			updateOptions,
 			goToNextStep,
+			activePlugins,
 		} = this.props;
 
 		await updateOptions( {
 			woocommerce_setup_jetpack_opted_in: true,
 		} );
-		await updateProfileItems( { wcs_jetpack: 'wizard' } );
+
+		const plugins = activePlugins.includes( 'jetpack' ) ? 'installed-wcs' : 'installed';
+		await updateProfileItems( { plugins } );
 
 		if ( ! isProfileItemsError ) {
-			recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
+			recordEvent( 'storeprofiler_welcome_clicked', { get_started: true, plugins } );
 			goToNextStep();
 		} else {
 			createNotice(
@@ -264,7 +273,9 @@ class Start extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItemsError, getActivePlugins, getOptions } = select( 'wc-api' );
+		const { getProfileItemsError, getActivePlugins, getOptions, getProfileItems } = select(
+			'wc-api'
+		);
 
 		const isProfileItemsError = Boolean( getProfileItemsError() );
 
@@ -272,11 +283,13 @@ export default compose(
 		const allowTracking = 'yes' === get( options, [ 'woocommerce_allow_tracking' ], false );
 
 		const activePlugins = getActivePlugins();
+		const profileItems = getProfileItems();
 
 		return {
 			isProfileItemsError,
 			activePlugins,
 			allowTracking,
+			profileItems,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -54,7 +54,7 @@ class Start extends Component {
 	async skipWizard() {
 		const { createNotice, isProfileItemsError, updateProfileItems } = this.props;
 
-		await updateProfileItems( { skipped: true, wcs_jetpack: 'skipped' } );
+		await updateProfileItems( { wcs_jetpack: 'skipped' } );
 
 		if ( isProfileItemsError ) {
 			createNotice(
@@ -63,11 +63,18 @@ class Start extends Component {
 			);
 		} else {
 			recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
+			return updateQueryString( { step: 'store-details' } );
 		}
 	}
 
 	async startWizard() {
-		const { createNotice, isProfileItemsError, updateProfileItems, updateOptions } = this.props;
+		const {
+			createNotice,
+			isProfileItemsError,
+			updateProfileItems,
+			updateOptions,
+			goToNextStep,
+		} = this.props;
 
 		await updateOptions( {
 			woocommerce_setup_jetpack_opted_in: true,
@@ -76,7 +83,7 @@ class Start extends Component {
 
 		if ( ! isProfileItemsError ) {
 			recordEvent( 'storeprofiler_welcome_clicked', { get_started: true } );
-			this.props.goToNextStep();
+			goToNextStep();
 		} else {
 			createNotice(
 				'error',

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -45,7 +45,7 @@ class StoreDetails extends Component {
 	onSubmit( values ) {
 		const { profileItems } = this.props;
 
-		if ( 'already-installed' === profileItems.wcs_jetpack ) {
+		if ( 'already-installed' === profileItems.plugins ) {
 			this.setState( { showUsageModal: true } );
 			return;
 		}

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -209,7 +209,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'wcs_jetpack'         => array(
+			'plugins'             => array(
 				'type'              => 'string',
 				'description'       => __( 'How the Jetpack/WooCommerce Services step was handled.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
@@ -217,8 +217,10 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'validate_callback' => 'rest_validate_request_arg',
 				'enum'              => array(
 					'skipped',
+					'skipped-wcs',
 					'already-installed',
-					'wizard',
+					'installed-wcs',
+					'installed',
 				),
 			),
 			'account_type'        => array(

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -209,13 +209,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'skipped'             => array(
-				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the profile was skipped.', 'woocommerce-admin' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-			),
 			'wcs_jetpack'         => array(
 				'type'              => 'string',
 				'description'       => __( 'How the Jetpack/WooCommerce Services step was handled.', 'woocommerce-admin' ),

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -99,9 +99,8 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertCount( 15, $properties );
+		$this->assertCount( 14, $properties );
 		$this->assertArrayHasKey( 'completed', $properties );
-		$this->assertArrayHasKey( 'skipped', $properties );
 		$this->assertArrayHasKey( 'account_type', $properties );
 		$this->assertArrayHasKey( 'industry', $properties );
 		$this->assertArrayHasKey( 'product_types', $properties );

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -112,7 +112,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'theme', $properties );
 		$this->assertArrayHasKey( 'wccom_connected', $properties );
 		$this->assertArrayHasKey( 'items_purchased', $properties );
-		$this->assertArrayHasKey( 'wcs_jetpack', $properties );
+		$this->assertArrayHasKey( 'plugins', $properties );
 		$this->assertArrayHasKey( 'setup_client', $properties );
 	}
 


### PR DESCRIPTION
Closes #2982.

This PR changes the behavior of the "Proceed without Jetpack/WooCommerce Services" link on the first page of the profile wizard.

Now the link will go to the store details step and the rest of the wizard (just like what happens automatically if Jetpack & WCS are already installed). None of these steps require a Jetpack connection.

This PR removes the skipped flag, since `wcs_jetpack` already tracks if the user skips the step. I updated the Help tab reset to just toggle the completed flag because of this. I think this will be fine, because even if you toggle it back to completed without filling out everything, your existing data still exists. I've added a tracks event so that we can include it in funnels if necessary.

To Test:
* Disable `WooCommerce Services`.
* Toggle the profile wizard back on under the `Help` menu.
* Test the proceed without Jetpack/WCS link. You should end up on the store details step.
* Test toggling the profile wizard back to completed.