### PR TITLE
Onboarding: Update homepage options call to use in-house namespace

### DIFF
--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -61,7 +61,7 @@ const onboardingHomepageNotice = () => {
 			null !== document.querySelector( '.components-snackbar__content' ) ? 'snackbar' : 'default';
 
 		apiFetch( {
-			path: '/wc-admin/v1/options',
+			path: '/wc-admin/options',
 			method: 'POST',
 			data: {
 				show_on_front: 'page',


### PR DESCRIPTION
Fixes #3238

https://github.com/woocommerce/woocommerce-admin/pull/3204 updated the `wc-admin/v1` namespace to `wc-admin` since it's an internally used API and does not need versioning.

The updated homepage notice script was being worked on simultaneously so this one slipped by us. 
 This PR updates the options call to use that namespace.

### Screenshots
<img width="274" alt="Screen Shot 2019-11-14 at 2 04 58 PM" src="https://user-images.githubusercontent.com/10561050/68830935-fff9e280-06e7-11ea-9c71-1e6efb8fe480.png">

### Detailed test instructions:

1. Delete any previously created homepages made via the task list.
2. Go to the task list Customize Appearance step.
3. Click "Create homepage."
4. Publish the homepage, noting no network errors with the options API.
5. Make sure the published homepage is once again set as the "Front page."