### PR TITLE
Add inbox note prompting to opt in to tracking

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -15,6 +15,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Extension;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Giving_Feedback_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 
 /**
  * WC_Admin_Events Class.
@@ -64,5 +65,6 @@ class Events {
 		WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();
 		WC_Admin_Notes_Facebook_Extension::possibly_add_facebook_note();
 		WC_Admin_Notes_Add_First_Product::possibly_add_first_product_note();
+		WC_Admin_Notes_Tracking_Opt_In::possibly_add_tracking_opt_in_note();
 	}
 }

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -15,6 +15,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Order_Milestones;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 
 /**
  * Feature plugin main class.
@@ -156,6 +157,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Order_Milestones();
 		new WC_Admin_Notes_Welcome_Message();
 		new WC_Admin_Notes_Facebook_Extension();
+		new WC_Admin_Notes_Tracking_Opt_In();
 	}
 
 	/**

--- a/src/Install.php
+++ b/src/Install.php
@@ -83,7 +83,9 @@ class Install {
 
 		delete_transient( 'wc_admin_installing' );
 
-		update_option( 'wc_admin_install_timestamp', time() );
+		// Use add_option() here to avoid overwriting this value with each
+		// plugin version update. We base plugin age off of this value.
+		add_option( 'wc_admin_install_timestamp', time() );
 		do_action( 'wc_admin_installed' );
 	}
 

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -75,6 +75,7 @@ class WC_Admin_Notes_Tracking_Opt_In {
 		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'tracking-dismiss', __( 'Dismiss', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, false );
 		$note->add_action( 'tracking-opt-in', __( 'Activate usage tracking', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 
 		$note->save();

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WooCommerce Admin Usage Tracking Opt In Note Provider.
+ *
+ * Adds a note to the merchant's inbox showing the benefits of the Facebook extension.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Tracking_Opt_In
+ */
+class WC_Admin_Notes_Tracking_Opt_In {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-usage-tracking-opt-in';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_admin_note_action_tracking-opt-in', array( $this, 'opt_in_to_tracking' ) );
+	}
+
+	/**
+	 * Possibly add Usage Tracking Opt In extension note.
+	 */
+	public static function possibly_add_tracking_opt_in_note() {
+		// Only show this note to stores that are opted out.
+		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			return;
+		}
+
+		// We want to show the note after one week.
+		if ( ! self::wc_admin_active_for( WEEK_IN_SECONDS ) ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+		
+		/* translators: 1: link to WooCommerce.com settings, 2: link to WooCommerce.com tracking documentation. */
+		$content_format = __(
+			'Gathering usage data allows us to improve WooCommerce. Your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. You can always visit the <a href="%1$s" target="_blank">Settings</a> and choose to stop sharing data. <a href="%2$s" target="_blank">Read more</a> about what data we collect.',
+			'woocommerce-admin'
+		);
+
+		$note_content = sprintf(
+			wp_kses(
+				$content_format,
+				array(
+					'a' => array(
+						'href'   => true,
+						'target' => true,
+					),
+				)
+			),
+			admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ),
+			'https://woocommerce.com/usage-tracking'
+		);
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Help WooCommerce improve with usage tracking', 'woocommerce-admin' ) );
+		$note->set_content( $note_content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'tracking-opt-in', __( 'Activate usage tracking', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+
+		$note->save();
+	}
+
+	/**
+	 * Opt in to usage tracking when note is actioned.
+	 *
+	 * @param WC_Admin_Note $note Note being acted upon.
+	 */
+	public function opt_in_to_tracking( $note ) {
+		if ( self::NOTE_NAME === $note->get_name() ) {
+			// Opt in to tracking and schedule the first data update.
+			// Same mechanism as in WC_Admin_Setup_Wizard::wc_setup_store_setup_save().
+			update_option( 'woocommerce_allow_tracking', 'yes' );
+			wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
+		}
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -54,24 +54,17 @@ class WC_Admin_Notes_Tracking_Opt_In {
 			return;
 		}
 		
-		/* translators: 1: link to WooCommerce.com settings, 2: link to WooCommerce.com tracking documentation. */
+		/* translators: 1: open link to WooCommerce.com settings, 2: open link to WooCommerce.com tracking documentation, 3: close link tag. */
 		$content_format = __(
-			'Gathering usage data allows us to improve WooCommerce. Your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. You can always visit the <a href="%1$s" target="_blank">Settings</a> and choose to stop sharing data. <a href="%2$s" target="_blank">Read more</a> about what data we collect.',
+			'Gathering usage data allows us to improve WooCommerce. Your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. You can always visit the %1$sSettings%3$s and choose to stop sharing data. %2$sRead more%3$s about what data we collect.',
 			'woocommerce-admin'
 		);
 
 		$note_content = sprintf(
-			wp_kses(
-				$content_format,
-				array(
-					'a' => array(
-						'href'   => true,
-						'target' => true,
-					),
-				)
-			),
-			admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ),
-			'https://woocommerce.com/usage-tracking'
+			$content_format,
+			'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ) ) . '" target="_blank">',
+			'<a href="https://woocommerce.com/usage-tracking" target="_blank">',
+			'</a>'
 		);
 
 		$note = new WC_Admin_Note();

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -53,7 +53,7 @@ class WC_Admin_Notes_Tracking_Opt_In {
 		if ( ! empty( $note_ids ) ) {
 			return;
 		}
-		
+
 		/* translators: 1: open link to WooCommerce.com settings, 2: open link to WooCommerce.com tracking documentation, 3: close link tag. */
 		$content_format = __(
 			'Gathering usage data allows us to improve WooCommerce. Your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. You can always visit the %1$sSettings%3$s and choose to stop sharing data. %2$sRead more%3$s about what data we collect.',


### PR DESCRIPTION
Fixes #2904.

This PR seeks to add an inbox note shown to stores at least 1 week old to prompt them to opt in to usage tracking.

**It also modifies the `Install` class behavior of updating the `wc_admin_install_timestamp` option whenever the DB is updated.** This gives us a more accurate picture of when WooCommerce Admin was first installed.

Note: the given copy is pretty long. Perhaps we can make it more brief? _cc: @pmcpinto_

### Screenshots

![Screen Shot 2019-10-25 at 11 57 22 AM](https://user-images.githubusercontent.com/63922/67596991-e1bf4900-f71e-11e9-93ac-9b763568bf88.png)

### Detailed test instructions:

- Ensure your store is 1 week old or older (based on `wc_admin_install_timestamp` option).
- Ensure you are opted IN to tracking (WooCommerce > Settings > Advanced > WooCommerce.com)
- Use Crontrol to run the wc_admin_daily job
- Ensure the inbox note is NOT created
- Ensure you are opted OUT OF to tracking (WooCommerce > Settings > Advanced > WooCommerce.com )
- Use Crontrol to run the wc_admin_daily job
- Ensure the inbox note IS created
- Verify the function of the links in the note copy
- Click the "allow tracking" CTA
- Verify the store is opted in to tracking (WooCommerce > Settings > Advanced > WooCommerce.com)
- Verify there is a pending `woocommerce_tracker_send_event` event scheduled (using Crontrol)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: add usage tracking inbox notice.