### PR TITLE
Fix default country on new stores

### DIFF
--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -35,11 +35,17 @@ class StoreDetails extends Component {
 			showUsageModal: false,
 		};
 
+		const countryState =
+			( profileItems.hasOwnProperty( 'setup_client' ) &&
+				null !== profileItems.setup_client &&
+				settings.woocommerce_default_country ) ||
+			'';
+
 		this.initialValues = {
 			addressLine1: settings.woocommerce_store_address || '',
 			addressLine2: settings.woocommerce_store_address_2 || '',
 			city: settings.woocommerce_store_city || '',
-			countryState: settings.woocommerce_default_country || '',
+			countryState,
 			postCode: settings.woocommerce_store_postcode || '',
 			isClient: profileItems.setup_client || false,
 		};


### PR DESCRIPTION
When testing one of the onboarding builds on a Jurassic Ninja site, I noticed that the country/state drop down was defaulting to the UK on a fresh site.

This is because WooCommerce sets a default country at the setting level, which ends up setting the the form input.

This PR updates the form so it only prefills data if the store step has been completed before.

### Detailed test instructions:

* Either test on a new site, or delete the `wc_onboarding_profile` option.
* Delete the `woocommerce_default_country` option.
* View the store details page `/wp-admin/admin.php?page=wc-admin&step=store-details` and verify that there is no country set.
* Fill out the form and continue. Then go back to the store details page and notice your value is present.
