### PR TITLE
Add tax filtering to orders data

### DIFF
--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -9,7 +9,7 @@ import { ORDER_STATUSES } from '@woocommerce/wc-admin-settings';
 /**
  * Internal dependencies
  */
-import { getCouponLabels, getProductLabels } from 'lib/async-requests';
+import { getCouponLabels, getProductLabels, getTaxRateLabels } from 'lib/async-requests';
 
 const ORDERS_REPORT_CHARTS_FILTER = 'woocommerce_admin_orders_report_charts';
 const ORDERS_REPORT_FILTERS_FILTER = 'woocommerce_admin_orders_report_filters';
@@ -183,6 +183,34 @@ export const advancedFilters = applyFilters( ORDERS_REPORT_ADVANCED_FILTERS_FILT
 					{ value: 'none', label: __( 'None', 'woocommerce-admin' ) },
 				],
 				defaultOption: 'all',
+			},
+		},
+		tax_rate: {
+			labels: {
+				add: __( 'Tax Rates', 'woocommerce-admin' ),
+				placeholder: __( 'Search tax rates', 'woocommerce-admin' ),
+				remove: __( 'Remove tax rate filter', 'woocommerce-admin' ),
+				rule: __( 'Select a tax rate filter match', 'woocommerce-admin' ),
+				/* translators: A sentence describing a tax rate filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+				title: __( '{{title}}Tax Rate{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+				filter: __( 'Select tax rates', 'woocommerce-admin' ),
+			},
+			rules: [
+				{
+					value: 'includes',
+					/* translators: Sentence fragment, logical, "Includes" refers to orders including a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+					label: _x( 'Includes', 'tax rate', 'woocommerce-admin' ),
+				},
+				{
+					value: 'excludes',
+					/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+					label: _x( 'Excludes', 'tax rate', 'woocommerce-admin' ),
+				},
+			],
+			input: {
+				component: 'Search',
+				type: 'taxes',
+				getLabels: getTaxRateLabels,
 			},
 		},
 	},

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -11,6 +11,7 @@ import { map } from 'lodash';
  */
 import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from '@woocommerce/currency';
+import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { getTaxCode } from './utils';
 import { numberFormat } from '@woocommerce/number';
 
@@ -71,12 +72,17 @@ export default class TaxesReportTable extends Component {
 
 	getRowsContent( taxes ) {
 		return map( taxes, tax => {
-			const { order_tax, orders_count, tax_rate, total_tax, shipping_tax } = tax;
+			const { query } = this.props;
+			const { order_tax, orders_count, tax_rate, tax_rate_id, total_tax, shipping_tax } = tax;
 			const taxCode = getTaxCode( tax );
 
-			// @todo Must link to the tax detail report
+			const persistedQuery = getPersistedQuery( query );
+			const ordersTaxLink = getNewPath( persistedQuery, '/analytics/orders', {
+				filter: 'advanced',
+				tax_rate_includes: tax_rate_id,
+			} );
 			const taxLink = (
-				<Link href="" type="wc-admin">
+				<Link href={ ordersTaxLink } type="wc-admin">
 					{ taxCode }
 				</Link>
 			);

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -14,6 +14,7 @@ import { getIdsFromQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import { getTaxCode } from 'analytics/report/taxes/utils';
 import { NAMESPACE } from 'wc-api/constants';
 
 /**
@@ -44,31 +45,36 @@ export function getRequestByIdString( path, handleData = identity ) {
 export const getCategoryLabels = getRequestByIdString(
 	NAMESPACE + '/products/categories',
 	category => ( {
-		id: category.id,
+		key: category.id,
 		label: category.name,
 	} )
 );
 
 export const getCouponLabels = getRequestByIdString( NAMESPACE + '/coupons', coupon => ( {
-	id: coupon.id,
+	key: coupon.id,
 	label: coupon.code,
 } ) );
 
 export const getCustomerLabels = getRequestByIdString( NAMESPACE + '/customers', customer => ( {
-	id: customer.id,
+	key: customer.id,
 	label: customer.name,
 } ) );
 
 export const getProductLabels = getRequestByIdString( NAMESPACE + '/products', product => ( {
-	id: product.id,
+	key: product.id,
 	label: product.name,
+} ) );
+
+export const getTaxRateLabels = getRequestByIdString( NAMESPACE + '/taxes', tax_rate => ( {
+	key: tax_rate.id,
+	label: getTaxCode( tax_rate ),
 } ) );
 
 export const getVariationLabels = getRequestByIdString(
 	query => NAMESPACE + `/products/${ query.products }/variations`,
 	variation => {
 		return {
-			id: variation.id,
+			key: variation.id,
 			label: variation.attributes.reduce(
 				( desc, attribute, index, arr ) =>
 					desc + `${ attribute.option }${ arr.length === index + 1 ? '' : ', ' }`,

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -43,25 +43,27 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args                     = array();
-		$args['before']           = $request['before'];
-		$args['after']            = $request['after'];
-		$args['page']             = $request['page'];
-		$args['per_page']         = $request['per_page'];
-		$args['orderby']          = $request['orderby'];
-		$args['order']            = $request['order'];
-		$args['product_includes'] = (array) $request['product_includes'];
-		$args['product_excludes'] = (array) $request['product_excludes'];
-		$args['coupon_includes']  = (array) $request['coupon_includes'];
-		$args['coupon_excludes']  = (array) $request['coupon_excludes'];
-		$args['status_is']        = (array) $request['status_is'];
-		$args['status_is_not']    = (array) $request['status_is_not'];
-		$args['customer_type']    = $request['customer_type'];
-		$args['extended_info']    = $request['extended_info'];
-		$args['refunds']          = $request['refunds'];
-		$args['match']            = $request['match'];
-		$args['order_includes']   = $request['order_includes'];
-		$args['order_excludes']   = $request['order_excludes'];
+		$args                      = array();
+		$args['before']            = $request['before'];
+		$args['after']             = $request['after'];
+		$args['page']              = $request['page'];
+		$args['per_page']          = $request['per_page'];
+		$args['orderby']           = $request['orderby'];
+		$args['order']             = $request['order'];
+		$args['product_includes']  = (array) $request['product_includes'];
+		$args['product_excludes']  = (array) $request['product_excludes'];
+		$args['coupon_includes']   = (array) $request['coupon_includes'];
+		$args['coupon_excludes']   = (array) $request['coupon_excludes'];
+		$args['tax_rate_includes'] = (array) $request['tax_rate_includes'];
+		$args['tax_rate_excludes'] = (array) $request['tax_rate_excludes'];
+		$args['status_is']         = (array) $request['status_is'];
+		$args['status_is_not']     = (array) $request['status_is_not'];
+		$args['customer_type']     = $request['customer_type'];
+		$args['extended_info']     = $request['extended_info'];
+		$args['refunds']           = $request['refunds'];
+		$args['match']             = $request['match'];
+		$args['order_includes']    = $request['order_includes'];
+		$args['order_excludes']    = $request['order_excludes'];
 
 		return $args;
 	}
@@ -252,9 +254,9 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                     = array();
-		$params['context']          = $this->get_context_param( array( 'default' => 'view' ) );
-		$params['page']             = array(
+		$params                      = array();
+		$params['context']           = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']              = array(
 			'description'       => __( 'Current page of the collection.', 'woocommerce-admin' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -262,7 +264,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']         = array(
+		$params['per_page']          = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce-admin' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -271,26 +273,26 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']            = array(
+		$params['after']             = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']           = array(
+		$params['before']            = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']            = array(
+		$params['order']             = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']          = array(
+		$params['orderby']           = array(
 			'description'       => __( 'Sort collection by object attribute.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'default'           => 'date',
@@ -301,7 +303,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product_includes'] = array(
+		$params['product_includes']  = array(
 			'description'       => __( 'Limit result set to items that have the specified product(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -311,7 +313,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product_excludes'] = array(
+		$params['product_excludes']  = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -321,7 +323,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['coupon_includes']  = array(
+		$params['coupon_includes']   = array(
 			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -331,7 +333,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			'sanitize_callback' => 'wp_parse_id_list',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['coupon_excludes']  = array(
+		$params['coupon_excludes']   = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -341,7 +343,27 @@ class Controller extends ReportsController implements ExportableInterface {
 			'validate_callback' => 'rest_validate_request_arg',
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['status_is']        = array(
+		$params['tax_rate_includes'] = array(
+			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['tax_rate_excludes'] = array(
+			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+		$params['status_is']         = array(
 			'description'       => __( 'Limit result set to items that have the specified order status.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -351,7 +373,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-		$params['status_is_not']    = array(
+		$params['status_is_not']     = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified order status.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
@@ -361,7 +383,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'string',
 			),
 		);
-		$params['customer_type']    = array(
+		$params['customer_type']     = array(
 			'description'       => __( 'Limit result set to returning or new customers.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'default'           => '',
@@ -372,7 +394,7 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['refunds']          = array(
+		$params['refunds']           = array(
 			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'default'           => '',
@@ -385,14 +407,14 @@ class Controller extends ReportsController implements ExportableInterface {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['extended_info']    = array(
+		$params['extended_info']     = array(
 			'description'       => __( 'Add additional piece of info about each coupon to the report.', 'woocommerce-admin' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'sanitize_callback' => 'wc_string_to_bool',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order_includes']   = array(
+		$params['order_includes']    = array(
 			'description'       => __( 'Limit result set to items that have the specified order ids.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',
@@ -401,7 +423,7 @@ class Controller extends ReportsController implements ExportableInterface {
 				'type' => 'integer',
 			),
 		);
-		$params['order_excludes']   = array(
+		$params['order_excludes']    = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified order ids.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_id_list',

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -51,17 +51,19 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 		$args['orderby']  = $request['orderby'];
 		$args['order']    = $request['order'];
 
-		$args['match']            = $request['match'];
-		$args['status_is']        = (array) $request['status_is'];
-		$args['status_is_not']    = (array) $request['status_is_not'];
-		$args['product_includes'] = (array) $request['product_includes'];
-		$args['product_excludes'] = (array) $request['product_excludes'];
-		$args['coupon_includes']  = (array) $request['coupon_includes'];
-		$args['coupon_excludes']  = (array) $request['coupon_excludes'];
-		$args['customer']         = $request['customer'];
-		$args['refunds']          = $request['refunds'];
-		$args['categories']       = (array) $request['categories'];
-		$args['segmentby']        = $request['segmentby'];
+		$args['match']             = $request['match'];
+		$args['status_is']         = (array) $request['status_is'];
+		$args['status_is_not']     = (array) $request['status_is_not'];
+		$args['product_includes']  = (array) $request['product_includes'];
+		$args['product_excludes']  = (array) $request['product_excludes'];
+		$args['coupon_includes']   = (array) $request['coupon_includes'];
+		$args['coupon_excludes']   = (array) $request['coupon_excludes'];
+		$args['tax_rate_includes'] = (array) $request['tax_rate_includes'];
+		$args['tax_rate_excludes'] = (array) $request['tax_rate_excludes'];
+		$args['customer']          = $request['customer'];
+		$args['refunds']           = $request['refunds'];
+		$args['categories']        = (array) $request['categories'];
+		$args['segmentby']         = $request['segmentby'];
 
 		return $args;
 	}
@@ -430,7 +432,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'sanitize_callback' => 'wp_parse_id_list',
 
 		);
-		$params['product_excludes'] = array(
+		$params['product_excludes']  = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified product(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -439,7 +441,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['coupon_includes']  = array(
+		$params['coupon_includes']   = array(
 			'description'       => __( 'Limit result set to items that have the specified coupon(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -448,7 +450,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['coupon_excludes']  = array(
+		$params['coupon_excludes']   = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -457,7 +459,27 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['customer']         = array(
+		$params['tax_rate_includes'] = array(
+			'description'       => __( 'Limit result set to items that have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['tax_rate_excludes'] = array(
+			'description'       => __( 'Limit result set to items that don\'t have the specified tax rate(s) assigned.', 'woocommerce-admin' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'integer',
+			),
+			'default'           => array(),
+			'validate_callback' => 'rest_validate_request_arg',
+			'sanitize_callback' => 'wp_parse_id_list',
+		);
+		$params['customer']          = array(
 			'description'       => __( 'Limit result set to items that don\'t have the specified coupon(s) assigned.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'enum'              => array(
@@ -466,7 +488,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['refunds']          = array(
+		$params['refunds']           = array(
 			'description'       => __( 'Limit result set to specific types of refunds.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'default'           => '',
@@ -479,7 +501,7 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['segmentby']        = array(
+		$params['segmentby']         = array(
 			'description'       => __( 'Segment the response by additional constraint.', 'woocommerce-admin' ),
 			'type'              => 'string',
 			'enum'              => array(


### PR DESCRIPTION
Fixes #3163 

* Adds in tax filtering to orders and order stats data stores.
* Adds in a tax filter to the orders page.
* Updates the link on the taxes page to point towards orders with that tax rate.

Note that there are some issues with text appearing in `SelectControl` affecting all advanced filters that I'll handle in a follow-up.

### Screenshots
<img width="446" alt="Screen Shot 2019-11-11 at 2 22 08 PM" src="https://user-images.githubusercontent.com/10561050/68565525-c11d2000-048e-11ea-8e78-32fb495f3762.png">
<img width="287" alt="Screen Shot 2019-11-11 at 2 22 00 PM" src="https://user-images.githubusercontent.com/10561050/68565526-c11d2000-048e-11ea-91eb-9cd2bdae052e.png">


### Detailed test instructions:

1. Create at least 2 tax rates.
2. Create at least 3 orders, with each tax rate and one without.
3. Select the new tax filter on the Orders page.
4. Make sure including and excluding tax rates works as expected.
5. Navigate to the taxes report.
6. Make sure the links for tax rates go to the filtered order report with that tax rate.