### PR TITLE
Use same wp-components version in bundle

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,7 +26,7 @@
     "@woocommerce/currency": "1.1.1",
     "@woocommerce/date": "1.0.7",
     "@woocommerce/navigation": "2.1.0",
-    "@wordpress/components": "7.4.0",
+    "@wordpress/components": "8.3.1",
     "@wordpress/compose": "3.7.1",
     "@wordpress/date": "3.5.0",
     "@wordpress/element": "2.8.1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,6 +37,10 @@
 		<exclude-pattern>src/*</exclude-pattern>
 	</rule>
 
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+      <exclude-pattern>src/*</exclude-pattern>
+    </rule>
+
 	<rule ref="Generic.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -302,7 +302,6 @@ class Loader {
 			self::get_url( 'components/index.js' ),
 			array(
 				'wp-api-fetch',
-				'wp-components',
 				'wp-data',
 				'wp-element',
 				'wp-hooks',
@@ -324,7 +323,7 @@ class Loader {
 		wp_register_style(
 			'wc-components',
 			self::get_url( 'components/style.css' ),
-			array( 'wp-components' ),
+			array(),
 			self::get_file_version( 'components/style.css' )
 		);
 		wp_style_add_data( 'wc-components', 'rtl', 'replace' );
@@ -332,7 +331,7 @@ class Loader {
 		wp_register_style(
 			'wc-components-ie',
 			self::get_url( 'components/ie.css' ),
-			array( 'wp-components' ),
+			array(),
 			self::get_file_version( 'components/ie.css' )
 		);
 		wp_style_add_data( 'wc-components-ie', 'rtl', 'replace' );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/2986

This PR aligns version numbers for `wp-components` for the main package and our own components.

I also noticed that we bundle wp-components, yet still require it as a resource. So I removed it as a dependency for loaders.

## Test

1. `'npm start` and check the app works without causing any errors.
2. In the console, confirm `wp.components` is undefined since we don't load it anymore