### PR TITLE
Fix dashboard (fix check for product_types in shipping)

### DIFF
--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -86,7 +86,9 @@ export function getTasks( { profileItems, options, query } ) {
 			icon: 'local_shipping',
 			container: <Shipping />,
 			completed: shippingZonesCount > 0,
-			visible: profileItems.product_types.includes( 'physical' ) || hasPhysicalProducts,
+			visible:
+				( profileItems.product_types && profileItems.product_types.includes( 'physical' ) ) ||
+				hasPhysicalProducts,
 		},
 		{
 			key: 'tax',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3056.

If you end up in a scenario where you skipped/completed the profiler before the product types step (which is possible if you close out of the wizard and then go to `Orders > Help > Setup Wizard` and skip), the dashboard would error out because `profileItems.product_types` wouldn't exist before the `.includes` call.

This PR fixes the check.

### Detailed test instructions:

* Delete the `wc_onboarding_profile` option from `wp_options`.
* Go to `Orders > Help > Setup Wizard` and skip the profile wizard.
* Visit the dashboard and make sure it loads.
