### PR TITLE
Show "add a product" notice to stores without published products

### DIFF
--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -111,7 +111,7 @@
 	}
 
 	.woocommerce-activity-card__actions {
-		a.components-button.is-button {
+		a.components-button.is-button:not(.is-primary) {
 			color: $gray-text;
 		}
 	}

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -68,7 +68,7 @@
 		}
 	}
 
-	.components-button.is-button.is-default {
+	.components-button.is-button.is-default:not(.is-primary) {
 		color: $gray-text;
 		border-color: $button-border;
 		background: $button;
@@ -85,7 +85,7 @@
 		}
 	}
 
-	.components-button.is-default:disabled {
+	.components-button.is-default:disabled:not(.is-primary) {
 		color: $button-disabled;
 		border-color: $button-disabled-border;
 		background: $button;

--- a/src/Events.php
+++ b/src/Events.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Add_First_Product;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Extension;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Giving_Feedback_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
@@ -62,5 +63,6 @@ class Events {
 		WC_Admin_Notes_Giving_Feedback_Notes::add_notes_for_admin_giving_feedback();
 		WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();
 		WC_Admin_Notes_Facebook_Extension::possibly_add_facebook_note();
+		WC_Admin_Notes_Add_First_Product::possibly_add_first_product_note();
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Add_First_Product.php
+++ b/src/Notes/WC_Admin_Notes_Add_First_Product.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * WooCommerce Admin Add First Product Note Provider.
+ *
+ * Adds a note to the merchant's inbox prompting them to add their first product.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Add_First_Product
+ */
+class WC_Admin_Notes_Add_First_Product {
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-add-first-product';
+
+	/**
+	 * Possibly add the note.
+	 */
+	public static function possibly_add_first_product_note() {
+		// Only show the note to stores without products.
+		$products = wp_count_posts( 'product' );
+
+		if ( 0 < (int) $products->publish ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$content = __( 'Grow your revenue by adding products to your store. Add products manually, import from a sheet, or migrate from another platform.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Add your first product', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'product' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'add-a-product', __( 'Add a product', 'woocommerce-admin' ), admin_url( 'post-new.php?post_type=product' ), WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+
+		$note->save();
+	}
+}


### PR DESCRIPTION
Fixes #2903 

This PR introduces a new note that prompts stores without products to add one.

Additionally, this PR contains a fix for the primary button styles in Inbox Actions.

#### Questions:

* What is the interplay with this and the OBW Task List? We probably shouldn't show this notice if the task list is being used.
* Should the notice dismiss when the CTA is clicked, or should we try to detect when the product was added?

### Screenshots

![Screen Shot 2019-10-28 at 11 33 53 AM](https://user-images.githubusercontent.com/63922/67702199-ea11c100-f976-11e9-891a-5583cbd63af9.png)

### Detailed test instructions:

- Ensure your store has no published products
- Use Crontrol to run the wc_admin_daily job
- Verify the "add a product" note is shown in the inbox
- Verify the primary button is styled correctly
- Verify the CTA takes you to the new product edit screen

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: prompt stores to add their first product(s).