### PR TITLE
Onboarding: Add no product option to product count dropdown

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -203,6 +203,10 @@ class BusinessDetails extends Component {
 	render() {
 		const productCountOptions = [
 			{
+				key: '0',
+				label: __( "I don't have any products yet.", 'woocommerce-admin' ),
+			},
+			{
 				key: '1-10',
 				label: this.getNumberRangeString( 1, 10 ),
 			},

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -266,6 +266,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 				'enum'              => array(
+					'0',
 					'1-10',
 					'11-100',
 					'101-1000',


### PR DESCRIPTION
Fixes #3080

Adds a "0" product count option to the Business Details step of the profiler.

### Screenshots
<img width="547" alt="Screen Shot 2019-10-23 at 1 31 45 PM" src="https://user-images.githubusercontent.com/10561050/67360839-8b74cd80-f599-11e9-892f-409e6a8f7b7a.png">

### Detailed test instructions:

1. Go to the Business Details step of the profiler. `wp-admin/admin.php?page=wc-admin&step=business-details`
2. Select "I don't have any products yet."
3. Continue to the next step after filling in required fields.
4. Make sure the profiler data is recorded and updated correctly ( wp_options name: `wc_onboarding_profile`)