### PR TITLE
fix typos in JS docs

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -10,7 +10,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import { SelectControl, TextControl } from '@woocommerce/components';
 

--- a/client/dashboard/profile-wizard/header-logo.js
+++ b/client/dashboard/profile-wizard/header-logo.js
@@ -7,8 +7,9 @@ import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
 
 /**
- * Internal depdencies
- */ import withSelect from 'wc-api/with-select';
+ * Internal dependencies
+ */
+import withSelect from 'wc-api/with-select';
 
 class HeaderLogo extends Component {
 	render() {

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -14,7 +14,7 @@ import { withDispatch } from '@wordpress/data';
 import { updateQueryString } from '@woocommerce/navigation';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import BusinessDetails from './steps/business-details';
 import Industry from './steps/industry';

--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -10,14 +10,14 @@ import { difference } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 
 /**
- * WooCommerce depdencies
+ * WooCommerce dependencies
  */
 import { H, Stepper, Card } from '@woocommerce/components';
 import { getNewPath, updateQueryString, getAdminLink } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -11,13 +11,13 @@ import { withDispatch } from '@wordpress/data';
 import { filter, get } from 'lodash';
 
 /**
- * WooCommerce depdencies
+ * WooCommerce dependencies
  */
 import { Card, H, Link } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import CardIcon from './images/card';
 import SecurityIcon from './images/security';

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -12,7 +12,7 @@ import { recordEvent } from 'lib/tracks';
 import { without, get } from 'lodash';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import { getCountryCode } from 'dashboard/utils';
 import { H, Card, Form } from '@woocommerce/components';

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -21,7 +21,7 @@ import { Card, H } from '@woocommerce/components';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import withSelect from 'wc-api/with-select';
 import './style.scss';

--- a/client/dashboard/profile-wizard/steps/theme/preview.js
+++ b/client/dashboard/profile-wizard/steps/theme/preview.js
@@ -14,7 +14,7 @@ import interpolateComponents from 'interpolate-components';
 import { WebPreview } from '@woocommerce/components';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import { recordEvent } from 'lib/tracks';
 

--- a/client/dashboard/profile-wizard/steps/usage-modal.js
+++ b/client/dashboard/profile-wizard/steps/usage-modal.js
@@ -12,7 +12,7 @@ import interpolateComponents from 'interpolate-components';
 import { FormToggle, Modal } from '@wordpress/components';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import { Link } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -17,7 +17,7 @@ import { Card, List, MenuItem, EllipsisMenu } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import './style.scss';
 import withSelect from 'wc-api/with-select';

--- a/client/dashboard/task-list/tasks/connect.js
+++ b/client/dashboard/task-list/tasks/connect.js
@@ -10,12 +10,12 @@ import { withDispatch } from '@wordpress/data';
 import { omit } from 'lodash';
 
 /**
- * WooCommerce depdencies
+ * WooCommerce dependencies
  */
 import { getHistory, getNewPath } from '@woocommerce/navigation';
 
 /**
- * Internal depdencies
+ * Internal dependencies
  */
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';


### PR DESCRIPTION
This PR fixes the misspelling `depdencies` that had been copied to several files over the course of development.