### PR TITLE
Use getenv in place of $_ENV

### DIFF
--- a/bin/generate-feature-config.php
+++ b/bin/generate-feature-config.php
@@ -11,7 +11,8 @@
  * - plugin: For the standalone feature plugin, for GitHub and WordPress.org.
  * - core: Stable features for WooCommerce core merge.
  */
-$phase = getenv( 'WC_ADMIN_PHASE' ) ? getenv( 'WC_ADMIN_PHASE' ) : ''; // WPCS: sanitization ok.
+
+$phase = getenv( 'WC_ADMIN_PHASE' );
 
 if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 	$phase = 'plugin'; // Default to plugin when running `npm run build`.

--- a/bin/generate-feature-config.php
+++ b/bin/generate-feature-config.php
@@ -11,7 +11,7 @@
  * - plugin: For the standalone feature plugin, for GitHub and WordPress.org.
  * - core: Stable features for WooCommerce core merge.
  */
-$phase = isset( $_ENV['WC_ADMIN_PHASE'] ) ? $_ENV['WC_ADMIN_PHASE'] : ''; // WPCS: sanitization ok.
+$phase = getenv( 'WC_ADMIN_PHASE' ) ? getenv( 'WC_ADMIN_PHASE' ) : ''; // WPCS: sanitization ok.
 
 if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 	$phase = 'plugin'; // Default to plugin when running `npm run build`.
@@ -19,8 +19,8 @@ if ( ! in_array( $phase, array( 'development', 'plugin', 'core' ), true ) ) {
 $config_json = file_get_contents( 'config/' . $phase . '.json' );
 $config      = json_decode( $config_json );
 
-if ( ! empty( $_ENV['WC_ADMIN_ADDITIONAL_FEATURES'] ) ) {
-	$additional_features = json_decode( $_ENV['WC_ADMIN_ADDITIONAL_FEATURES'], true );
+if ( ! empty( getenv( 'WC_ADMIN_ADDITIONAL_FEATURES' ) ) ) {
+	$additional_features = json_decode( getenv( 'WC_ADMIN_ADDITIONAL_FEATURES' ), true );
 	if ( is_array( $additional_features ) ) {
 		foreach ( $additional_features as $feature => $enabled ) {
 			$config->features->$feature = $enabled;


### PR DESCRIPTION
Fixes #3074

Swaps out `$_ENV` for `getenv()`.  I couldn't find much documentation on it, but it looks like the `$_ENV` superglobal doesn't work well across some environments so cross environment variables weren't being read.

### Detailed test instructions:

1. (optional) Use an environment that can't handle `$_ENV` - not sure if this will do it, but running an Apache webserver with PHP 7.2.0.
2.  Run various `npm` commands like `npm run dev` and `npm run build`.
3. Make sure the build sets the `feature-config.php` file as expected.