### PR TITLE
Onboarding: Add task view and product import track events

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -29,7 +29,8 @@ class TaskDashboard extends Component {
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-task-dashboard__body' );
 
-		this.recordEvent();
+		this.recordTaskView();
+		this.recordTaskListView();
 
 		if ( this.props.inline ) {
 			this.props.updateOptions( {
@@ -38,12 +39,33 @@ class TaskDashboard extends Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { task } = this.props.query;
+		const { task: prevTask } = prevProps.query;
+
+		if ( prevTask !== task ) {
+			this.recordTaskView();
+		}
+	}
+
 	componentWillUnmount() {
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-task-dashboard__body' );
 	}
 
-	recordEvent() {
+	recordTaskView() {
+		const { task } = this.props.query;
+
+		if ( ! task ) {
+			return;
+		}
+
+		recordEvent( 'task_view', {
+			task_name: task,
+		} );
+	}
+
+	recordTaskListView() {
 		if ( this.getCurrentTask() ) {
 			return;
 		}

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -104,6 +104,8 @@ class Appearance extends Component {
 		const { createNotice } = this.props;
 		this.setState( { isPending: true } );
 
+		recordEvent( 'tasklist_appearance_import_demo', {} );
+
 		apiFetch( {
 			path: `${ WC_ADMIN_NAMESPACE }/onboarding/tasks/import_sample_products`,
 			method: 'POST',


### PR DESCRIPTION
Fixes #3109

Adds in 2 track events for tracking individual event views and product demo import.

### Detailed test instructions:

1. Go to the task list and make sure an event is fired for viewing the task list `tasklist_view`, but not the individual task `task_view`.
2. Go to various tasks and make sure the event is triggered for each task on route change.
3. Go to an individual task and refresh, making sure the `task_view` is still triggered.
4. Without any store products, go to the Customize Appearance task and click "Import products" and make sure the `tasklist_appearance_import_demo` event is fired.