### PR TITLE
Onboarding: Use ShipStation for AU, GB, and CA

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -180,11 +180,17 @@ class Shipping extends Component {
 			{
 				key: 'label_printing',
 				label: __( 'Enable shipping label printing', 'woocommerce-admin' ),
-				description: __(
-					'With WooCommerce Services and Jetpack you can save time at the ' +
-						'Post Office by printing your shipping labels at home',
-					'woocommerce-admin'
-				),
+				description: [ 'GB', 'CA', 'AU' ].includes( countryCode )
+					? __(
+							'We recommend using ShipStation to save time at the post office by printing your shipping ' +
+								'labels at home. Try ShipStation free for 30 days. Learn more.',
+							'woocommerce-admin'
+						)
+					: __(
+							'With WooCommerce Services and Jetpack you can save time at the ' +
+								'Post Office by printing your shipping labels at home',
+							'woocommerce-admin'
+						),
 				content: (
 					<Plugins
 						onComplete={ () => {
@@ -195,6 +201,11 @@ class Shipping extends Component {
 							recordEvent( 'tasklist_shipping_label_printing', { install: false } );
 							getHistory().push( getNewPath( {}, '/', {} ) );
 						} }
+						pluginSlugs={
+							[ 'GB', 'CA', 'AU' ].includes( countryCode )
+								? [ 'woocommerce-shipstation-integration' ]
+								: [ 'jetpack', 'woocommerce-services' ]
+						}
 						{ ...this.props }
 					/>
 				),
@@ -259,11 +270,9 @@ export default compose(
 		return { countryCode, countryName, isSettingsError, isSettingsRequesting, settings };
 	} ),
 	withDispatch( dispatch => {
-		const { createNotice } = dispatch( 'core/notices' );
 		const { updateSettings } = dispatch( 'wc-api' );
 
 		return {
-			createNotice,
 			updateSettings,
 		};
 	} )

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -270,9 +270,11 @@ export default compose(
 		return { countryCode, countryName, isSettingsError, isSettingsRequesting, settings };
 	} ),
 	withDispatch( dispatch => {
+		const { createNotice } = dispatch( 'core/notices' );
 		const { updateSettings } = dispatch( 'wc-api' );
 
 		return {
+			createNotice,
 			updateSettings,
 		};
 	} )

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -7,12 +7,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { filter } from 'lodash';
+import interpolateComponents from 'interpolate-components';
 import { withDispatch } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
-import { Card, Stepper } from '@woocommerce/components';
+import { Card, Link, Stepper } from '@woocommerce/components';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
@@ -143,6 +144,9 @@ class Shipping extends Component {
 
 	getSteps() {
 		const { countryCode } = this.props;
+		const plugins = [ 'GB', 'CA', 'AU' ].includes( countryCode )
+			? [ 'woocommerce-shipstation-integration' ]
+			: [ 'jetpack', 'woocommerce-services' ];
 
 		const steps = [
 			{
@@ -181,11 +185,22 @@ class Shipping extends Component {
 				key: 'label_printing',
 				label: __( 'Enable shipping label printing', 'woocommerce-admin' ),
 				description: [ 'GB', 'CA', 'AU' ].includes( countryCode )
-					? __(
-							'We recommend using ShipStation to save time at the post office by printing your shipping ' +
-								'labels at home. Try ShipStation free for 30 days. Learn more.',
-							'woocommerce-admin'
-						)
+					? interpolateComponents( {
+							mixedString: __(
+								'We recommend using ShipStation to save time at the post office by printing your shipping ' +
+									'labels at home. Try ShipStation free for 30 days. {{link}}Learn more{{/link}}.',
+								'woocommerce-admin'
+							),
+							components: {
+								link: (
+									<Link
+										href="https://docs.woocommerce.com/document/shipstation-for-woocommerce/"
+										target="_blank"
+										type="external"
+									/>
+								),
+							},
+						} )
 					: __(
 							'With WooCommerce Services and Jetpack you can save time at the ' +
 								'Post Office by printing your shipping labels at home',
@@ -194,18 +209,14 @@ class Shipping extends Component {
 				content: (
 					<Plugins
 						onComplete={ () => {
-							recordEvent( 'tasklist_shipping_label_printing', { install: true } );
+							recordEvent( 'tasklist_shipping_label_printing', { install: true, plugins } );
 							this.completeStep();
 						} }
 						onSkip={ () => {
-							recordEvent( 'tasklist_shipping_label_printing', { install: false } );
+							recordEvent( 'tasklist_shipping_label_printing', { install: false, plugins } );
 							getHistory().push( getNewPath( {}, '/', {} ) );
 						} }
-						pluginSlugs={
-							[ 'GB', 'CA', 'AU' ].includes( countryCode )
-								? [ 'woocommerce-shipstation-integration' ]
-								: [ 'jetpack', 'woocommerce-services' ]
-						}
+						pluginSlugs={ plugins }
 						{ ...this.props }
 					/>
 				),

--- a/client/dashboard/task-list/tasks/steps/plugins.js
+++ b/client/dashboard/task-list/tasks/steps/plugins.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from 'newspack-components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { difference } from 'lodash';
+import { difference, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withDispatch } from '@wordpress/data';
 
@@ -146,6 +146,7 @@ Plugins.propTypes = {
 
 Plugins.defaultProps = {
 	autoInstall: false,
+	onError: noop,
 	pluginSlugs: [ 'jetpack', 'woocommerce-services' ],
 };
 

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -12,4 +12,8 @@ export const pluginNames = {
 	'woocommerce-services': __( 'WooCommerce Services', 'woocommerce-admin' ),
 	'mailchimp-for-woocommerce': __( 'Mailchimp for WooCommerce', 'woocommerce-admin' ),
 	'facebook-for-woocommerce': __( 'Facebook for WooCommerce', 'woocommerce-admin' ),
+	'woocommerce-shipstation-integration': __(
+		'WooCommerce ShipStation Gateway',
+		'woocommerce-admin'
+	),
 };

--- a/packages/components/src/stepper/index.js
+++ b/packages/components/src/stepper/index.js
@@ -109,7 +109,7 @@ Stepper.propTypes = {
 			/**
 			 * Description displayed beneath the label.
 			 */
-			description: PropTypes.string,
+			description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
 			/**
 			 * Optionally mark a step complete regardless of step index.
 			 */

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -467,15 +467,16 @@ class Onboarding {
 		return apply_filters(
 			'woocommerce_onboarding_plugins_whitelist',
 			array(
-				'facebook-for-woocommerce'        => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
-				'mailchimp-for-woocommerce'       => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',
-				'jetpack'                         => 'jetpack/jetpack.php',
-				'woocommerce-services'            => 'woocommerce-services/woocommerce-services.php',
-				'woocommerce-gateway-stripe'      => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
+				'facebook-for-woocommerce'            => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
+				'mailchimp-for-woocommerce'           => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',
+				'jetpack'                             => 'jetpack/jetpack.php',
+				'woocommerce-services'                => 'woocommerce-services/woocommerce-services.php',
+				'woocommerce-gateway-stripe'          => 'woocommerce-gateway-stripe/woocommerce-gateway-stripe.php',
 				'woocommerce-gateway-paypal-express-checkout' => 'woocommerce-gateway-paypal-express-checkout/woocommerce-gateway-paypal-express-checkout.php',
-				'klarna-checkout-for-woocommerce' => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
-				'klarna-payments-for-woocommerce' => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
-				'woocommerce-square'              => 'woocommerce-square/woocommerce-square.php',
+				'klarna-checkout-for-woocommerce'     => 'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
+				'klarna-payments-for-woocommerce'     => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
+				'woocommerce-square'                  => 'woocommerce-square/woocommerce-square.php',
+				'woocommerce-shipstation-integration' => 'woocommerce-shipstation-integration/woocommerce-shipstation.php',
 			)
 		);
 	}


### PR DESCRIPTION
Fixes #3193

Uses ShipStation for the shipping step when the country is Australia, the United Kingdom, or Canada.

### Screenshots
<img width="716" alt="Screen Shot 2019-11-11 at 4 59 19 PM" src="https://user-images.githubusercontent.com/10561050/68574482-eddc3200-04a4-11ea-85ec-0b2d00858144.png">

### Detailed test instructions:

1. Set your store to one of the Shipstation countries (AU, GB, or CA).
2. Go to the Shipping task in the task list.
3. Go to the 3rd step and click "Install and Enable."
4. Make sure ShipStation is installed and activated.
5. Change your store to the US and make sure the 3rd step prompts to install Jetpack and WCS instead.