### PR TITLE
restrict admin page wrap padding to page wrap

### DIFF
--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -18,6 +18,9 @@
 				width: calc(100% - 40px);
 			}
 		}
+		.wrap {
+			padding: 0;
+		}
 	}
 
 	#woocommerce-embedded-root.is-embed-loading + #wpbody .wrap {


### PR DESCRIPTION
Fixes #2923

The `.woocommerce-embed-page .wrap` padding was added to give the dashboard page padding. A side effect of the current CSS is that it applies to all interior `.wrap` selectors in the page. This PR adds `.woocommerce-embed-page .wrap .wrap` padding to restrict the outer selector to the main page `.wrap`.

### Screenshots

<img width="739" alt="Screen Shot 2019-10-31 at 10 11 57 AM" src="https://user-images.githubusercontent.com/343847/67949680-e6747900-fbc6-11e9-809c-ce6631f3c385.png">

### Detailed test instructions:

- Activate WooCommerce Subscriptions
- Check that the field alignments match the screenshot

### Changelog Note:

Tweak: Field misalignment in product edit screen.