### PR TITLE
Enable onboarding in the plugin build for those who have opted-in

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -24,6 +24,7 @@ import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
+import { isOnboardingEnabled } from 'dashboard/utils';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -198,7 +199,7 @@ class CustomizableDashboard extends Component {
 			.map( section => section.key );
 
 		if (
-			window.wcAdminFeatures.onboarding &&
+			isOnboardingEnabled() &&
 			wcSettings.onboarding &&
 			! taskListHidden &&
 			( query.task || ! taskListCompleted )
@@ -208,7 +209,7 @@ class CustomizableDashboard extends Component {
 
 		return (
 			<Fragment>
-				{ window.wcAdminFeatures.onboarding &&
+				{ isOnboardingEnabled() &&
 					wcSettings.onboarding &&
 					! taskListHidden &&
 					taskListCompleted && <TaskList query={ query } inline /> }
@@ -250,7 +251,7 @@ export default compose(
 			userPrefSections: userData.dashboard_sections,
 		};
 
-		if ( window.wcAdminFeatures.onboarding ) {
+		if ( isOnboardingEnabled() ) {
 			const profileItems = getProfileItems();
 			const tasks = getTasks( {
 				profileItems,

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -20,6 +20,7 @@ import './style.scss';
 import CustomizableDashboard from './customizable';
 import ProfileWizard from './profile-wizard';
 import withSelect from 'wc-api/with-select';
+import { isOnboardingEnabled } from 'dashboard/utils';
 
 class Dashboard extends Component {
 	componentDidUpdate( prevProps ) {
@@ -56,7 +57,7 @@ class Dashboard extends Component {
 	}
 
 	redirectToCart() {
-		if ( ! window.wcAdminFeatures.onboarding ) {
+		if ( ! isOnboardingEnabled() ) {
 			return;
 		}
 
@@ -77,7 +78,7 @@ class Dashboard extends Component {
 	render() {
 		const { path, profileItems, query } = this.props;
 
-		if ( window.wcAdminFeatures.onboarding && ! profileItems.completed ) {
+		if ( isOnboardingEnabled() && ! profileItems.completed ) {
 			return <ProfileWizard query={ query } />;
 		}
 
@@ -91,7 +92,7 @@ class Dashboard extends Component {
 
 export default compose(
 	withSelect( select => {
-		if ( ! window.wcAdminFeatures.onboarding ) {
+		if ( ! isOnboardingEnabled() ) {
 			return;
 		}
 

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -105,10 +105,6 @@ class Theme extends Component {
 	}
 
 	redirectToCart() {
-		if ( ! window.wcAdminFeatures.onboarding ) {
-			return;
-		}
-
 		document.body.classList.add( 'woocommerce-admin-is-loading' );
 
 		const productIds = this.getProductIds();

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -1,3 +1,10 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
 /**
  * Gets the country code from a country:state value string.
  *
@@ -12,4 +19,20 @@ export function getCountryCode( countryState ) {
 	}
 
 	return countryState.split( ':' )[ 0 ];
+}
+
+/**
+ * Returns if the onboarding feature of WooCommerce Admin should be enabled.
+ *
+ * While we preform an a/b test of onboarding, the feature will be enabled within the plugin build,
+ * but only if the user recieved the test/opted in.
+ *
+ * @return {bool} True if the onboarding is enabled.
+ */
+export function isOnboardingEnabled() {
+	if ( ! window.wcAdminFeatures.onboarding ) {
+		return false;
+	}
+
+	return getSetting( 'onboardingEnabled', false );
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"devdocs": false,
-		"onboarding": false,
+		"onboarding": true,
 		"store-alerts": true
 	}
 }

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -75,7 +75,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\Themes',
 		);
 
-		if ( Loader::is_feature_enabled( 'onboarding' ) ) {
+		if ( Loader::is_onboarding_enabled() ) {
 			$controllers = array_merge(
 				$controllers,
 				array(

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -291,7 +291,7 @@ class FeaturePlugin {
 	 * Adds a menu item for the wc-admin devdocs.
 	 */
 	public function register_devdocs_page() {
-		if ( Loader::is_feature_enabled( 'devdocs' ) && defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		if ( Loader::is_dev() ) {
 			wc_admin_register_page(
 				array(
 					'title'  => 'DevDocs',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -49,6 +49,11 @@ class Onboarding {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
+
+		if ( ! Loader::is_onboarding_enabled() ) {
+			return;
+		}
+
 		// Include WC Admin Onboarding classes.
 		if ( self::should_show_tasks() ) {
 			OnboardingTasks::get_instance();
@@ -173,12 +178,15 @@ class Onboarding {
 
 			if ( ! is_wp_error( $theme_data ) ) {
 				$theme_data = json_decode( $theme_data['body'] );
-				usort( $theme_data->products, function ($product_1, $product_2) {
-					if ( 'Storefront' === $product_1->slug ) {
-						return -1;
+				usort(
+					$theme_data->products,
+					function ( $product_1, $product_2 ) {
+						if ( 'Storefront' === $product_1->slug ) {
+							return -1;
+						}
+						return $product_1->id < $product_2->id ? 1 : -1;
 					}
-					return $product_1->id < $product_2->id ? 1 : -1;
-				} );
+				);
 
 				foreach ( $theme_data->products as $theme ) {
 					$slug                                       = sanitize_title( $theme->slug );
@@ -411,14 +419,42 @@ class Onboarding {
 	/**
 	 * Returns a list of Stripe supported countries. This method can be removed once merged to core.
 	 *
-	 * @param array $endpoints Array of preloaded endpoints.
 	 * @return array
 	 */
 	private static function get_stripe_supported_countries() {
 		// https://stripe.com/global.
 		return array(
-			'AU', 'AT', 'BE', 'CA', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HK', 'IE', 'IT', 'JP', 'LV', 'LT', 'LU', 'MY', 'NL', 'NZ', 'NO',
-			'PL', 'PT', 'SG', 'SK', 'SI', 'ES', 'SE', 'CH', 'GB', 'US',
+			'AU',
+			'AT',
+			'BE',
+			'CA',
+			'DK',
+			'EE',
+			'FI',
+			'FR',
+			'DE',
+			'GR',
+			'HK',
+			'IE',
+			'IT',
+			'JP',
+			'LV',
+			'LT',
+			'LU',
+			'MY',
+			'NL',
+			'NZ',
+			'NO',
+			'PL',
+			'PT',
+			'SG',
+			'SK',
+			'SI',
+			'ES',
+			'SE',
+			'CH',
+			'GB',
+			'US',
 		);
 	}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -96,6 +96,16 @@ class Loader {
 	}
 
 	/**
+	 * Returns true if WooCommerce Admin is currently running in a development environment.
+	 */
+	public static function is_dev() {
+		if ( self::is_feature_enabled( 'devdocs' ) && defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Gets an array of enabled WooCommerce Admin features/sections.
 	 *
 	 * @return bool Enabled Woocommerce Admin features/sections.
@@ -113,6 +123,28 @@ class Loader {
 	public static function is_feature_enabled( $feature ) {
 		$features = self::get_features();
 		return in_array( $feature, $features, true );
+	}
+
+	/**
+	 * Returns if the onboarding feature of WooCommerce Admin should be enabled.
+	 *
+	 * While we preform an a/b test of onboarding, the feature will be enabled within the plugin build, but only if the user recieved the test/opted in.
+	 *
+	 * @return bool Returns true if the onboarding is enabled.
+	 */
+	public static function is_onboarding_enabled() {
+		if ( ! self::is_feature_enabled( 'onboarding' ) ) {
+			return false;
+		}
+
+		$onboarding_opt_in        = get_option( 'wc_onboarding_opt_in', false );
+		$onboarding_filter_opt_in = defined( 'WOOCOMMERCE_ADMIN_SHOW_ONBOARDING' ) && true === WOOCOMMERCE_ADMIN_SHOW_ONBOARDING;
+
+		if ( self::is_dev() || $onboarding_filter_opt_in || $onboarding_opt_in ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -585,12 +617,12 @@ class Loader {
 
 		$preload_settings = apply_filters( 'woocommerce_admin_preload_settings', array() );
 		if ( ! empty( $preload_settings ) ) {
-			$setting_options = new \WC_REST_Setting_Options_V2_Controller;
+			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
 				$group_settings   = $setting_options->get_group_settings( $group );
 				$preload_settings = [];
-				foreach( $group_settings as $option ) {
-					$preload_settings[ $option[ 'id' ] ] = $option[ 'value' ];
+				foreach ( $group_settings as $option ) {
+					$preload_settings[ $option['id'] ] = $option['value'];
 				}
 				$settings['preloadSettings'][ $group ] = $preload_settings;
 			}
@@ -607,9 +639,10 @@ class Loader {
 		$settings['notifyLowStockAmount'] = get_option( 'woocommerce_notify_low_stock_amount' );
 		// @todo On merge, once plugin images are added to core WooCommerce, `wcAdminAssetUrl` can be retired,
 		// and `wcAssetUrl` can be used in its place throughout the codebase.
-		$settings['wcAdminAssetUrl'] = plugins_url( 'images/', dirname( __DIR__ ) . '/woocommerce-admin.php' );
-		$settings['wcVersion']       = WC_VERSION;
-		$settings['siteUrl']         = site_url();
+		$settings['wcAdminAssetUrl']   = plugins_url( 'images/', dirname( __DIR__ ) . '/woocommerce-admin.php' );
+		$settings['wcVersion']         = WC_VERSION;
+		$settings['siteUrl']           = site_url();
+		$settings['onboardingEnabled'] = self::is_onboarding_enabled();
 
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$settings['dataEndpoints'] = isset( $settings['dataEndpoints'] )

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -137,8 +137,8 @@ class Loader {
 			return false;
 		}
 
-		$onboarding_opt_in        = get_option( 'wc_onboarding_opt_in', false );
-		$onboarding_filter_opt_in = defined( 'WOOCOMMERCE_ADMIN_SHOW_ONBOARDING' ) && true === WOOCOMMERCE_ADMIN_SHOW_ONBOARDING;
+		$onboarding_opt_in        = 'yes' === get_option( 'wc_onboarding_opt_in', 'no' );
+		$onboarding_filter_opt_in = defined( 'WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED' ) && true === WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED;
 
 		if ( self::is_dev() || $onboarding_filter_opt_in || $onboarding_opt_in ) {
 			return true;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,6 +89,7 @@ function _manually_load_plugin() {
 	define( 'WC_USE_TRANSACTIONS', false );
 	update_option( 'woocommerce_enable_coupons', 'yes' );
 	update_option( 'woocommerce_calc_taxes', 'yes' );
+	define( 'WOOCOMMERCE_ADMIN_SHOW_ONBOARDING', true );
 
 	require_once wc_dir() . '/woocommerce.php';
 	require dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,7 +89,7 @@ function _manually_load_plugin() {
 	define( 'WC_USE_TRANSACTIONS', false );
 	update_option( 'woocommerce_enable_coupons', 'yes' );
 	update_option( 'woocommerce_calc_taxes', 'yes' );
-	define( 'WOOCOMMERCE_ADMIN_SHOW_ONBOARDING', true );
+	define( 'WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED', true );
 
 	require_once wc_dir() . '/woocommerce.php';
 	require dirname( __DIR__ ) . '/vendor/autoload.php';


### PR DESCRIPTION
Part of woocommerce/woocommerce-admin#2759.

To enable split testing in WooCommerce Core (which can only install .org released versions of the plugin), and to make it easier for internal testers and user testing, this enables the onboarding feature in our plugin build/release. 

There are additional checks so that the relevant code only runs in development, or if a user has opted in via WooCommerce Core (https://github.com/woocommerce/woocommerce/pull/24991) or via a filter.

(The purpose for is filter is so we can release a simple plugin that sets the filter to true for internal testers, and then internal testers just need to use the normal build of WooCommerce Admin).

### Detailed test instructions:

* Build the development  version of WooCommerce Admin (`npm start` this branch).
* Test a few different onboarding features and make sure everything looks OK.
* Run `npm run build:release` to build the normal plugin release.
* Enable it on a test site and make sure onboarding features do not display.
* Set the `wc_onboarding_opt_in` option to `true` in your database.
* Refresh, and see the onboarding feature active.
* Set the value back to false.
* Refresh, and see no onboarding.
* Set `WOOCOMMERCE_ADMIN_ENABLE_ONBOARDING` to `yes` in your `wp-config.php`, refresh and see the onboarding feature active.

### Changelog Note:

Enhancement: New onboarding experience for opt-in users.
