### PR TITLE
Fix filter gap on analytics select controls

### DIFF
--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -13,7 +13,7 @@
 
 	.components-select-control__input {
 		height: 38px;
-		padding: 0;
+		padding: 0 0 0 $gap-smaller;
 		margin: 0;
 	}
 


### PR DESCRIPTION
This fixes a slight alignment issue with the select control labels under the analytics advanced filters.

Before

<img width="749" alt="Screen Shot 2019-11-15 at 7 40 09 AM" src="https://user-images.githubusercontent.com/689165/68944749-a0014b80-077c-11ea-9824-4af4a6065d83.png">

After

<img width="870" alt="Screen Shot 2019-11-15 at 7 51 01 AM" src="https://user-images.githubusercontent.com/689165/68944769-af809480-077c-11ea-9446-ad562e4df129.png">

### Detailed test instructions:

* Go to any advanced filter with a Search component. (e.g., Products filter on Orders report)
* Make sure the labels visually look OK