### PR TITLE
Filter invalid statuses from saved statuses

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -64,6 +64,8 @@ class Loader {
 		add_action( 'in_admin_header', array( __CLASS__, 'embed_page_header' ) );
 		add_filter( 'woocommerce_settings_groups', array( __CLASS__, 'add_settings_group' ) );
 		add_filter( 'woocommerce_settings-wc_admin', array( __CLASS__, 'add_settings' ) );
+		add_filter( 'option_woocommerce_actionable_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
+		add_filter( 'option_woocommerce_excluded_report_order_statuses', array( __CLASS__, 'filter_invalid_statuses' ) );
 		add_action( 'admin_head', array( __CLASS__, 'remove_notices' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_after_notices' ), PHP_INT_MAX );
@@ -381,7 +383,7 @@ class Loader {
 		wp_enqueue_style( 'wc-material-icons' );
 
 		// Use server-side detection to prevent unneccessary stylesheet loading in other browsers.
-		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : ''; // WPCS: sanitization ok.
+		$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : ''; // phpcs:ignore sanitization ok.
 		preg_match( '/MSIE (.*?);/', $user_agent, $matches );
 		if ( count( $matches ) < 2 ) {
 			preg_match( '/Trident\/\d{1,2}.\d{1,2}; rv:([0-9]*)/', $user_agent, $matches );
@@ -729,6 +731,21 @@ class Loader {
 			'type'        => 'text',
 		);
 		return $settings;
+	}
+
+	/**
+	 * Filter invalid statuses from saved settings to avoid removed statuses throwing errors.
+	 *
+	 * @param array|null $value Saved order statuses.
+	 * @return array|null
+	 */
+	public static function filter_invalid_statuses( $value ) {
+		if ( is_array( $value ) ) {
+			$valid_statuses = array_keys( self::get_order_statuses( wc_get_order_statuses() ) );
+			$value          = array_intersect( $value, $valid_statuses );
+		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3144

Removes statuses that aren't valid wc order statuses in case a status is added and later removed.

### Screenshots
<img width="476" alt="Screen Shot 2019-11-18 at 4 34 11 PM" src="https://user-images.githubusercontent.com/10561050/69036689-5dac6880-0a21-11ea-95da-c05fe2116cdf.png">
<img width="516" alt="Screen Shot 2019-11-18 at 4 33 56 PM" src="https://user-images.githubusercontent.com/10561050/69036690-5dac6880-0a21-11ea-874e-ab08734a9550.png">


### Detailed test instructions:

1. Create a custom order status.
2. Add that order status to actionable and/or excluded order statuses under Analytics->Settings.
3. Delete the custom order status.
4. Refresh and go to any wc-admin page.
5. Check that no errors exist in the console and actionable orders and excluded order statuses still work as expected, leaving the valid statuses in place, but not querying the invalid ones.