### PR TITLE
use a filter to set default locale

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -117,8 +117,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( file_exists( $file ) && class_exists( 'WC_Product_CSV_Importer' ) ) {
 			// Override locale so we can return mappings from WooCommerce in English language stores.
-			global $locale;
-			$locale         = false; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			add_filter( 'locale', '__return_false', 9999 );
 			$importer_class = apply_filters( 'woocommerce_product_csv_importer_class', 'WC_Product_CSV_Importer' );
 			$args           = array(
 				'parse'   => true,


### PR DESCRIPTION
Fixes #3217

This PR replaces the global override of the `$locale` variable with the `locale` filter to set it to the same value.

### Detailed test instructions:

- Run `vendor/bin/phpcs src/API/OnboardingTasks.php`
- Run `phpunit tests/api/onboarding-tasks.php`

### Changelog Note:
