### PR TITLE
Address revenue discrepancies

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -25,7 +25,7 @@ export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net Revenue', 'woocommerce-admin' ),
+		label: __( 'Net Product Revenue', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -25,7 +25,7 @@ export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net Product Revenue', 'woocommerce-admin' ),
+		label: __( 'Net Sales', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -123,7 +123,7 @@ class CategoriesReportTable extends Component {
 				value: numberFormat( items_sold ),
 			},
 			{
-				label: __( 'net product revenue', 'woocommerce-admin' ),
+				label: __( 'net sales', 'woocommerce-admin' ),
 				value: formatCurrency( net_revenue ),
 			},
 			{

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -123,7 +123,7 @@ class CategoriesReportTable extends Component {
 				value: numberFormat( items_sold ),
 			},
 			{
-				label: __( 'net revenue', 'woocommerce-admin' ),
+				label: __( 'net product revenue', 'woocommerce-admin' ),
 				value: formatCurrency( net_revenue ),
 			},
 			{

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -25,7 +25,7 @@ export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net Product Revenue', 'woocommerce-admin' ),
+		label: __( 'Net Sales', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -25,7 +25,7 @@ export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 	},
 	{
 		key: 'net_revenue',
-		label: __( 'Net Revenue', 'woocommerce-admin' ),
+		label: __( 'Net Product Revenue', 'woocommerce-admin' ),
 		order: 'desc',
 		orderby: 'net_revenue',
 		type: 'currency',

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -227,7 +227,7 @@ class ProductsReportTable extends Component {
 				value: numberFormat( items_sold ),
 			},
 			{
-				label: __( 'net product revenue', 'woocommerce-admin' ),
+				label: __( 'net sales', 'woocommerce-admin' ),
 				value: formatCurrency( net_revenue ),
 			},
 			{

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -227,7 +227,7 @@ class ProductsReportTable extends Component {
 				value: numberFormat( items_sold ),
 			},
 			{
-				label: __( 'net revenue', 'woocommerce-admin' ),
+				label: __( 'net product revenue', 'woocommerce-admin' ),
 				value: formatCurrency( net_revenue ),
 			},
 			{

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -427,7 +427,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$tax_amount += isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : 0;
 			}
 
-			$net_revenue = round( $order_item->get_subtotal( 'edit' ), $decimals );
+			$net_revenue = round( $order_item->get_total( 'edit' ), $decimals );
 			if ( $round_tax ) {
 				$tax_amount = round( $tax_amount, $decimals );
 			}

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -402,6 +402,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$order_items = $order->get_items();
 		$num_updated = 0;
+		$decimals    = wc_get_price_decimals();
+		$round_tax   = 'no' === get_option( 'woocommerce_tax_round_at_subtotal' );
 
 		foreach ( $order_items as $order_item ) {
 			$order_item_id       = $order_item->get_id();
@@ -425,7 +427,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$tax_amount += isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : 0;
 			}
 
-			$net_revenue = $order_item->get_subtotal( 'edit' );
+			$net_revenue = round( $order_item->get_subtotal( 'edit' ), $decimals );
+			if ( $round_tax ) {
+				$tax_amount = round( $tax_amount, $decimals );
+			}
 
 			$result = $wpdb->replace(
 				$wpdb->prefix . self::TABLE_NAME,

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -401,7 +401,7 @@ class ReportsSync {
 			$wpdb->prepare(
 				"SELECT ID FROM {$wpdb->posts}
 				WHERE post_type IN ( 'shop_order', 'shop_order_refund' )
-				AND post_status NOT IN ( 'auto-draft', 'trash' )
+				AND post_status NOT IN ( 'wc-auto-draft', 'auto-draft', 'trash' )
 				{$where_clause}
 				ORDER BY post_date ASC
 				LIMIT %d


### PR DESCRIPTION
Fixes #2855
See #2918

This PR addresses the revenue discrepancies between Product and Order revenue totals. Categories use Product totals and Revenue uses Order totals.

This PR makes the following changes:
- Re-label the product revenue total on the Product/Categories screens to `Net Product Revenue`

Product revenue does not include coupons, fees, or partial refunds (existing stores may have flat amount refunds not applied to products). If we were to include these amounts in the report total, then the sum of net revenue in the table would not sum to the totals in the header/footer. 

- Exclude `wc-auto-draft` orders from import

The amounts on these orders were being included in the product revenue but excluded from the order revenue.

- Round product line item total amounts on product lookup for tax inclusive pricing. If WC is configured to round tax on the line item, then the tax is also rounded.

This change only affects sites that have tax inclusive pricing. With tax inclusive pricing the line items totals on the order contain unrounded currency fractions. It only takes a few of these to produce a total discrepancy.

### Detailed test instructions:

- On `master`
- Set WC to tax inclusive pricing
- Set a tax rate of 11% or more
- Use `wc-smooth-generator` to generate 10-20 orders
- Add a partial refund to one of the orders
- Create a manual order and apply a fixed amount coupon
- Create a second order and set the product price to 1/2 of the regular price when adding the line item (for #2918)
- Run the jobs to import the orders
- Load the Product & Order Analytics for today, note discrepancies
- Switch to this PR
- Re-import your data with Skip existing unchecked
- Compare Product & Order Analytics for today

### Changelog Note:

Fix: Address discrepancies in Revenue totals between Analytics screens.