### PR TITLE
Select control: fix misalignment and hide scroll bar

### DIFF
--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -44,6 +44,7 @@
 		font-size: 13px;
 		color: #72777c;
 		position: static;
+		transform: none;
 		margin: 0;
 		width: 100%;
 	}

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -117,7 +117,7 @@
 		right: 0;
 		top: 57px;
 		z-index: 10;
-		overflow-y: scroll;
+		overflow-y: auto;
 		max-height: 350px;
 
 		&.is-static {


### PR DESCRIPTION
### Screenshots
_Before:_
![Peek 2019-11-12 14-40](https://user-images.githubusercontent.com/3616980/68676484-710b8f80-055a-11ea-8394-1d2331f24cb0.gif)

_After:_
![Peek 2019-11-12 14-38](https://user-images.githubusercontent.com/3616980/68676486-749f1680-055a-11ea-8de8-a0fab9f6842f.gif)

### Detailed test instructions:
- Open the select control and verify there is no scroll bar (this issue might not be reproducible with Mac OS because it hides scrollbars by default).
- Open the select control and with the keyboard (<kdb>Alt</kbd>+<kdb>Tab</kbd>) focus the previous element. Verify the text is not misaligned.