### PR TITLE
Onboarding: Add redirect URL option to jetpack connection URL

### DIFF
--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -13,7 +13,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce depdencies
  */
 import { H, Stepper, Card } from '@woocommerce/components';
-import { updateQueryString } from '@woocommerce/navigation';
+import { getNewPath, updateQueryString } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -169,11 +169,14 @@ export default compose(
 		const installationErrors = getPluginInstallationErrors( plugins );
 		const installedPlugins = Object.keys( getPluginInstallations( plugins ) );
 
-		const isJetpackConnectUrlRequesting = isGetJetpackConnectUrlRequesting();
-		const jetpackConnectUrlError = getJetpackConnectUrlError();
+		const queryArgs = {
+			redirect_url: getNewPath( { step: 'store-details' } ),
+		};
+		const isJetpackConnectUrlRequesting = isGetJetpackConnectUrlRequesting( queryArgs );
+		const jetpackConnectUrlError = getJetpackConnectUrlError( queryArgs );
 		let jetpackConnectUrl = null;
 		if ( activatedPlugins.includes( 'jetpack' ) ) {
-			jetpackConnectUrl = getJetpackConnectUrl();
+			jetpackConnectUrl = getJetpackConnectUrl( queryArgs );
 		}
 
 		const errors = [];

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -61,9 +61,12 @@ export default compose(
 			getJetpackConnectUrlError,
 		} = select( 'wc-api' );
 
-		const isRequesting = isGetJetpackConnectUrlRequesting();
-		const error = getJetpackConnectUrlError();
-		const jetpackConnectUrl = getJetpackConnectUrl();
+		const queryArgs = {
+			redirect_url: window.location.href,
+		};
+		const isRequesting = isGetJetpackConnectUrlRequesting( queryArgs );
+		const error = getJetpackConnectUrlError( queryArgs );
+		const jetpackConnectUrl = getJetpackConnectUrl( queryArgs );
 
 		return {
 			error,

--- a/client/wc-api/onboarding/selectors.js
+++ b/client/wc-api/onboarding/selectors.js
@@ -50,17 +50,21 @@ const isGetProfileItemsRequesting = getResource => () => {
 };
 
 const getJetpackConnectUrl = ( getResource, requireResource ) => (
+	query = {},
 	requirement = DEFAULT_REQUIREMENT
 ) => {
-	return requireResource( requirement, 'jetpack-connect-url' ).data;
+	const resourceName = getResourceName( 'jetpack-connect-url', query );
+	return requireResource( requirement, resourceName ).data;
 };
 
-const getJetpackConnectUrlError = getResource => () => {
-	return getResource( 'jetpack-connect-url' ).error;
+const getJetpackConnectUrlError = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'jetpack-connect-url', query );
+	return getResource( resourceName ).error;
 };
 
-const isGetJetpackConnectUrlRequesting = getResource => () => {
-	const { lastReceived, lastRequested } = getResource( 'jetpack-connect-url' );
+const isGetJetpackConnectUrlRequesting = getResource => ( query = {} ) => {
+	const resourceName = getResourceName( 'jetpack-connect-url', query );
+	const { lastReceived, lastRequested } = getResource( resourceName );
 
 	if ( isNil( lastRequested ) || isNil( lastReceived ) ) {
 		return true;

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -273,25 +273,16 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 	/**
 	 * Generates a Jetpack Connect URL.
 	 *
+	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array Connection URL for Jetpack
 	 */
-	public function connect_jetpack() {
+	public function connect_jetpack( $request ) {
 		if ( ! class_exists( '\Jetpack' ) ) {
 			return new \WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce-admin' ), 404 );
 		}
 
-		$next_step_slug = apply_filters( 'woocommerce_onboarding_after_jetpack_step', 'store-details' );
-		$redirect_url   = esc_url_raw(
-			add_query_arg(
-				array(
-					'page' => 'wc-admin',
-					'step' => $next_step_slug,
-				),
-				admin_url( 'admin.php' )
-			)
-		);
-
-		$connect_url = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
+		$redirect_url = apply_filters( 'woocommerce_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
+		$connect_url  = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
 
 		if ( defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ) {
 			$connect_url = add_query_arg(


### PR DESCRIPTION
Fixes #3019

* Adds a `redirect_url` param to the Jetpack REST API.
* Allows query arguments to be added to the jetpack connection URL selectors in the wc-api.
* Updates areas retrieving the jetpack connection URL with respective redirects.

### Detailed test instructions:

1. Add a valid URL (must be the same host as your WP install) as a param to `wc-admin/v1/onboarding/plugins/connect-jetpack`.
2. Make sure the URL is added as a redirect in the response in the `connectAction` property.
3. Visit the plugin install step of the profiler and various tasks with a Jetpack connection step.
4. Make sure you're redirected back to the right page after connection.