### PR TITLE
Onboarding: Fix checkbox group gap

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -211,7 +211,7 @@
 	}
 
 	.woocommerce-profile-wizard__checkbox-group {
-		margin: -$gap -$gap 0 -$gap;
+		margin: #{-$gap} #{-$gap} 0 -#{$gap};
 
 		.muriel-checkbox {
 			margin-top: 0;


### PR DESCRIPTION
Fixes a negative margin issue I introduced in 

### Before
<img width="494" alt="Screen Shot 2019-11-04 at 3 39 33 PM" src="https://user-images.githubusercontent.com/10561050/68105491-a5a79780-ff19-11e9-9b22-688c36bfd6ee.png">

### After
<img width="516" alt="Screen Shot 2019-11-04 at 3 39 55 PM" src="https://user-images.githubusercontent.com/10561050/68105486-a3ddd400-ff19-11e9-84d5-fd09e8b9952e.png">


### Detailed test instructions:

1. Enable the profiler.
2. Visit the industry step.
3. Make sure the checkbox group margin works as expected.