### PR TITLE
Onboarding: Add store is ready for launch note

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -30,6 +30,12 @@ class TaskDashboard extends Component {
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
 
 		this.recordEvent();
+
+		if ( this.props.inline ) {
+			this.props.updateOptions( {
+				woocommerce_task_list_complete: true,
+			} );
+		}
 	}
 
 	componentWillUnmount() {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -49,14 +49,15 @@ class Onboarding {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
-		if ( ! is_admin() ) {
-			return;
-		}
-
 		// Include WC Admin Onboarding classes.
 		if ( $this->should_show_tasks() ) {
 			OnboardingTasks::get_instance();
 		}
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		// Old settings injection.
 		// Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -9,6 +9,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding;
 
 /**
  * Contains the logic for completing onboarding tasks.
@@ -43,6 +44,7 @@ class OnboardingTasks {
 	 */
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_media_scripts' ) );
+		add_action( 'admin_init', array( $this, 'add_completion_note' ) );
 		// Old settings injection.
 		// Run after Onboarding.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 30 );
@@ -170,5 +172,12 @@ class OnboardingTasks {
 		);
 
 		return $tax_supported_countries;
+	}
+
+	/**
+	 * Add the task list completion note after completing all tasks.
+	 */
+	public static function add_completion_note() {
+		WC_Admin_Notes_Onboarding::add_task_list_complete_note();
 	}
 }

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -43,8 +43,14 @@ class OnboardingTasks {
 	 * Constructor
 	 */
 	public function __construct() {
+		// This hook needs to run when options are updated via REST.		
+		add_action( 'add_option_woocommerce_task_list_complete', array( $this, 'add_completion_note' ), 10, 2 );
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_media_scripts' ) );
-		add_action( 'admin_init', array( $this, 'add_completion_note' ) );
 		// Old settings injection.
 		// Run after Onboarding.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 30 );
@@ -176,8 +182,13 @@ class OnboardingTasks {
 
 	/**
 	 * Add the task list completion note after completing all tasks.
+	 *
+	 * @param mixed $old_value Old value.
+	 * @param mixed $new_value New value.
 	 */
-	public static function add_completion_note() {
-		WC_Admin_Notes_Onboarding::add_task_list_complete_note();
+	public static function add_completion_note( $old_value, $new_value ) {
+		if ( $new_value ) {
+			WC_Admin_Notes_Onboarding::add_task_list_complete_note();
+		}
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Onboarding.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * WooCommerce Admin: Store ready note
+ *
+ * Adds notes for store onboarding and setup.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Onboarding.
+ */
+class WC_Admin_Notes_Onboarding {
+	const NOTE_NAME = 'wc-admin-task-list-complete';
+
+	/**
+	 * Creates a note for task list completion.
+	 */
+	public static function add_task_list_complete_note() {
+		$is_task_list_complete = get_option( 'woocommerce_task_list_complete', false );
+		if ( ! $is_task_list_complete ) {
+			return;
+		}
+
+		// See if we've already created this kind of note so we don't do it again.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Congratulations - your store is ready for launch!', 'woocommerce-admin' ) );
+		$note->set_content( __( 'You’re ready to take your first order - may the sales roll in!', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'notice' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'market-store',
+			__( 'Market my store', 'woocommerce-admin' ),
+			'https://woocommerce.com/product-category/woocommerce-extensions/marketing-extensions/'
+		);
+
+		$note->save();
+	}
+}


### PR DESCRIPTION
Fixes #2995

Adds a note when all tasks are completed in the task list.

Questions:

* This note is only triggered after page refresh since the hook is not fired over the REST request.  Should we create read and create note queries in wc-api to add this note via REST?
* Is the marketing button URL okay for now?

### Screenshots
<img width="528" alt="Screen Shot 2019-10-17 at 6 02 44 PM" src="https://user-images.githubusercontent.com/10561050/66999316-56cfc480-f108-11e9-9597-d24c57269bd0.png">


### Detailed test instructions:
1.  Complete all items in the task list.
2. Refresh or go to another admin page.
3. Note the note in your inbox.
4. Make sure this note is not duplicated when repeating these steps.