### PR TITLE
Onboarding - Fix homepage notice on Gutenberg save

### DIFF
--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -2,9 +2,10 @@
 /**
  * External dependencies
  */
-import { select, subscribe, dispatch } from '@wordpress/data';
+import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import domReady from '@wordpress/dom-ready';
 
 /**
  * WooCommerce dependencies
@@ -12,63 +13,92 @@ import apiFetch from '@wordpress/api-fetch';
 import { getAdminLink } from '@woocommerce/navigation';
 
 /**
- * Displays a notice on page save and updates the hompage options.
+ * Returns a promise and resolves when the post begins to publish.
  *
- * Adapted from WSUWP Help Docs by Washington State University (GPL v2).
- * https://github.com/washingtonstateuniversity/WSUWP-Plugin-Help-Docs/blob/master/src/_js/blocks/notices.js
+ * @return {Promise} Promise for overlay existence.
+ */
+const saveStarted = () => {
+	if ( document.querySelector( '.editor-post-publish-button' ) === null ) {
+		const promise = new Promise( resolve => {
+			requestAnimationFrame( resolve );
+		} );
+		return promise.then( () => saveStarted() );
+	}
+
+	return Promise.resolve( true );
+};
+
+/**
+ * Returns a promise and resolves when the post has been saved and notices have shown.
+ *
+ * @return {Promise} Promise for overlay existence.
+ */
+const saveCompleted = () => {
+	if (
+		null === document.querySelector( '.components-notice__content' ) &&
+		null === document.querySelector( '.components-snackbar__content' )
+	) {
+		const promise = new Promise( resolve => {
+			requestAnimationFrame( resolve );
+		} );
+		return promise.then( () => saveCompleted() );
+	}
+
+	return Promise.resolve( true );
+};
+
+/**
+ * Displays a notice on page save and updates the hompage options.
  */
 const onboardingHomepageNotice = () => {
-	const post = select( 'core/editor' ).getCurrentPost();
+	const saveButton = document.querySelector( '.editor-post-publish-button' );
+	if ( saveButton.classList.contains( 'is-clicked' ) ) {
+		return;
+	}
 
-	const noticeMeta = {
-		wasPublishingPost: select( 'core/editor' ).isPublishingPost(),
-		wasStatus: post.status,
-	};
+	saveButton.classList.add( 'is-clicked' );
 
-	subscribe( () => {
-		const isPublishingPost = select( 'core/editor' ).isPublishingPost();
-		const isStatus = select( 'core/editor' ).getCurrentPost().status;
+	saveCompleted().then( () => {
+		const postId = document.querySelector( '#post_ID' ).value;
+		const notificationType =
+			null !== document.querySelector( '.components-snackbar__content' ) ? 'snackbar' : 'default';
 
-		const shouldTriggerAdminNotice =
-			'publish' === isStatus && noticeMeta.wasPublishingPost && ! isStatus.isPublishingPost;
+		apiFetch( {
+			path: '/wc-admin/v1/options',
+			method: 'POST',
+			data: {
+				show_on_front: 'page',
+				page_on_front: postId,
+			},
+		} );
 
-		noticeMeta.wasPublishingPost = isPublishingPost;
-		noticeMeta.wasStatus = isStatus;
-
-		if ( shouldTriggerAdminNotice ) {
-			if ( select( 'core/editor' ).didPostSaveRequestSucceed() ) {
-				setTimeout( () => {
-					wp.data.dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
-				}, 0 );
-
-				apiFetch( {
-					path: '/wc-admin/v1/options',
-					method: 'POST',
-					data: {
-						show_on_front: 'page',
-						page_on_front: post.id,
-					},
-				} );
-
-				dispatch( 'core/notices' ).createSuccessNotice(
-					__( 'Your homepage was published.', 'woocommerce-admin' ),
+		dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
+		dispatch( 'core/notices' ).createSuccessNotice(
+			__( 'Your homepage was published.', 'woocommerce-admin' ),
+			{
+				id: 'WOOCOMMERCE_ONBOARDING_HOME_PAGE_NOTICE',
+				type: notificationType,
+				actions: [
 					{
-						id: 'WOOCOMMERCE_ONBOARDING_HOME_PAGE_NOTICE',
-						actions: [
-							{
-								url: getAdminLink( 'admin.php?page=wc-admin&task=appearance' ),
-								label: __( 'Continue setup.', 'woocommerce-admin' ),
-							},
-						],
-					}
-				);
+						url: getAdminLink( 'admin.php?page=wc-admin&task=appearance' ),
+						label: __( 'Continue setup.', 'woocommerce-admin' ),
+					},
+				],
 			}
-		}
+		);
 	} );
 };
 
-wp.domReady( () => {
-	if ( 'page' === select( 'core/editor' ).getCurrentPostType() ) {
-		onboardingHomepageNotice();
+domReady( () => {
+	const publishButton = document.querySelector( '.editor-post-publish-panel__toggle' );
+	if ( publishButton ) {
+		publishButton.addEventListener( 'click', function() {
+			saveStarted().then( () => {
+				const confirmButton = document.querySelector( '.editor-post-publish-button' );
+				if ( confirmButton ) {
+					confirmButton.addEventListener( 'click', onboardingHomepageNotice );
+				}
+			} );
+		} );
 	}
 } );

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -34,10 +34,7 @@ const saveStarted = () => {
  * @return {Promise} Promise for overlay existence.
  */
 const saveCompleted = () => {
-	if (
-		null === document.querySelector( '.components-notice__content' ) &&
-		null === document.querySelector( '.components-snackbar__content' )
-	) {
+	if ( null === document.querySelector( '.post-publish-panel__postpublish' ) ) {
 		const promise = new Promise( resolve => {
 			requestAnimationFrame( resolve );
 		} );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -184,7 +184,7 @@ class OnboardingTasks {
 	public static function add_onboarding_homepage_notice_admin_script( $hook ) {
 		global $post;
 		if ( 'post.php' === $hook && 'page' === $post->post_type && isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) && 'homepage' === $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) { // phpcs:ignore csrf ok.
-			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation' ), WC_ADMIN_VERSION_NUMBER, true );
+			wp_enqueue_script( 'onboarding-homepage-notice', Loader::get_url( 'wp-admin-scripts/onboarding-homepage-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 		}
 	}
 


### PR DESCRIPTION
Fixes #3155.

I wasn't able to reproduce all the 5.2.4 errors myself, but did have trouble getting the notice to fire correctly in 5.3.

This PR rearchitects the homepage notice logic, based on Josh's PR: #3192. I think my original path of subscribing to the changes and looking for the right combinations of events would be more useful if we weren't already loading the JS on a very specific path. Hooking onto the click targets also allows me to more consistently display the notice at the right time across versions.

Note that in 5.3, the notice is a `Snackbar` notification. 5.2 retains the green notice. This is to stay consistent with other post notices in those respective versions.

### Screenshots

##### 5.2

<img width="612" alt="Screen Shot 2019-11-11 at 12 31 15 PM" src="https://user-images.githubusercontent.com/689165/68608097-1998f100-0480-11ea-8425-d5c4286eebfb.png">

##### 5.3

<img width="622" alt="Screen Shot 2019-11-11 at 12 29 36 PM" src="https://user-images.githubusercontent.com/689165/68608119-27e70d00-0480-11ea-9119-418c69d8150c.png">

### Detailed test instructions:

* Test using 5.2.4/5.2.5-alpha
* Delete your homepage and enable the task list
* Go to the appearance task and create a homepage
* Hit the publish button twice, and you should see a success notice.
* Update to 5.3.
* Delete your homepage
* Go to the appearance task and create a homepage
* Hit the publish button twice, and you should see a success notice.