### PR TITLE
Fix vendor scripts not loading

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -7,8 +7,6 @@
  * @package WooCommerce/Admin
  */
 
-defined( 'ABSPATH' ) || exit;
-
 use \Automattic\WooCommerce\Admin\Install as Installer;
 
 /**


### PR DESCRIPTION
Fixes #3171

Removes an early exit from the update functions file that prevents vendor files from running with these autoloaded files.

### Screenshots
<img width="516" alt="Screen Shot 2019-11-05 at 6 54 35 PM" src="https://user-images.githubusercontent.com/10561050/68202007-d5c86680-fffd-11e9-9dde-8655588d649a.png">


### Detailed test instructions:

1. Navigate to your wc-admin plugin directory in a terminal.
2. Run `./vendor/bin/phpcs --version`.
3. Make sure a version is returned.
4. Optionally also test with `phpunit` and `phpcbf`.