### PR TITLE
Fix asset image URL and business extension images

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -155,11 +155,14 @@
 			margin-bottom: $gap-smaller;
 		}
 
-		.woocommerce-profile-wizard__benefit-content p {
-			padding-bottom: $gap;
-			margin-top: 0;
-			border-bottom: 1px solid $studio-gray-5;
-			font-size: 14px;
+		.woocommerce-profile-wizard__benefit-content {
+			margin-left: $gap;
+			p {
+				padding-bottom: $gap;
+				margin-top: 0;
+				border-bottom: 1px solid $studio-gray-5;
+				font-size: 14px;
+			}
 		}
 
 		.woocommerce-profile-wizard__benefit-toggle {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -594,7 +594,7 @@ class Loader {
 		$settings['notifyLowStockAmount'] = get_option( 'woocommerce_notify_low_stock_amount' );
 		// @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired,
 		// and `wcAssetUrl` can be used in its place throughout the codebase.
-		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', plugin_dir_path( dirname( __DIR__ ) ) . 'woocommerce-admin.php' );
+		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', dirname( __DIR__ ) . '/woocommerce-admin.php' );
 
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$settings['dataEndpoints'] = isset( $settings['dataEndpoints'] )


### PR DESCRIPTION
`wcAdminAssetUrl` was returning `https://:site/wp-content/plugins/images/...` without the plugin directory name, so the business extension images were failing to load.

Before:

<img width="515" alt="Screen Shot 2019-10-18 at 9 15 17 AM" src="https://user-images.githubusercontent.com/689165/67099229-8c69c180-f18b-11e9-8bb9-556eba442126.png">

After:

<img width="549" alt="Screen Shot 2019-10-18 at 9 39 27 AM" src="https://user-images.githubusercontent.com/689165/67099235-912e7580-f18b-11e9-8f72-b7308b57170c.png">

To Test:
* Enable the profile wizard (Orders > Help > Setup Wizard)
* View the business details step `/wp-admin/admin.php?page=wc-admin&step=business-details`. Fill out the fields until the extensions show up. Verify images show.