### PR TITLE
Onboarding: Redirect to wccom cart if purchases required

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -8,6 +8,11 @@ import { compose } from '@wordpress/compose';
 import { get } from 'lodash';
 
 /**
+ * WooCommerce dependencies
+ */
+import { updateQueryString } from '@woocommerce/navigation';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -29,6 +34,7 @@ class Dashboard extends Component {
 		const prevProfileItems = get( prevProps, 'profileItems', {} );
 
 		if ( profileItems.completed && ! prevProfileItems.completed ) {
+			updateQueryString( {}, '/', {} );
 			this.redirectToCart();
 		}
 	}

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -16,6 +16,14 @@ import ProfileWizard from './profile-wizard';
 import withSelect from 'wc-api/with-select';
 
 class Dashboard extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			isRedirecting: false,
+		};
+	}
+
 	componentDidUpdate( prevProps ) {
 		const profileItems = get( this.props, 'profileItems', {} );
 		const prevProfileItems = get( prevProps, 'profileItems', {} );
@@ -55,6 +63,8 @@ class Dashboard extends Component {
 			return;
 		}
 
+		this.setState( { isRedirecting: true } );
+
 		const url = addQueryArgs( 'https://woocommerce.com/cart', {
 			'wccom-back': window.location.href,
 			'wccom-replace-with': productIds.join( ',' ),
@@ -64,6 +74,11 @@ class Dashboard extends Component {
 
 	render() {
 		const { path, profileItems, query } = this.props;
+		const { isRedirecting } = this.state;
+
+		if ( isRedirecting ) {
+			return null;
+		}
 
 		if ( window.wcAdminFeatures.onboarding && ! profileItems.completed ) {
 			return <ProfileWizard query={ query } />;

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -21,14 +21,6 @@ import ProfileWizard from './profile-wizard';
 import withSelect from 'wc-api/with-select';
 
 class Dashboard extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			isRedirecting: false,
-		};
-	}
-
 	componentDidUpdate( prevProps ) {
 		const profileItems = get( this.props, 'profileItems', {} );
 		const prevProfileItems = get( prevProps, 'profileItems', {} );
@@ -69,7 +61,7 @@ class Dashboard extends Component {
 			return;
 		}
 
-		this.setState( { isRedirecting: true } );
+		document.body.classList.add( 'woocommerce-admin-is-loading' );
 
 		const url = addQueryArgs( 'https://woocommerce.com/cart', {
 			'wccom-back': window.location.href,
@@ -80,11 +72,6 @@ class Dashboard extends Component {
 
 	render() {
 		const { path, profileItems, query } = this.props;
-		const { isRedirecting } = this.state;
-
-		if ( isRedirecting ) {
-			return null;
-		}
 
 		if ( window.wcAdminFeatures.onboarding && ! profileItems.completed ) {
 			return <ProfileWizard query={ query } />;

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -32,13 +32,17 @@ class Dashboard extends Component {
 	}
 
 	getProductIds() {
+		const productIds = [];
 		const profileItems = get( this.props, 'profileItems', {} );
 
-		const productIds = profileItems.product_types.map(
-			type =>
-				wcSettings.onboarding.productTypes[ type ] &&
-				wcSettings.onboarding.productTypes[ type ].product
-		);
+		profileItems.product_types.forEach( product_type => {
+			if (
+				wcSettings.onboarding.productTypes[ product_type ] &&
+				wcSettings.onboarding.productTypes[ product_type ].product
+			) {
+				productIds.push( wcSettings.onboarding.productTypes[ product_type ].product );
+			}
+		} );
 
 		const theme = wcSettings.onboarding.themes.find(
 			themeData => themeData.slug === profileItems.theme

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -10,6 +10,7 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import { updateQueryString } from '@woocommerce/navigation';
 
 /**
@@ -34,19 +35,18 @@ class Dashboard extends Component {
 	getProductIds() {
 		const productIds = [];
 		const profileItems = get( this.props, 'profileItems', {} );
+		const onboarding = getSetting( 'onboarding', {} );
 
 		profileItems.product_types.forEach( product_type => {
 			if (
-				wcSettings.onboarding.productTypes[ product_type ] &&
-				wcSettings.onboarding.productTypes[ product_type ].product
+				onboarding.productTypes[ product_type ] &&
+				onboarding.productTypes[ product_type ].product
 			) {
-				productIds.push( wcSettings.onboarding.productTypes[ product_type ].product );
+				productIds.push( onboarding.productTypes[ product_type ].product );
 			}
 		} );
 
-		const theme = wcSettings.onboarding.themes.find(
-			themeData => themeData.slug === profileItems.theme
-		);
+		const theme = onboarding.themes.find( themeData => themeData.slug === profileItems.theme );
 
 		if ( theme && theme.id && ! theme.is_installed ) {
 			productIds.push( theme.id );

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -2,8 +2,10 @@
 /**
  * External dependencies
  */
+import { addQueryArgs } from '@wordpress/url';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +16,52 @@ import ProfileWizard from './profile-wizard';
 import withSelect from 'wc-api/with-select';
 
 class Dashboard extends Component {
+	componentDidUpdate( prevProps ) {
+		const profileItems = get( this.props, 'profileItems', {} );
+		const prevProfileItems = get( prevProps, 'profileItems', {} );
+
+		if ( profileItems.completed && ! prevProfileItems.completed ) {
+			this.redirectToCart();
+		}
+	}
+
+	getProductIds() {
+		const profileItems = get( this.props, 'profileItems', {} );
+
+		const productIds = profileItems.product_types.map(
+			type =>
+				wcSettings.onboarding.productTypes[ type ] &&
+				wcSettings.onboarding.productTypes[ type ].product
+		);
+
+		const theme = wcSettings.onboarding.themes.find(
+			themeData => themeData.slug === profileItems.theme
+		);
+
+		if ( theme && theme.id && ! theme.is_installed ) {
+			productIds.push( theme.id );
+		}
+
+		return productIds;
+	}
+
+	redirectToCart() {
+		if ( ! window.wcAdminFeatures.onboarding ) {
+			return;
+		}
+
+		const productIds = this.getProductIds();
+		if ( ! productIds.length ) {
+			return;
+		}
+
+		const url = addQueryArgs( 'https://woocommerce.com/cart', {
+			'wccom-back': window.location.href,
+			'wccom-replace-with': productIds.join( ',' ),
+		} );
+		window.location = url;
+	}
+
 	render() {
 		const { path, profileItems, query } = this.props;
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -31,6 +31,7 @@
 	#adminmenumain,
 	#wpfooter,
 	#wpadminbar,
+	#wpbody-content,
 	.woocommerce-layout__header,
 	.update-nag,
 	.woocommerce-store-alerts,


### PR DESCRIPTION
Fixes #2160 

Redirects to the wccom cart if product types warrant or theme purchase is required.

**Note:** I've experienced some issues with the theme not getting updated in time since it's the last step.  This is related to https://github.com/woocommerce/woocommerce-admin/issues/2959 so will address that in a separate PR.

### Screenshots
<img width="1099" alt="Screen Shot 2019-10-29 at 11 23 32 AM" src="https://user-images.githubusercontent.com/10561050/67736781-cec0b780-fa43-11e9-9412-c64d635e52da.png">


### Detailed test instructions:

1. Optionally set up a wccom testing site.  https://github.com/Automattic/woocommerce.com
2. Enable the profiler.
3. Walk through the steps, adding some product types that require purchase and a non-installed theme.
4. After choosing a theme, check that you're redirected to the wccom cart/checkout.  
5.  Replace with the wccom testing site URL/TLD if set up.
6.  Note the necessary items in the cart (keep in mind the theme bug mentioned above).
7. Completing the checkout should redirect back to the store dashboard.
8. Re-enable the profiler.
9. Choose product types and a theme that don't require purchase.
10. Note that no redirect occurs.