### PR TITLE
Fetch autocomplete countries from the API rather than wcSettings object.

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -120,13 +120,13 @@ export const advancedFilters = applyFilters( CUSTOMERS_REPORT_ADVANCED_FILTERS_F
 				type: 'countries',
 				getLabels: async value => {
 					const allLabels = countries.map( country => ( {
-						id: country.code,
+						key: country.code,
 						label: decodeEntities( country.name ),
 					} ) );
 
 					const labels = value.split( ',' );
 					return await allLabels.filter( label => {
-						return labels.includes( label.id );
+						return labels.includes( label.key );
 					} );
 				},
 			},

--- a/packages/components/src/search/autocompleters/countries.js
+++ b/packages/components/src/search/autocompleters/countries.js
@@ -5,13 +5,16 @@
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { Fragment } from '@wordpress/element';
-import { getSetting } from '@woocommerce/wc-admin-settings';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { computeSuggestionMatch } from './utils';
 import Flag from '../../flag';
+
+// Cache countries to avoid repeated requests.
+let allCountries = null;
 
 /**
  * A country completer.
@@ -24,8 +27,16 @@ export default {
 	className: 'woocommerce-search__country-result',
 	isDebounced: true,
 	options() {
-		const { countries } = getSetting( 'dataEndpoints', { countries: undefined } );
-		return countries || [];
+		// Returned cached countries if we've already received them.
+		if ( allCountries ) {
+			return Promise.resolve( allCountries );
+		}
+		// Make the request for country data.
+		return apiFetch( { path: '/wc-analytics/data/countries' } ).then( result => {
+			// Cache the response.
+			allCountries = result;
+			return allCountries;
+		} );
 	},
 	getOptionIdentifier( country ) {
 		return country.code;
@@ -39,6 +50,7 @@ export default {
 	getOptionLabel( country, query ) {
 		const name = decodeEntities( country.name );
 		const match = computeSuggestionMatch( name, query ) || {};
+
 		return (
 			<Fragment>
 				<Flag
@@ -47,14 +59,22 @@ export default {
 					code={ country.code }
 					size={ 18 }
 					hideFromScreenReader
-				/>,
+				/>
 				<span key="name" className="woocommerce-search__result-name" aria-label={ name }>
-					{ match.suggestionBeforeMatch }
-					<strong className="components-form-token-field__suggestion-match">
-						{ match.suggestionMatch }
-					</strong>
-					{ match.suggestionAfterMatch }
-				</span>,
+					{
+						query
+						? (
+							<Fragment>
+								{ match.suggestionBeforeMatch }
+								<strong className="components-form-token-field__suggestion-match">
+									{ match.suggestionMatch }
+								</strong>
+								{ match.suggestionAfterMatch }
+							</Fragment>
+						)
+						: name
+					}
+				</span>
 			</Fragment>
 		);
 	},

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -304,6 +304,7 @@ class Loader {
 				'wp-data',
 				'wp-element',
 				'wp-hooks',
+				'wp-html-entities',
 				'wp-i18n',
 				'wp-keycodes',
 				'wc-csv',


### PR DESCRIPTION
Fixes #3028.

This PR seeks to decouple the countries autocompleter from the `wcSettings` object, fetching them from the API instead. It also fixes a bug in the country advanced filter in the Customers Report.

### Detailed test instructions:

- Open the Customers Report
- Add a country advanced filter
- Verify it's function (note that there appears to be a bug, in `master` as well, that keeps the selected country text in the input after selection)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: Search component: remove dependency on settings global from countries autocompleter.