### PR TITLE
Onboarding - Add extra plugin debug to plugin installation

### DIFF
--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -211,7 +211,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 				$logger_source
 			);
 			$logger->debug(
-				wc_print_r( $api, true ),
+				'api: ' . wc_print_r( $api, true ),
 				$logger_source
 			);
 			return new \WP_Error( 'woocommerce_rest_plugin_install', __( 'The requested plugin could not be installed.', 'woocommerce-admin' ), 500 );
@@ -226,7 +226,15 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 				$logger_source
 			);
 			$logger->debug(
-				wc_print_r( $result, true ),
+				'upgrader: ' . wc_print_r( $upgrader, true ),
+				$logger_source
+			);
+			$logger->debug(
+				'api: ' . wc_print_r( $api, true ),
+				$logger_source
+			);
+			$logger->debug(
+				'result: ' . wc_print_r( $result, true ),
 				$logger_source
 			);
 			return new \WP_Error( 'woocommerce_rest_plugin_install', __( 'The requested plugin could not be installed.', 'woocommerce-admin' ), 500 );

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -199,7 +199,21 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 			)
 		);
 
+		// Log extra debug for plugin installation.
+		$logger        = wc_get_logger();
+		$logger_source = array(
+			'source' => 'woocommerce-admin',
+		);
+
 		if ( is_wp_error( $api ) ) {
+			$logger->info(
+				sprintf( 'The requested plugin `%s` could not be installed. plugins_api call failed.', sanitize_key( $slug ) ),
+				$logger_source
+			);
+			$logger->debug(
+				wc_print_r( $api, true ),
+				$logger_source
+			);
 			return new \WP_Error( 'woocommerce_rest_plugin_install', __( 'The requested plugin could not be installed.', 'woocommerce-admin' ), 500 );
 		}
 
@@ -207,6 +221,14 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		$result   = $upgrader->install( $api->download_link );
 
 		if ( is_wp_error( $result ) || is_null( $result ) ) {
+			$logger->info(
+				sprintf( 'The requested plugin `%s` could not be installed. install call failed.', sanitize_key( $slug ) ),
+				$logger_source
+			);
+			$logger->debug(
+				wc_print_r( $result, true ),
+				$logger_source
+			);
 			return new \WP_Error( 'woocommerce_rest_plugin_install', __( 'The requested plugin could not be installed.', 'woocommerce-admin' ), 500 );
 		}
 


### PR DESCRIPTION
To help investigate https://github.com/woocommerce/woocommerce-admin/issues/3265, which seems fairly reproducible on a fresh site, this PR adds some additional logging to the plugin installation endpoint. I'm thinking we should plan on cutting an onboarding release soon, and hopefully we can catch something useful from the extra debug info.

### Detailed test instructions:

To fully test that the logging code works, go into `src/API/OnboardingPlugins.php` and make a change to `install_plugin` that would allow one of the two `woocommerce_rest_plugin_install` errors to occur.

For example, you could change `'slug'   => sanitize_key( $slug ),` to `'slug'   => '',`.

Now delete WooCommerce Services, and enable the profile wizard.

Go to the first step, and see the installation fail.

You should now be able to go under `WooCommerce > Status > Logs` and find the `woocommerce-admin` log. It should have debug like this:

<img width="1015" alt="Screen Shot 2019-11-18 at 1 22 52 PM" src="https://user-images.githubusercontent.com/689165/69078748-8bd07f00-0a06-11ea-91a2-f3604f5e5674.png">
