### PR TITLE
Update WooCommerce compatibility version to 3.8.0

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -12,7 +12,7 @@
  * Requires PHP: 5.6.20
  *
  * WC requires at least: 3.6.0
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  *
  * @package WC_Admin
  */


### PR DESCRIPTION
Reported in the support forums:

https://wordpress.org/support/topic/compatibility-with-3-8-2/

I tested it in a test site and the last version of WooCommerce Admin seems to work perfectly with WooCommerce 3.8.0, so we should update the _tested up to_ version.

* If I'm not wrong, WooCommerce Admin 0.22.0 will be released end of this week/beginning of the next one, is that right? Do you think we should release a minor 0.21.1 version with this fix immediately?

### Changelog Note:

WooCommerce Admin has been marked as compatible with WooCommerce 3.8.0.
