### PR TITLE
Onboarding: Update check for TOS accepted in tax step

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -106,12 +106,12 @@ class Tax extends Component {
 	}
 
 	isTaxJarSupported() {
-		const { countryCode, wc_connect_options } = this.props;
+		const { countryCode, tosAccepted } = this.props;
 		const { automatedTaxSupportedCountries = [], taxJarActivated } = getSetting( 'onboarding', {} );
 
 		return (
 			! taxJarActivated && // WCS integration doesn't work with the official TaxJar plugin.
-			wc_connect_options.tos_accepted &&
+			tosAccepted &&
 			automatedTaxSupportedCountries.includes( countryCode )
 		);
 	}
@@ -380,11 +380,10 @@ export default compose(
 		const countryCode = getCountryCode( generalSettings.woocommerce_default_country );
 		const activePlugins = getActivePlugins();
 		const pluginsToActivate = difference( [ 'jetpack', 'woocommerce-services' ], activePlugins );
-		const wc_connect_options = get(
-			getOptions( [ 'wc_connect_options' ] ),
-			'wc_connect_options',
-			{}
-		);
+		const options = getOptions( [ 'wc_connect_options', 'woocommerce_setup_jetpack_opted_in' ] );
+		const wc_connect_options = get( options, 'wc_connect_options', {} );
+		const tosAccepted =
+			wc_connect_options.tos_accepted || options.woocommerce_setup_jetpack_opted_in;
 
 		return {
 			countryCode,
@@ -396,7 +395,7 @@ export default compose(
 			taxSettings,
 			isJetpackConnected: isJetpackConnected(),
 			pluginsToActivate,
-			wc_connect_options,
+			tosAccepted,
 		};
 	} ),
 	withDispatch( dispatch => {


### PR DESCRIPTION
Fixes (possibly) #3151

Checks for `wc_connect_options.tos_accepted` as well as `woocommerce_setup_jetpack_opted_in` in the tax step.

I believe what is happening is that `woocommerce_setup_jetpack_opted_in` gets updated to `true` in the profiler.  This usually will cause `wc_connect_options.tos_accepted` to be set to `true` on `before_woocommerce_init` but because the page is never reloaded, this event does not get triggered.

`wc_connect_options` is preloaded so the old value will still be in place, causing the tax step to initially not allow automatic taxes until the page is refreshed or the fresh data freshness to expire.

@pmcpinto Can you test out this branch to see if it resolves the issue you were having?  [Here's a prebuilt wc admin zip.](https://mc.a8c.com/includes/img-uploader/files/1573719878-woocommerce-admin-onboarding.zip)

### Screenshots
<img width="721" alt="Screen Shot 2019-11-14 at 4 22 51 PM" src="https://user-images.githubusercontent.com/10561050/68839304-65a39a00-06fb-11ea-8829-aaa0365a674f.png">

### Detailed test instructions:

1. On a fresh site, walk through the profiler being careful to not refresh the page.
2. Complete the profiler with a valid tax jar country and installing WCS and Jetpack.
3. Go to the task list tax step.
4. After data is loaded, the above automatic tax screen should be shown.