### PR TITLE
Onboarding: Don't skip start step if TOS not accepted

### DIFF
--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -162,8 +162,7 @@ class Start extends Component {
 					'Save time at the Post Office by printing USPS shipping labels at home.',
 					'woocommerce-admin'
 				),
-				visible:
-					activePlugins.includes( 'jetpack' ) && ! activePlugins.includes( 'woocommerce-services' ),
+				visible: activePlugins.includes( 'jetpack' ),
 			},
 			{
 				title: __( 'Simple payment setup', 'woocommerce-admin' ),
@@ -172,8 +171,7 @@ class Start extends Component {
 					'WooCommerce Services enables us to provision Stripe and Paypal accounts quickly and easily for you.',
 					'woocommerce-admin'
 				),
-				visible:
-					activePlugins.includes( 'jetpack' ) && ! activePlugins.includes( 'woocommerce-services' ),
+				visible: activePlugins.includes( 'jetpack' ),
 			},
 		];
 	}

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -41,10 +41,11 @@ class Start extends Component {
 	}
 
 	componentDidMount() {
-		const { updateProfileItems, profileItems } = this.props;
+		const { updateProfileItems, profileItems, tosAccepted } = this.props;
 		if (
 			this.props.activePlugins.includes( 'jetpack' ) &&
-			this.props.activePlugins.includes( 'woocommerce-services' )
+			this.props.activePlugins.includes( 'woocommerce-services' ) &&
+			tosAccepted
 		) {
 			// Don't track event again if they revisit the start page.
 			if ( 'already-installed' !== profileItems.plugins ) {
@@ -279,8 +280,8 @@ export default compose(
 
 		const isProfileItemsError = Boolean( getProfileItemsError() );
 
-		const options = getOptions( [ 'woocommerce_allow_tracking' ] );
-		const allowTracking = 'yes' === get( options, [ 'woocommerce_allow_tracking' ], false );
+		const options = getOptions( [ 'woocommerce_setup_jetpack_opted_in', 'wc_connect_options' ] );
+		const tosAccepted = get( options, [ 'wc_connect_options' ], {} ).tos_accepted;
 
 		const activePlugins = getActivePlugins();
 		const profileItems = getProfileItems();
@@ -288,7 +289,7 @@ export default compose(
 		return {
 			isProfileItemsError,
 			activePlugins,
-			allowTracking,
+			tosAccepted,
 			profileItems,
 		};
 	} ),

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -357,10 +357,12 @@ class Onboarding {
 			return $options;
 		}
 
+		$options[] = 'wc_connect_options';
 		$options[] = 'woocommerce_task_list_prompt_shown';
 		$options[] = 'woocommerce_onboarding_payments';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
+
 		return $options;
 	}
 


### PR DESCRIPTION
Fixes #3018 

Doesn't skip the first step of the onboarding profiler if TOS hasn't been accepted yet.

### Detailed test instructions:

1. Set WCS `tos_accepted` to false. `WC_Connect_Options::update_option( 'tos_accepted', false );`
2. Go to the first step in the Onboarding profiler. `/wp-admin/admin.php?page=wc-admin`
3. Make sure the start step is not skipped to Store Details.
4. Click `Get started`.
5. After proceeding past the start step, visit the start step again.
5. Make sure it's skipped as `tos_accepted` should now be true.