### PR TITLE
Update styles to work with WP 5.3

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -40,11 +40,6 @@
 		}
 	}
 
-	.muriel-checkbox input[type='checkbox']:checked::before {
-		margin-left: -4px;
-		margin-top: -3px;
-	}
-
 	.woocommerce-profile-wizard__container {
 		.woocommerce-profile-wizard__tos {
 			font-size: 12px;
@@ -225,6 +220,11 @@
 			position: relative;
 			padding: $gap-small $gap;
 			min-height: 56px;
+
+			input[type='checkbox']:checked::before {
+				left: -1px;
+				top: 0;
+			}
 
 			&::after {
 				content: '';

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -40,6 +40,11 @@
 		}
 	}
 
+	.muriel-checkbox input[type='checkbox']:checked:before {
+		margin-left: -4px;
+		margin-top: -3px;
+	}
+
 	.woocommerce-profile-wizard__container {
 		.woocommerce-profile-wizard__tos {
 			font-size: 12px;
@@ -247,6 +252,7 @@
 
 			label.components-checkbox-control__label {
 				color: $studio-gray-80;
+				margin-top: $gap-smallest;
 			}
 
 			label.components-checkbox-control__label,
@@ -370,6 +376,10 @@
 			min-width: 160px;
 			align-self: flex-end;
 			margin-bottom: 0;
+		}
+
+		.muriel-checkbox input[type='checkbox']:checked {
+			content: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($studio-white)}%27%2F%3E%3C%2Fsvg%3E');
 		}
 
 		.muriel-checkbox label.components-checkbox-control__label {

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -40,7 +40,7 @@
 		}
 	}
 
-	.muriel-checkbox input[type='checkbox']:checked:before {
+	.muriel-checkbox input[type='checkbox']:checked::before {
 		margin-left: -4px;
 		margin-top: -3px;
 	}

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -132,12 +132,6 @@
 		height: 18px;
 	}
 
-	.muriel-checkbox input[type='checkbox']:checked::before {
-		font-size: 18px;
-		margin-left: -3px;
-		margin-top: -1px;
-	}
-
 	.muriel-button.is-button {
 		height: 48px;
 

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -117,7 +117,7 @@
 			display: none;
 			position: absolute;
 			left: $gap;
-			top: 26px;
+			top: 28px;
 			z-index: 1;
 			font-size: 16px;
 			line-height: 24px;
@@ -206,6 +206,8 @@
 		max-width: 96px;
 		background: $studio-gray-0;
 		padding: $gap-small;
+		align-self: start;
+		margin-top: $gap;
 
 		img {
 			max-width: 72px;
@@ -222,6 +224,11 @@
 		margin-top: $gap;
 		margin-left: $gap-larger;
 		padding-top: $gap;
+
+		.components-base-control__field {
+			align-items: center;
+			display: flex;
+		}
 
 		.components-checkbox-control__input {
 			margin-left: -$gap-larger;

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -9,6 +9,10 @@
 	}
 }
 
+@function url-friendly-colour( $color ) {
+	@return '%23' + str-slice( '#{ $color }', 2, -1 );
+}
+
 @mixin hover-state {
 	&:hover,
 	&:active,

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -129,3 +129,15 @@
 		display: flex;
 	}
 }
+
+.wp-version-less-than-5-3 {
+	.muriel-input-text.empty input {
+		top: 17px;
+	}
+
+	&.woocommerce-profile-wizard__body .muriel-checkbox input[type='checkbox']:checked::before,
+	.woocommerce-layout input[type='checkbox']:checked::before {
+		margin-left: -2px;
+		margin-top: -3px;
+	}
+}

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -101,14 +101,6 @@
 		border: 2px solid $studio-woocommerce-purple-60;
 	}
 
-	input[type='checkbox']:checked::before {
-		color: $studio-white;
-		font-size: 18px;
-		margin-left: -4px;
-		margin-top: -3px;
-		content: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($studio-white)}%27%2F%3E%3C%2Fsvg%3E');
-	}
-
 	input[type='radio']:checked::before {
 		font-size: 18px;
 		margin-left: 4px;
@@ -116,8 +108,27 @@
 		background-color: $studio-white;
 	}
 
-	.muriel-input-text.empty input {
-		top: 12px;
+	input[type='checkbox']:checked::before,
+	.muriel-checkbox input[type='checkbox']:checked::before {
+		font-size: 16px;
+		color: $studio-white;
+		content: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($studio-white)}%27%2F%3E%3C%2Fsvg%3E');
+		margin-left: -2px;
+		margin-top: 0;
+		height: 18px;
+		width: 16px;
+	}
+
+	.muriel-checkbox input[type='checkbox']:checked::before {
+		margin-left: 0;
+		margin-top: 0;
+		position: absolute;
+		left: 1px;
+		top: 4px;
+	}
+
+	.muriel-input-text input {
+		min-height: auto;
 	}
 
 	.muriel-input-text.with-value input {
@@ -127,17 +138,5 @@
 	.muriel-checkbox .components-base-control__field {
 		align-items: center;
 		display: flex;
-	}
-}
-
-.wp-version-less-than-5-3 {
-	.muriel-input-text.empty input {
-		top: 17px;
-	}
-
-	&.woocommerce-profile-wizard__body .muriel-checkbox input[type='checkbox']:checked::before,
-	.woocommerce-layout input[type='checkbox']:checked::before {
-		margin-left: -2px;
-		margin-top: -3px;
 	}
 }

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -97,11 +97,16 @@
 		border-color: $studio-woocommerce-purple-60;
 	}
 
+	input[type='checkbox']:focus:checked {
+		border: 2px solid $studio-woocommerce-purple-60;
+	}
+
 	input[type='checkbox']:checked::before {
 		color: $studio-white;
 		font-size: 18px;
-		margin-left: -2.5px;
-		margin-top: -1px;
+		margin-left: -4px;
+		margin-top: -3px;
+		content: url('data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($studio-white)}%27%2F%3E%3C%2Fsvg%3E');
 	}
 
 	input[type='radio']:checked::before {
@@ -109,5 +114,18 @@
 		margin-left: 4px;
 		margin-top: 4px;
 		background-color: $studio-white;
+	}
+
+	.muriel-input-text.empty input {
+		top: 12px;
+	}
+
+	.muriel-input-text.with-value input {
+		top: 24px;
+	}
+
+	.muriel-checkbox .components-base-control__field {
+		align-items: center;
+		display: flex;
 	}
 }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -436,6 +436,8 @@ class Loader {
 	 * @param string $admin_body_class Body class to add.
 	 */
 	public static function add_admin_body_classes( $admin_body_class = '' ) {
+		global $wp_version;
+
 		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
 			return $admin_body_class;
 		}
@@ -455,6 +457,11 @@ class Loader {
 		$features = self::get_features();
 		foreach ( $features as $feature_key ) {
 			$classes[] = sanitize_html_class( 'woocommerce-feature-enabled-' . $feature_key );
+		}
+
+		// WordPress returns the version string in the body, but we would have to list multiple versions in our CSS to target older versions.
+		if ( ! version_compare( $wp_version, '5.2.4', '>' ) ) { // Checks greater than latest (5.2.4) to catch versions like 5.3-RC2-* correctly.
+			$classes[] = 'wp-version-less-than-5-3';
 		}
 
 		$admin_body_class = implode( ' ', array_unique( $classes ) );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -436,8 +436,6 @@ class Loader {
 	 * @param string $admin_body_class Body class to add.
 	 */
 	public static function add_admin_body_classes( $admin_body_class = '' ) {
-		global $wp_version;
-
 		if ( ! self::is_admin_page() && ! self::is_embed_page() ) {
 			return $admin_body_class;
 		}
@@ -457,11 +455,6 @@ class Loader {
 		$features = self::get_features();
 		foreach ( $features as $feature_key ) {
 			$classes[] = sanitize_html_class( 'woocommerce-feature-enabled-' . $feature_key );
-		}
-
-		// WordPress returns the version string in the body, but we would have to list multiple versions in our CSS to target older versions.
-		if ( ! version_compare( $wp_version, '5.2.4', '>' ) ) { // Checks greater than latest (5.2.4) to catch versions like 5.3-RC2-* correctly.
-			$classes[] = 'wp-version-less-than-5-3';
 		}
 
 		$admin_body_class = implode( ' ', array_unique( $classes ) );


### PR DESCRIPTION
There have been CSS changes in 5.3 that have messed up parts of our onboarding layout, and some of the checkboxes on the analytic setting page.

See https://make.wordpress.org/core/2019/10/18/noteworthy-admin-css-changes-in-wordpress-5-3/.

This PR adjusts the styles so everything looks good again.

It also adds a body class, so that things continue to look good in older versions as well.

#### Screenshots / some examples:

Before
<img width="428" alt="Screen Shot 2019-10-22 at 2 06 41 PM" src="https://user-images.githubusercontent.com/689165/67317827-a29fb680-f4d8-11e9-8758-a1d7168d59cf.png">

After
<img width="398" alt="Screen Shot 2019-10-22 at 2 07 32 PM" src="https://user-images.githubusercontent.com/689165/67317932-c9f68380-f4d8-11e9-9eca-b649327d9f07.png">

Before
<img width="762" alt="Screen Shot 2019-10-22 at 2 02 40 PM" src="https://user-images.githubusercontent.com/689165/67318009-e72b5200-f4d8-11e9-91f4-2dfb325ec4d7.png">

After
<img width="662" alt="Screen Shot 2019-10-22 at 2 35 08 PM" src="https://user-images.githubusercontent.com/689165/67318193-2b1e5700-f4d9-11e9-9701-1912fb989a9e.png">

#### To Test:
* Update your site to WP 5.3 RC 1 or nightly
* Test the various flows and make sure things look OK visually
* Look at the settings analytics page