### PR TITLE
Filter empty keywords from autocompleters

### DIFF
--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -77,7 +77,7 @@ class Search extends Component {
 			const formattedOption = {
 				key: autocompleter.getOptionIdentifier( option ),
 				label: autocompleter.getOptionLabel( option, query ),
-				keywords: autocompleter.getOptionKeywords( option ),
+				keywords: autocompleter.getOptionKeywords( option ).filter( Boolean ),
 				value: option,
 			};
 			formattedOptions.push( formattedOption );


### PR DESCRIPTION
Fixes #3256

Filters empty strings from the keywords so items aren't shown before searching in the `Search` component.

### Before
<img width="368" alt="Screen Shot 2019-11-15 at 2 54 13 PM" src="https://user-images.githubusercontent.com/10561050/68923864-4c155780-07ba-11ea-9c2d-60e8287f5388.png">


### After
<img width="395" alt="Screen Shot 2019-11-15 at 3 06 04 PM" src="https://user-images.githubusercontent.com/10561050/68923867-4ddf1b00-07ba-11ea-99d8-eff61455f428.png">


### Detailed test instructions:

1. Create a product with an empty string for a sku.
2. Go to the products report and use the single product filter.
3. Note that no item is shown before searching.