### PR TITLE
Update ShipStation 'Learn more' link

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -194,7 +194,7 @@ class Shipping extends Component {
 							components: {
 								link: (
 									<Link
-										href="https://docs.woocommerce.com/document/shipstation-for-woocommerce/"
+										href="https://woocommerce.com/products/shipstation-integration"
 										target="_blank"
 										type="external"
 									/>


### PR DESCRIPTION
Fixes #3211

Changes the "Learn more" link for ShipStation.

### Screenshots
<img width="716" alt="Screen Shot 2019-11-12 at 6 24 48 PM" src="https://user-images.githubusercontent.com/10561050/68663523-cf943600-0579-11ea-85be-c0f3185a72e6.png">


### Detailed test instructions:

1. Change your store to a ShipStation enabled country (UK, AU, or CA).
2. Enable the task list and go to the "Shipping" step.
3. Make sure the "Learn more" link points to `https://woocommerce.com/products/shipstation-integration/`