### PR TITLE
Add notices to return to task list on product and homepage tasks.

### DIFF
--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -146,7 +146,7 @@ class Appearance extends Component {
 
 				this.setState( { isPending: false } );
 				if ( response.edit_post_link ) {
-					window.location = `${ response.edit_post_link }&wc_onboarding_active_task=homepage`;
+					window.location = `${ response.edit_post_link }&wc-onboarding=homepage`;
 				}
 			} )
 			.catch( error => {

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -146,7 +146,7 @@ class Appearance extends Component {
 
 				this.setState( { isPending: false } );
 				if ( response.edit_post_link ) {
-					window.location = `${ response.edit_post_link }&wc-onboarding=homepage`;
+					window.location = `${ response.edit_post_link }&wc_onboarding_active_task=homepage`;
 				}
 			} )
 			.catch( error => {

--- a/client/wp-admin-scripts/README.md
+++ b/client/wp-admin-scripts/README.md
@@ -1,0 +1,5 @@
+Scripts located in this directory are meant to be loaded on wp-admin pages outside the context of WooCommerce Admin, such as the post editor.
+
+Scripts must be manually enqueued with any neccessary dependencies. For example, `onboarding-homepage-notice` uses the WooCommerce navigation package:
+
+`wp_enqueue_script(  'onboarding-homepage-notice', Loader::get_url( 'wp-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation' ) );`

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -21,29 +21,17 @@ const onboardingHomepageNotice = () => {
 	const post = select( 'core/editor' ).getCurrentPost();
 
 	const noticeMeta = {
-		wasSavingPost: select( 'core/editor' ).isSavingPost(),
-		wasAutosavingPost: select( 'core/editor' ).isAutosavingPost(),
 		wasPublishingPost: select( 'core/editor' ).isPublishingPost(),
 		wasStatus: post.status,
 	};
 
 	subscribe( () => {
-		const isSavingPost = select( 'core/editor' ).isSavingPost();
-		const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
 		const isPublishingPost = select( 'core/editor' ).isPublishingPost();
 		const isStatus = select( 'core/editor' ).getCurrentPost().status;
 
-		// This triggers when the homepage is first published.
 		const shouldTriggerAdminNotice =
-			noticeMeta.wasSavingPost &&
-			! isSavingPost &&
-			noticeMeta.wasPublishingPost &&
-			! isPublishingPost &&
-			! noticeMeta.wasAutosavingPos &&
-			'publish' === isStatus;
+			'publish' === isStatus && noticeMeta.wasPublishingPost && ! isStatus.isPublishingPost;
 
-		noticeMeta.wasSavingPost = isSavingPost;
-		noticeMeta.wasAutosavingPost = isAutosavingPost;
 		noticeMeta.wasPublishingPost = isPublishingPost;
 		noticeMeta.wasStatus = isStatus;
 
@@ -65,11 +53,11 @@ const onboardingHomepageNotice = () => {
 				dispatch( 'core/notices' ).createSuccessNotice(
 					__( 'Your homepage was published.', 'woocommerce-admin' ),
 					{
-						id: 'ONBOARDING_HOME_PAGE_NOTICE',
+						id: 'WOOCOMMERCE_ONBOARDING_HOME_PAGE_NOTICE',
 						actions: [
 							{
 								url: getAdminLink( 'admin.php?page=wc-admin&task=appearance' ),
-								label: 'Continue setup.',
+								label: __( 'Continue setup.', 'woocommerce-admin' ),
 							},
 						],
 					}

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -1,0 +1,86 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { select, subscribe, dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getAdminLink } from '@woocommerce/navigation';
+
+/**
+ * Displays a notice on page save and updates the hompage options.
+ *
+ * Adapted from WSUWP Help Docs by Washington State University (GPL v2).
+ * https://github.com/washingtonstateuniversity/WSUWP-Plugin-Help-Docs/blob/master/src/_js/blocks/notices.js
+ */
+const onboardingHomepageNotice = () => {
+	const post = select( 'core/editor' ).getCurrentPost();
+
+	const noticeMeta = {
+		wasSavingPost: select( 'core/editor' ).isSavingPost(),
+		wasAutosavingPost: select( 'core/editor' ).isAutosavingPost(),
+		wasPublishingPost: select( 'core/editor' ).isPublishingPost(),
+		wasStatus: post.status,
+	};
+
+	subscribe( () => {
+		const isSavingPost = select( 'core/editor' ).isSavingPost();
+		const isAutosavingPost = select( 'core/editor' ).isAutosavingPost();
+		const isPublishingPost = select( 'core/editor' ).isPublishingPost();
+		const isStatus = select( 'core/editor' ).getCurrentPost().status;
+
+		// This triggers when the homepage is first published.
+		const shouldTriggerAdminNotice =
+			noticeMeta.wasSavingPost &&
+			! isSavingPost &&
+			noticeMeta.wasPublishingPost &&
+			! isPublishingPost &&
+			! noticeMeta.wasAutosavingPos &&
+			'publish' === isStatus;
+
+		noticeMeta.wasSavingPost = isSavingPost;
+		noticeMeta.wasAutosavingPost = isAutosavingPost;
+		noticeMeta.wasPublishingPost = isPublishingPost;
+		noticeMeta.wasStatus = isStatus;
+
+		if ( shouldTriggerAdminNotice ) {
+			if ( select( 'core/editor' ).didPostSaveRequestSucceed() ) {
+				setTimeout( () => {
+					wp.data.dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
+				}, 0 );
+
+				apiFetch( {
+					path: '/wc-admin/v1/options',
+					method: 'POST',
+					data: {
+						show_on_front: 'page',
+						page_on_front: post.id,
+					},
+				} );
+
+				dispatch( 'core/notices' ).createSuccessNotice(
+					__( 'Your homepage was published.', 'woocommerce-admin' ),
+					{
+						id: 'ONBOARDING_HOME_PAGE_NOTICE',
+						actions: [
+							{
+								url: getAdminLink( 'admin.php?page=wc-admin&task=appearance' ),
+								label: 'Continue setup.',
+							},
+						],
+					}
+				);
+			}
+		}
+	} );
+};
+
+wp.domReady( () => {
+	if ( 'page' === select( 'core/editor' ).getCurrentPostType() ) {
+		onboardingHomepageNotice();
+	}
+} );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -175,7 +175,7 @@ class OnboardingTasks {
 	 */
 	function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
-		if ( $hook == 'post.php' && 'page' === $post->post_type && isset( $_GET[ 'wc-onboarding' ] ) && 'homepage' === $_GET[ 'wc-onboarding' ] ) { // WPCS: csrf ok.
+		if ( $hook == 'post.php' && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // WPCS: csrf ok.
 			wp_enqueue_script(  'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation' ) );
 		}
 	}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use \Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding;
 
@@ -56,8 +57,10 @@ class OnboardingTasks {
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 30 );
 		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 30 );
+
 		add_action( 'admin_init', array( $this, 'set_active_task' ), 20 );
-		add_action( 'current_screen', array( $this, 'check_active_task_completion' ), 1000 );
+		add_filter( 'post_updated_messages', array( $this, 'update_product_success_message' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ), 10, 1 );
 	}
 
 	/**
@@ -95,9 +98,8 @@ class OnboardingTasks {
 		return $settings;
 	}
 
-
 	/**
-	 * Temporarily store the active task.
+	 * Temporarily store the active task to persist across page loads when neccessary (such as publishing a product). Most tasks do not need to do this.
 	 */
 	public static function set_active_task() {
 		if ( isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ) { // WPCS: csrf ok.
@@ -116,19 +118,21 @@ class OnboardingTasks {
 	}
 
 	/**
-	 * Check for active task completion and redirect if complete.
+	 * Check for active task completion, and clears the transient.
 	 */
 	public static function check_active_task_completion() {
 		$active_task = get_transient( self::ACTIVE_TASK_TRANSIENT );
+
 		if ( ! $active_task ) {
-			return;
+			return false;
 		}
 
 		if ( self::check_task_completion( $active_task ) ) {
 			delete_transient( self::ACTIVE_TASK_TRANSIENT );
-			wp_safe_redirect( wc_admin_url() );
-			exit;
+			return true;
 		}
+
+		return false;
 	}
 
 	/**
@@ -142,27 +146,38 @@ class OnboardingTasks {
 			case 'products':
 				$products = wp_count_posts( 'product' );
 				return (int) $products->publish > 0 || (int) $products->draft > 0;
-
 			case 'homepage':
-				// @todo This should be run client-side in a Gutenberg hook and add a notice
-				// to return to the task list if complete.
 				$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
-
 				if ( ! $homepage_id ) {
 					return false;
 				}
-
 				$post      = get_post( $homepage_id );
 				$completed = $post && 'publish' === $post->post_status;
-				if ( $completed ) {
-					update_option( 'show_on_front', 'page' );
-					update_option( 'page_on_front', $homepage_id );
-				}
-
 				return $completed;
 		}
-
 		return false;
+	}
+
+	/**
+	 * Updates the product published message with a continue setup link, if the products task is currently active.
+	 */
+	function update_product_success_message( $messages ) {
+		if ( ! $this->check_active_task_completion() ) {
+			return $messages;
+		}
+		/* translators: 1: onboarding task list url */
+		$messages['product'][6] = sprintf( __( 'You created your first product! <a href="%s">Continue Setup</a>.', 'woocommerce-admin' ), esc_url( wc_admin_url() ) );
+		return $messages;
+	}
+
+	/**
+	 * Hooks into the post page to display a different success notice and sets the active page as the site's home page if visted from onboarding.
+	 */
+	function add_onboarding_homepage_notice_admin_script( $hook ) {
+		global $post;
+		if ( $hook == 'post.php' && 'page' === $post->post_type && isset( $_GET[ 'wc-onboarding' ] ) && 'homepage' === $_GET[ 'wc-onboarding' ] ) { // WPCS: csrf ok.
+			wp_enqueue_script(  'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation' ) );
+		}
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,13 @@ wcAdminPackages.forEach( name => {
 	entryPoints[ name ] = `./packages/${ name }`;
 } );
 
+const wpAdminScripts = [
+	'onboarding-homepage-notice',
+];
+wpAdminScripts.forEach( name => {
+	entryPoints[ name ] = `./client/wp-admin-scripts/${ name }`;
+} );
+
 const webpackConfig = {
 	mode: NODE_ENV,
 	entry: {
@@ -70,7 +77,9 @@ const webpackConfig = {
 		...entryPoints,
 	},
 	output: {
-		filename: './dist/[name]/index.js',
+		filename: ( data ) => {
+			return wpAdminScripts.includes( data.chunk.name ) ? './dist/wp-admin-scripts/[name].js' : './dist/[name]/index.js';
+		},
 		path: __dirname,
 		library: [ 'wc', '[modulename]' ],
 		libraryTarget: 'this',


### PR DESCRIPTION
Closes #2890.

This PR updates the success notices that are displayed when creating a product through the onboarding flow or when creating a homepage through the onboarding flow. This way users can continue setup easily.

Since this requires a separate script to be loaded (separate from the main app entry point or embedded view), I've added a new folder to house scripts like this (I imagine there will be other instances in the future, as we update screens and experiences). I wasn’t sure what exactly to call these, so I’ve named the folder `wp-admin-scripts` (since `wp-scripts` is used by a core NPM package). But I’m open to changing this if anyone has a suggestion.

### Screenshots

<img width="944" alt="Screen Shot 2019-10-16 at 4 06 25 PM" src="https://user-images.githubusercontent.com/689165/66954727-f6b91f80-f02e-11e9-91e4-2ad60879d04c.png">

<img width="941" alt="Screen Shot 2019-10-16 at 4 14 20 PM" src="https://user-images.githubusercontent.com/689165/66955290-0a18ba80-f030-11e9-9bb9-1f307a1122c1.png">

### Detailed test instructions:

* Make sure the profile wizard is disabled, but the task list is enabled. (Under `Orders > Help > Setup Wizard`).

To test the products notice:

* Delete all of your products.
* Go to the task list and select “add your first product”, followed by the “Add manually” option.
* Add some product information and hit publish.
* You should see the “you created your first product!” message, with a link to continue setup.

To test the homepage notice:

* Delete your front page.
* Go to the task list and select “personalize your store”. Click “create homepage”.
* Make any desired changes to the homepage template, and then hit publish twice.
* You should see a “Your homepage was published.” Message, with a continue setup link.