### PR TITLE
Onboarding: Automatically enable tax calculations for manual configuration

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -256,21 +256,23 @@ class Tax extends Component {
 							{ __( 'Configure', 'woocommerce-admin' ) }
 						</Button>
 						<p>
-							{ interpolateComponents( {
-								mixedString: __(
-									'By clicking "Configure" you\'re enabling tax rates and calculations. More info {{link}}here{{/link}}.',
-									'woocommerce-admin'
-								),
-								components: {
-									link: (
-										<Link
-											href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-1"
-											target="_blank"
-											type="external"
-										/>
+							{ 'yes' !== generalSettings.woocommerce_calc_taxes &&
+								interpolateComponents( {
+									mixedString: __(
+										'By clicking "Configure" you\'re enabling tax rates and calculations.' +
+											'More info {{link}}here{{/link}}.',
+										'woocommerce-admin'
 									),
-								},
-							} ) }
+									components: {
+										link: (
+											<Link
+												href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-1"
+												target="_blank"
+												type="external"
+											/>
+										),
+									},
+								} ) }
 						</p>
 					</Fragment>
 				),

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from 'newspack-components';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { difference, filter, get } from 'lodash';
 import interpolateComponents from 'interpolate-components';
@@ -13,7 +13,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { Card, H, Stepper } from '@woocommerce/components';
+import { Card, H, Link, Stepper } from '@woocommerce/components';
 import { getAdminLink, getHistory, getNewPath } from '@woocommerce/navigation';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
@@ -251,9 +251,28 @@ class Tax extends Component {
 					'woocommerce-admin'
 				),
 				content: (
-					<Button isPrimary isBusy={ isPending } onClick={ this.configureTaxRates }>
-						{ __( 'Configure', 'woocommerce-admin' ) }
-					</Button>
+					<Fragment>
+						<Button isPrimary isBusy={ isPending } onClick={ this.configureTaxRates }>
+							{ __( 'Configure', 'woocommerce-admin' ) }
+						</Button>
+						<p>
+							{ interpolateComponents( {
+								mixedString: __(
+									'By clicking "Configure" you\'re enabling tax rates and calculations. More info {{link}}here{{/link}}.',
+									'woocommerce-admin'
+								),
+								components: {
+									link: (
+										<Link
+											href="https://docs.woocommerce.com/document/setting-up-taxes-in-woocommerce/#section-1"
+											target="_blank"
+											type="external"
+										/>
+									),
+								},
+							} ) }
+						</p>
+					</Fragment>
 				),
 				visible: ! this.isTaxJarSupported(),
 			},


### PR DESCRIPTION
Fixes #3150

Enables tax calculations for manual configuration of tax if the user clicks "Configure."  Allows users to directly go to the tax rates page instead of manually enabling and navigating the settings pages.

### Screenshots
<img width="679" alt="Screen Shot 2019-11-05 at 8 32 37 AM" src="https://user-images.githubusercontent.com/10561050/68169454-3082a380-ffa7-11e9-8587-6a1f36f8fd1d.png">

### Detailed test instructions:

1. Set your store to a TaxJar non-supported country (see - https://developers.taxjar.com/api/reference/#countries )
2. Uncheck "Enable tax rates and calculations" under WooCommerce settings.
3. Go to the tax task.
4. Click "Configure" on the last step.
5. Check that you are redirected to the standard rates page.
6. Go back to the tax task and click on "Configure" again, checking that you are once again redirected to the standard rates page (this time should not update the tax calc option if already enabled and should result in immediate redirect instead of a temporary busy state).