### PR TITLE
Onboarding: Fix header error in homepage template

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -118,7 +118,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( file_exists( $file ) && class_exists( 'WC_Product_CSV_Importer' ) ) {
 			// Override locale so we can return mappings from WooCommerce in English language stores.
 			global $locale;
-			$locale         = false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+			$locale         = false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
 			$args           = array(
 				'parse'   => true,
@@ -298,7 +298,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		return $cover . '
 		<!-- wp:heading {"align":"center"} -->
-		<h2 class="has-text-align-center">' . __( 'New products', 'woocommerce-admin' ) . '</h2>
+		<h2 style="text-align:center">' . __( 'New Products', 'woocommerce-admin' ) . '</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:woocommerce/product-new /--> ' .


### PR DESCRIPTION
Fixes #3219

A header block was throwing an error in WP 5.2.4.  This fixes that.

### Before
<img width="893" alt="Screen Shot 2019-11-13 at 4 05 33 PM" src="https://user-images.githubusercontent.com/10561050/68744369-7090f880-062f-11ea-9cdf-1bae6fd2bd85.png">


### After
<img width="887" alt="Screen Shot 2019-11-13 at 3 57 57 PM" src="https://user-images.githubusercontent.com/10561050/68744335-5b1bce80-062f-11ea-9ee6-7c984b72562c.png">

### Detailed test instructions:

1. Delete any previous homepage generated from onboarding.
2. Go to the onboarding task list.
3. Under the Customize Appearance task, click "Create homepage."
4. Make sure all blocks are rendered.