### PR TITLE
Fix ellipsis menu style

### DIFF
--- a/packages/components/src/ellipsis-menu/style.scss
+++ b/packages/components/src/ellipsis-menu/style.scss
@@ -4,7 +4,6 @@
 }
 
 .woocommerce-ellipsis-menu__toggle {
-	height: 24px;
 	justify-content: center;
 	vertical-align: middle;
 	width: 24px;


### PR DESCRIPTION
Currently the ellipsis menu in card and section headers  is partially cut off

### Screenshots

Currently
<img width="1175" alt="Screen Shot 2019-10-30 at 4 29 07 PM" src="https://user-images.githubusercontent.com/4500952/67906871-399cec00-fb33-11e9-9371-c030b5488a82.png">

note, the third dot in the ellipsis is cut in half, and the entire icon is aligned too low.

With this fix
<img width="1172" alt="Screen Shot 2019-10-30 at 4 29 02 PM" src="https://user-images.githubusercontent.com/4500952/67906933-6b15b780-fb33-11e9-8a07-e6fe4fa2b016.png">

### Detailed test instructions:

Verify the ellipsis menu displays properly, both in card headers and in dashboard section headers. 
