### PR TITLE
return a value from create pages API call

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -384,9 +384,12 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	/**
 	 * Creates base store starter pages like my account and checkout.
 	 * Note that WC_Install::create_pages already checks if pages exist before creating them again.
+	 *
+	 * @return bool
 	 */
 	public static function create_store_pages() {
 		\WC_Install::create_pages();
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
After finishing the store details in the onboarding flow an `Uncaught in Promise` exception is logged to the browser console.

This PR adds a return value to the `wc-admin/onboarding/tasks/create_store_pages` API callback which is returned to the client as valid json.

### Detailed test instructions:

- Reset onboarding `wp option delete wc_onboarding_profile`
- Navigate through the onboarding through to the theme selection page
- Check that there are no exceptions logged in the browser console
