### PR TITLE
Correctly offset for week start annual date changes

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -16,6 +16,7 @@ import {
 	getAllowedIntervalsForQuery,
 	getCurrentDates,
 	getDateFormatsForInterval,
+	getDateParamsFromQuery,
 	getIntervalForQuery,
 	getChartTypeForQuery,
 	getPreviousDate,
@@ -74,6 +75,7 @@ export class ReportChart extends Component {
 	getTimeChartData() {
 		const { query, primaryData, secondaryData, selectedChart } = this.props;
 		const currentInterval = getIntervalForQuery( query );
+		const { period } = getDateParamsFromQuery( query );
 		const { primary, secondary } = getCurrentDates( query );
 
 		const chartData = primaryData.data.intervals.map( function( interval, index ) {
@@ -82,7 +84,8 @@ export class ReportChart extends Component {
 				primary.after,
 				secondary.after,
 				query.compare,
-				currentInterval
+				currentInterval,
+				period
 			);
 
 			const secondaryInterval = secondaryData.data.intervals[ index ];

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -156,9 +156,7 @@ export function getLastPeriod( period, compare ) {
 			'week' === period
 				? primaryStart
 						.clone()
-						.subtract( 1, 'years' )
-						.week( primaryStart.week() )
-						.startOf( 'week' )
+						.subtract( 364, 'days' )
 				: primaryStart.clone().subtract( 1, 'years' );
 		secondaryEnd = secondaryStart.clone().endOf( period );
 	}
@@ -193,9 +191,7 @@ export function getCurrentPeriod( period, compare ) {
 			'week' === period
 				? primaryStart
 						.clone()
-						.subtract( 1, 'years' )
-						.week( primaryStart.week() )
-						.startOf( 'week' )
+						.subtract( 364, 'days' )
 				: primaryStart.clone().subtract( 1, 'years' );
 		secondaryEnd = secondaryStart.clone().add( daysSoFar, 'days' );
 	}
@@ -348,12 +344,16 @@ export const getDateDifferenceInDays = ( date, date2 ) => {
  * @param {String|Moment.moment} date2 - secondary start
  * @param {String} compare - `previous_period`  or `previous_year`
  * @param {String} interval - interval
+ * @param {string} period - period value, ie `week`
  * @return {Moment.moment}  - Calculated date
  */
-export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
+export const getPreviousDate = ( date, date1, date2, compare, interval, period ) => {
 	const dateMoment = moment( date );
 
 	if ( 'previous_year' === compare ) {
+		if ( 'week' === period ) {
+			return dateMoment.clone().subtract( 364, 'days' );
+		}
 		return dateMoment.clone().subtract( 1, 'years' );
 	}
 


### PR DESCRIPTION
Fixes #2888

The day of the week for a given date changes year to year. The `Week to Date` calculates the previous year's week uses the same date range. This week started on Monday Oct 28, 2019. The same week last year was Monday Oct 29, 2019.

This PR updates the dashboard to request and label the previous year's week using the correct dates for the previous year.

### Detailed test instructions:

- Use smooth generator to create 20 orders between the past Sunday and today and 20 orders for the same date range in 2018 **plus** one day on the end
- In `master` load `This Month` and note the chart amount for 1 year ago today
- Switch to `This Week` and compare the amount for 1 day ago yesterday to the previous
- Switch to this branch
- `This Month` should show the same
- `This Week` should have the amounts in the same locations but labelled with the correct dates 

### Changelog Note:

Fix: Apply correct date labels to previous year for This Week comparison.