### PR TITLE
Update filter picker to use key instead of id

### DIFF
--- a/packages/components/src/filter-picker/index.js
+++ b/packages/components/src/filter-picker/index.js
@@ -126,7 +126,7 @@ class FilterPicker extends Component {
 		const { value, settings } = filter;
 		const { param: filterParam } = settings;
 		if ( tag ) {
-			this.update( value, { [ filterParam ]: tag.id } );
+			this.update( value, { [ filterParam ]: tag.key } );
 			onClose();
 		} else {
 			this.update( config.defaultValue || DEFAULT_FILTER );


### PR DESCRIPTION
Fixes #3210

Fixes a bug I introduced when replacing the `Autocomplete` component with the `SelectControl` component that used a property `id` instead of `key`.

### Screenshots
<img width="395" alt="Screen Shot 2019-11-12 at 8 15 53 PM" src="https://user-images.githubusercontent.com/10561050/68671039-61576f80-0589-11ea-90de-7dff977a6218.png">


### Detailed test instructions:

1.  Go to the products report.
2. Filter by a single product.
3. Note the URL updates correctly with the product ID and the data is filtered accordingly.