### PR TITLE
Onboarding: Localize currency ranges inside translated string

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -127,7 +127,8 @@ class BusinessDetails extends Component {
 
 		return _x(
 			format( min ) + ' - ' + format( max ),
-			'store product count range or revenue range',
+			'store product count range or revenue range, range should be modified' +
+				'to better match currency if the conversion differs greatly from USD',
 			'woocommerce-admin'
 		);
 	}

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -119,14 +119,16 @@ class BusinessDetails extends Component {
 	}
 
 	getNumberRangeString( min, max = false, format = numberFormat ) {
+		// The localized strings below do not use sprintf to allow
+		// formatting the range on a per currency basis via translation.
 		if ( ! max ) {
-			return sprintf( _x( '%s+', 'store product count', 'woocommerce-admin' ), format( min ) );
+			return _x( format( min ) + '+', 'store product count or revenue', 'woocommerce-admin' );
 		}
 
-		return sprintf(
-			_x( '%s - %s', 'store product count', 'woocommerce-admin' ),
-			format( min ),
-			format( max )
+		return _x(
+			format( min ) + ' - ' + format( max ),
+			'store product count range or revenue range',
+			'woocommerce-admin'
 		);
 	}
 
@@ -246,9 +248,10 @@ class BusinessDetails extends Component {
 			},
 			{
 				key: 'more-than-250000',
-				label: sprintf(
-					_x( 'More than %s', 'More than a certain revenue amount', 'woocommerce-admin' ),
-					formatCurrency( 250000 )
+				label: _x(
+					'More than ' + formatCurrency( 250000 ),
+					'More than a certain revenue amount',
+					'woocommerce-admin'
 				),
 			},
 		];

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -119,17 +119,17 @@ class BusinessDetails extends Component {
 	}
 
 	getNumberRangeString( min, max = false, format = numberFormat ) {
-		// The localized strings below do not use sprintf to allow
-		// formatting the range on a per currency basis via translation.
 		if ( ! max ) {
-			return _x( format( min ) + '+', 'store product count or revenue', 'woocommerce-admin' );
+			return sprintf(
+				_x( '%s+', 'store product count or revenue', 'woocommerce-admin' ),
+				format( min )
+			);
 		}
 
-		return _x(
-			format( min ) + ' - ' + format( max ),
-			'store product count range or revenue range, range should be modified' +
-				'to better match currency if the conversion differs greatly from USD',
-			'woocommerce-admin'
+		return sprintf(
+			_x( '%1$s - %2$s', 'store product count or revenue range', 'woocommerce-admin' ),
+			format( min ),
+			format( max )
 		);
 	}
 
@@ -249,10 +249,9 @@ class BusinessDetails extends Component {
 			},
 			{
 				key: 'more-than-250000',
-				label: _x(
-					'More than ' + formatCurrency( 250000 ),
-					'More than a certain revenue amount',
-					'woocommerce-admin'
+				label: sprintf(
+					_x( 'More than %s', 'More than a certain revenue amount', 'woocommerce-admin' ),
+					formatCurrency( 250000 )
 				),
 			},
 		];


### PR DESCRIPTION
Fixes (part of) #2768

Adds the currency symbol and amount directly to the string to allow translators to update the range based on currency.

### Screenshots
<img width="509" alt="Screen Shot 2019-10-17 at 6 24 13 PM" src="https://user-images.githubusercontent.com/10561050/67001020-77e5e480-f10b-11e9-9905-3006748a64bd.png">


### Detailed test instructions:
1. Enable the onboarding profiler if not enabled.
2. Go to the business details step. `wp-admin/admin.php?page=wc-admin&step=business-details`
3. Make sure the revenue and product dropdowns continue working as expected.