### PR TITLE
Onboarding: Update return to task list notices

### DIFF
--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -181,4 +181,12 @@ body.woocommerce-page {
 			color: $studio-white;
 		}
 	}
+
+	.components-snackbar .components-button.is-tertiary {
+		color: $studio-white;
+
+		&:not(:disabled):not([aria-disabled='true']):not(.is-default):hover {
+			color: $studio-white;
+		}
+	}
 }

--- a/client/wp-admin-scripts/onboarding-product-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-product-notice/index.js
@@ -1,0 +1,34 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getAdminLink } from '@woocommerce/navigation';
+
+/**
+ * Displays a notice after product creation.
+ */
+const showProductCompletionNotice = () => {
+	dispatch( 'core/notices' ).createSuccessNotice(
+		__( 'You created your first product!', 'woocommerce-admin' ),
+		{
+			id: 'WOOCOMMERCE_ONBOARDING_PRODUCT_NOTICE',
+			actions: [
+				{
+					url: getAdminLink( 'admin.php?page=wc-admin' ),
+					label: __( 'Continue setup.', 'woocommerce-admin' ),
+				},
+			],
+		}
+	);
+};
+
+domReady( () => {
+	showProductCompletionNotice();
+} );

--- a/client/wp-admin-scripts/onboarding-tax-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-tax-notice/index.js
@@ -40,7 +40,7 @@ const showTaxCompletionNotice = () => {
 	saveButton.classList.add( 'is-clicked' );
 	saveCompleted().then( () =>
 		dispatch( 'core/notices' ).createSuccessNotice(
-			__( "You've added your first tax rate!.", 'woocommerce-admin' ),
+			__( "You've added your first tax rate!", 'woocommerce-admin' ),
 			{
 				id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
 				actions: [

--- a/client/wp-admin-scripts/onboarding-tax-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-tax-notice/index.js
@@ -40,7 +40,7 @@ const showTaxCompletionNotice = () => {
 	saveButton.classList.add( 'is-clicked' );
 	saveCompleted().then( () =>
 		dispatch( 'core/notices' ).createSuccessNotice(
-			__( 'Your tax settings have been saved.', 'woocommerce-admin' ),
+			__( "You've added your first tax rate!.", 'woocommerce-admin' ),
 			{
 				id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
 				actions: [

--- a/client/wp-admin-scripts/onboarding-tax-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-tax-notice/index.js
@@ -12,20 +12,45 @@ import domReady from '@wordpress/dom-ready';
 import { getAdminLink } from '@woocommerce/navigation';
 
 /**
+ * Returns a promise and resolves when the loader overlay no longer exists.
+ *
+ * @return {Promise} Promise for overlay existence.
+ */
+const saveCompleted = () => {
+	if ( document.querySelector( '.blockUI.blockOverlay' ) !== null ) {
+		const promise = new Promise( resolve => {
+			requestAnimationFrame( resolve );
+		} );
+		return promise.then( () => saveCompleted() );
+	}
+
+	return Promise.resolve( true );
+};
+
+/**
  * Displays a notice on tax settings save.
  */
 const showTaxCompletionNotice = () => {
-	dispatch( 'core/notices' ).createSuccessNotice(
-		__( 'Your tax settings have been saved.', 'woocommerce-admin' ),
-		{
-			id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
-			actions: [
-				{
-					url: getAdminLink( 'admin.php?page=wc-admin' ),
-					label: __( 'Continue setup.', 'woocommerce-admin' ),
-				},
-			],
-		}
+	const saveButton = document.querySelector( '.woocommerce-save-button' );
+
+	if ( saveButton.classList.contains( 'is-clicked' ) ) {
+		return;
+	}
+
+	saveButton.classList.add( 'is-clicked' );
+	saveCompleted().then( () =>
+		dispatch( 'core/notices' ).createSuccessNotice(
+			__( 'Your tax settings have been saved.', 'woocommerce-admin' ),
+			{
+				id: 'WOOCOMMERCE_ONBOARDING_TAX_NOTICE',
+				actions: [
+					{
+						url: getAdminLink( 'admin.php?page=wc-admin' ),
+						label: __( 'Continue setup.', 'woocommerce-admin' ),
+					},
+				],
+			}
+		)
 	);
 };
 

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -58,10 +58,10 @@ class OnboardingTasks {
 		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 30 );
 
-		add_action( 'admin_init', array( $this, 'set_active_task' ), 20 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_notice_admin_script' ), 10, 1 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ), 10, 1 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ), 10, 1 );
+		add_action( 'admin_init', array( $this, 'set_active_task' ), 5 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_notice_admin_script' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ) );
 	}
 
 	/**
@@ -206,14 +206,14 @@ class OnboardingTasks {
 	 * Adds a notice to return to the task list when the save button is clicked on tax settings pages.
 	 */
 	public static function add_onboarding_tax_notice_admin_script() {
-		$page        = isset( $_GET['page'] ) ? $_GET['page'] : ''; // phpcs:ignore csrf ok, sanitization ok.
-		$tab         = isset( $_GET['tab'] ) ? $_GET['tab'] : ''; // phpcs:ignore csrf ok, sanitization ok.
-		$active_task = isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ? $_GET[ self::ACTIVE_TASK_TRANSIENT ] : ''; // phpcs:ignore csrf ok, sanitization ok.
+		$page = isset( $_GET['page'] ) ? $_GET['page'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+		$tab  = isset( $_GET['tab'] ) ? $_GET['tab'] : ''; // phpcs:ignore csrf ok, sanitization ok.
 
 		if (
 			'wc-settings' === $page &&
 			'tax' === $tab &&
-			'tax' === $active_task
+			'tax' === self::get_active_task() &&
+			! self::is_active_task_complete()
 		) {
 			wp_enqueue_script( 'onboarding-tax-notice', Loader::get_url( 'wp-admin-scripts/onboarding-tax-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 		}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -59,7 +59,7 @@ class OnboardingTasks {
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 30 );
 
 		add_action( 'admin_init', array( $this, 'set_active_task' ), 20 );
-		add_filter( 'post_updated_messages', array( $this, 'update_product_success_message' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_notice_admin_script' ), 10, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ), 10, 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ), 10, 1 );
 	}
@@ -120,10 +120,19 @@ class OnboardingTasks {
 	}
 
 	/**
+	 * Get the name of the active task.
+	 *
+	 * @return string
+	 */
+	public static function get_active_task() {
+		return get_transient( self::ACTIVE_TASK_TRANSIENT );
+	}
+
+	/**
 	 * Check for active task completion, and clears the transient.
 	 */
-	public static function check_active_task_completion() {
-		$active_task = get_transient( self::ACTIVE_TASK_TRANSIENT );
+	public static function is_active_task_complete() {
+		$active_task = self::get_active_task();
 
 		if ( ! $active_task ) {
 			return false;
@@ -163,17 +172,22 @@ class OnboardingTasks {
 	}
 
 	/**
-	 * Updates the product published message with a continue setup link, if the products task is currently active.
+	 * Hooks into the product page to add a notice to return to the task list if a product was added.
 	 *
-	 * @param array $messages Array of messages to display.
+	 * @param string $hook Page hook.
 	 */
-	public static function update_product_success_message( $messages ) {
-		if ( ! self::check_active_task_completion() ) {
-			return $messages;
+	public static function add_onboarding_product_notice_admin_script( $hook ) {
+		global $post;
+		if (
+			'post.php' !== $hook ||
+			'product' !== $post->post_type ||
+			'products' !== self::get_active_task() ||
+			! self::is_active_task_complete()
+		) {
+			return;
 		}
-		/* translators: 1: onboarding task list url */
-		$messages['product'][6] = sprintf( __( 'You created your first product! <a href="%s">Continue Setup</a>.', 'woocommerce-admin' ), esc_url( wc_admin_url() ) );
-		return $messages;
+
+		wp_enqueue_script( 'onboarding-product-notice', Loader::get_url( 'wp-admin-scripts/onboarding-product-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ wcAdminPackages.forEach( name => {
 
 const wpAdminScripts = [
 	'onboarding-homepage-notice',
+	'onboarding-product-notice',
 	'onboarding-tax-notice',
 ];
 wpAdminScripts.forEach( name => {


### PR DESCRIPTION
Fixes #3191

* Uses `core/notices` for product notices.
* Updates the tax notice to only show when save is complete (when the Backbone overlay disappears) and only on first save.
* Leaves homepoage notices the same since these use `core/notices` already, but are styled this way in the editor (appears to be intentional styling in GB).

### Screenshots
<img width="441" alt="Screen Shot 2019-11-08 at 1 41 33 PM" src="https://user-images.githubusercontent.com/10561050/68452589-f24ae580-022d-11ea-9ad6-e76f08519d6f.png">


### Detailed test instructions:

1.  Use a site with no products, homepage, or taxes set up.
2. Add a product (publish), homepage (publish), and tax (save) on respective screens.
3. Note the messages to return to task list.