### PR TITLE
Add src/Package.php for Core inclusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
       "includes/wc-admin-update-functions.php"
     ],
     "psr-4": {
-      "Automattic\\WooCommerce\\WCAdmin\\": "src/"
+      "Automattic\\WooCommerce\\Admin\\": "src/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
       "includes/wc-admin-update-functions.php"
     ],
     "psr-4": {
-      "Automattic\\WooCommerce\\Admin\\": "src/"
+      "Automattic\\WooCommerce\\WCAdmin\\": "src/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "automattic/jetpack-autoloader": "1.2.0",
     "composer/installers": "1.7.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
+    "automattic/jetpack-autoloader": "1.3.2",
     "composer/installers": "1.7.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "automattic/jetpack-autoloader": "1.3.2",
+    "automattic/jetpack-autoloader": "1.2.0",
     "composer/installers": "1.7.0"
   },
   "require-dev": {

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -56,7 +56,7 @@ class FeaturePlugin {
 		$this->define_constants();
 		register_activation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
 		register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
-		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
+		self::on_plugins_loaded(); // because the action has already been called.
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}
 
@@ -282,6 +282,18 @@ class FeaturePlugin {
 	 * @param array $features Array of feature slugs.
 	 */
 	public function replace_supported_features( $features ) {
+		/** This function doesn't exist yet. */
+		function wc_admin_get_feature_config() {
+			return array(
+				'activity-panels'                  => true,
+				'analytics'                        => true,
+				'analytics-dashboard'              => true,
+				'analytics-dashboard/customizable' => true,
+				'devdocs'                          => true,
+				'onboarding'                       => true,
+				'store-alerts'                     => true,
+			);
+		}
 		$feature_config = apply_filters( 'wc_admin_get_feature_config', wc_admin_get_feature_config() );
 		$features       = array_keys( array_filter( $feature_config ) );
 		return $features;

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -282,18 +282,6 @@ class FeaturePlugin {
 	 * @param array $features Array of feature slugs.
 	 */
 	public function replace_supported_features( $features ) {
-		/** This function doesn't exist yet. */
-		function wc_admin_get_feature_config() {
-			return array(
-				'activity-panels'                  => true,
-				'analytics'                        => true,
-				'analytics-dashboard'              => true,
-				'analytics-dashboard/customizable' => true,
-				'devdocs'                          => true,
-				'onboarding'                       => true,
-				'store-alerts'                     => true,
-			);
-		}
 		$feature_config = apply_filters( 'wc_admin_get_feature_config', wc_admin_get_feature_config() );
 		$features       = array_keys( array_filter( $feature_config ) );
 		return $features;

--- a/src/Package.php
+++ b/src/Package.php
@@ -2,7 +2,7 @@
 /**
  * Returns information about the package and handles init.
  *
- * @package Automattic/WooCommerce/ExamplePackage
+ * @package Automattic/WooCommerce/WCAdmin
  */
 
 namespace Automattic\WooCommerce\WCAdmin;

--- a/src/Package.php
+++ b/src/Package.php
@@ -5,9 +5,7 @@
  * @package Automattic/WooCommerce/WCAdmin
  */
 
-namespace Automattic\WooCommerce\WCAdmin;
-
-use \Automattic\WooCommerce\Admin\FeaturePlugin;
+namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -9,6 +9,24 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once WC_ABSPATH . 'packages/woocommerce-admin/includes/core-functions.php';
+require_once WC_ABSPATH . 'packages/woocommerce-admin/includes/feature-config.php';
+require_once WC_ABSPATH . 'packages/woocommerce-admin/includes/page-controller-functions.php';
+require_once WC_ABSPATH . 'packages/woocommerce-admin/includes/wc-admin-update-functions.php';
+
+/** This function doesn't exist yet. */
+function wc_admin_get_feature_config() {
+	return array(
+		'activity-panels'                  => true,
+		'analytics'                        => true,
+		'analytics-dashboard'              => true,
+		'analytics-dashboard/customizable' => true,
+		'devdocs'                          => true,
+		'onboarding'                       => true,
+		'store-alerts'                     => true,
+	);
+}
+
 /**
  * Main package class.
  */

--- a/src/Package.php
+++ b/src/Package.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Returns information about the package and handles init.
+ *
+ * @package Automattic/WooCommerce/ExamplePackage
+ */
+
+namespace Automattic\WooCommerce\WCAdmin;
+
+use \Automattic\WooCommerce\Admin\FeaturePlugin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main package class.
+ */
+class Package {
+
+	/**
+	 * Version.
+	 *
+	 * @var string
+	 */
+	const VERSION = '0.21.0';
+
+	/**
+	 * Init the package.
+	 */
+	public static function init() {
+		FeaturePlugin::instance()->init();
+	}
+
+	/**
+	 * Return the version of the package.
+	 *
+	 * @return string
+	 */
+	public static function get_version() {
+		return self::VERSION;
+	}
+
+	/**
+	 * Return the path to the package.
+	 *
+	 * @return string
+	 */
+	public static function get_path() {
+		return dirname( __DIR__ );
+	}
+}


### PR DESCRIPTION
Partially addresses https://github.com/woocommerce/woocommerce-admin/issues/3176

Add src/Package.php so Core can use it not as a plugin.