### PR TITLE
Reset state before firing onChange in SelectControl

### DIFF
--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -94,6 +94,8 @@ export class SelectControl extends Component {
 		const { query } = this.state;
 		const newSelected = multiple ? [ ...selected, option ] : [ option ];
 
+		this.reset( newSelected );
+
 		// Trigger a change if the selected value is different and pass back
 		// an array or string depending on the original value.
 		if ( Array.isArray( selected ) ) {
@@ -104,8 +106,6 @@ export class SelectControl extends Component {
 		} else if ( selected !== option.key ) {
 			onChange( option.key, query );
 		}
-
-		this.reset( newSelected );
 	}
 
 	decrementSelectedIndex() {


### PR DESCRIPTION
Fixes #3240

Certain components like the filters dropdown remove the `SelectControl` after an `onChange` event is triggered.  This throws an error since the state attempts to update after this `onChange` event.

### Screenshots
<img width="373" alt="Screen Shot 2019-11-15 at 11 50 36 AM" src="https://user-images.githubusercontent.com/10561050/68915725-342fda80-079e-11ea-90eb-e03ffe42eca3.png">


### Detailed test instructions:

1.  Go to the products report and filter by a single product.
2. Select an item by navigating with the arrow keys and hitting "enter."
3.  Make sure no error is thrown in the console.
4. Make sure `SelectControl`s in the devdocs and other areas continue to work as expected.