### PR TITLE
Add a tracks queue to delay event recording & log embed page views

### DIFF
--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -14,7 +14,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Card, Stepper, TextControl } from '@woocommerce/components';
-import { getHistory, getNewPath, getQuery } from '@woocommerce/navigation';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -46,13 +46,6 @@ class Appearance extends Component {
 		this.importProducts = this.importProducts.bind( this );
 		this.updateLogo = this.updateLogo.bind( this );
 		this.updateNotice = this.updateNotice.bind( this );
-	}
-
-	componentDidMount() {
-		const { from } = getQuery();
-		if ( 'homepage' === from ) {
-			recordEvent( 'tasklist_appearance_continue_setup', {} );
-		}
 	}
 
 	async componentDidUpdate( prevProps ) {

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -25,7 +25,7 @@ import { getCountryCode } from 'dashboard/utils';
 import Plugins from './steps/plugins';
 import StoreLocation from './steps/location';
 import withSelect from 'wc-api/with-select';
-import { recordEvent } from 'lib/tracks';
+import { recordEvent, queueRecordEvent } from 'lib/tracks';
 
 class Tax extends Component {
 	constructor( props ) {
@@ -215,7 +215,7 @@ class Tax extends Component {
 							this.completeStep();
 						} }
 						onSkip={ () => {
-							recordEvent( 'tasklist_tax_install_extensions', { install_extensions: false } );
+							queueRecordEvent( 'tasklist_tax_install_extensions', { install_extensions: false } );
 							window.location.href = getAdminLink(
 								'admin.php?page=wc-settings&tab=tax&section=standard'
 							);

--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -59,6 +59,13 @@ class Layout extends Component {
 	}
 
 	recordPageViewTrack() {
+		const { isEmbedded } = this.props;
+		if ( isEmbedded ) {
+			const path = document.location.pathname + document.location.search;
+			recordPageView( path, { isEmbedded } );
+			return;
+		}
+
 		const pathname = get( this.props, 'location.pathname' );
 		if ( ! pathname ) {
 			return;

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -113,14 +113,15 @@ export function queueRecordEvent( eventName, eventProperties ) {
  * Record a page view to Tracks
  *
  * @param {String} path the page/path to record a page view for
+ * @param {Object} extraProperties extra event properties to include in the event
  */
 
-export function recordPageView( path ) {
+export function recordPageView( path, extraProperties ) {
 	if ( ! path ) {
 		return;
 	}
 
-	recordEvent( 'page_view', { path } );
+	recordEvent( 'page_view', { path, ...extraProperties } );
 
 	// Process queue.
 	tracksQueue.process();

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -30,6 +30,85 @@ export function recordEvent( eventName, eventProperties ) {
 	window.wcTracks.recordEvent( eventName, eventProperties );
 }
 
+const tracksQueue = {
+	localStorageKey: function() {
+		return 'tracksQueue';
+	},
+
+	clear: function() {
+		if ( ! window.localStorage ) {
+			return;
+		}
+
+		window.localStorage.removeItem( tracksQueue.localStorageKey() );
+	},
+
+	get: function() {
+		if ( ! window.localStorage ) {
+			return [];
+		}
+
+		let items = window.localStorage.getItem( tracksQueue.localStorageKey() );
+
+		items = items ? JSON.parse( items ) : [];
+		items = Array.isArray( items ) ? items : [];
+
+		return items;
+	},
+
+	add: function( ...args ) {
+		if ( ! window.localStorage ) {
+			// If unable to queue, run it now.
+			tracksDebug( 'Unable to queue, running now', { args } );
+			recordEvent.apply( null, args || undefined );
+			return;
+		}
+
+		let items = tracksQueue.get();
+		const newItem = { args };
+
+		items.push( newItem );
+		items = items.slice( -100 ); // Upper limit.
+
+		tracksDebug( 'Adding new item to queue.', newItem );
+		window.localStorage.setItem( tracksQueue.localStorageKey(), JSON.stringify( items ) );
+	},
+
+	process: function() {
+		if ( ! window.localStorage ) {
+			return; // Not possible.
+		}
+
+		const items = tracksQueue.get();
+		tracksQueue.clear();
+
+		tracksDebug( 'Processing items in queue.', items );
+
+		items.forEach( item => {
+			if ( 'object' === typeof item ) {
+				tracksDebug( 'Processing item in queue.', item );
+				recordEvent.apply( null, item.args || undefined );
+			}
+		} );
+	},
+};
+
+/**
+ * Queue a tracks event.
+ *
+ * This allows you to delay tracks  events that would otherwise cause a race condition.
+ * For example, when we trigger `wcadmin_tasklist_appearance_continue_setup` we're simultaneously moving the user to a new page via
+ * `window.location`. This is an example of a race condition that should be avoided by enqueueing the event,
+ * and therefore running it on the next pageview.
+ *
+ * @param {String} eventName The name of the event to record, don't include the wcadmin_ prefix
+ * @param {Object} eventProperties event properties to include in the event
+ */
+
+export function queueRecordEvent( eventName, eventProperties ) {
+	tracksQueue.add( eventName, eventProperties );
+}
+
 /**
  * Record a page view to Tracks
  *
@@ -40,5 +119,9 @@ export function recordPageView( path ) {
 	if ( ! path ) {
 		return;
 	}
+
 	recordEvent( 'page_view', { path } );
+
+	// Process queue.
+	tracksQueue.process();
 }

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -13,6 +13,11 @@ import domReady from '@wordpress/dom-ready';
 import { getAdminLink } from '@woocommerce/navigation';
 
 /**
+ * Internal dependencies
+ */
+import { queueRecordEvent } from 'lib/tracks';
+
+/**
  * Returns a promise and resolves when the post begins to publish.
  *
  * @return {Promise} Promise for overlay existence.
@@ -78,7 +83,10 @@ const onboardingHomepageNotice = () => {
 				actions: [
 					{
 						label: __( 'Continue setup.', 'woocommerce-admin' ),
-						url: getAdminLink( 'admin.php?page=wc-admin&task=appearance&from=homepage' ),
+						onClick: () => {
+							queueRecordEvent( 'tasklist_appearance_continue_setup', {} );
+							window.location = getAdminLink( 'admin.php?page=wc-admin&task=appearance' );
+						},
 					},
 				],
 			}


### PR DESCRIPTION
While fixing some issues in #3220, I added an event that would fire during a window.location redirect. Josh raised a potential issue with `recordEvent` not finishing before the redirect happens.

After doing some research, we realized that this could happen and Calypso works around it with an analytics queue. They store the event details in localStorage (which will run before the redirect) and process the events on the next page view. The [Calypso code](https://github.com/Automattic/wp-calypso/blob/7b1cb7ba4f36656487e1ff6261b752bb5bcb7590/client/lib/analytics/index.js#L282) for it is actually pretty straight forward, so this PR adds our own implementation of it. You can use `queueRecordEvent` in these instances.

In addition, I've also added functionality to record embedded page views (the bits of wc-admin on classic pages). This allows the queue to run on classic pages as well, and seems useful for prioritizing future pages for overhaul (cc @timmyc).

### Detailed test instructions:

* Enter `localStorage.setItem( 'debug', 'wc-admin:*' );` into your console. Leave your console open.
* Enable the task list
* Delete your homepage
* Go to the appearance task and create a new homepage
* Publish, and click the “continue setup” button
* You should see some debug about the event getting added to the queue (if the redirect happens too fast, there will be more debug on the next page)
* When the appearance task loads again, you should see a debug message about the queue processing, and the `tasklist_appearance_continue_setup` event will fire
* Disable WooCommerce Services and delete your tax rates
* Go to the tax task and click 'skip' when you are offered Jetpack & WooCommerce Services
* You should see the `tasklist_tax_install_extensions` event fire on the tax settings page.

<img width="524" alt="Screen Shot 2019-11-14 at 11 01 59 AM" src="https://user-images.githubusercontent.com/689165/68874199-c9639e00-06ce-11ea-846d-ead58ae07cc4.png">
