### PR TITLE
Remove Previous Year week alignment

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -152,15 +152,8 @@ export function getLastPeriod( period, compare ) {
 			secondaryStart = secondaryEnd.clone().subtract( daysDiff, 'days' );
 		}
 	} else {
-		secondaryStart =
-			'week' === period
-				? primaryStart
-						.clone()
-						.subtract( 1, 'years' )
-						.week( primaryStart.week() )
-						.startOf( 'week' )
-				: primaryStart.clone().subtract( 1, 'years' );
-		secondaryEnd = secondaryStart.clone().endOf( period );
+		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
+		secondaryEnd = primaryEnd.clone().subtract( 1, 'years' );
 	}
 	return {
 		primaryStart,
@@ -189,15 +182,9 @@ export function getCurrentPeriod( period, compare ) {
 		secondaryStart = primaryStart.clone().subtract( 1, period );
 		secondaryEnd = primaryEnd.clone().subtract( 1, period );
 	} else {
-		secondaryStart =
-			'week' === period
-				? primaryStart
-						.clone()
-						.subtract( 1, 'years' )
-						.week( primaryStart.week() )
-						.startOf( 'week' )
-				: primaryStart.clone().subtract( 1, 'years' );
-		secondaryEnd = secondaryStart.clone().add( daysSoFar, 'days' );
+		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
+		// Set the end time to 23:59:59.
+		secondaryEnd = secondaryStart.clone().add( daysSoFar + 1, 'days' ).subtract( 1, 'seconds' );
 	}
 	return {
 		primaryStart,

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -213,11 +213,8 @@ describe( 'getCurrentPeriod', () => {
 		it( 'should return correct values for previous_year', () => {
 			const dateValue = getCurrentPeriod( 'week', 'previous_year' );
 			const daysSoFar = today.diff( thisWeekStart, 'days' );
-			const thisWeekLastYearStart = thisWeekStart
-				.clone()
-				.subtract( 1, 'years' )
-				.week( thisWeekStart.week() )
-				.startOf( 'week' );
+			// Last year weeks are aligned by calendar date not day of week.
+			const thisWeekLastYearStart = thisWeekStart.clone().subtract( 1, 'years' );
 			const todayThisWeekLastYear = thisWeekLastYearStart.clone().add( daysSoFar, 'days' );
 
 			expect( thisWeekLastYearStart.isSame( dateValue.secondaryStart, 'day' ) ).toBe( true );
@@ -394,12 +391,9 @@ describe( 'getLastPeriod', () => {
 		it( 'should return correct values for previous_year', () => {
 			const dateValue = getLastPeriod( 'week', 'previous_year' );
 
-			const lastWeekLastYearStart = lastWeekStart
-				.clone()
-				.subtract( 1, 'year' )
-				.week( lastWeekStart.week() )
-				.startOf( 'week' );
-			const lastWeekLastYearEnd = lastWeekLastYearStart.clone().endOf( 'week' );
+			// Last year weeks are aligned by calendar date not day of week.
+			const lastWeekLastYearStart = lastWeekStart.clone().subtract( 1, 'year' );
+			const lastWeekLastYearEnd = lastWeekEnd.clone().subtract( 1, 'year' );
 
 			expect( lastWeekLastYearStart.isSame( dateValue.secondaryStart, 'day' ) ).toBe( true );
 			expect( lastWeekLastYearEnd.isSame( dateValue.secondaryEnd, 'day' ) ).toBe( true );


### PR DESCRIPTION
Fixes #2888 
Supersedes #3129

This PR removes the logic that aligned the previous year's week in week comparisons. The aligned data was being labeled as if it were 1 calendar year by calendar date.

In the last year's data, it includes data to the end of the last day in the period.

### Detailed test instructions:

- Use smooth generator to create 20 orders between the past Sunday and today and 20 orders for the same date range in 2018 **plus** one day on the end
- In `master` load `This Month` and note the chart amount for 1 year ago today
- Switch to `This Week` and compare the amount for 1 day ago yesterday to the previous
- Switch to this branch
- `This Month` should show the same
- `This Week` should have the amounts in the correct locations

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Retrieve week last year data by calendar date instead of week alignment.