### PR TITLE
Create store pages during onboarding

### DIFF
--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { Button, CheckboxControl } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -43,6 +44,10 @@ class StoreDetails extends Component {
 
 		this.onContinue = this.onContinue.bind( this );
 		this.onSubmit = this.onSubmit.bind( this );
+	}
+
+	componentWillUnmount() {
+		apiFetch( { path: '/wc-admin/v1/onboarding/tasks/create_store_pages', method: 'POST' } );
 	}
 
 	deriveCurrencySettings( countryState ) {
@@ -175,11 +180,11 @@ export default compose(
 			getProfileItems,
 		} = select( 'wc-api' );
 
-		const profileItems = getProfileItems();
-
 		const settings = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );
 		const isSettingsRequesting = isGetSettingsRequesting( 'general' );
+
+		const profileItems = getProfileItems();
 		const isProfileItemsError = Boolean( getProfileItemsError() );
 
 		return {

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -52,12 +52,25 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/create_store_pages',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_store_pages' ),
+					'permission_callback' => array( $this, 'create_pages_permission_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/create_homepage',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_homepage' ),
-					'permission_callback' => array( $this, 'create_homepage_permission_check' ),
+					'permission_callback' => array( $this, 'create_pages_permission_check' ),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -84,9 +97,9 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|boolean
 	 */
-	public function create_homepage_permission_check( $request ) {
+	public function create_pages_permission_check( $request ) {
 		if ( ! wc_rest_check_post_permissions( 'page', 'create' ) || ! current_user_can( 'manage_options' ) ) {
-			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create a new homepage.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_create', __( 'Sorry, you are not allowed to create new pages.', 'woocommerce-admin' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -359,6 +372,14 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		}
 
 		return $images_for_post;
+	}
+
+	/*
+	 * Creates base store starter pages like my account and checkout.
+	 * Note that WC_Install::create_pages already checks if pages exist before creating them again.
+	 */
+	public static function create_store_pages() {
+		\WC_Install::create_pages();
 	}
 
 	/**


### PR DESCRIPTION
Closes #3148.

This PR creates the base store pages that are needed for the store to function (my account, checkout, etc).

I wasn't 100% sure where to create these, but I decided to do it at the end of the store details step like the current onboarding wizard (saves after address step).

### Detailed test instructions:

* Delete your existing store pages.
* Complete the store details step, verify that the pages are created.
* Complete the store details step again, verify that you don't end up with duplicate pages.