### PR TITLE
Fix broken plugin builds by adding missing feature flag check

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -246,30 +246,31 @@ export default compose(
 		const { getCurrentUserData, getProfileItems, getOptions } = select( 'wc-api' );
 		const userData = getCurrentUserData();
 
-		const profileItems = getProfileItems();
-		const taskListHidden =
-			'yes' ===
-			get(
-				getOptions( [ 'woocommerce_task_list_hidden' ] ),
-				[ 'woocommerce_task_list_hidden' ],
-				'no'
-			);
-
-		const tasks = getTasks( {
-			profileItems,
-			options: getOptions( [ 'woocommerce_onboarding_payments' ] ),
-			query: props.query,
-		} );
-
-		const visibleTasks = filter( tasks, task => task.visible );
-		const completedTasks = filter( tasks, task => task.visible && task.completed );
-		const taskListCompleted = visibleTasks.length === completedTasks.length;
-
-		return {
-			taskListHidden,
-			taskListCompleted,
+		const withSelectData = {
 			userPrefSections: userData.dashboard_sections,
 		};
+
+		if ( window.wcAdminFeatures.onboarding ) {
+			const profileItems = getProfileItems();
+			const tasks = getTasks( {
+				profileItems,
+				options: getOptions( [ 'woocommerce_onboarding_payments' ] ),
+				query: props.query,
+			} );
+			const visibleTasks = filter( tasks, task => task.visible );
+			const completedTasks = filter( tasks, task => task.visible && task.completed );
+
+			withSelectData.taskListCompleted = visibleTasks.length === completedTasks.length;
+			withSelectData.taskListHidden =
+				'yes' ===
+				get(
+					getOptions( [ 'woocommerce_task_list_hidden' ] ),
+					[ 'woocommerce_task_list_hidden' ],
+					'no'
+				);
+		}
+
+		return withSelectData;
 	} ),
 	withDispatch( dispatch => {
 		const { updateCurrentUserData } = dispatch( 'wc-api' );


### PR DESCRIPTION
In my recent PR, I added some selector usage to the main dashboard file, but did not wrap it in a feature flag check:

https://github.com/woocommerce/woocommerce-admin/pull/3021/files#diff-7e78b545fb7e8e978068d6402c22ede7R244-R273

This means the code worked in development (where the correct API data is present), but would break when running a plugin build generated by `build:release`.

This PR adds the missing feature check. cc @psealock 

### Detailed test instructions:

* `npm start` and test that the task dashboard shows in development. You may need to enable it under `Orders > Help > Setup Wizard > Toggle Task List`.
* Run `npm run build:release`. Upload the resulting plugin to a test site. Verify that the dashboard loads normally with no onboarding code.