### PR TITLE
Remove unnecessary horizontal scroll bar visible from select control

### DIFF
--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -109,7 +109,7 @@
 		right: 0;
 		top: 57px;
 		z-index: 10;
-		overflow: scroll;
+		overflow-y: scroll;
 		max-height: 350px;
 
 		&.is-static {


### PR DESCRIPTION
### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/67165900-ca810400-f38a-11e9-8cc9-6cbb3b586c43.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/67165905-d2d93f00-f38a-11e9-9091-51e7c9977aa4.png)

### Detailed test instructions:

- In a non-Mac OS open the select control component (For example, in the first step of the profile wizard) and verify there is no horizontal scrollbar.