### PR TITLE
Update query param used for the new WooCommerce + Jetpack Onboarding UI

### DIFF
--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -282,7 +282,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		}
 
 		$redirect_url = apply_filters( 'woocommerce_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
-		$connect_url  = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
+		$connect_url  = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
 
 		// @todo When implementing user-facing split testing, this should be abled to a default of 'production'.
 		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'wpcalypso';

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -661,7 +661,7 @@ class Onboarding {
 				)
 			);
 
-			$connect_url = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-setup-wizard' );
+			$connect_url = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
 			$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
 			wp_redirect( $connect_url );


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-admin/issues/3055.

Our initial implementation of the new Calypso UI used a query parameter named `?from=woocommerce-setup-wizard` -- which was already being passed by the current WooCommerce core setup experience.

This updates the logic that displays the new UI to use a different query parameter instead ( `woocommerce-onboarding`).

This allows both query parameters to work along side each other and show their respective versions of the Jetpack connect UI.

### Detailed test instructions:

- Run this branch
- Run https://github.com/Automattic/wp-calypso/pull/37495 and follow the testing directions there, verifying that you see the new WooCommerce UI.
