### PR TITLE
Onboarding: Add the ability to toggle on or off the new onboarding

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -699,6 +699,10 @@ class Onboarding {
 				$help_tab['content'] .= '<p><a href="' . wc_admin_url( '&test_wc_helper_connect=1' ) . '" class="button button-primary">' . __( 'Connect', 'woocommerce-admin' ) . '</a></p>';
 			}
 
+			$help_tab['content'] .= '<h3>' . __( 'New onboarding experience', 'woocommerce-admin' ) . '</h3>';
+			$help_tab['content'] .= '<p>' . __( 'To disable the new WooCommerce onboarding experience, click the button below.', 'woocommerce-admin' ) . '</p>';
+			$help_tab['content'] .= '<p><a href="' . wc_admin_url( '&enable_onboarding=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>';
+
 			$screen->add_help_tab( $help_tab );
 		}
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -50,7 +50,12 @@ class Onboarding {
 	 */
 	public function __construct() {
 
+		// Adds the ability to toggle the new onboarding experience on or off.
+		// @todo We should consider when we want to remove the abillity to toggle this feature.
+		add_action( 'current_screen', array( $this, 'enable_onboarding' ) );
+
 		if ( ! Loader::is_onboarding_enabled() ) {
+			add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
 			return;
 		}
 
@@ -75,7 +80,7 @@ class Onboarding {
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'finish_paypal_connect' ) );
 		add_action( 'current_screen', array( $this, 'finish_square_connect' ) );
-		add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
+		add_action( 'current_screen', array( $this, 'add_help_tab' ), 60 );
 		add_action( 'current_screen', array( $this, 'reset_profiler' ) );
 		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
@@ -593,9 +598,60 @@ class Onboarding {
 	}
 
 	/**
-	 * Update the help tab setup link to reset the onboarding profiler.
+	 * Update the existing help tab and add an option to enable the new onboarding experience.
 	 */
 	public static function update_help_tab() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {
+			return;
+		}
+
+		$help_tabs = $screen->get_help_tabs();
+
+		foreach ( $help_tabs as $help_tab ) {
+			if ( 'woocommerce_onboard_tab' !== $help_tab['id'] ) {
+				continue;
+			}
+
+			$screen->remove_help_tab( 'woocommerce_onboard_tab' );
+			$help_tab['content'] .= '<h3>' . __( 'New onboarding experience', 'woocommerce-admin' ) . '</h3>';
+			$help_tab['content'] .= '<p>' . __( 'If you want to try out the new WooCommerce onboarding experience, click the button below.', 'woocommerce-admin' ) . '</p>';
+			$help_tab['content'] .= '<p><a href="' . wc_admin_url( '&enable_onboarding=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>';
+			$screen->add_help_tab( $help_tab );
+		}
+	}
+
+	/**
+	 * Reset the onboarding profiler and redirect to the profiler.
+	 */
+	public static function enable_onboarding() {
+		if (
+			! Loader::is_admin_page() ||
+			! isset( $_GET['enable_onboarding'] ) // phpcs:ignore CSRF ok.
+		) {
+			return;
+		}
+
+		$enabled = 1 === absint( $_GET['enable_onboarding'] ); // phpcs:ignore CSRF ok.
+
+		wc_admin_record_tracks_event(
+			'wcadmin_onboarding_toggled',
+			array(
+				'previous'  => ! $enabled,
+				'new_value' => $enabled,
+			)
+		);
+
+		update_option( 'wc_onboarding_opt_in', $enabled ? 'yes' : 'no' );
+		wp_safe_redirect( wc_admin_url() );
+		exit;
+	}
+
+	/**
+	 * Update the help tab setup link to reset the onboarding profiler.
+	 */
+	public static function add_help_tab() {
 		$screen = get_current_screen();
 
 		if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -49,9 +49,8 @@ class Onboarding {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
-
 		// Adds the ability to toggle the new onboarding experience on or off.
-		// @todo We should consider when we want to remove the abillity to toggle this feature.
+		// @todo This option should be removed when merging the onboarding feature to core.
 		add_action( 'current_screen', array( $this, 'enable_onboarding' ) );
 
 		if ( ! Loader::is_onboarding_enabled() ) {


### PR DESCRIPTION
Fixes #3227

Adds the ability to toggle on or off the new onboarding experience via a button in the "Help" tab.  Not sure if want to keep this for all users ( /cc @pmcpinto ) but it may prove useful for testing releases in the meantime.

### Screenshots
<img width="793" alt="Screen Shot 2019-11-13 at 3 38 57 PM" src="https://user-images.githubusercontent.com/10561050/68742800-01fe6b80-062c-11ea-85c7-9f196084d9ca.png">


### Detailed test instructions:

1. Make sure you have all constants that would show the onboarding turned off (`WP_DEBUG`, `WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED`, `SCRIPT_DEBUG`) and delete the option `wc_onboarding_opt_in` from `wp_options`.
2. Open the "Products" page.
3. Click the "Help" tab in the upper right corner.
4. Click on "Setup Wizard."
5. Click "Enable" underneath the new onboarding experience heading.
6. Make sure the new onboarding is now enabled.
7.  Repeat the process, but this time clicking the "Disable" button that should be shown at the bottom of the "Setup wizard" tab.