### PR TITLE
Add the ability to create custom plugin builds

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+ZIP_FILE='woocommerce-admin.zip';
+
+while [ $# -gt 0 ]; do
+	if [[ $1 == '-f' || $1 == '--features' ]]; then
+		export WC_ADMIN_ADDITIONAL_FEATURES="$2"
+	fi
+	if [[ $1 == '-s' || $1 == '--slug' ]]; then
+		ZIP_FILE="woocommerce-admin-$2.zip";
+	fi
+	shift
+done
+
 # Exit if any command fails.
 set -e
 
@@ -74,7 +86,7 @@ build_files=$(ls dist/*/*.{js,css})
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
-zip -r woocommerce-admin.zip \
+zip -r ${ZIP_FILE} \
 	woocommerce-admin.php \
 	uninstall.php \
 	includes/ \

--- a/bin/generate-feature-config.php
+++ b/bin/generate-feature-config.php
@@ -11,15 +11,16 @@
  * - plugin: For the standalone feature plugin, for GitHub and WordPress.org.
  * - core: Stable features for WooCommerce core merge.
  */
-$phase = isset( $_SERVER['WC_ADMIN_PHASE'] ) ? $_SERVER['WC_ADMIN_PHASE'] : ''; // WPCS: sanitization ok.
+$phase = isset( $_ENV['WC_ADMIN_PHASE'] ) ? $_ENV['WC_ADMIN_PHASE'] : ''; // WPCS: sanitization ok.
+
 if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 	$phase = 'plugin'; // Default to plugin when running `npm run build`.
 }
 $config_json = file_get_contents( 'config/' . $phase . '.json' );
 $config      = json_decode( $config_json );
 
-if ( ! empty( $_SERVER['WC_ADMIN_ADDITIONAL_FEATURES'] ) ) {
-	$additional_features = json_decode( $_SERVER['WC_ADMIN_ADDITIONAL_FEATURES'], true );
+if ( ! empty( $_ENV['WC_ADMIN_ADDITIONAL_FEATURES'] ) ) {
+	$additional_features = json_decode( $_ENV['WC_ADMIN_ADDITIONAL_FEATURES'], true );
 	if ( is_array( $additional_features ) ) {
 		foreach ( $additional_features as $feature => $enabled ) {
 			$config->features->$feature = $enabled;

--- a/bin/generate-feature-config.php
+++ b/bin/generate-feature-config.php
@@ -18,6 +18,14 @@ if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 $config_json = file_get_contents( 'config/' . $phase . '.json' );
 $config      = json_decode( $config_json );
 
+if ( ! empty( $_SERVER['WC_ADMIN_ADDITIONAL_FEATURES'] ) ) {
+	$additional_features = json_decode( $_SERVER['WC_ADMIN_ADDITIONAL_FEATURES'], true );
+	if ( is_array( $additional_features ) ) {
+		foreach ( $additional_features as $feature => $enabled ) {
+			$config->features->$feature = $enabled;
+		}
+	}
+}
 
 if ( 'core' !== $phase ) {
 	$write  = "<?php\n";

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -16,6 +16,16 @@ We currently support the following environments:
 Flags can be added to the files located in the `config/` directory. Make sure to add a flag for each environment and explicitly set the flag to false.
 Please add new feature flags alphabetically so they are easy to find.
 
+## Building custom plugin builds
+
+Sometimes it is useful to create a test zip of a plugin, separate from the released WordPress.org version. This makes internal testing easier for non developers, removing the requirment of using Git and NPM commands. These releases are usually uploaded to GitHub releases as a pre release.
+
+You can use the `build:release` command with the `--slug` and `--features` arguments to create a custom build. Base feature flags will be pulled from `config/plugin.json` and your additional changes are overlaid on top. When the build is complete, a `woocommerce-admin-$slug.zip` file will be generated.
+
+For example, to create a `woocommerce-admin-onboarding.zip` build by enabling onboarding in addition to the feature flags defined in `config/plugin.json`, you would run:
+
+`npm run build:release -- --slug onboarding --features '{"onboarding":true}'`.
+
 ## Basic Use - Client
 
 The `window.wcAdminFeatures` constant is a global variable containing the feature flags.

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -284,14 +284,9 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		$redirect_url = apply_filters( 'woocommerce_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
 		$connect_url  = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
 
-		if ( defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ) {
-			$connect_url = add_query_arg(
-				array(
-					'calypso_env' => WOOCOMMERCE_CALYPSO_ENVIRONMENT,
-				),
-				$connect_url
-			);
-		}
+		// @todo When implementing user-facing split testing, this should be abled to a default of 'production'.
+		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'wpcalypso';
+		$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
 		return( array(
 			'slug'          => 'jetpack',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -568,7 +568,8 @@ class Onboarding {
 	 * Allows quick access to testing the calypso parts of onboarding.
 	 */
 	public static function calypso_tests() {
-		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
+		// @todo When implementing user-facing split testing, this should be abled to a default of 'production'.
+		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'wpcalypso';
 
 		if ( Loader::is_admin_page() && class_exists( 'Jetpack' ) && isset( $_GET['test_wc_jetpack_connect'] ) && 1 === absint( $_GET['test_wc_jetpack_connect'] ) ) { // WPCS: CSRF ok.
 			$redirect_url = esc_url_raw(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,8 @@ if ( [ 'development', 'plugin', 'core' ].indexOf( WC_ADMIN_PHASE ) === -1 ) {
 	WC_ADMIN_PHASE = 'core';
 }
 const WC_ADMIN_CONFIG = require( path.join( __dirname, 'config', WC_ADMIN_PHASE + '.json' ) );
+const WC_ADMIN_ADDITIONAL_FEATURES = process.env.WC_ADMIN_ADDITIONAL_FEATURES &&
+	JSON.parse( process.env.WC_ADMIN_ADDITIONAL_FEATURES ) || {};
 
 const externals = {
 	'@wordpress/api-fetch': { this: [ 'wp', 'apiFetch' ] },
@@ -161,7 +163,7 @@ const webpackConfig = {
 		new FixStyleOnlyEntriesPlugin(),
 		// Inject the current feature flags.
 		new DefinePlugin( {
-			'window.wcAdminFeatures': { ...WC_ADMIN_CONFIG.features },
+			'window.wcAdminFeatures': { ...WC_ADMIN_CONFIG.features, ...WC_ADMIN_ADDITIONAL_FEATURES },
 		} ),
 		new CustomTemplatedPathPlugin( {
 			modulename( outputPath, data ) {


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-admin/issues/3038.

This PR adds the ability to generate custom plugin builds. We would like to start testing onboarding with others inside of Automattic, including non-developers. Being able to generate and provide a zip so testers don't need to build development will increase testing adoption.

I wanted to make this more general purpose, so the `build:release` command now accepts some optional arguments: `--slug` and `--features`. Base feature flags are pulled from `config/plugin.json` and your additional changes are overlaid on top. When the build is complete, a `woocommerce-admin-$slug.zip` file will be generated.

For example, to create a `woocommerce-admin-onboarding.zip` build by enabling onboarding in addition to the feature flags defined in `config/plugin.json`, the command would be:

`npm run build:release -- --slug onboarding --features '{"onboarding":true}'`.

This PR also sets the default calypso environment to `wpcalypso` for now, so that Calypso changes can also easily be tested without needing to build a local copy of Calypso: https://github.com/Automattic/wp-calypso/pull/36790

### Detailed test instructions:

* Test running the default `npm run build:release`  command and verify things look as they should.
* Test running `npm run build:release -- --slug onboarding --features '{"onboarding":true}'`. Uploading the resulting zip on another test site (such as wpsandbox) should allow you to test onboarding. You may need to reset the wizard under `Orders > Help > Setup Wizard`.