### PR TITLE
Update payments task based on feebback

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -136,7 +136,11 @@ class TaskDashboard extends Component {
 				<i className="material-icons-outlined">{ task.icon }</i>
 			);
 			task.after = <i className="material-icons-outlined">chevron_right</i>;
-			task.onClick = () => updateQueryString( { task: task.key } );
+
+			if ( ! task.onClick ) {
+				task.onClick = () => updateQueryString( { task: task.key } );
+			}
+
 			return task;
 		} );
 

--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -12,6 +12,7 @@ import { get } from 'lodash';
  * WooCommerce dependencies
  */
 import { getSetting } from '@woocommerce/wc-admin-settings';
+import { updateQueryString, getAdminLink } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -113,6 +114,13 @@ export function getTasks( { profileItems, options, query } ) {
 			icon: 'payment',
 			container: <Payments />,
 			completed: paymentsCompleted,
+			onClick: () => {
+				if ( paymentsCompleted ) {
+					window.location = getAdminLink( 'admin.php?page=wc-settings&tab=checkout' );
+					return;
+				}
+				updateQueryString( { task: 'payments' } );
+			},
 			visible: true,
 		},
 	];

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -97,9 +97,48 @@ class Payments extends Component {
 		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
 
+	isStripeEnabledByDefault() {
+		const { countryCode } = this.props;
+		// Stripe should be checked by default in the following countries: https://stripe.com/global.
+		const supportedCountries = [
+			'AU',
+			'AT',
+			'BE',
+			'CA',
+			'DK',
+			'EE',
+			'FI',
+			'FR',
+			'DE',
+			'GR',
+			'HK',
+			'IE',
+			'IT',
+			'JP',
+			'LV',
+			'LT',
+			'LU',
+			'MY',
+			'NL',
+			'NZ',
+			'NO',
+			'PL',
+			'PT',
+			'SG',
+			'SK',
+			'SI',
+			'ES',
+			'SE',
+			'CH',
+			'GB',
+			'US',
+		];
+		return supportedCountries.includes( countryCode );
+	}
+
 	getInitialValues() {
 		const values = {
-			stripe: false,
+			stripe: this.isStripeEnabledByDefault(),
 			paypal: false,
 			klarna_checkout: false,
 			klarna_payments: false,
@@ -451,7 +490,6 @@ class Payments extends Component {
 
 	render() {
 		const { step, methodRequestPending } = this.state;
-		const { isSettingsRequesting } = this.props;
 		return (
 			<Form
 				initialValues={ this.getInitialValues() }
@@ -465,7 +503,7 @@ class Payments extends Component {
 							<Card className="is-narrow">
 								<Stepper
 									isVertical
-									isPending={ methodRequestPending || isSettingsRequesting || 'install' === step }
+									isPending={ methodRequestPending || 'install' === step }
 									currentStep={ step }
 									steps={ this.getSteps() }
 								/>
@@ -480,22 +518,15 @@ class Payments extends Component {
 
 export default compose(
 	withSelect( select => {
-		const {
-			getSettings,
-			getSettingsError,
-			isGetSettingsRequesting,
-			getProfileItems,
-			isJetpackConnected,
-			getActivePlugins,
-			getOptions,
-		} = select( 'wc-api' );
+		const { getProfileItems, isJetpackConnected, getActivePlugins, getOptions } = select(
+			'wc-api'
+		);
 
-		const settings = getSettings( 'general' );
-		const isSettingsError = Boolean( getSettingsError( 'general' ) );
-		const isSettingsRequesting = isGetSettingsRequesting( 'general' );
-		const countryCode = getCountryCode( settings.woocommerce_default_country );
-
-		const options = getOptions( [ 'woocommerce_onboarding_payments' ] );
+		const options = getOptions( [
+			'woocommerce_onboarding_payments',
+			'woocommerce_default_country',
+		] );
+		const countryCode = getCountryCode( options.woocommerce_default_country );
 
 		const methods = get( options, [ 'woocommerce_onboarding_payments', 'methods' ], [] );
 		const installed = get( options, [ 'woocommerce_onboarding_payments', 'installed' ], false );
@@ -505,9 +536,6 @@ export default compose(
 
 		return {
 			countryCode,
-			isSettingsError,
-			isSettingsRequesting,
-			settings,
 			profileItems: getProfileItems(),
 			activePlugins: getActivePlugins(),
 			isJetpackConnected: isJetpackConnected(),

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -16,7 +16,7 @@ import { withDispatch } from '@wordpress/data';
  */
 import { Form, Card, Stepper, TextControl, List } from '@woocommerce/components';
 import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
-import { WC_ASSET_URL as wcAssetUrl } from '@woocommerce/wc-admin-settings';
+import { WC_ASSET_URL as wcAssetUrl, getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -97,48 +97,16 @@ class Payments extends Component {
 		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
 
-	isStripeEnabledByDefault() {
+	isStripeEnabled() {
 		const { countryCode } = this.props;
-		// Stripe should be checked by default in the following countries: https://stripe.com/global.
-		const supportedCountries = [
-			'AU',
-			'AT',
-			'BE',
-			'CA',
-			'DK',
-			'EE',
-			'FI',
-			'FR',
-			'DE',
-			'GR',
-			'HK',
-			'IE',
-			'IT',
-			'JP',
-			'LV',
-			'LT',
-			'LU',
-			'MY',
-			'NL',
-			'NZ',
-			'NO',
-			'PL',
-			'PT',
-			'SG',
-			'SK',
-			'SI',
-			'ES',
-			'SE',
-			'CH',
-			'GB',
-			'US',
-		];
-		return supportedCountries.includes( countryCode );
+		const stripeCountries = getSetting( 'onboarding', { stripeSupportedCountries: [] } )
+			.stripeSupportedCountries;
+		return stripeCountries.includes( countryCode );
 	}
 
 	getInitialValues() {
 		const values = {
-			stripe: this.isStripeEnabledByDefault(),
+			stripe: this.isStripeEnabled(),
 			paypal: false,
 			klarna_checkout: false,
 			klarna_payments: false,
@@ -252,7 +220,7 @@ class Payments extends Component {
 				),
 				before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
 				after: <FormToggle { ...getInputProps( 'stripe' ) } />,
-				visible: true,
+				visible: this.isStripeEnabled(),
 			},
 			{
 				key: 'paypal',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -362,6 +362,7 @@ class Onboarding {
 		$options[] = 'woocommerce_onboarding_payments';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
+		$options[] = 'woocommerce_default_country';
 
 		return $options;
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -389,12 +389,7 @@ class Onboarding {
 	 * @return array
 	 */
 	private static function get_stripe_supported_countries() {
-		$wc_countries = WC()->countries;
-		if ( method_exists( $wc_countries, 'get_stripe_supported_countries' ) ) {
-			return $wc_countries->get_stripe_supported_countries();
-		}
-
-		// @todo Remove this fallback once we are targeting a version of WooCommerce with the above method. https://github.com/woocommerce/woocommerce/pull/24897.
+		// https://stripe.com/global.
 		return array(
 			'AU', 'AT', 'BE', 'CA', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HK', 'IE', 'IT', 'JP', 'LV', 'LT', 'LU', 'MY', 'NL', 'NZ', 'NO',
 			'PL', 'PT', 'SG', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB', 'US',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -338,7 +338,8 @@ class Onboarding {
 
 		// Only fetch if the onboarding wizard OR the task list is incomplete.
 		if ( self::should_show_profiler() || self::should_show_tasks() ) {
-			$settings['onboarding']['activePlugins'] = self::get_active_plugins();
+			$settings['onboarding']['activePlugins']            = self::get_active_plugins();
+			$settings['onboarding']['stripeSupportedCountries'] = self::get_stripe_supported_countries();
 		}
 
 		return $settings;
@@ -379,6 +380,25 @@ class Onboarding {
 		}
 		$endpoints['jetpackStatus'] = '/jetpack/v4/connection';
 		return $endpoints;
+	}
+
+	/**
+	 * Returns a list of Stripe supported countries. This method can be removed once merged to core.
+	 *
+	 * @param array $endpoints Array of preloaded endpoints.
+	 * @return array
+	 */
+	private static function get_stripe_supported_countries() {
+		$wc_countries = WC()->countries;
+		if ( method_exists( $wc_countries, 'get_stripe_supported_countries' ) ) {
+			return $wc_countries->get_stripe_supported_countries();
+		}
+
+		// @todo Remove this fallback once we are targeting a version of WooCommerce with the above method. https://github.com/woocommerce/woocommerce/pull/24897.
+		return array(
+			'AU', 'AT', 'BE', 'CA', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HK', 'IE', 'IT', 'JP', 'LV', 'LT', 'LU', 'MY', 'NL', 'NZ', 'NO',
+			'PL', 'PT', 'SG', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB', 'US',
+		);
 	}
 
 	/**


### PR DESCRIPTION
See Paul's comment here: p90Yrv-1iA-p2 #comment-2683.

This PR makes the following updates to the payments task:

* Stripe is enabled by default in supported countries (https://stripe.com/global).
* When the payment task is completed, clicking on the completed task will take you to payment settings instead of rerunning the task. I agree with Paul's feedback here that clicking the task should allow you to update the current settings instead of rerunning the wizard.

To Test:
* Delete the `woocommerce_onboarding_payments` option.
* Set your country under WooCommerce Settings to one of the supported stripe countries.
* Go to the payment task and verify that the option is pre-checked.
* Complete the task.
* Click the completed task and see you are taken to payment settings.