### PR TITLE
Onboarding: Add return to task list after saving taxes

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -129,8 +129,6 @@ class Tax extends Component {
 	configureTaxRates() {
 		const { generalSettings, updateSettings } = this.props;
 
-		recordEvent( 'tasklist_tax_config_rates' );
-
 		if ( 'yes' !== generalSettings.woocommerce_calc_taxes ) {
 			this.setState( { isPending: true } );
 			updateSettings( {
@@ -166,7 +164,7 @@ class Tax extends Component {
 			if ( automatedTaxEnabled ) {
 				getHistory().push( getNewPath( {}, '/', {} ) );
 			} else {
-				window.location = getAdminLink( 'admin.php?page=wc-settings&tab=tax&section=standard' );
+				this.configureTaxRates();
 			}
 		} else {
 			createNotice(
@@ -254,7 +252,14 @@ class Tax extends Component {
 				),
 				content: (
 					<Fragment>
-						<Button isPrimary isBusy={ isPending } onClick={ this.configureTaxRates }>
+						<Button
+							isPrimary
+							isBusy={ isPending }
+							onClick={ () => {
+								recordEvent( 'tasklist_tax_config_rates' );
+								this.configureTaxRates();
+							} }
+						>
 							{ __( 'Configure', 'woocommerce-admin' ) }
 						</Button>
 						<p>

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -139,7 +139,9 @@ class Tax extends Component {
 				},
 			} );
 		} else {
-			window.location = getAdminLink( 'admin.php?page=wc-settings&tab=tax&section=standard' );
+			window.location = getAdminLink(
+				'admin.php?page=wc-settings&tab=tax&section=standard&wc_onboarding_active_task=tax'
+			);
 		}
 	}
 

--- a/client/wp-admin-scripts/README.md
+++ b/client/wp-admin-scripts/README.md
@@ -1,4 +1,4 @@
-Scripts located in this directory are meant to be loaded on wp-admin pages outside the context of WooCommerce Admin, such as the post editor.
+Scripts located in this directory are meant to be loaded on wp-admin pages outside the context of WooCommerce Admin, such as the post editor. Adding the script name to `wpAdminScripts` in the Webpack config will automatically build these scripts.
 
 Scripts must be manually enqueued with any neccessary dependencies. For example, `onboarding-homepage-notice` uses the WooCommerce navigation package:
 

--- a/client/wp-admin-scripts/onboarding-tax-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-tax-notice/index.js
@@ -16,7 +16,7 @@ import { getAdminLink } from '@woocommerce/navigation';
  */
 const showTaxCompletionNotice = () => {
 	dispatch( 'core/notices' ).createSuccessNotice(
-		__( 'Your tax tax settings have been saved.', 'woocommerce-admin' ),
+		__( 'Your tax settings have been saved.', 'woocommerce-admin' ),
 		{
 			id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
 			actions: [

--- a/client/wp-admin-scripts/onboarding-tax-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-tax-notice/index.js
@@ -1,0 +1,37 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getAdminLink } from '@woocommerce/navigation';
+
+/**
+ * Displays a notice on tax settings save.
+ */
+const showTaxCompletionNotice = () => {
+	dispatch( 'core/notices' ).createSuccessNotice(
+		__( 'Your tax tax settings have been saved.', 'woocommerce-admin' ),
+		{
+			id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
+			actions: [
+				{
+					url: getAdminLink( 'admin.php?page=wc-admin' ),
+					label: __( 'Continue setup.', 'woocommerce-admin' ),
+				},
+			],
+		}
+	);
+};
+
+domReady( () => {
+	const saveButton = document.querySelector( '.woocommerce-save-button' );
+	if ( saveButton ) {
+		saveButton.addEventListener( 'click', showTaxCompletionNotice );
+	}
+} );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -44,7 +44,7 @@ class OnboardingTasks {
 	 * Constructor
 	 */
 	public function __construct() {
-		// This hook needs to run when options are updated via REST.		
+		// This hook needs to run when options are updated via REST.
 		add_action( 'add_option_woocommerce_task_list_complete', array( $this, 'add_completion_note' ), 10, 2 );
 
 		if ( ! is_admin() ) {
@@ -163,9 +163,11 @@ class OnboardingTasks {
 
 	/**
 	 * Updates the product published message with a continue setup link, if the products task is currently active.
+	 *
+	 * @param array $messages Array of messages to display.
 	 */
-	function update_product_success_message( $messages ) {
-		if ( ! $this->check_active_task_completion() ) {
+	public static function update_product_success_message( $messages ) {
+		if ( ! self::check_active_task_completion() ) {
 			return $messages;
 		}
 		/* translators: 1: onboarding task list url */
@@ -175,25 +177,30 @@ class OnboardingTasks {
 
 	/**
 	 * Hooks into the post page to display a different success notice and sets the active page as the site's home page if visted from onboarding.
+	 *
+	 * @param string $hook Page hook.
 	 */
-	function add_onboarding_homepage_notice_admin_script( $hook ) {
+	public static function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
-		if ( $hook == 'post.php' && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // WPCS: csrf ok.
-			wp_enqueue_script(  'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation' ) );
+		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
+			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation' ), WC_ADMIN_VERSION_NUMBER, true );
 		}
 	}
 
 	/**
 	 * Adds a notice to return to the task list when the save button is clicked on tax settings pages.
 	 */
-	function add_onboarding_tax_notice_admin_script() {
+	public static function add_onboarding_tax_notice_admin_script() {
+		$page        = isset( $_GET['page'] ) ? $_GET['page'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+		$tab         = isset( $_GET['tab'] ) ? $_GET['tab'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+		$active_task = isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ? $_GET[ self::ACTIVE_TASK_TRANSIENT ] : ''; // phpcs:ignore csrf ok, sanitization ok.
+
 		if (
-			'wc-settings' === $_GET[ 'page' ] &&
-			'tax' === $_GET[ 'tab' ] &&
-			isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) &&
-			'tax' === $_GET[ self::ACTIVE_TASK_TRANSIENT ]
+			'wc-settings' === $page &&
+			'tax' === $tab &&
+			'tax' === $active_task
 		) {
-			wp_enqueue_script(  'onboarding-tax-notice', Loader::get_url( 'wp-admin-scripts/onboarding-tax-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ) );
+			wp_enqueue_script( 'onboarding-tax-notice', Loader::get_url( 'wp-admin-scripts/onboarding-tax-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 		}
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ wcAdminPackages.forEach( name => {
 
 const wpAdminScripts = [
 	'onboarding-homepage-notice',
+	'onboarding-tax-notice',
 ];
 wpAdminScripts.forEach( name => {
 	entryPoints[ name ] = `./client/wp-admin-scripts/${ name }`;


### PR DESCRIPTION
Fixes #3149

Adds a notice to return to the task list after saving taxes.

Note that this just fires on "Save" click.  There doesn't seem to be a way to hook into the actual save trigger, but open to input here if this doesn't seem like a great solution.

### Screenshots
<img width="944" alt="Screen Shot 2019-11-05 at 6 00 24 PM" src="https://user-images.githubusercontent.com/10561050/68198147-71ee6f80-fff6-11e9-948a-5a895c0fd78c.png">

### Detailed test instructions:

1. Go to the task list and use a non-supported TaxJar company to force manual configuration.
2. Click the "Configure" button.
3. Add a tax rate and click "Save."
4. Note that a notice pops up with a link to return to the task list.
5. Note that navigating to the tax settings from the menu (WooCommerce->Settings) does not trigger this notice on save.