### PR TITLE
Add an autofill option to SelectControl

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -94,6 +94,7 @@ export function StoreAddress( props ) {
 			/>
 
 			<SelectControl
+				autofill="country_state"
 				label={ __( 'Country / State', 'woocommerce-admin' ) }
 				required
 				options={ countryStateOptions }

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { escapeRegExp } from 'lodash';
 import { Fragment } from '@wordpress/element';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -83,22 +83,30 @@ export function getCountryStateAutofill( options, countryState, setValue ) {
 	const [ autofillCountry, setAutofillCountry ] = useState( '' );
 	const [ autofillState, setAutofillState ] = useState( '' );
 
-	let filteredOptions = [];
-	if ( autofillState.length || autofillCountry.length ) {
-		const countrySearch = new RegExp( escapeRegExp( autofillCountry.replace( /\s/g, '' ) ), 'i' );
-		filteredOptions = options.filter( option =>
-			countrySearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
-		);
-	}
-	if ( autofillCountry.length && autofillState.length ) {
-		const stateSearch = new RegExp( escapeRegExp( autofillState.replace( /\s/g, '' ) ), 'i' );
-		filteredOptions = filteredOptions.filter( option =>
-			stateSearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
-		);
-	}
-	if ( 1 === filteredOptions.length && countryState !== filteredOptions[ 0 ].key ) {
-		setValue( 'countryState', filteredOptions[ 0 ].key );
-	}
+	useEffect(
+		() => {
+			let filteredOptions = [];
+			if ( autofillState.length || autofillCountry.length ) {
+				const countrySearch = new RegExp(
+					escapeRegExp( autofillCountry.replace( /\s/g, '' ) ),
+					'i'
+				);
+				filteredOptions = options.filter( option =>
+					countrySearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
+				);
+			}
+			if ( autofillCountry.length && autofillState.length ) {
+				const stateSearch = new RegExp( escapeRegExp( autofillState.replace( /\s/g, '' ) ), 'i' );
+				filteredOptions = filteredOptions.filter( option =>
+					stateSearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
+				);
+			}
+			if ( 1 === filteredOptions.length && countryState !== filteredOptions[ 0 ].key ) {
+				setValue( 'countryState', filteredOptions[ 0 ].key );
+			}
+		},
+		[ autofillCountry, autofillState ]
+	);
 
 	return (
 		<Fragment>

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -155,19 +155,19 @@ export function StoreAddress( props ) {
 				{ ...getInputProps( 'addressLine2' ) }
 			/>
 
-			{ getCountryStateAutofill(
-				countryStateOptions,
-				getInputProps( 'countryState' ).value,
-				setValue
-			) }
-
 			<SelectControl
 				label={ __( 'Country / State', 'woocommerce-admin' ) }
 				required
 				options={ countryStateOptions }
 				isSearchable
 				{ ...getInputProps( 'countryState' ) }
-			/>
+			>
+				{ getCountryStateAutofill(
+					countryStateOptions,
+					getInputProps( 'countryState' ).value,
+					setValue
+				) }
+			</SelectControl>
 
 			<TextControl
 				label={ __( 'City', 'woocommerce-admin' ) }

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -4,7 +4,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useMemo } from 'react';
+import { escapeRegExp } from 'lodash';
+import { Fragment } from '@wordpress/element';
+import { useMemo, useState } from 'react';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -70,13 +72,65 @@ export function getCountryStateOptions() {
 }
 
 /**
+ * Get the autofill countryState fields and set value from filtered options.
+ *
+ * @param {Array} options Array of filterable options.
+ * @param {String} countryState The value of the countryState field.
+ * @param {Function} setValue Set value of the countryState input.
+ * @return {Object} React component.
+ */
+export function getCountryStateAutofill( options, countryState, setValue ) {
+	const [ autofillCountry, setAutofillCountry ] = useState( '' );
+	const [ autofillState, setAutofillState ] = useState( '' );
+
+	let filteredOptions = [];
+	if ( autofillState.length || autofillCountry.length ) {
+		const countrySearch = new RegExp( escapeRegExp( autofillCountry.replace( /\s/g, '' ) ), 'i' );
+		filteredOptions = options.filter( option =>
+			countrySearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
+		);
+	}
+	if ( autofillCountry.length && autofillState.length ) {
+		const stateSearch = new RegExp( escapeRegExp( autofillState.replace( /\s/g, '' ) ), 'i' );
+		filteredOptions = filteredOptions.filter( option =>
+			stateSearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
+		);
+	}
+	if ( 1 === filteredOptions.length && countryState !== filteredOptions[ 0 ].key ) {
+		setValue( 'countryState', filteredOptions[ 0 ].key );
+	}
+
+	return (
+		<Fragment>
+			<input
+				onChange={ event => setAutofillCountry( event.target.value ) }
+				value={ autofillCountry }
+				name="country"
+				type="text"
+				className="woocommerce-select-control__autofill-input"
+				tabIndex="-1"
+			/>
+
+			<input
+				onChange={ event => setAutofillState( event.target.value ) }
+				value={ autofillState }
+				name="state"
+				type="text"
+				className="woocommerce-select-control__autofill-input"
+				tabIndex="-1"
+			/>
+		</Fragment>
+	);
+}
+
+/**
  * Store address fields.
  *
  * @param {Object} props Props for input components.
  * @return {Object} -
  */
 export function StoreAddress( props ) {
-	const { getInputProps } = props;
+	const { getInputProps, setValue } = props;
 	const countryStateOptions = useMemo( () => getCountryStateOptions(), [] );
 
 	return (
@@ -93,8 +147,13 @@ export function StoreAddress( props ) {
 				{ ...getInputProps( 'addressLine2' ) }
 			/>
 
+			{ getCountryStateAutofill(
+				countryStateOptions,
+				getInputProps( 'countryState' ).value,
+				setValue
+			) }
+
 			<SelectControl
-				autofill="country_state"
 				label={ __( 'Country / State', 'woocommerce-admin' ) }
 				required
 				options={ countryStateOptions }

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -110,7 +110,7 @@ class StoreDetails extends Component {
 						onSubmitCallback={ this.onSubmit }
 						validate={ validateStoreAddress }
 					>
-						{ ( { getInputProps, handleSubmit, values, isValidForm } ) => (
+						{ ( { getInputProps, handleSubmit, values, isValidForm, setValue } ) => (
 							<Fragment>
 								{ showUsageModal && (
 									<UsageModal
@@ -118,7 +118,7 @@ class StoreDetails extends Component {
 										onClose={ () => this.setState( { showUsageModal: false } ) }
 									/>
 								) }
-								<StoreAddress getInputProps={ getInputProps } />
+								<StoreAddress getInputProps={ getInputProps } setValue={ setValue } />
 								<CheckboxControl
 									label={ __( "I'm setting up a store for a client", 'woocommerce-admin' ) }
 									{ ...getInputProps( 'isClient' ) }

--- a/client/dashboard/task-list/tasks/steps/location.js
+++ b/client/dashboard/task-list/tasks/steps/location.js
@@ -81,9 +81,9 @@ export default class StoreLocation extends Component {
 				onSubmitCallback={ this.onSubmit }
 				validate={ validateStoreAddress }
 			>
-				{ ( { getInputProps, handleSubmit } ) => (
+				{ ( { getInputProps, handleSubmit, setValue } ) => (
 					<Fragment>
-						<StoreAddress getInputProps={ getInputProps } />
+						<StoreAddress getInputProps={ getInputProps } setValue={ setValue } />
 						<Button isPrimary onClick={ handleSubmit }>
 							{ __( 'Continue', 'woocommerce-admin' ) }
 						</Button>

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -110,6 +110,7 @@ class Control extends Component {
 
 		return (
 			<input
+				autoComplete="off"
 				className="woocommerce-select-control__control-input"
 				id={ `woocommerce-select-control-${ instanceId }__control-input` }
 				ref={ this.input }

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -134,14 +134,14 @@ class Control extends Component {
 	}
 
 	getInputValue() {
-		const { isSearchable, multiple, query, selected } = this.props;
+		const { isFocused, isSearchable, multiple, query, selected } = this.props;
 		const selectedValue = selected.length ? selected[ 0 ].label : '';
 
 		if ( ! isSearchable && multiple ) {
 			return '';
 		}
 
-		return isSearchable ? query : selectedValue;
+		return isSearchable && isFocused ? query : selectedValue;
 	}
 
 	render() {

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -238,7 +238,15 @@ export class SelectControl extends Component {
 	}
 
 	render() {
-		const { autofill, className, inlineTags, instanceId, isSearchable, options } = this.props;
+		const {
+			autofill,
+			children,
+			className,
+			inlineTags,
+			instanceId,
+			isSearchable,
+			options,
+		} = this.props;
 		const { isExpanded, isFocused, selectedIndex } = this.state;
 
 		const hasTags = this.hasTags();
@@ -266,6 +274,7 @@ export class SelectControl extends Component {
 						tabIndex="-1"
 					/>
 				) }
+				{ children }
 				<Control
 					{ ...this.props }
 					{ ...this.state }
@@ -305,6 +314,10 @@ SelectControl.propTypes = {
 	 * Name to use for the autofill field, not used if no string is passed.
 	 */
 	autofill: PropTypes.string,
+	/**
+	 * A renderable component (or string) which will be displayed before the `Control` of this component.
+	 */
+	children: PropTypes.node,
 	/**
 	 * Class name applied to parent div.
 	 */

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -25,6 +25,7 @@ export class SelectControl extends Component {
 	static getInitialState() {
 		return {
 			isExpanded: false,
+			isFocused: false,
 			query: '',
 		};
 	}
@@ -199,7 +200,7 @@ export class SelectControl extends Component {
 
 	search( query ) {
 		const { hideBeforeSearch, onSearch, options } = this.props;
-		this.setState( { query } );
+		this.setState( { query, isFocused: true } );
 
 		const promise = ( this.activePromise = Promise.resolve( onSearch( options, query ) ).then(
 			searchOptions => {
@@ -238,7 +239,7 @@ export class SelectControl extends Component {
 
 	render() {
 		const { autofill, className, inlineTags, instanceId, isSearchable, options } = this.props;
-		const { isExpanded, selectedIndex } = this.state;
+		const { isExpanded, isFocused, selectedIndex } = this.state;
 
 		const hasTags = this.hasTags();
 		const { key: selectedKey = '' } = options[ selectedIndex ] || {};
@@ -251,6 +252,7 @@ export class SelectControl extends Component {
 			<div
 				className={ classnames( 'woocommerce-select-control', className, {
 					'has-inline-tags': hasTags && inlineTags,
+					'is-focused': isFocused,
 					'is-searchable': isSearchable,
 				} ) }
 				ref={ this.bindNode }

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -40,6 +40,7 @@ export class SelectControl extends Component {
 		this.bindNode = this.bindNode.bind( this );
 		this.decrementSelectedIndex = this.decrementSelectedIndex.bind( this );
 		this.incrementSelectedIndex = this.incrementSelectedIndex.bind( this );
+		this.onAutofillChange = this.onAutofillChange.bind( this );
 		this.search = this.search.bind( this );
 		this.selectOption = this.selectOption.bind( this );
 		this.setExpanded = this.setExpanded.bind( this );
@@ -226,8 +227,17 @@ export class SelectControl extends Component {
 		) );
 	}
 
+	onAutofillChange( event ) {
+		const { options } = this.props;
+		const filteredOptions = this.getFilteredOptions( options, event.target.value );
+
+		if ( 1 === filteredOptions.length ) {
+			this.selectOption( filteredOptions[ 0 ] );
+		}
+	}
+
 	render() {
-		const { className, inlineTags, instanceId, isSearchable, options } = this.props;
+		const { autofill, className, inlineTags, instanceId, isSearchable, options } = this.props;
 		const { isExpanded, selectedIndex } = this.state;
 
 		const hasTags = this.hasTags();
@@ -245,6 +255,15 @@ export class SelectControl extends Component {
 				} ) }
 				ref={ this.bindNode }
 			>
+				{ autofill && (
+					<input
+						onChange={ this.onAutofillChange }
+						name={ autofill }
+						type="text"
+						className="woocommerce-select-control__autofill-input"
+						tabIndex="-1"
+					/>
+				) }
 				<Control
 					{ ...this.props }
 					{ ...this.state }
@@ -280,6 +299,10 @@ export class SelectControl extends Component {
 }
 
 SelectControl.propTypes = {
+	/**
+	 * Name to use for the autofill field, not used if no string is passed.
+	 */
+	autofill: PropTypes.string,
 	/**
 	 * Class name applied to parent div.
 	 */
@@ -380,6 +403,7 @@ SelectControl.propTypes = {
 };
 
 SelectControl.defaultProps = {
+	autofill: null,
 	excludeSelectedOptions: true,
 	getSearchExpression: identity,
 	inlineTags: false,

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -75,6 +75,11 @@
 		}
 	}
 
+	.woocommerce-select-control__autofill-input {
+		position: absolute;
+		z-index: -1;
+	}
+
 	.woocommerce-select-control__tags {
 		position: relative;
 		margin: $gap-small 0;


### PR DESCRIPTION
Fixes #3102

Adds an `autofill` prop to `SelectControl` to attempt autofilling a field.  This PR:

* Will add an extra input positioned absolutely behind the base component.  Display and visibility CSS properties prevent autofill from occurring on a field in most browsers.
* Filters existing options in a list, but will not perform any async requests.
* Adds a prop to control the name of the field to encourage the correct autofill information from the browser.
* Selects an option if a single match is found from the list of options.

### Screenshots
<img width="486" alt="Screen Shot 2019-10-25 at 3 46 55 PM" src="https://user-images.githubusercontent.com/10561050/67552948-b187a280-f73e-11e9-83a1-27712ed4b9d0.png">

### Detailed test instructions:

1. Create or find an existing `SelectControl` field with an `autofill` prop.
2.  Create autofill information that matches only one of your options in that `SelectControl`.
3.  Use the browser's autofill feature on another field.
4. Note that the actual `SelectControl` option is set after autofilling.