### PR TITLE
Make WooCommerce brand localizable

### DIFF
--- a/client/dashboard/profile-wizard/header-logo.js
+++ b/client/dashboard/profile-wizard/header-logo.js
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
@@ -14,7 +15,9 @@ class HeaderLogo extends Component {
 	render() {
 		const { isJetpackConnected } = this.props;
 
-		const ariaLabel = ! isJetpackConnected ? 'Jetpack + WooCommerce' : 'WooCommerce';
+		const ariaLabel = ! isJetpackConnected
+			? __( 'Jetpack + WooCommerce', 'woocommerce-admin' )
+			: __( 'WooCommerce', 'woocommerce-admin' );
 		const classes = classNames( 'woocommerce-profile-wizard__header-logo', {
 			'woocommerce-profile-wizard__header-logo-with-jetpack': ! isJetpackConnected,
 		} );

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -97,7 +97,7 @@ class Header extends Component {
 							type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
 							onClick={ this.trackLinkClick }
 						>
-							WooCommerce
+							{ __( 'WooCommerce', 'woocommerce-admin' ) }
 						</Link>
 					</span>
 					{ _sections.map( ( section, i ) => {


### PR DESCRIPTION
Closes #3246

The word _WooCommerce_ is localizable in WooCommerce Core:

https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin-menus.php#L62

So it makes sense making it localizable here too.