### PR TITLE
Allow WP 5.2 to satisfy dependencies

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -221,7 +221,7 @@ class FeaturePlugin {
 
 		if ( ! $woocommerce_minimum_met ) {
 			$errors[] = sprintf(
-				/* translators: URL of WooCommerce plugin */
+				/* translators: 1: URL of WooCommerce plugin, 2: The minimum WooCommerce version number */
 				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WooCommerce</a> %2$s or greater to be installed and active.', 'woocommerce-admin' ),
 				'https://wordpress.org/plugins/woocommerce/',
 				$minimum_woocommerce_version
@@ -230,7 +230,7 @@ class FeaturePlugin {
 
 		if ( ! $wordpress_minimum_met ) {
 			$errors[] = sprintf(
-				/* translators: 1: URL of WordPress.org, 2: URL of WooCommerce plugin */
+				/* translators: 1: URL of WordPress.org, 2: The minimum WordPress version number */
 				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WordPress</a> %2$s or greater to be installed and active.', 'woocommerce-admin' ),
 				'https://wordpress.org/',
 				$minimum_wordpress_version

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -78,7 +78,7 @@ class FeaturePlugin {
 	public function on_deactivation() {
 		// Check if we are deactivating due to dependencies not being satisfied.
 		// If WooCommerce is disabled we can't include files that depend upon it.
-		if ( ! $this->check_dependencies() ) {
+		if ( ! $this->has_satisfied_dependencies() ) {
 			return;
 		}
 
@@ -97,7 +97,7 @@ class FeaturePlugin {
 	public function on_plugins_loaded() {
 		$this->load_plugin_textdomain();
 
-		if ( ! $this->check_dependencies() ) {
+		if ( ! $this->has_satisfied_dependencies() ) {
 			add_action( 'admin_init', array( $this, 'deactivate_self' ) );
 			add_action( 'admin_notices', array( $this, 'render_dependencies_notice' ) );
 			return;
@@ -207,18 +207,47 @@ class FeaturePlugin {
 	}
 
 	/**
+	 * Get an array of dependency error messages.
+	 *
+	 * @return array
+	 */
+	protected function get_dependency_errors() {
+		$errors                      = array();
+		$wordpress_version           = get_bloginfo( 'version' );
+		$minimum_wordpress_version   = '5.2';
+		$minimum_woocommerce_version = '3.6';
+		$wordpress_minimum_met       = version_compare( $wordpress_version, $minimum_wordpress_version, '>=' );
+		$woocommerce_minimum_met     = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, $minimum_woocommerce_version, '>=' );
+
+		if ( ! $woocommerce_minimum_met ) {
+			$errors[] = sprintf(
+				/* translators: URL of WooCommerce plugin */
+				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WooCommerce</a> %2$s or greater to be installed and active.', 'woocommerce-admin' ),
+				'https://wordpress.org/plugins/woocommerce/',
+				$minimum_woocommerce_version
+			);
+		}
+
+		if ( ! $wordpress_minimum_met ) {
+			$errors[] = sprintf(
+				/* translators: 1: URL of WordPress.org, 2: URL of WooCommerce plugin */
+				__( 'The WooCommerce Admin feature plugin requires <a href="%1$s">WordPress</a> %2$s or greater to be installed and active.', 'woocommerce-admin' ),
+				'https://wordpress.org/',
+				$minimum_wordpress_version
+			);
+		}
+
+		return $errors;
+	}
+
+	/**
 	 * Returns true if all dependencies for the wc-admin plugin are loaded.
 	 *
 	 * @return bool
 	 */
-	protected function check_dependencies() {
-		$woocommerce_minimum_met = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, '3.6', '>=' );
-		if ( ! $woocommerce_minimum_met ) {
-			return false;
-		}
-
-		$wordpress_version = get_bloginfo( 'version' );
-		return version_compare( $wordpress_version, '5.2.0', '>=' );
+	protected function has_satisfied_dependencies() {
+		$dependency_errors = $this->get_dependency_errors();
+		return 0 === count( $dependency_errors );
 	}
 
 	/**
@@ -242,25 +271,8 @@ class FeaturePlugin {
 	 * Notify users of the plugin requirements.
 	 */
 	public function render_dependencies_notice() {
-		// The notice varies by WordPress version.
-		$wordpress_version    = get_bloginfo( 'version' );
-		$has_valid_wp_version = version_compare( $wordpress_version, '5.2.0', '>=' );
-
-		if ( $has_valid_wp_version ) {
-			$message = sprintf(
-				/* translators: URL of WooCommerce plugin */
-				__( 'The WooCommerce Admin feature plugin requires <a href="%s">WooCommerce</a> 3.6 or greater to be installed and active.', 'woocommerce-admin' ),
-				'https://wordpress.org/plugins/woocommerce/'
-			);
-		} else {
-			$message = sprintf(
-				/* translators: 1: URL of WordPress.org, 2: URL of WooCommerce plugin */
-				__( 'The WooCommerce Admin feature plugin requires both <a href="%1$s">WordPress</a> 5.2 or greater and <a href="%2$s">WooCommerce</a> 3.6 or greater to be installed and active.', 'woocommerce-admin' ),
-				'https://wordpress.org/',
-				'https://wordpress.org/plugins/woocommerce/'
-			);
-		}
-		printf( '<div class="error"><p>%s</p></div>', $message ); /* WPCS: xss ok. */
+		$message = $this->get_dependency_errors();
+		printf( '<div class="error"><p>%s</p></div>', implode( ' ', $message ) ); /* phpcs:ignore xss ok. */
 	}
 
 	/**
@@ -273,7 +285,7 @@ class FeaturePlugin {
 			__( 'Or you can download a pre-built version of the plugin by visiting <a href="%1$s">the releases page in the repository</a>.', 'woocommerce-admin' ),
 			'https://github.com/woocommerce/woocommerce-admin/releases'
 		);
-		printf( '<div class="error"><p>%s %s</p></div>', $message_one, $message_two ); /* WPCS: xss ok. */
+		printf( '<div class="error"><p>%s %s</p></div>', $message_one, $message_two ); /* phpcs:ignore xss ok. */
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3181

`version_compare()` in PHP does not recognize `5.2` and `5.2.0` despite some specs saying it should and others saying `5.2` is not a valid version number.  This PR uses `5.2` to allow the WP 5.2 version to work as expected.

It also adds a small refactor to dependencies and respective errors so that we can reduce the number of places the version number is used.

### Detailed test instructions:

1. Download and install the WP 5.2 release - https://wordpress.org/wordpress-5.2.zip
2. Install WooCommerce >=3.6.
3. Note that activation of wc admin works.
4. Try with later or previous versions of WC/WP and make sure you receive the expected error messages or activation.