### PR TITLE
Onboarding: Remove notice to run the old setup wizard

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -81,6 +81,7 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
+		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
 	}
 
 	/**
@@ -766,5 +767,20 @@ class Onboarding {
 		update_option( 'woocommerce_task_list_hidden', $new_value );
 		wp_safe_redirect( wc_admin_url() );
 		exit;
+	}
+
+	/**
+	 * Remove the install notice that prompts the user to visit the old onboarding setup wizard.
+	 *
+	 * @param bool   $show Show or hide the notice.
+	 * @param string $notice The slug of the notice.
+	 * @return bool
+	 */
+	public static function remove_install_notice( $show, $notice ) {
+		if ( 'install' === $notice ) {
+			return false;
+		}
+
+		return $show;
 	}
 }


### PR DESCRIPTION
Fixes #3228

Removes the old setup wizard notice if the new onboarding is active.

I don’t think we’ll want to modify content in this notice since most of our notifications are moving towards using the inbox, so this PR simply removes the old notice.

### Screenshots (before)
<img width="489" alt="Screen Shot 2019-11-13 at 5 19 54 PM" src="https://user-images.githubusercontent.com/10561050/68751708-01ba9c00-063d-11ea-95d2-6436c726827b.png">


### Detailed test instructions:

1. Install WC in a new WP install and don’t go through any setup steps.
2. Make sure onboarding is enabled.
3. Navigate to any core pages (e.g., Dashboard, Plugins, etc).
4. Make sure the old notice is no longer shown.