### PR TITLE
Onboarding: Add email marketing note if profiler is complete

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -16,6 +16,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Giving_Feedback_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
 
 /**
  * WC_Admin_Events Class.
@@ -66,5 +67,6 @@ class Events {
 		WC_Admin_Notes_Facebook_Extension::possibly_add_facebook_note();
 		WC_Admin_Notes_Add_First_Product::possibly_add_first_product_note();
 		WC_Admin_Notes_Tracking_Opt_In::possibly_add_tracking_opt_in_note();
+		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_onboarding_email_marketing_note();
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WooCommerce Admin Onboarding Email Marketing Note Provider.
+ *
+ * Adds a note to sign up to email marketing after completing the profiler.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Onboarding_Email_Marketing
+ */
+class WC_Admin_Notes_Onboarding_Email_Marketing {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-onboarding-email-marketing';
+
+	/**
+	 * Possibly add email marketing note.
+	 */
+	public static function possibly_add_onboarding_email_marketing_note() {
+		// We want to show the email marketing note after day 2 if the profiler is complete.
+		$onboarding_data     = get_option( 'wc_onboarding_profile', array() );
+		$is_completed        = isset( $onboarding_data['completed'] ) && true === $onboarding_data['completed'];
+		$two_days_in_seconds = 2 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $two_days_in_seconds ) || ! $is_completed ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$content = __( 'We\'re here for you — get tips, product updates, and inspiration straight to your mailbox.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Tips, product updates, and inspiration', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'mail' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'yes-please', __( 'Yes please!', 'woocommerce-admin' ), 'https://woocommerce.us8.list-manage.com/subscribe/post?u=2c1434dc56f9506bf3c3ecd21&amp;id=13860df971&amp;SIGNUPPAGE=plugin' );
+		$note->save();
+	}
+}


### PR DESCRIPTION
Fixes #3079

Adds the email marketing signup as a note after the profiler is complete if wc-admin has been installed for at least 2 days.

**Questions**
* The copy is mostly taken from the old signup form.  Any changes we should make here? /cc @pmcpinto @jameskoster
* The message is not set to show until wc-admin has been installed for at least 2 days and the profiler has been completed.  I think 2 days is a good buffer to avoid information overload, but open to input here.
* This Mailchimp form question is a little weird given they've already installed WC.  Wondering if there's a different form or some param we should be passing here.

<img width="638" alt="Screen Shot 2019-11-12 at 7 42 20 PM" src="https://user-images.githubusercontent.com/10561050/68669417-69151500-0585-11ea-8d3a-cffdc52e94f6.png">


### Screenshots
<img width="524" alt="Screen Shot 2019-11-12 at 7 41 28 PM" src="https://user-images.githubusercontent.com/10561050/68669250-0ae83200-0585-11ea-96bf-a036e157ba0a.png">

### Detailed test instructions:

1. Have a site that's had wc-admin installed for at least 2 days.
2. Complete the onboarding profiler.
3. Run the `wc_admin_daily` cron event.
4. Note the note and make sure the link "Yes please!" points to the correct signup form.