### PR TITLE
Fix payment task display on mobile

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -323,6 +323,47 @@
 			margin-left: $gap-smallest;
 		}
 	}
+
+	@include breakpoint( '<600px' ) {
+		.woocommerce-list__item > .woocommerce-list__item-inner {
+			flex-direction: column;
+		}
+
+		.woocommerce-list__item-title {
+			border-top: 0;
+		}
+
+		.woocommerce-list__item .woocommerce-list__item-before {
+			margin-top: 0;
+			order: 1;
+		}
+
+		.woocommerce-task-payments__woocommerce-services-options {
+			margin-top: $gap-smaller;
+			border-top: 0;
+		}
+
+		.woocommerce-task-payments__woocommerce-services-options .muriel-component {
+			margin-left: -$gap-larger;
+		}
+
+		.woocommerce-list__item .woocommerce-list__item-after {
+			margin-left: 0;
+			order: 2;
+			align-self: flex-end;
+			margin-top: -$gap-larger;
+		}
+
+		.woocommerce-list__item .woocommerce-list__item-text {
+			order: 3;
+			margin-top: $gap;
+		}
+
+		.woocommerce-task-payments__woocommerce-services-options .components-checkbox-control__label {
+			margin-left: -$gap-larger;
+			margin-top: -$gap-smaller;
+		}
+	}
 }
 
 .woocommerce-task-appearance {


### PR DESCRIPTION
Fixes #3229.

This PR updates the CSS for the payments task on mobile view, so the content and options better fit.

<img width="583" alt="Screen Shot 2019-11-13 at 1 19 30 PM" src="https://user-images.githubusercontent.com/689165/68792077-a8d90c80-0618-11ea-8f9d-ca6154552847.png">

### Detailed test instructions:

* Delete the `woocommerce_onboarding_payments` option if you have it set, so that you can run through the payments task again.
* Enable the task list and go to the payments task
* Narrow your viewport below 600
* See the above screeenshot