### PR TITLE
Set SelectControl input background to transparent

### DIFF
--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -46,6 +46,7 @@
 			width: 100%;
 			line-height: 24px;
 			text-align: left;
+			background: transparent;
 
 			&::-webkit-search-cancel-button {
 				display: none;


### PR DESCRIPTION
Fixes #3066

Sets the input (for search or button) inside a `SelectControl` to transparent to fix Firefox styling.

### Before
<img width="510" alt="Screen Shot 2019-10-21 at 3 05 08 PM" src="https://user-images.githubusercontent.com/10561050/67183508-35c2e880-f414-11e9-9823-b56844a17e75.png">

### After
<img width="532" alt="Screen Shot 2019-10-21 at 3 02 54 PM" src="https://user-images.githubusercontent.com/10561050/67183510-36f41580-f414-11e9-8181-0d82ca4e0176.png">

### Detailed test instructions:

1. Open any page with a `SelectControl` input that is not searchable (e.g., Business Details or devdocs).
2. Make sure non-searchable select boxes don't have gray background inputs.