### PR TITLE
Onboarding: Sort WC themes by ID

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -172,6 +172,12 @@ class Onboarding {
 
 			if ( ! is_wp_error( $theme_data ) ) {
 				$theme_data = json_decode( $theme_data['body'] );
+				usort( $theme_data->products, function ($product_1, $product_2) {
+					if ( 'Storefront' === $product_1->slug ) {
+						return -1;
+					}
+					return $product_1->id < $product_2->id ? 1 : -1;
+				} );
 
 				foreach ( $theme_data->products as $theme ) {
 					$slug                                       = sanitize_title( $theme->slug );


### PR DESCRIPTION
Fixes #3076

Sorts themes by ID (which should be mostly the same as sorting by "newest") since date is not a sorting option in the WC themes API.

### Screenshots
<img width="870" alt="Screen Shot 2019-10-24 at 7 55 46 AM" src="https://user-images.githubusercontent.com/10561050/67442545-ce837f00-f633-11e9-9bfc-1479c70d2870.png">

### Detailed test instructions:

1. Delete the `wc_onboarding_themes` transient.
2. Load the themes step of the onboarding profiler. `wp-admin/admin.php?page=wc-admin&step=theme`
3. Make sure the theme order comes out to:
* Active theme
* Storefront
* Newest to oldest WC themes
