### PR TITLE
Handle Jetpack being disconnected on the start page

### DIFF
--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -21,6 +21,7 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
  */
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
+import { pluginNames } from 'wc-api/onboarding/constants';
 
 const pluginsToInstall = [ 'jetpack', 'woocommerce-services' ];
 const { activePlugins = [] } = getSetting( 'onboarding', {} );
@@ -121,12 +122,7 @@ class Plugins extends Component {
 			);
 		}
 
-		let pluginLabel = __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' );
-		if ( plugins.includes( 'jetpack' ) && ! plugins.includes( 'woocommerce-services' ) ) {
-			pluginLabel = __( 'Jetpack', 'woocommerce-admin' );
-		} else if ( ! plugins.includes( 'jetpack' ) && plugins.includes( 'woocommerce-services' ) ) {
-			pluginLabel = __( 'WooCommerce Services', 'woocommerce-admin' );
-		}
+		const pluginLabel = plugins.map( pluginSlug => pluginNames[ pluginSlug ] ).join( ' & ' );
 
 		return (
 			<Fragment>

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -13,7 +13,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce depdencies
  */
 import { H, Stepper, Card } from '@woocommerce/components';
-import { getNewPath, updateQueryString } from '@woocommerce/navigation';
+import { getNewPath, updateQueryString, getAdminLink } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -21,7 +21,6 @@ import { getSetting } from '@woocommerce/wc-admin-settings';
  */
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
-import { pluginNames } from 'wc-api/onboarding/constants';
 
 const pluginsToInstall = [ 'jetpack', 'woocommerce-services' ];
 const { activePlugins = [] } = getSetting( 'onboarding', {} );
@@ -40,9 +39,11 @@ class Plugins extends Component {
 	}
 
 	componentDidMount() {
-		if ( 0 === plugins.length ) {
+		const { isJetpackConnected } = this.props;
+		if ( 0 === plugins.length && isJetpackConnected ) {
 			return updateQueryString( { step: 'store-details' } );
 		}
+
 		this.props.installPlugins( plugins );
 	}
 
@@ -53,6 +54,7 @@ class Plugins extends Component {
 			installedPlugins,
 			activatedPlugins,
 			jetpackConnectUrl,
+			isJetpackConnected,
 		} = this.props;
 
 		if ( jetpackConnectUrl ) {
@@ -75,7 +77,8 @@ class Plugins extends Component {
 		if (
 			! plugins.includes( 'jetpack' ) &&
 			prevProps.activatedPlugins.length !== plugins.length &&
-			activatedPlugins.length === plugins.length
+			activatedPlugins.length === plugins.length &&
+			isJetpackConnected
 		) {
 			/* eslint-disable react/no-did-update-set-state */
 			return updateQueryString( { step: 'store-details' } );
@@ -98,12 +101,32 @@ class Plugins extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting } = this.props;
+		const { hasErrors, isRequesting, isJetpackConnected } = this.props;
 		const { step } = this.state;
 
-		const pluginLabel = plugins.includes( 'jetpack' )
-			? Object.values( pluginNames ).join( ' & ' )
-			: pluginNames[ 'woocommerce-services' ];
+		if ( 0 === plugins.length && ! isJetpackConnected ) {
+			return (
+				<Fragment>
+					<H className="woocommerce-profile-wizard__header-title">
+						{ __( 'Connecting your store', 'woocommerce-admin' ) }
+					</H>
+
+					<p>
+						{ __(
+							'You will be redirected to WordPress.com to continue connecting your site.',
+							'woocommerce-admin'
+						) }{' '}
+					</p>
+				</Fragment>
+			);
+		}
+
+		let pluginLabel = __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' );
+		if ( plugins.includes( 'jetpack' ) && ! plugins.includes( 'woocommerce-services' ) ) {
+			pluginLabel = __( 'Jetpack', 'woocommerce-admin' );
+		} else if ( ! plugins.includes( 'jetpack' ) && plugins.includes( 'woocommerce-services' ) ) {
+			pluginLabel = __( 'WooCommerce Services', 'woocommerce-admin' );
+		}
 
 		return (
 			<Fragment>
@@ -159,6 +182,7 @@ export default compose(
 			getPluginActivationErrors,
 			isPluginActivateRequesting,
 			isPluginInstallRequesting,
+			isJetpackConnected,
 		} = select( 'wc-api' );
 
 		const isRequesting =
@@ -170,12 +194,16 @@ export default compose(
 		const installedPlugins = Object.keys( getPluginInstallations( plugins ) );
 
 		const queryArgs = {
-			redirect_url: getNewPath( { step: 'store-details' } ),
+			redirect_url: getAdminLink( getNewPath( { step: 'store-details' } ) ),
 		};
 		const isJetpackConnectUrlRequesting = isGetJetpackConnectUrlRequesting( queryArgs );
 		const jetpackConnectUrlError = getJetpackConnectUrlError( queryArgs );
 		let jetpackConnectUrl = null;
-		if ( activatedPlugins.includes( 'jetpack' ) ) {
+		if (
+			activatedPlugins.includes( 'jetpack' ) ||
+			( 0 === plugins.length && ! isJetpackConnected() ) ||
+			( activatedPlugins.includes( 'woocommerce-services' ) && ! isJetpackConnected() )
+		) {
 			jetpackConnectUrl = getJetpackConnectUrl( queryArgs );
 		}
 
@@ -199,6 +227,7 @@ export default compose(
 			errors,
 			hasErrors,
 			isRequesting,
+			isJetpackConnected: isJetpackConnected(),
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -28,6 +28,7 @@ import PrintIcon from './images/print';
 import withSelect from 'wc-api/with-select';
 import UsageModal from '../usage-modal';
 import { recordEvent } from 'lib/tracks';
+import { pluginNames } from 'wc-api/onboarding/constants';
 
 class Start extends Component {
 	constructor( props ) {
@@ -195,12 +196,16 @@ class Start extends Component {
 		const { showUsageModal, continueAction } = this.state;
 		const { isJetpackConnected, activePlugins } = this.props;
 
-		let pluginNames = __( 'Jetpack & WooCommerce Services', 'woocommerce-admin' );
-		if ( ! isJetpackConnected && activePlugins.includes( 'woocommerce-services' ) ) {
-			pluginNames = __( 'Jetpack', 'woocommerce-admin' );
-		} else if ( isJetpackConnected && ! activePlugins.includes( 'woocommerce-services' ) ) {
-			pluginNames = __( 'WooCommerce Services', 'woocommerce-admin' );
+		const pluginsToInstall = [];
+		if ( ! isJetpackConnected ) {
+			pluginsToInstall.push( 'jetpack' );
 		}
+		if ( ! activePlugins.includes( 'woocommerce-services' ) ) {
+			pluginsToInstall.push( 'woocommerce-services' );
+		}
+		const pluginNamesString = pluginsToInstall
+			.map( pluginSlug => pluginNames[ pluginSlug ] )
+			.join( ' & ' );
 
 		return (
 			<Fragment>
@@ -224,7 +229,7 @@ class Start extends Component {
 									'{{strong}}%s{{/strong}}.',
 								'woocommerce-admin'
 							),
-							pluginNames
+							pluginNamesString
 						),
 						components: {
 							strong: <strong />,
@@ -270,7 +275,7 @@ class Start extends Component {
 						className="woocommerce-profile-wizard__skip"
 						onClick={ () => this.setState( { showUsageModal: true, continueAction: 'skip' } ) }
 					>
-						{ sprintf( __( 'Proceed without %s', 'woocommerce-admin' ), pluginNames ) }
+						{ sprintf( __( 'Proceed without %s', 'woocommerce-admin' ), pluginNamesString ) }
 					</Button>
 				</p>
 			</Fragment>


### PR DESCRIPTION
Closes #3063.

This PR updates the start page to handle Jetpack being disconnected. Previously, we didn't check the status and just assumed activated == connected, so the user would miss out on being able to connect up front.

Now a special case is handled for if both plugins are active but still need connection.

It also fixes the store step redirect URL.

To Test:
* Disconnect Jetpack but make sure it and WooCommerce Services are active
* Go to the start page of the profile wizard. You should see Jetpack benefits. Click continue and you should be redirect into the connection flow (no activate / install prompt).
* Optional: Test with other combinations of the plugins active/deactivated.