### PR TITLE
Left align dropdown button text in SelectControl

### DIFF
--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -122,6 +122,7 @@
 		padding: $gap;
 		min-height: 56px;
 		font-size: 16px;
+		text-align: left;
 
 		&.is-selected,
 		&:hover {


### PR DESCRIPTION
Fixes #3082

Left aligns all button text in `SelectControl` dropdowns.

### Before
<img width="471" alt="Screen Shot 2019-10-23 at 1 39 57 PM" src="https://user-images.githubusercontent.com/10561050/67361279-b875b000-f59a-11e9-87df-1e01884998e8.png">

### After
<img width="473" alt="Screen Shot 2019-10-23 at 1 39 28 PM" src="https://user-images.githubusercontent.com/10561050/67361285-bad80a00-f59a-11e9-8799-7ac6d23942bb.png">

### Detailed test instructions:

1. Open the "Business Details" step of the onboarding profiler (or any `SelectControl` with text long enough to extend 2 lines).
2. Make sure text is left aligned in options with text that extends over 2 lines or more.