### PR TITLE
Onboarding: Pass connection parameters to install extensions

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -331,6 +331,23 @@
 	}
 }
 
+.woocommerce-profile-wizard__step-setup {
+	margin-top: 90px;
+
+	.woocommerce-spinner {
+		margin-top: 150px;
+		width: 80px;
+		min-width: 80px;
+		height: 80px;
+		max-height: 80px;
+
+		circle {
+			stroke: $studio-woocommerce-purple-60;
+			stroke-width: 8px;
+		}
+	}
+}
+
 .woocommerce-profile-wizard__header.is-stepper {
 	svg > g {
 		transform: initial;


### PR DESCRIPTION
Closes #2477.

This PR wires up the cart URL with the correct connection parameters, so that the in-app purchase flow works after purchasing. 

Note that there are a few issues with the flow (https://github.com/Automattic/woocommerce.com/issues/6617, https://github.com/Automattic/woocommerce.com/issues/6618) but extensions and themes do install and activate correctly.

No matter what I pass for `wccom-back`, this also seems to only redirect to the plugins screens.

@joshuatf Unfortunately, since I have to generate the cart URL server side (nonce), I had to add back in a pending screen. The screen only displays if we actually have products to purchase, and it should be relatively quick. Sorry for the back and forth on that.

### Screenshots

<img width="947" alt="Screen Shot 2019-10-31 at 3 14 30 PM" src="https://user-images.githubusercontent.com/689165/67980646-471aaa80-fbf5-11e9-80cc-3fdb6707ecd2.png">

<img width="456" alt="Screen Shot 2019-10-31 at 3 46 54 PM" src="https://user-images.githubusercontent.com/689165/67981133-53533780-fbf6-11e9-8e6a-7d35c003d1ea.png">

<img width="952" alt="Screen Shot 2019-10-31 at 3 48 59 PM" src="https://user-images.githubusercontent.com/689165/67981141-59491880-fbf6-11e9-9ce8-27321e43419c.png">

<img width="450" alt="Screen Shot 2019-10-31 at 3 49 36 PM" src="https://user-images.githubusercontent.com/689165/67981146-5d753600-fbf6-11e9-955b-cb91b1aaaaee.png">

### Detailed test instructions:

* Go through the profiler, selecting options that will require purchase (product types and/or a non-installed theme).
* Make sure the theme step redirects to the cart after a brief loading screen.
* Continue purchasing the products on WooCommerce.com, fully completing the purchase flow.
* Click the `Add to site` button.
* Sit through the installation steps.
* You should be redirected back to the plugins screen (temporary for now).
* Visit the dashboard and make sure the profile wizard no longer shows.
* Re-enable the profiler and walk through the steps selecting options that don't require purchase and selecting the currently active theme.
* Note that the wccom redirect is skipped (you shouldn't see the pending screen at all) and the profiler is complete since the theme is already active.