### PR TITLE
Update '&' to 'and' in industry labels per style guide

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -110,12 +110,12 @@ class Onboarding {
 		return apply_filters(
 			'woocommerce_admin_onboarding_industries',
 			array(
-				'fashion-apparel-accessories' => __( 'Fashion, apparel, & accessories', 'woocommerce-admin' ),
-				'health-beauty'               => __( 'Health & beauty', 'woocommerce-admin' ),
-				'art-music-photography'       => __( 'Art, music, & photography', 'woocommerce-admin' ),
-				'electronics-computers'       => __( 'Electronics & computers', 'woocommerce-admin' ),
-				'food-drink'                  => __( 'Food & drink', 'woocommerce-admin' ),
-				'home-furniture-garden'       => __( 'Home, furniture, & garden', 'woocommerce-admin' ),
+				'fashion-apparel-accessories' => __( 'Fashion, apparel, and accessories', 'woocommerce-admin' ),
+				'health-beauty'               => __( 'Health and beauty', 'woocommerce-admin' ),
+				'art-music-photography'       => __( 'Art, music, and photography', 'woocommerce-admin' ),
+				'electronics-computers'       => __( 'Electronics and computers', 'woocommerce-admin' ),
+				'food-drink'                  => __( 'Food and drink', 'woocommerce-admin' ),
+				'home-furniture-garden'       => __( 'Home, furniture, and garden', 'woocommerce-admin' ),
 				'other'                       => __( 'Other', 'woocommerce-admin' ),
 			)
 		);


### PR DESCRIPTION
Per the WooCommerce marketplace style guide (https://docs.woocommerce.com/document/grammar-punctuation-style-guide/#ampersands) we should be using 'and' in our industry labels.

Reported at p90Yrv-1iA-p2.

### Screenshots

<img width="588" alt="Screen Shot 2019-11-01 at 12 05 24 PM" src="https://user-images.githubusercontent.com/689165/68038432-54d93a00-fca0-11e9-94dd-0de6ae6fd9d6.png">

### Detailed test instructions:

* Check out the industry page and verify the labels look correct.