### PR TITLE
Onboarding: Fix mobile styling issues in profiler

### DIFF
--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -94,7 +94,7 @@ class Industry extends Component {
 				<p className="woocommerce-profile-wizard__intro-paragraph">
 					{ __( 'Choose any that apply' ) }
 				</p>
-				<Card className="has-checkbox-group">
+				<Card>
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ Object.keys( industries ).map( slug => {
 							return (

--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -96,7 +96,7 @@ class ProductTypes extends Component {
 				</H>
 				<p>{ __( 'Choose any that apply' ) }</p>
 
-				<Card className="has-checkbox-group">
+				<Card>
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ Object.keys( productTypes ).map( slug => {
 							const helpText = interpolateComponents( {

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -104,8 +104,10 @@
 			margin-top: 13px;
 			display: block;
 			float: left;
+			width: auto;
 			min-width: 106px;
 			height: 40px;
+			line-height: 1;
 			margin-right: $gap-smaller;
 			box-shadow: none;
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -30,13 +30,9 @@
 		.muriel-button {
 			display: flex;
 			margin: $gap-smaller auto 0;
-			min-width: 310px;
+			width: 310px;
 			max-width: 100%;
 			justify-content: center;
-		}
-
-		&.has-checkbox-group .woocommerce-card__body {
-			padding: 0 0 $gap;
 		}
 	}
 
@@ -208,12 +204,15 @@
 			justify-content: flex-end;
 
 			.muriel-checkbox label.components-checkbox-control__label {
+				display: inline-block;
 				margin-left: $gap-small;
 			}
 		}
 	}
 
 	.woocommerce-profile-wizard__checkbox-group {
+		margin: -16px -16px 0 -16px;
+
 		.muriel-checkbox {
 			margin-top: 0;
 			margin-bottom: 0;
@@ -283,6 +282,13 @@
 		&.is-active {
 			box-shadow: 0 0 0 1px $studio-woocommerce-purple-60;
 			border-color: $studio-woocommerce-purple-60;
+		}
+
+		.components-base-control__label {
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			max-width: calc(100% - #{$gap * 2} - 24px);
 		}
 
 		&::after {
@@ -356,7 +362,8 @@
 }
 
 .components-modal__frame.woocommerce-profile-wizard__usage-modal {
-	min-width: 600px;
+	width: 600px;
+	max-width: 100%;
 
 	.components-modal__header {
 		border-bottom: 0;

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -211,7 +211,7 @@
 	}
 
 	.woocommerce-profile-wizard__checkbox-group {
-		margin: -16px -16px 0 -16px;
+		margin: -$gap -$gap 0 -$gap;
 
 		.muriel-checkbox {
 			margin-top: 0;


### PR DESCRIPTION
Fixes #3143

Fixes:
* Buttons overflowing cards and reverts padding for checkbox groups.
* Truncates long labels in select boxes.
* Updates max/min width for the modal.

### Screenshots
<img width="318" alt="Screen Shot 2019-11-01 at 1 32 27 PM" src="https://user-images.githubusercontent.com/10561050/68004516-c5865380-fcac-11e9-96f5-5a17edf1667f.png">
<img width="342" alt="Screen Shot 2019-11-01 at 1 32 21 PM" src="https://user-images.githubusercontent.com/10561050/68004517-c61eea00-fcac-11e9-8652-2b05d057f0ef.png">

### Detailed test instructions:

1. Visit the profiler.
2. Walk through each step on a smaller screen size (<=480px).
3.  Make sure there are no obvious styling issues.