### PR TITLE
Onboarding: Scroll to top when navigating between pages

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -71,6 +71,15 @@ class ProfileWizard extends Component {
 		this.goToNextStep = this.goToNextStep.bind( this );
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { step: prevStep } = prevProps.query;
+		const { step } = this.props.query;
+
+		if ( prevStep !== step ) {
+			window.document.documentElement.scrollTop = 0;
+		}
+	}
+
 	componentDidMount() {
 		document.documentElement.classList.remove( 'wp-toolbar' );
 		document.body.classList.add( 'woocommerce-onboarding' );

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -38,6 +38,15 @@ class TaskDashboard extends Component {
 		}
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { task: prevTask } = prevProps.query;
+		const { task } = this.props.query;
+
+		if ( prevTask !== task ) {
+			window.document.documentElement.scrollTop = 0;
+		}
+	}
+
 	componentWillUnmount() {
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-task-dashboard__body' );


### PR DESCRIPTION
Fixes #3118

Scrolls to top between task or step navigation.  

### Detailed test instructions:

1. Go to the profiler and task list.
2. Navigate between tasks/steps.
3. Note that navigating between them, the window scrolls to the top. (You may need to make the viewport height smaller to see this, especially for some profiler steps)