### PR TITLE
capitalize WooCommerce Services

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -208,7 +208,7 @@ class Tax extends Component {
 				key: 'plugins',
 				label: __( 'Install Jetpack and WooCommerce Services', 'woocommerce-admin' ),
 				description: __(
-					'Jetpack and WooCommerce services allow you to automate sales tax calculations',
+					'Jetpack and WooCommerce Services allow you to automate sales tax calculations',
 					'woocommerce-admin'
 				),
 				content: (


### PR DESCRIPTION
This PR fixes the capitalization of an instance of `WooCommerce Services`.
