### PR TITLE
move stock stats sync functions to ReportsSync

### DIFF
--- a/src/API/Reports/Stock/Stats/DataStore.php
+++ b/src/API/Reports/Stock/Stats/DataStore.php
@@ -132,23 +132,3 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		return intval( $query->found_posts );
 	}
 }
-
-/**
- * Clear the count cache when products are added or updated, or when
- * the no/low stock options are changed.
- *
- * @param int $id Post/product ID.
- */
-function wc_admin_clear_stock_count_cache( $id ) {
-	delete_transient( 'wc_admin_stock_count_lowstock' );
-	delete_transient( 'wc_admin_product_count' );
-	$status_options = wc_get_product_stock_status_options();
-	foreach ( $status_options as $status => $label ) {
-		delete_transient( 'wc_admin_stock_count_' . $status );
-	}
-}
-
-add_action( 'woocommerce_update_product', 'wc_admin_clear_stock_count_cache' );
-add_action( 'woocommerce_new_product', 'wc_admin_clear_stock_count_cache' );
-add_action( 'update_option_woocommerce_notify_low_stock_amount', 'wc_admin_clear_stock_count_cache' );
-add_action( 'update_option_woocommerce_notify_no_stock_amount', 'wc_admin_clear_stock_count_cache' );


### PR DESCRIPTION
Fixes #3054

This PR moves the stock sync functions to the ReportsSync class. These handlers were missed in the PSR-4 code reorg #2712.

### Detailed test instructions:

- Edit the stock on a product to a value that should set the low stock flag
- Check the stock panel to see that the product is listed
- Edit the stock amount on a product currently shown in the low stock panel that should clear the low stock flag
- Check the stock panel to see that the product is not listed

### Changelog Note:

none needed