### PR TITLE
Onboarding - Fix busted tracks events and add missing event

### DIFF
--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -14,7 +14,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Card, Stepper, TextControl } from '@woocommerce/components';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import { getHistory, getNewPath, getQuery } from '@woocommerce/navigation';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -46,6 +46,13 @@ class Appearance extends Component {
 		this.importProducts = this.importProducts.bind( this );
 		this.updateLogo = this.updateLogo.bind( this );
 		this.updateNotice = this.updateNotice.bind( this );
+	}
+
+	componentDidMount() {
+		const { from } = getQuery();
+		if ( 'homepage' === from ) {
+			recordEvent( 'tasklist_appearance_continue_setup', {} );
+		}
 	}
 
 	async componentDidUpdate( prevProps ) {

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -14,7 +14,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Card, Stepper, TextControl } from '@woocommerce/components';
-import { getHistory, getNewPath, getQuery } from '@woocommerce/navigation';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -46,13 +46,6 @@ class Appearance extends Component {
 		this.importProducts = this.importProducts.bind( this );
 		this.updateLogo = this.updateLogo.bind( this );
 		this.updateNotice = this.updateNotice.bind( this );
-	}
-
-	componentDidMount() {
-		const { from } = getQuery();
-		if ( 'homepage' === from ) {
-			recordEvent( 'tasklist_appearance_continue_setup', {} );
-		}
 	}
 
 	async componentDidUpdate( prevProps ) {

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -28,13 +28,15 @@ import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 
 class Tax extends Component {
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 
 		this.initialState = {
 			isPending: false,
 			stepIndex: 0,
 			automatedTaxEnabled: true,
+			// Cache the value of pluginsToActivate so that we can show/hide tasks based on it, but not have them update mid task.
+			pluginsToActivate: props.pluginsToActivate,
 		};
 
 		this.state = this.initialState;
@@ -177,13 +179,8 @@ class Tax extends Component {
 	}
 
 	getSteps() {
-		const {
-			generalSettings,
-			isGeneralSettingsRequesting,
-			isJetpackConnected,
-			pluginsToActivate,
-		} = this.props;
-		const { isPending } = this.state;
+		const { generalSettings, isGeneralSettingsRequesting, isJetpackConnected } = this.props;
+		const { isPending, pluginsToActivate } = this.state;
 
 		const steps = [
 			{
@@ -334,7 +331,7 @@ class Tax extends Component {
 							<Button
 								isPrimary
 								onClick={ () => {
-									recordEvent( 'tasklist_tax_setup_automated_simple', {
+									recordEvent( 'tasklist_tax_setup_automated_proceed', {
 										setup_automatically: true,
 									} );
 									this.setState( { automatedTaxEnabled: true }, this.updateAutomatedTax );
@@ -344,7 +341,7 @@ class Tax extends Component {
 							</Button>
 							<Button
 								onClick={ () => {
-									recordEvent( 'tasklist_tax_setup_automated_simple', {
+									recordEvent( 'tasklist_tax_setup_automated_proceed', {
 										setup_automatically: false,
 									} );
 									this.setState( { automatedTaxEnabled: false }, this.updateAutomatedTax );

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -25,7 +25,7 @@ import { getCountryCode } from 'dashboard/utils';
 import Plugins from './steps/plugins';
 import StoreLocation from './steps/location';
 import withSelect from 'wc-api/with-select';
-import { recordEvent } from 'lib/tracks';
+import { recordEvent, queueRecordEvent } from 'lib/tracks';
 
 class Tax extends Component {
 	constructor( props ) {
@@ -215,7 +215,7 @@ class Tax extends Component {
 							this.completeStep();
 						} }
 						onSkip={ () => {
-							recordEvent( 'tasklist_tax_install_extensions', { install_extensions: false } );
+							queueRecordEvent( 'tasklist_tax_install_extensions', { install_extensions: false } );
 							window.location.href = getAdminLink(
 								'admin.php?page=wc-settings&tab=tax&section=standard'
 							);

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -59,6 +59,13 @@ class Layout extends Component {
 	}
 
 	recordPageViewTrack() {
+		const { isEmbedded } = this.props;
+		if ( isEmbedded ) {
+			const path = document.location.pathname + document.location.search;
+			recordPageView( path, { isEmbedded } );
+			return;
+		}
+
 		const pathname = get( this.props, 'location.pathname' );
 		if ( ! pathname ) {
 			return;

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -30,15 +30,99 @@ export function recordEvent( eventName, eventProperties ) {
 	window.wcTracks.recordEvent( eventName, eventProperties );
 }
 
+const tracksQueue = {
+	localStorageKey: function() {
+		return 'tracksQueue';
+	},
+
+	clear: function() {
+		if ( ! window.localStorage ) {
+			return;
+		}
+
+		window.localStorage.removeItem( tracksQueue.localStorageKey() );
+	},
+
+	get: function() {
+		if ( ! window.localStorage ) {
+			return [];
+		}
+
+		let items = window.localStorage.getItem( tracksQueue.localStorageKey() );
+
+		items = items ? JSON.parse( items ) : [];
+		items = Array.isArray( items ) ? items : [];
+
+		return items;
+	},
+
+	add: function( ...args ) {
+		if ( ! window.localStorage ) {
+			// If unable to queue, run it now.
+			tracksDebug( 'Unable to queue, running now', { args } );
+			recordEvent.apply( null, args || undefined );
+			return;
+		}
+
+		let items = tracksQueue.get();
+		const newItem = { args };
+
+		items.push( newItem );
+		items = items.slice( -100 ); // Upper limit.
+
+		tracksDebug( 'Adding new item to queue.', newItem );
+		window.localStorage.setItem( tracksQueue.localStorageKey(), JSON.stringify( items ) );
+	},
+
+	process: function() {
+		if ( ! window.localStorage ) {
+			return; // Not possible.
+		}
+
+		const items = tracksQueue.get();
+		tracksQueue.clear();
+
+		tracksDebug( 'Processing items in queue.', items );
+
+		items.forEach( item => {
+			if ( 'object' === typeof item ) {
+				tracksDebug( 'Processing item in queue.', item );
+				recordEvent.apply( null, item.args || undefined );
+			}
+		} );
+	},
+};
+
+/**
+ * Queue a tracks event.
+ *
+ * This allows you to delay tracks  events that would otherwise cause a race condition.
+ * For example, when we trigger `wcadmin_tasklist_appearance_continue_setup` we're simultaneously moving the user to a new page via
+ * `window.location`. This is an example of a race condition that should be avoided by enqueueing the event,
+ * and therefore running it on the next pageview.
+ *
+ * @param {String} eventName The name of the event to record, don't include the wcadmin_ prefix
+ * @param {Object} eventProperties event properties to include in the event
+ */
+
+export function queueRecordEvent( eventName, eventProperties ) {
+	tracksQueue.add( eventName, eventProperties );
+}
+
 /**
  * Record a page view to Tracks
  *
  * @param {String} path the page/path to record a page view for
+ * @param {Object} extraProperties extra event properties to include in the event
  */
 
-export function recordPageView( path ) {
+export function recordPageView( path, extraProperties ) {
 	if ( ! path ) {
 		return;
 	}
-	recordEvent( 'page_view', { path } );
+
+	recordEvent( 'page_view', { path, ...extraProperties } );
+
+	// Process queue.
+	tracksQueue.process();
 }

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -13,6 +13,11 @@ import domReady from '@wordpress/dom-ready';
 import { getAdminLink } from '@woocommerce/navigation';
 
 /**
+ * Internal dependencies
+ */
+import { queueRecordEvent } from 'lib/tracks';
+
+/**
  * Returns a promise and resolves when the post begins to publish.
  *
  * @return {Promise} Promise for overlay existence.
@@ -78,7 +83,10 @@ const onboardingHomepageNotice = () => {
 				actions: [
 					{
 						label: __( 'Continue setup.', 'woocommerce-admin' ),
-						url: getAdminLink( 'admin.php?page=wc-admin&task=appearance&from=homepage' ),
+						onClick: () => {
+							queueRecordEvent( 'tasklist_appearance_continue_setup', {} );
+							window.location = getAdminLink( 'admin.php?page=wc-admin&task=appearance' );
+						},
 					},
 				],
 			}

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -13,6 +13,11 @@ import domReady from '@wordpress/dom-ready';
 import { getAdminLink } from '@woocommerce/navigation';
 
 /**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
+/**
  * Returns a promise and resolves when the post begins to publish.
  *
  * @return {Promise} Promise for overlay existence.
@@ -77,8 +82,11 @@ const onboardingHomepageNotice = () => {
 				type: notificationType,
 				actions: [
 					{
-						url: getAdminLink( 'admin.php?page=wc-admin&task=appearance' ),
 						label: __( 'Continue setup.', 'woocommerce-admin' ),
+						onClick: () => {
+							recordEvent( 'tasklist_appearance_continue_setup', {} );
+							window.location = getAdminLink( 'admin.php?page=wc-admin&task=appearance' );
+						},
 					},
 				],
 			}

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -13,11 +13,6 @@ import domReady from '@wordpress/dom-ready';
 import { getAdminLink } from '@woocommerce/navigation';
 
 /**
- * Internal dependencies
- */
-import { recordEvent } from 'lib/tracks';
-
-/**
  * Returns a promise and resolves when the post begins to publish.
  *
  * @return {Promise} Promise for overlay existence.
@@ -83,10 +78,7 @@ const onboardingHomepageNotice = () => {
 				actions: [
 					{
 						label: __( 'Continue setup.', 'woocommerce-admin' ),
-						onClick: () => {
-							recordEvent( 'tasklist_appearance_continue_setup', {} );
-							window.location = getAdminLink( 'admin.php?page=wc-admin&task=appearance' );
-						},
+						url: getAdminLink( 'admin.php?page=wc-admin&task=appearance&from=homepage' ),
 					},
 				],
 			}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -63,6 +63,9 @@ class Onboarding {
 			OnboardingTasks::get_instance();
 		}
 
+		// Rest API hooks need to run before is_admin() checks.
+		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
+
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -84,7 +87,6 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
-		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
 	}
 


### PR DESCRIPTION
Fixes #3208.

This PR:

* Adds a `wcadmin_tasklist_appearance_continue_setup` event that is fired when you click on the continue setup homepage notice
* Renames `wcadmin_tasklist_tax_setup_automated_simple` to `wcadmin_tasklist_tax_setup_automated_proceed` per p1573575958016300-slack-wc-onboarding
* Fixes a condition where plugins would finish installing on the Tax task, but onComplete and the `wcadmin_tasklist_tax_install_extensions` event wouldn't fire because the task is immediately unmounted when pluginsToActive becomes 0.
* Fixes `wcadmin_storeprofiler_store_theme_upload` and the theme upload onComplete handler by moving the necessary theme data hook to the correct location.

### Detailed test instructions:
* Enter `localStorage.setItem( 'debug', 'wc-admin:*' );` into your developer console.

* Enable the task list
* Delete your homepage
* Go to the appearance task and create a new homepage
* Publish, and click the “continue setup” button
* See the `tasklist_appearance_continue_setup` event fire

* Make sure that you have WooCommerce Services and Jetpack enabled and your country set to US (so you get the “good news” message)
* Click confirm or skip and verify `wcadmin_tasklist_tax_setup_automated_proceed` is fired.


* Deactivate WooCommerce Services or Jetpack
* Go to the tax task, and install the offered extensions
* Verify that the `wcadmin_tasklist_tax_install_extensions` event fires

* Enable the store profile wizard
* Go to the theme step and upload a theme
* Verify that the `wcadmin_storeprofiler_store_theme_upload` event fires, and you see your uploaded theme image / name / description.

