### PR TITLE
Fix selected value showing for multiple SelectControl

### DIFF
--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -137,11 +137,17 @@ class Control extends Component {
 		const { isFocused, isSearchable, multiple, query, selected } = this.props;
 		const selectedValue = selected.length ? selected[ 0 ].label : '';
 
-		if ( ! isSearchable && multiple ) {
-			return '';
+		// Show the selected value for simple select dropdowns.
+		if ( ! multiple && ! isFocused ) {
+			return selectedValue;
 		}
 
-		return isSearchable && isFocused ? query : selectedValue;
+		// Show the search query when focused on searchable controls.
+		if ( isSearchable && isFocused ) {
+			return query;
+		}
+
+		return '';
 	}
 
 	render() {


### PR DESCRIPTION
Fixes #3199
Fixes #3241 

Fixes a bug where the first selected value (usually displayed for simple selects) was being shown at the end of `SelectControl` inputs with multiple tags.

### Before
<img width="663" alt="68567799-e745be80-0494-11ea-9151-30eea48ea2ba" src="https://user-images.githubusercontent.com/10561050/68908728-1d31be00-0787-11ea-912f-5e9c7854d1ed.png">


### After
<img width="582" alt="Screen Shot 2019-11-15 at 9 04 01 AM" src="https://user-images.githubusercontent.com/10561050/68908729-1efb8180-0787-11ea-8682-74444aacea54.png">


### Detailed test instructions:

1. Go to any advanced filter with a `Search` component. (e.g., Products filter on Orders report)
2. Search and select some tags.
3. Make sure no input text is visible after the tags.
4. Check the devdocs and make sure other variations of props in `SelectControl` continue to work as expected.
5. Optionally check other areas where `SelectControl` are used to verify no regressions have been made.