### PR TITLE
Fix label positioning for SelectControl in IE11

### DIFF
--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -31,6 +31,8 @@
 
 		.components-base-control__label {
 			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
 			color: $studio-gray-50;
 			font-size: 16px;
 		}


### PR DESCRIPTION
Fixes #3071 

Adds specific positioning to the label to prevent an overlap that occurs between the label and input on IE11.

### Screenshots
<img width="584" alt="Screen Shot 2019-10-30 at 7 19 00 PM" src="https://user-images.githubusercontent.com/10561050/67854195-dae36c80-fb4a-11e9-8b7d-34953fd09539.png">

### Detailed test instructions:

1. Open the devdocs or "Store Details" page in the onboarding profiler.
2. Make sure the `SelectControl` label/inputs are styled correctly before and after focus as well as when values are added.