### PR TITLE
Onboarding: Add color to button text to pages with class woocommerce-page

### DIFF
--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -143,3 +143,13 @@
 		background-color: $studio-white;
 	}
 }
+
+body.woocommerce-page {
+	.components-button.is-button.is-primary {
+		color: $studio-white;
+
+		&:hover {
+			color: $studio-white;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3106 

Adds the white text color back to buttons outside of `.woocommerce-layout`.

### Before
<img width="631" alt="Screen Shot 2019-10-25 at 8 50 40 AM" src="https://user-images.githubusercontent.com/10561050/67557103-ffa0a400-f746-11e9-90eb-7dbfb5084751.png">

### After
<img width="648" alt="Screen Shot 2019-10-25 at 4 40 23 PM" src="https://user-images.githubusercontent.com/10561050/67557099-fe6f7700-f746-11e9-9c16-cd65d5f426ec.png">

### Detailed test instructions:

1. Enable the store profiler and go to the start page `wp-admin/admin.php?page=wc-admin` (Deactivate jetpack or wcs if the start page is unreachable).
2. Click "Get started."
3. Make sure the button text is white and no other styling issues exist.
4. Make sure this styling doesn't affect buttons outside of WooCommerce.