### PR TITLE
Onboarding: Stretch theme image to fit card container

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -150,7 +150,12 @@ class Theme extends Component {
 		return (
 			<Card className="woocommerce-profile-wizard__theme" key={ theme.slug }>
 				{ image && (
-					<img alt={ title } src={ image } className="woocommerce-profile-wizard__theme-image" />
+					<div
+						className="woocommerce-profile-wizard__theme-image"
+						style={ { backgroundImage: `url(${ image })` } }
+						role="img"
+						aria-label={ title }
+					/>
 				) }
 				<div className="woocommerce-profile-wizard__theme-details">
 					<H className="woocommerce-profile-wizard__theme-name">

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -62,8 +62,9 @@
 	}
 
 	.woocommerce-profile-wizard__theme-image {
-		display: block;
 		width: 100%;
+		height: 300px;
+		background-size: cover;
 	}
 
 	.woocommerce-profile-wizard__theme-name {


### PR DESCRIPTION
Fixes #3264

Stretches the images by using them as a background image to avoid blank spaces between theme names and images.

### Before
<img width="486" alt="Screen Shot 2019-11-18 at 9 49 50 AM" src="https://user-images.githubusercontent.com/10561050/69024768-25942e00-09ff-11ea-9a14-ceaccb6a0ebe.png">

### After
<img width="453" alt="Screen Shot 2019-11-18 at 12 25 54 PM" src="https://user-images.githubusercontent.com/10561050/69024764-2200a700-09ff-11ea-85da-490c750dda86.png">

### Detailed test instructions:

1. Go to the theme step of the profiler.
2. Make sure images fit inside the card without any blank spaces.