### PR TITLE
Fix missing product tutorial and activity panels

### DIFF
--- a/client/dashboard/task-list/tasks/products.js
+++ b/client/dashboard/task-list/tasks/products.js
@@ -23,7 +23,9 @@ const subTasks = [
 		before: <i className="material-icons-outlined">add_box</i>,
 		after: <i className="material-icons-outlined">chevron_right</i>,
 		onClick: () => recordEvent( 'tasklist_add_product', { method: 'manually' } ),
-		href: getAdminLink( 'post-new.php?post_type=product&wc_onboarding_active_task=products' ),
+		href: getAdminLink(
+			'post-new.php?post_type=product&wc_onboarding_active_task=products&tutorial=true'
+		),
 	},
 	{
 		title: __( 'Import', 'woocommerce-admin' ),

--- a/includes/connect-existing-pages.php
+++ b/includes/connect-existing-pages.php
@@ -61,6 +61,25 @@ wc_admin_connect_page(
 	)
 );
 
+// WooCommerce > Settings > Tax
+wc_admin_connect_page(
+	array(
+		'id'        => 'woocommerce-settings-tax',
+		'parent'    => 'woocommerce-settings',
+		'screen_id' => 'woocommerce_page_wc-settings-tax',
+		'title'     => array(
+			__( 'Tax', 'woocommerce-admin' ),
+		),
+		'path'      => add_query_arg(
+			array(
+				'page' => 'wc-settings',
+				'tab'  => 'tax',
+			),
+			$admin_page_base
+		),
+	)
+);
+
 // WooCommerce > Settings > Shipping > Shipping zones (default tab).
 wc_admin_connect_page(
 	array(
@@ -219,6 +238,25 @@ foreach ( $wc_email_ids as $email_id ) {
 		)
 	);
 }
+
+// WooCommerce > Settings > Integration
+wc_admin_connect_page(
+	array(
+		'id'        => 'woocommerce-settings-integration',
+		'parent'    => 'woocommerce-settings',
+		'screen_id' => 'woocommerce_page_wc-settings-integration',
+		'title'     => array(
+			__( 'Integration', 'woocommerce-admin' ),
+		),
+		'path'      => add_query_arg(
+			array(
+				'page' => 'wc-settings',
+				'tab'  => 'integration',
+			),
+			$admin_page_base
+		),
+	)
+);
 
 // WooCommerce > Settings > Advanced > Page setup (default tab).
 wc_admin_connect_page(


### PR DESCRIPTION
This PR fixes a couple issues reported in our internal testing thread.

* WooCommerce's product tutorial tooltips will now display when creating a product through the task list.
* Missing activity panels/breadcrumbs have been added to the Tax & Integration setting pages.

### Screenshots

<img width="622" alt="Screen Shot 2019-10-28 at 12 35 47 PM" src="https://user-images.githubusercontent.com/689165/67697781-7d4ef480-f97f-11e9-87a1-2fd2138fbf65.png">

<img width="1019" alt="Screen Shot 2019-10-28 at 12 36 09 PM" src="https://user-images.githubusercontent.com/689165/67697815-8a6be380-f97f-11e9-8401-891b53be3ba0.png">

### Detailed test instructions:

* Go to `WooCommerce > Settings > Tax` and `WooCommerce > Settings > Integration` and verify the activity panels are displayed.
* Create a new product via the task list > add product task and verify the new product tutorial displays.