### PR TITLE
Onboarding - Select the stripe account checkbox by default

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -314,8 +314,13 @@
 		.components-checkbox-control__label {
 			font-size: 16px;
 			line-height: 22px;
-			padding-left: $gap-small;
+			padding-left: 0;
+			margin-left: -$gap-large;
 			color: #1a1a1a;
+		}
+
+		.muriel-component {
+			margin-left: $gap-smallest;
 		}
 	}
 }

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -105,14 +105,15 @@ class Payments extends Component {
 	}
 
 	getInitialValues() {
+		const stripeEmail = getSetting( 'onboarding', { userEmail: '' } ).userEmail;
 		const values = {
 			stripe: this.isStripeEnabled(),
 			paypal: false,
 			klarna_checkout: false,
 			klarna_payments: false,
 			square: false,
-			create_stripe: false,
-			stripe_email: '',
+			create_stripe: this.isStripeEnabled(),
+			stripe_email: ( this.isStripeEnabled() && stripeEmail ) || '',
 		};
 		return values;
 	}
@@ -393,7 +394,7 @@ class Payments extends Component {
 						manualConfig={ manualConfig }
 						markConfigured={ this.markConfigured }
 						setRequestPending={ this.setMethodRequestPending }
-						createAccount={ values.create_stripe }
+						createAccount={ values.create_stripe && ! manualConfig }
 						email={ values.stripe_email }
 						countryCode={ countryCode }
 						returnUrl={ getAdminLink( 'admin.php?page=wc-admin&task=payments&stripe-connect=1' ) }

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -357,6 +357,8 @@ class Onboarding {
 			$settings['onboarding']['stripeSupportedCountries'] = self::get_stripe_supported_countries();
 			$settings['onboarding']['euCountries']              = WC()->countries->get_european_union_countries();
 			$settings['onboarding']['connectNonce']             = wp_create_nonce( 'connect' );
+			$current_user                                       = wp_get_current_user();
+			$settings['onboarding']['userEmail']                = esc_html( $current_user->user_email );
 		}
 
 		return $settings;


### PR DESCRIPTION
Per p90Yrv-1iA-p2 #comment-2764, this PR checks the stripe checkbox by default, and pre-fills the users email. 

It also fixes alignment with the checkbox, which seems to have changed.

### Screenshots

Before:

<img width="465" alt="Screen Shot 2019-11-07 at 12 42 29 PM" src="https://user-images.githubusercontent.com/689165/68418807-f8c25a00-0166-11ea-89f4-b45f4bcca009.png">

After:

<img width="747" alt="Screen Shot 2019-11-07 at 12 35 12 PM" src="https://user-images.githubusercontent.com/689165/68418823-02e45880-0167-11ea-9eb0-65d871606901.png">

### Detailed test instructions:

* Delete the `woocommerce_onboarding_payments` option from your database.
* Make sure you have Jetpack and WCS connected and have a Stripe friendly country set for your store.
* Go to the payments task. The Stripe create account checkbox should be enabled and your email prefilled.