### PR TITLE
Onboarding: Skip homepage step when classic editor is in use

### DIFF
--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -34,7 +34,7 @@ export function getTasks( { profileItems, options, query } ) {
 		shippingZonesCount,
 	} = getSetting( 'onboarding', {
 		customLogo: '',
-		hasHomePage: false,
+		hasHomepage: false,
 		hasPhysicalProducts: false,
 		hasProducts: false,
 		isTaxComplete: false,

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -83,7 +83,7 @@ class OnboardingTasks {
 		// task completion along with cache busting for active tasks.
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
 		$settings['onboarding']['customLogo']                     = get_theme_mod( 'custom_logo', false );
-		$settings['onboarding']['hasHomepage']                    = self::check_task_completion( 'homepage' );
+		$settings['onboarding']['hasHomepage']                    = self::check_task_completion( 'homepage' ) || 'classic' === get_option( 'classic-editor-replace' );
 		$settings['onboarding']['hasPhysicalProducts']            = count(
 			wc_get_products(
 				array(


### PR DESCRIPTION
Fixes #3233

Skips the homepage step and homepage conditions for Customize Appearance if the classic editor is being used.

### Screenshots
<img width="727" alt="Screen Shot 2019-11-14 at 3 27 39 PM" src="https://user-images.githubusercontent.com/10561050/68835738-ac8d9180-06f3-11ea-9a30-b026b5dab5bf.png">
<img width="458" alt="Screen Shot 2019-11-14 at 3 27 32 PM" src="https://user-images.githubusercontent.com/10561050/68835739-ac8d9180-06f3-11ea-86b1-ca861ad0d76d.png">


### Detailed test instructions:

1. Delete any previous homepages created via the task list.
2. Install the Classic Editor plugin - https://wordpress.org/plugins/classic-editor/
3. Change the editor mode to "Classic" under Settings->Writing.
4. Make sure the customize appearance task is marked complete if a custom logo is set and entering the customize appearance does not show the homepage step.
5. Switch the editor mode to "Block."
6. Make sure the homepage task is not completed and the homepage step is shown.