### PR TITLE
Onboarding: Check if official TaxJar plugin exists before enabling WCS integration

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -107,10 +107,12 @@ class Tax extends Component {
 
 	isTaxJarSupported() {
 		const { countryCode, wc_connect_options } = this.props;
-		const { automatedTaxSupportedCountries = [] } = getSetting( 'onboarding', {} );
+		const { automatedTaxSupportedCountries = [], taxJarActivated } = getSetting( 'onboarding', {} );
 
 		return (
-			wc_connect_options.tos_accepted && automatedTaxSupportedCountries.includes( countryCode )
+			! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
+			wc_connect_options.tos_accepted &&
+			automatedTaxSupportedCountries.includes( countryCode )
 		);
 	}
 

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -95,6 +95,7 @@ class OnboardingTasks {
 		$settings['onboarding']['hasProducts']                    = self::check_task_completion( 'products' );
 		$settings['onboarding']['isTaxComplete']                  = self::check_task_completion( 'tax' );
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
+		$settings['onboarding']['taxJarActivated']                = class_exists( 'WC_Taxjar' );
 
 		return $settings;
 	}


### PR DESCRIPTION
Fixes #3051

Doesn't allow the automated tax screen if TaxJar is enabled since WCS does not integrate with this plugin.

### Screenshots
<img width="722" alt="Screen Shot 2019-11-06 at 4 03 28 PM" src="https://user-images.githubusercontent.com/10561050/68279722-fe5c6900-00ae-11ea-86c2-d732b9679fe6.png">

### Detailed test instructions:

1. Make sure the official TaxJar plugin is not activated on your site.
2. Meet all the requirements to automated taxes (WCS & Jetpack installed/connected, TaxJar supported country, store address filled in).
3. Make sure you can see the above "Good news" screen in the tax task.
4. Activate the official TaxJar plugin.
5. Revisit the task tax and make sure you can't see the "Good news" screen.