### PR TITLE
Add wc admin card classes to leaderboards

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
@@ -50,13 +51,15 @@ export class Leaderboard extends Component {
 		const { isRequesting, isError, totalRows, title } = this.props;
 		const rows = this.getFormattedRows();
 
+		const classes = classnames( 'woocommerce-leaderboard', 'woocommerce-analytics__card' );
+
 		if ( isError ) {
-			return <ReportError className="woocommerce-leaderboard" isError />;
+			return <ReportError className={ classes } isError />;
 		}
 
 		if ( ! isRequesting && rows.length === 0 ) {
 			return (
-				<Card title={ title } className="woocommerce-leaderboard woocommerce-analytics__card">
+				<Card title={ title } className={ classes }>
 					<EmptyTable>
 						{ __( 'No data recorded for the selected time period.', 'woocommerce-admin' ) }
 					</EmptyTable>
@@ -66,7 +69,7 @@ export class Leaderboard extends Component {
 
 		return (
 			<TableCard
-				className="woocommerce-leaderboard"
+				className={ classes }
 				headers={ this.getFormattedHeaders() }
 				isLoading={ isRequesting }
 				rows={ rows }

--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
@@ -50,8 +49,7 @@ export class Leaderboard extends Component {
 	render() {
 		const { isRequesting, isError, totalRows, title } = this.props;
 		const rows = this.getFormattedRows();
-
-		const classes = classnames( 'woocommerce-leaderboard', 'woocommerce-analytics__card' );
+		const classes = 'woocommerce-leaderboard woocommerce-analytics__card';
 
 		if ( isError ) {
 			return <ReportError className={ classes } isError />;

--- a/client/analytics/report/style.scss
+++ b/client/analytics/report/style.scss
@@ -13,6 +13,9 @@
 	}
 }
 
+// @todo Once we switch to the Gutenberg `Card` component, we should probably
+// drop this class and override all cards within the wc-admin scope or make an
+// exportable card based on the Gutenberg component that houses wc-admin styles.
 .woocommerce-analytics__card {
 	border-radius: 0;
 	border: 1px solid $core-grey-light-700;


### PR DESCRIPTION
Fixes #3075

Adds the analytics card class to various states for leaderboards to avoid default card styling.

### Before
<img width="744" alt="Screen Shot 2019-11-18 at 2 12 16 PM" src="https://user-images.githubusercontent.com/10561050/69028788-0bae1780-0a0e-11ea-8190-2ed6d314ad2e.png">

### After
<img width="738" alt="Screen Shot 2019-11-18 at 2 15 27 PM" src="https://user-images.githubusercontent.com/10561050/69028790-0d77db00-0a0e-11ea-9f69-de6d989a6b3f.png">

### Detailed test instructions:

1. Go to the leaderboards section in the dashboard.
2. Make sure the leaderboard card header styles match other analytic card styles in wc-admin.
3. Change the date to a time where data exists and does not exist for that leaderboard.  Make sure all states show the correct leaderboard header style (no data, loading, and has data).