### PR TITLE
Onboarding: Pre-fill profiler fields with data

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -8,7 +8,7 @@ import { compose } from '@wordpress/compose';
 import { FormToggle } from '@wordpress/components';
 import { Button } from 'newspack-components';
 import { withDispatch } from '@wordpress/data';
-import { keys, pickBy } from 'lodash';
+import { keys, get, pickBy } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -29,16 +29,18 @@ import { pluginNames } from 'wc-api/onboarding/constants';
 const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
 
 class BusinessDetails extends Component {
-	constructor() {
+	constructor( props ) {
 		super();
+		const profileItems = get( props, 'profileItems', {} );
+		const businessExtensions = get( profileItems, 'business_extensions', [] );
 
 		this.initialValues = {
-			other_platform: '',
-			product_count: '',
-			selling_venues: '',
-			revenue: '',
-			'facebook-for-woocommerce': true,
-			'mailchimp-for-woocommerce': true,
+			other_platform: profileItems.other_platform || '',
+			product_count: profileItems.product_count || '',
+			selling_venues: profileItems.selling_venues || '',
+			revenue: profileItems.revenue || '',
+			'facebook-for-woocommerce': businessExtensions.includes( 'facebook-for-woocommerce' ),
+			'mailchimp-for-woocommerce': businessExtensions.includes( 'mailchimp-for-woocommerce' ),
 		};
 
 		this.state = {
@@ -432,11 +434,12 @@ class BusinessDetails extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItemsError } = select( 'wc-api' );
+		const { getProfileItems, getProfileItemsError } = select( 'wc-api' );
 
-		const isError = Boolean( getProfileItemsError() );
-
-		return { isError };
+		return {
+			isError: Boolean( getProfileItemsError() ),
+			profileItems: getProfileItems(),
+		};
 	} ),
 	withDispatch( dispatch => {
 		const { updateProfileItems } = dispatch( 'wc-api' );

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -32,15 +32,19 @@ class BusinessDetails extends Component {
 	constructor( props ) {
 		super();
 		const profileItems = get( props, 'profileItems', {} );
-		const businessExtensions = get( profileItems, 'business_extensions', [] );
+		const businessExtensions = get( profileItems, 'business_extensions', false );
 
 		this.initialValues = {
 			other_platform: profileItems.other_platform || '',
 			product_count: profileItems.product_count || '',
 			selling_venues: profileItems.selling_venues || '',
 			revenue: profileItems.revenue || '',
-			'facebook-for-woocommerce': businessExtensions.includes( 'facebook-for-woocommerce' ),
-			'mailchimp-for-woocommerce': businessExtensions.includes( 'mailchimp-for-woocommerce' ),
+			'facebook-for-woocommerce': businessExtensions
+				? businessExtensions.includes( 'facebook-for-woocommerce' )
+				: true,
+			'mailchimp-for-woocommerce': businessExtensions
+				? businessExtensions.includes( 'mailchimp-for-woocommerce' )
+				: true,
 		};
 
 		this.state = {

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -5,8 +5,8 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Button, CheckboxControl } from 'newspack-components';
-import { includes, filter } from 'lodash';
 import { compose } from '@wordpress/compose';
+import { filter, get, includes } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 
 /**
@@ -24,11 +24,13 @@ import { recordEvent } from 'lib/tracks';
 const onboarding = getSetting( 'onboarding', {} );
 
 class Industry extends Component {
-	constructor() {
+	constructor( props ) {
+		const profileItems = get( props, 'profileItems', {} );
+
 		super();
 		this.state = {
 			error: null,
-			selected: [],
+			selected: profileItems.industry || [],
 		};
 		this.onContinue = this.onContinue.bind( this );
 		this.onChange = this.onChange.bind( this );
@@ -86,6 +88,7 @@ class Industry extends Component {
 	render() {
 		const { industries } = onboarding;
 		const { error, selected } = this.state;
+
 		return (
 			<Fragment>
 				<H className="woocommerce-profile-wizard__header-title">
@@ -102,6 +105,7 @@ class Industry extends Component {
 									key={ slug }
 									label={ industries[ slug ] }
 									onChange={ () => this.onChange( slug ) }
+									checked={ selected.includes( slug ) }
 								/>
 							);
 						} ) }
@@ -119,11 +123,12 @@ class Industry extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItemsError } = select( 'wc-api' );
+		const { getProfileItems, getProfileItemsError } = select( 'wc-api' );
 
-		const isError = Boolean( getProfileItemsError() );
-
-		return { isError };
+		return {
+			isError: Boolean( getProfileItemsError() ),
+			profileItems: getProfileItems(),
+		};
 	} ),
 	withDispatch( dispatch => {
 		const { updateProfileItems } = dispatch( 'wc-api' );

--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { Button, CheckboxControl } from 'newspack-components';
-import { includes, filter } from 'lodash';
+import { includes, filter, get } from 'lodash';
 import interpolateComponents from 'interpolate-components';
 import { withDispatch } from '@wordpress/data';
 
@@ -19,12 +19,13 @@ import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 
 class ProductTypes extends Component {
-	constructor() {
+	constructor( props ) {
 		super();
+		const profileItems = get( props, 'profileItems', {} );
 
 		this.state = {
 			error: null,
-			selected: [],
+			selected: profileItems.product_types || [],
 		};
 
 		this.onContinue = this.onContinue.bind( this );
@@ -125,6 +126,7 @@ class ProductTypes extends Component {
 									label={ productTypes[ slug ].label }
 									help={ helpText }
 									onChange={ () => this.onChange( slug ) }
+									checked={ selected.includes( slug ) }
 								/>
 							);
 						} ) }
@@ -147,11 +149,12 @@ class ProductTypes extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItemsError } = select( 'wc-api' );
+		const { getProfileItems, getProfileItemsError } = select( 'wc-api' );
 
-		const isError = Boolean( getProfileItemsError() );
-
-		return { isError };
+		return {
+			isError: Boolean( getProfileItemsError() ),
+			profileItems: getProfileItems(),
+		};
 	} ),
 	withDispatch( dispatch => {
 		const { updateProfileItems } = dispatch( 'wc-api' );

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -8,7 +8,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { recordEvent } from 'lib/tracks';
-import { without } from 'lodash';
+import { without, get } from 'lodash';
 
 /**
  * Internal depdencies
@@ -25,20 +25,22 @@ import UsageModal from './usage-modal';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 class StoreDetails extends Component {
-	constructor() {
+	constructor( props ) {
 		super( ...arguments );
+		const settings = get( props, 'settings', false );
+		const profileItems = get( props, 'profileItems', {} );
 
 		this.state = {
 			showUsageModal: false,
 		};
 
 		this.initialValues = {
-			addressLine1: '',
-			addressLine2: '',
-			city: '',
-			countryState: '',
-			postCode: '',
-			isClient: false,
+			addressLine1: settings.woocommerce_store_address || '',
+			addressLine2: settings.woocommerce_store_address_2 || '',
+			city: settings.woocommerce_store_city || '',
+			countryState: settings.woocommerce_default_country || '',
+			postCode: settings.woocommerce_store_postcode || '',
+			isClient: profileItems.setup_client || false,
 		};
 
 		this.onContinue = this.onContinue.bind( this );
@@ -121,6 +123,7 @@ class StoreDetails extends Component {
 
 	render() {
 		const { showUsageModal } = this.state;
+
 		return (
 			<Fragment>
 				<H className="woocommerce-profile-wizard__header-title">

--- a/client/wc-api/settings/selectors.js
+++ b/client/wc-api/settings/selectors.js
@@ -6,6 +6,11 @@
 import { isNil } from 'lodash';
 
 /**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+/**
  * Internal dependencies
  */
 import { DEFAULT_REQUIREMENT } from '../constants';
@@ -20,8 +25,20 @@ const getSettings = ( getResource, requireResource ) => (
 	const ids = requireResource( requirement, resourceName ).data || [];
 	const settings = {};
 
+	if ( ! ids.length ) {
+		const preloadSettings = getSetting( 'preloadSettings', {} );
+		if ( preloadSettings[ group ] ) {
+			return preloadSettings[ group ];
+		}
+	}
+
 	ids.forEach( id => {
-		settings[ id ] = getResource( getResourceName( resourceName, id ) ).data;
+		settings[ id ] = getSetting(
+			'preloadSettings',
+			{},
+			preloadSettings =>
+				getResource( getResourceName( resourceName, id ) ).data || preloadSettings[ id ]
+		);
 	} );
 
 	return settings;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -65,6 +65,7 @@ class Onboarding {
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'finish_paypal_connect' ) );
@@ -372,6 +373,22 @@ class Onboarding {
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce_default_country';
+
+		return $options;
+	}
+
+	/**
+	 * Preload WC setting options to prime state of the application.
+	 *
+	 * @param array $options Array of options to preload.
+	 * @return array
+	 */
+	public function preload_settings( $options ) {
+		if ( ! self::should_show_profiler() ) {
+			return $options;
+		}
+
+		$options[] = 'general';
 
 		return $options;
 	}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -583,6 +583,19 @@ class Loader {
 			}
 		}
 
+		$preload_settings = apply_filters( 'woocommerce_admin_preload_settings', array() );
+		if ( ! empty( $preload_settings ) ) {
+			$setting_options = new \WC_REST_Setting_Options_V2_Controller;
+			foreach ( $preload_settings as $group ) {
+				$group_settings   = $setting_options->get_group_settings( $group );
+				$preload_settings = [];
+				foreach( $group_settings as $option ) {
+					$preload_settings[ $option[ 'id' ] ] = $option[ 'value' ];
+				}
+				$settings['preloadSettings'][ $group ] = $preload_settings;
+			}
+		}
+
 		$current_user_data = array();
 		foreach ( self::get_user_data_fields() as $user_field ) {
 			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true ) );


### PR DESCRIPTION
Fixes #3164

Pre-fills all profiler fields with data if previously filled in.
Also adds a preload settings filter to preload entire WC setting groups.

### Screenshots
<img width="528" alt="Screen Shot 2019-11-04 at 2 45 16 PM" src="https://user-images.githubusercontent.com/10561050/68103486-ff0bc880-ff11-11e9-95cf-187c19b0fae9.png">

### Detailed test instructions:

1. Make sure you've completed the profiler or go through each step and complete it.
2. Enable the profiler.
3. Walk through each step of the profiler, verifying that previously chosen items or information is filled in.