### PR TITLE
Add tracking to inbox note views.

### DIFF
--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -1,0 +1,71 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import { ActivityCard } from '../../activity-card';
+import NoteAction from './action';
+import sanitizeHTML from 'lib/sanitize-html';
+import classnames from 'classnames';
+
+class InboxNoteCard extends Component {
+	render() {
+		const { lastRead, note } = this.props;
+
+		const getButtonsFromActions = () => {
+			if ( ! note.actions ) {
+				return [];
+			}
+			return note.actions.map( action => <NoteAction noteId={ note.id } action={ action } /> );
+		};
+
+		return (
+			<ActivityCard
+				key={ note.id }
+				className={ classnames( 'woocommerce-inbox-activity-card', {
+					actioned: 'unactioned' !== note.status,
+				} ) }
+				title={ note.title }
+				date={ note.date_created }
+				icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
+				unread={
+					! lastRead ||
+					! note.date_created_gmt ||
+					new Date( note.date_created_gmt + 'Z' ).getTime() > lastRead
+				}
+				actions={ getButtonsFromActions( note ) }
+			>
+				<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />
+			</ActivityCard>
+		);
+	}
+}
+
+InboxNoteCard.propTypes = {
+	note: PropTypes.shape( {
+		id: PropTypes.number,
+		status: PropTypes.string,
+		title: PropTypes.string,
+		icon: PropTypes.string,
+		content: PropTypes.string,
+		date_created: PropTypes.string,
+		date_created_gmt: PropTypes.string,
+		actions: PropTypes.arrayOf(
+			PropTypes.shape( {
+				id: PropTypes.number.isRequired,
+				url: PropTypes.string,
+				label: PropTypes.string.isRequired,
+				primary: PropTypes.bool.isRequired,
+			} )
+		),
+	} ),
+	lastRead: PropTypes.number,
+};
+
+export default InboxNoteCard;

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -27,9 +27,21 @@ class InboxNoteCard extends Component {
 	onVisible( isVisible ) {
 		if ( isVisible && ! this.hasBeenSeen ) {
 			const { note } = this.props;
-			const { content, name, title } = note;
+			const {
+				content: note_content,
+				name: note_name,
+				title: note_title,
+				type: note_type,
+				icon: note_icon,
+			} = note;
 
-			recordEvent( 'inbox_note_view', { content, name, title } );
+			recordEvent( 'inbox_note_view', {
+				note_content,
+				note_name,
+				note_title,
+				note_type,
+				note_icon,
+			} );
 
 			this.hasBeenSeen = true;
 		}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -56,7 +56,9 @@ class InboxPanel extends Component {
 
 		const notesArray = Object.keys( notes ).map( key => notes[ key ] );
 
-		return notesArray.map( note => <InboxNoteCard note={ note } lastRead={ lastRead } /> );
+		return notesArray.map( note => (
+			<InboxNoteCard key={ note.id } note={ note } lastRead={ lastRead } />
+		) );
 	}
 
 	render() {

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -13,12 +13,10 @@ import { withDispatch } from '@wordpress/data';
  */
 import { ActivityCard, ActivityCardPlaceholder } from '../../activity-card';
 import ActivityHeader from '../../activity-header';
-import NoteAction from './action';
+import InboxNoteCard from './card';
 import { EmptyContent, Section } from '@woocommerce/components';
-import sanitizeHTML from 'lib/sanitize-html';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
-import classnames from 'classnames';
 
 class InboxPanel extends Component {
 	constructor( props ) {
@@ -56,36 +54,9 @@ class InboxPanel extends Component {
 			return this.renderEmptyCard();
 		}
 
-		const getButtonsFromActions = note => {
-			if ( ! note.actions ) {
-				return [];
-			}
-			return note.actions.map( action => (
-				<NoteAction noteId={ note.id } action={ action } />
-			) );
-		};
-
 		const notesArray = Object.keys( notes ).map( key => notes[ key ] );
 
-		return notesArray.map( note => (
-			<ActivityCard
-				key={ note.id }
-				className={ classnames( 'woocommerce-inbox-activity-card', {
-					actioned: 'unactioned' !== note.status,
-				} ) }
-				title={ note.title }
-				date={ note.date_created }
-				icon={ <Gridicon icon={ note.icon } size={ 48 } /> }
-				unread={
-					! lastRead ||
-					! note.date_created_gmt ||
-					new Date( note.date_created_gmt + 'Z' ).getTime() > lastRead
-				}
-				actions={ getButtonsFromActions( note ) }
-			>
-				<span dangerouslySetInnerHTML={ sanitizeHTML( note.content ) } />
-			</ActivityCard>
-		) );
+		return notesArray.map( note => <InboxNoteCard note={ note } lastRead={ lastRead } /> );
 	}
 
 	render() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9413,8 +9413,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -9435,14 +9434,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9457,20 +9454,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9587,8 +9581,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -9600,7 +9593,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9615,7 +9607,6 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9623,14 +9614,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9649,7 +9638,6 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9730,8 +9718,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9743,7 +9730,6 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9829,8 +9815,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "optional": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9866,7 +9851,6 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9886,7 +9870,6 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9930,14 +9913,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -17056,6 +17037,14 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-visibility-sensor": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
+      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-with-direction": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "react-dates": "17.2.0",
     "react-router-dom": "5.1.0",
     "react-transition-group": "2.9.0",
+    "react-visibility-sensor": "5.1.1",
     "redux": "4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #2939.

This PR seeks to introduce a new Tracks event that fires when Inbox Notes are viewed. The ultimate goal is to determine each note's conversion rate.

To accomplish this goal, a new dependency was added: [`react-visibility-sensor`](https://www.npmjs.com/package/react-visibility-sensor).

This PR is based off the work in https://github.com/woocommerce/woocommerce-admin/pull/3039 since it introduces a bespoke `<InboxNoteCard>` component.

### Detailed test instructions:

- Open your developer console
- Open the Activity Panel, go to Inbox
- Verify that a Tracks event fires for each note visible in the panel
- Scroll down in the panel
- Verify that any newly visible notes have a Tracks event fired for them
- Verify that scrolling back up in the panel does not fire extra events for the previously seen notes

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: track inbox note views.
