### PR TITLE
rename DS get_* to add_* where function does not return values

### DIFF
--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -71,7 +71,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'items_sold'     => 'SUM(product_qty) as items_sold',
 			'net_revenue'    => 'SUM(product_net_revenue) AS net_revenue',
@@ -85,11 +85,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_product_lookup_table = self::get_db_table_name();
 
-		$this->get_time_period_sql_params( $query_args, $order_product_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_product_lookup_table );
 
 		// join wp_order_product_lookup_table with relationships and taxonomies
 		// @todo How to handle custom product tables?
@@ -102,9 +102,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			// Limit is left out here so that the grouping in code by PHP can be applied correctly.
 			// This also needs to be put after the term_taxonomy JOIN so that we can match the correct term name.
-			$this->get_order_by_params( $query_args, 'outer', 'default_results.category_id' );
+			$this->add_order_by_params( $query_args, 'outer', 'default_results.category_id' );
 		} else {
-			$this->get_order_by_params( $query_args, 'inner', "{$wpdb->wc_category_lookup}.category_tree_id" );
+			$this->add_order_by_params( $query_args, 'inner', "{$wpdb->wc_category_lookup}.category_tree_id" );
 		}
 
 		// @todo Only products in the category C or orders with products from category C (and, possibly others?).
@@ -124,7 +124,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param string $from_arg   Target of the JOIN sql param.
 	 * @param string $id_cell    ID cell identifier, like `table_name.id_column_name`.
 	 */
-	protected function get_order_by_params( $query_args, $from_arg, $id_cell ) {
+	protected function add_order_by_params( $query_args, $from_arg, $id_cell ) {
 		global $wpdb;
 		$lookup_table    = self::get_db_table_name();
 		$order_by_clause = $this->add_order_by_clause( $query_args, $this );
@@ -243,7 +243,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$this->subquery->add_sql_clause( 'select', $this->selected_columns( $query_args ) );
 			$included_categories = $this->get_included_categories_array( $query_args );
-			$this->get_sql_query_params( $query_args );
+			$this->add_sql_query_params( $query_args );
 
 			if ( count( $included_categories ) > 0 ) {
 				$fields    = $this->get_fields( $query_args );

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -56,7 +56,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'coupon_id'    => 'coupon_id',
 			'amount'       => 'SUM(discount_amount) as amount',
@@ -90,20 +90,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_coupon_lookup_table = self::get_db_table_name();
 
-		$this->get_time_period_sql_params( $query_args, $order_coupon_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_coupon_lookup_table );
 		$this->get_limit_sql_params( $query_args );
 
 		$included_coupons = $this->get_included_coupons( $query_args, 'coupons' );
 		if ( $included_coupons ) {
 			$this->subquery->add_sql_clause( 'where', "AND {$order_coupon_lookup_table}.coupon_id IN ({$included_coupons})" );
 
-			$this->get_order_by_params( $query_args, 'outer', 'default_results.coupon_id' );
+			$this->add_order_by_params( $query_args, 'outer', 'default_results.coupon_id' );
 		} else {
-			$this->get_order_by_params( $query_args, 'inner', "{$order_coupon_lookup_table}.coupon_id" );
+			$this->add_order_by_params( $query_args, 'inner', "{$order_coupon_lookup_table}.coupon_id" );
 		}
 
 		$this->add_order_status_clause( $query_args, $order_coupon_lookup_table, $this->subquery );
@@ -116,7 +116,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param string $from_arg   Target of the JOIN sql param.
 	 * @param string $id_cell    ID cell identifier, like `table_name.id_column_name`.
 	 */
-	protected function get_order_by_params( $query_args, $from_arg, $id_cell ) {
+	protected function add_order_by_params( $query_args, $from_arg, $id_cell ) {
 		global $wpdb;
 		$lookup_table    = self::get_db_table_name();
 		$order_by_clause = $this->add_order_by_clause( $query_args, $this );
@@ -249,7 +249,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$included_coupons = $this->get_included_coupons_array( $query_args );
 			$limit_params     = $this->get_limit_params( $query_args );
 			$this->subquery->add_sql_clause( 'select', $selections );
-			$this->get_sql_query_params( $query_args );
+			$this->add_sql_query_params( $query_args );
 
 			if ( count( $included_coupons ) > 0 ) {
 				$total_results = count( $included_coupons );

--- a/src/API/Reports/Coupons/Stats/DataStore.php
+++ b/src/API/Reports/Coupons/Stats/DataStore.php
@@ -57,7 +57,7 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'amount'        => 'SUM(discount_amount) as amount',
 			'coupons_count' => 'COUNT(DISTINCT coupon_id) as coupons_count',
@@ -75,7 +75,7 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 
 		$clauses = array(
 			'where' => '',
-			'join' => '',
+			'join'  => '',
 		);
 
 		$order_coupon_lookup_table = self::get_db_table_name();
@@ -91,8 +91,8 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 			$clauses['where'] .= " AND ( {$order_status_filter} )";
 		}
 
-		$this->get_time_period_sql_params( $query_args, $order_coupon_lookup_table );
-		$this->get_intervals_sql_params( $query_args, $order_coupon_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_coupon_lookup_table );
+		$this->add_intervals_sql_params( $query_args, $order_coupon_lookup_table );
 		$clauses['where_time'] = $this->get_sql_clause( 'where_time' );
 
 		$this->interval_query->add_sql_clause( 'limit', $this->get_sql_clause( 'limit' ) );
@@ -178,12 +178,12 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 			}
 
 			// @todo remove these assignements when refactoring segmenter classes to use query objects.
-			$totals_query    = array(
+			$totals_query          = array(
 				'from_clause'       => $this->total_query->get_sql_clause( 'join' ),
 				'where_time_clause' => $this->total_query->get_sql_clause( 'where_time' ),
 				'where_clause'      => $this->total_query->get_sql_clause( 'where' ),
 			);
-			$intervals_query = array(
+			$intervals_query       = array(
 				'select_clause'     => $this->get_sql_clause( 'select' ),
 				'from_clause'       => $this->interval_query->get_sql_clause( 'join' ),
 				'where_time_clause' => $this->interval_query->get_sql_clause( 'where_time' ),

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -59,7 +59,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	protected function assign_report_columns() {
 		global $wpdb;
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'id'               => "{$table_name}.customer_id as id",
 			'user_id'          => 'user_id',
@@ -121,7 +121,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param array  $query_args Parameters supplied by the user.
 	 * @param string $table_name Name of the db table relevant for the date constraint.
 	 */
-	protected function get_time_period_sql_params( $query_args, $table_name ) {
+	protected function add_time_period_sql_params( $query_args, $table_name ) {
 		global $wpdb;
 
 		$this->clear_sql_clause( array( 'where', 'where_time', 'having' ) );
@@ -188,14 +188,14 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 		$customer_lookup_table  = self::get_db_table_name();
 		$order_stats_table_name = $wpdb->prefix . 'wc_order_stats';
 
-		$this->get_time_period_sql_params( $query_args, $customer_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $customer_lookup_table );
 		$this->get_limit_sql_params( $query_args );
-		$this->get_order_by_sql_params( $query_args );
+		$this->add_order_by_sql_params( $query_args );
 		$this->subquery->add_sql_clause( 'left_join', "LEFT JOIN {$order_stats_table_name} ON {$customer_lookup_table}.customer_id = {$order_stats_table_name}.customer_id" );
 
 		$match_operator = $this->get_match_operator( $query_args );
@@ -352,7 +352,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			);
 
 			$selections       = $this->selected_columns( $query_args );
-			$sql_query_params = $this->get_sql_query_params( $query_args );
+			$sql_query_params = $this->add_sql_query_params( $query_args );
 
 			$db_records_count = (int) $wpdb->get_var(
 				"SELECT COUNT(*) FROM (

--- a/src/API/Reports/Customers/Stats/DataStore.php
+++ b/src/API/Reports/Customers/Stats/DataStore.php
@@ -93,8 +93,8 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 				'avg_avg_order_value' => 0.0,
 			);
 
-			$selections       = $this->selected_columns( $query_args );
-			$sql_query_params = $this->get_sql_query_params( $query_args );
+			$selections = $this->selected_columns( $query_args );
+			$this->add_sql_query_params( $query_args );
 			// Clear SQL clauses set for parent class queries that are different here.
 			$this->subquery->clear_sql_clause( 'select' );
 			$this->subquery->add_sql_clause( 'select', 'SUM( gross_total ) AS total_spend,' );

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -462,10 +462,10 @@ class DataStore extends SqlQuery {
 				}
 			}
 			// @todo - Do this without modifying $query_args?
-			$query_args['adj_after']               = $new_start_date;
-			$query_args['adj_before']              = $new_end_date;
-			$adj_after                             = $new_start_date->format( TimeInterval::$sql_datetime_format );
-			$adj_before                            = $new_end_date->format( TimeInterval::$sql_datetime_format );
+			$query_args['adj_after']  = $new_start_date;
+			$query_args['adj_before'] = $new_end_date;
+			$adj_after                = $new_start_date->format( TimeInterval::$sql_datetime_format );
+			$adj_before               = $new_end_date->format( TimeInterval::$sql_datetime_format );
 			$this->interval_query->clear_sql_clause( array( 'where_time', 'limit' ) );
 			$this->interval_query->add_sql_clause( 'where_time', "AND {$table_name}.date_created <= '$adj_before'" );
 			$this->interval_query->add_sql_clause( 'where_time', "AND {$table_name}.date_created >= '$adj_after'" );
@@ -649,7 +649,7 @@ class DataStore extends SqlQuery {
 	 * @param array  $query_args Parameters supplied by the user.
 	 * @param string $table_name Name of the db table relevant for the date constraint.
 	 */
-	protected function get_time_period_sql_params( $query_args, $table_name ) {
+	protected function add_time_period_sql_params( $query_args, $table_name ) {
 		$this->clear_sql_clause( array( 'from', 'where_time', 'where' ) );
 		if ( isset( $this->subquery ) ) {
 			$this->subquery->clear_sql_clause( 'where_time' );
@@ -777,7 +777,7 @@ class DataStore extends SqlQuery {
 	 *
 	 * @param array $query_args Parameters supplied by the user.
 	 */
-	protected function get_order_by_sql_params( $query_args ) {
+	protected function add_order_by_sql_params( $query_args ) {
 		if ( isset( $query_args['orderby'] ) ) {
 			$order_by_clause = $this->normalize_order_by( $query_args['orderby'] );
 		} else {
@@ -795,13 +795,13 @@ class DataStore extends SqlQuery {
 	 * @param array  $query_args Parameters supplied by the user.
 	 * @param string $table_name Name of the db table relevant for the date constraint.
 	 */
-	protected function get_intervals_sql_params( $query_args, $table_name ) {
+	protected function add_intervals_sql_params( $query_args, $table_name ) {
 		$this->clear_sql_clause( array( 'from', 'where_time', 'where' ) );
 
-		$this->get_time_period_sql_params( $query_args, $table_name );
+		$this->add_time_period_sql_params( $query_args, $table_name );
 
 		if ( isset( $query_args['interval'] ) && '' !== $query_args['interval'] ) {
-			$interval                         = $query_args['interval'];
+			$interval = $query_args['interval'];
 			$this->clear_sql_clause( 'select' );
 			$this->add_sql_clause( 'select', TimeInterval::db_datetime_format( $interval, $table_name ) );
 		}

--- a/src/API/Reports/Downloads/DataStore.php
+++ b/src/API/Reports/Downloads/DataStore.php
@@ -77,7 +77,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 
 		$lookup_table     = self::get_db_table_name();
@@ -86,7 +86,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$where_filters    = array();
 		$join             = "JOIN {$permission_table} as product_permissions ON {$lookup_table}.permission_id = product_permissions.permission_id";
 
-		$where_time = $this->get_time_period_sql_params( $query_args, $lookup_table );
+		$where_time = $this->add_time_period_sql_params( $query_args, $lookup_table );
 		if ( $where_time ) {
 			if ( isset( $this->subquery ) ) {
 				$this->subquery->add_sql_clause( 'where_time', $where_time );
@@ -180,7 +180,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		} else {
 			$this->interval_query->add_sql_clause( 'join', $join );
 		}
-		$this->get_order_by( $query_args );
+		$this->add_order_by( $query_args );
 	}
 
 	/**
@@ -236,7 +236,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param string $table_name Name of the db table relevant for the date constraint.
 	 * @return string
 	 */
-	protected function get_time_period_sql_params( $query_args, $table_name ) {
+	protected function add_time_period_sql_params( $query_args, $table_name ) {
 		$where_time = '';
 		if ( $query_args['before'] ) {
 			$datetime_str = $query_args['before']->format( TimeInterval::$sql_datetime_format );
@@ -257,7 +257,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Parameters supplied by the user.
 	 */
-	protected function get_order_by( $query_args ) {
+	protected function add_order_by( $query_args ) {
 		global $wpdb;
 		$this->clear_sql_clause( 'order_by' );
 		$order_by = '';
@@ -314,8 +314,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => 0,
 			);
 
-			$selections       = $this->selected_columns( $query_args );
-			$sql_query_params = $this->get_sql_query_params( $query_args );
+			$selections = $this->selected_columns( $query_args );
+			$this->add_sql_query_params( $query_args );
 
 			$db_records_count = (int) $wpdb->get_var(
 				"SELECT COUNT(*) FROM (

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -86,9 +86,9 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 		if ( false === $data ) {
 			$this->initialize_queries();
 			$selections = $this->selected_columns( $query_args );
-			$this->get_sql_query_params( $query_args );
-			$this->get_time_period_sql_params( $query_args, $table_name );
-			$this->get_intervals_sql_params( $query_args, $table_name );
+			$this->add_sql_query_params( $query_args );
+			$this->add_time_period_sql_params( $query_args, $table_name );
+			$this->add_intervals_sql_params( $query_args, $table_name );
 
 			$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
 			$this->interval_query->str_replace_clause( 'select', 'date_created', 'timestamp' );

--- a/src/API/Reports/Orders/DataStore.php
+++ b/src/API/Reports/Orders/DataStore.php
@@ -82,7 +82,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_stats_lookup_table   = self::get_db_table_name();
 		$order_coupon_lookup_table  = $wpdb->prefix . 'wc_order_coupon_lookup';
@@ -91,9 +91,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$operator                   = $this->get_match_operator( $query_args );
 		$where_subquery             = array();
 
-		$this->get_time_period_sql_params( $query_args, $order_stats_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_stats_lookup_table );
 		$this->get_limit_sql_params( $query_args );
-		$this->get_order_by_sql_params( $query_args );
+		$this->add_order_by_sql_params( $query_args );
 
 		$status_subquery = $this->get_status_subquery( $query_args );
 		if ( $status_subquery ) {
@@ -221,7 +221,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$selections = $this->selected_columns( $query_args );
 			$params     = $this->get_limit_params( $query_args );
-			$this->get_sql_query_params( $query_args );
+			$this->add_sql_query_params( $query_args );
 			$db_records_count = (int) $wpdb->get_var(
 				"SELECT COUNT(*) FROM (
 					{$this->subquery->get_query_statement()}

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -257,9 +257,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			);
 
 			$selections = $this->selected_columns( $query_args );
-			$this->get_time_period_sql_params( $query_args, $table_name );
-			$this->get_intervals_sql_params( $query_args, $table_name );
-			$this->get_order_by_sql_params( $query_args );
+			$this->add_time_period_sql_params( $query_args, $table_name );
+			$this->add_intervals_sql_params( $query_args, $table_name );
+			$this->add_order_by_sql_params( $query_args );
 			$where_time  = $this->get_sql_clause( 'where_time' );
 			$params      = $this->get_limit_sql_params( $query_args );
 			$coupon_join = "LEFT JOIN (

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -330,11 +330,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 				$products_query = $this->get_query_statement();
 			} else {
-				$db_records_count = (int) $wpdb->get_var(
-					"SELECT COUNT(*) FROM (
+				$count_query      = "SELECT COUNT(*) FROM (
 						{$this->subquery->get_query_statement()}
-					) AS tt"
-				); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+					) AS tt";
+				$db_records_count = (int) $wpdb->get_var(
+					$count_query // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				);
 
 				$total_results = $db_records_count;
 				$total_pages   = (int) ceil( $db_records_count / $params['per_page'] );
@@ -351,9 +352,9 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			}
 
 			$product_data = $wpdb->get_results(
-				$products_query,
+				$products_query, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				ARRAY_A
-			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
+			);
 
 			if ( null === $product_data ) {
 				return $data;
@@ -391,7 +392,13 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 
 		$table_name     = self::get_db_table_name();
-		$existing_items = $wpdb->get_col( $wpdb->prepare( "SELECT order_item_id FROM {$table_name} WHERE order_id = %d", $order_id ) );
+		$existing_items = $wpdb->get_col(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT order_item_id FROM {$table_name} WHERE order_id = %d",
+				$order_id
+			)
+		);
 		$existing_items = array_flip( $existing_items );
 		$order_items    = $order->get_items();
 		$num_updated    = 0;
@@ -480,6 +487,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			array_unshift( $existing_items, $order_id );
 			$wpdb->query(
 				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					"DELETE FROM {$table_name} WHERE order_id = %d AND order_item_id in ({$format})",
 					$existing_items
 				)

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -89,7 +89,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'product_id'   => 'product_id',
 			'items_sold'   => 'SUM(product_qty) as items_sold',
@@ -112,7 +112,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param string $arg_name   Target of the JOIN sql param.
 	 * @param string $id_cell    ID cell identifier, like `table_name.id_column_name`.
 	 */
-	protected function get_from_sql_params( $query_args, $arg_name, $id_cell ) {
+	protected function add_from_sql_params( $query_args, $arg_name, $id_cell ) {
 		global $wpdb;
 
 		$type = 'join';
@@ -146,20 +146,20 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_product_lookup_table = self::get_db_table_name();
 
-		$this->get_time_period_sql_params( $query_args, $order_product_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_product_lookup_table );
 		$this->get_limit_sql_params( $query_args );
-		$this->get_order_by_sql_params( $query_args );
+		$this->add_order_by_sql_params( $query_args );
 
 		$included_products = $this->get_included_products( $query_args );
 		if ( $included_products ) {
-			$this->get_from_sql_params( $query_args, 'outer', 'default_results.product_id' );
+			$this->add_from_sql_params( $query_args, 'outer', 'default_results.product_id' );
 			$this->subquery->add_sql_clause( 'where', "AND {$order_product_lookup_table}.product_id IN ({$included_products})" );
 		} else {
-			$this->get_from_sql_params( $query_args, 'inner', "{$order_product_lookup_table}.product_id" );
+			$this->add_from_sql_params( $query_args, 'inner', "{$order_product_lookup_table}.product_id" );
 		}
 
 		$included_variations = $this->get_included_variations( $query_args );
@@ -302,7 +302,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$selections        = $this->selected_columns( $query_args );
 			$included_products = $this->get_included_products_array( $query_args );
 			$params            = $this->get_limit_params( $query_args );
-			$this->get_sql_query_params( $query_args );
+			$this->add_sql_query_params( $query_args );
 
 			if ( count( $included_products ) > 0 ) {
 				$total_results = count( $included_products );
@@ -399,7 +399,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		$round_tax      = 'no' === get_option( 'woocommerce_tax_round_at_subtotal' );
 
 		foreach ( $order_items as $order_item ) {
-			$order_item_id       = $order_item->get_id();
+			$order_item_id = $order_item->get_id();
 			unset( $existing_items[ $order_item_id ] );
 			$product_qty         = $order_item->get_quantity( 'edit' );
 			$shipping_amount     = $order->get_item_shipping_amount( $order_item );

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -46,7 +46,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'items_sold'       => 'SUM(product_qty) as items_sold',
 			'net_revenue'      => 'SUM(product_net_revenue) AS net_revenue',
@@ -84,11 +84,11 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 			$products_where_clause .= " AND ( {$order_status_filter} )";
 		}
 
-		$this->get_time_period_sql_params( $query_args, $order_product_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_product_lookup_table );
 		$this->total_query->add_sql_clause( 'where', $products_where_clause );
 		$this->total_query->add_sql_clause( 'join', $products_from_clause );
 
-		$this->get_intervals_sql_params( $query_args, $order_product_lookup_table );
+		$this->add_intervals_sql_params( $query_args, $order_product_lookup_table );
 		$this->interval_query->add_sql_clause( 'where', $products_where_clause );
 		$this->interval_query->add_sql_clause( 'join', $products_from_clause );
 		$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -63,7 +63,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'tax_rate_id'  => "{$table_name}.tax_rate_id",
 			'name'         => 'tax_rate_name as name',
@@ -91,7 +91,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param array  $query_args          Query arguments supplied by the user.
 	 * @param string $order_status_filter Order status subquery.
 	 */
-	protected function get_from_sql_params( $query_args, $order_status_filter ) {
+	protected function add_from_sql_params( $query_args, $order_status_filter ) {
 		global $wpdb;
 		$table_name = self::get_db_table_name();
 
@@ -111,16 +111,16 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 
 		$order_tax_lookup_table = self::get_db_table_name();
 
-		$this->get_time_period_sql_params( $query_args, $order_tax_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_tax_lookup_table );
 		$this->get_limit_sql_params( $query_args );
-		$this->get_order_by_sql_params( $query_args );
+		$this->add_order_by_sql_params( $query_args );
 		$order_status_filter = $this->get_status_subquery( $query_args );
-		$this->get_from_sql_params( $query_args, $order_status_filter );
+		$this->add_from_sql_params( $query_args, $order_status_filter );
 
 		if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {
 			$allowed_taxes = self::get_filtered_ids( $query_args, 'taxes' );
@@ -174,7 +174,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'page_no' => 0,
 			);
 
-			$this->get_sql_query_params( $query_args );
+			$this->add_sql_query_params( $query_args );
 			$params = $this->get_limit_params( $query_args );
 
 			if ( isset( $query_args['taxes'] ) && ! empty( $query_args['taxes'] ) ) {

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -86,10 +86,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$taxes_where_clause .= " AND ( {$order_status_filter} )";
 		}
 
-		$this->get_time_period_sql_params( $query_args, $order_tax_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_tax_lookup_table );
 		$this->total_query->add_sql_clause( 'where', $taxes_where_clause );
 
-		$this->get_intervals_sql_params( $query_args, $order_tax_lookup_table );
+		$this->add_intervals_sql_params( $query_args, $order_tax_lookup_table );
 		$this->interval_query->add_sql_clause( 'where', $taxes_where_clause );
 		$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
 		$this->interval_query->add_sql_clause( 'where_time', $this->get_sql_clause( 'where_time' ) );

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -80,7 +80,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Assign report columns once full table name has been assigned.
 	 */
 	protected function assign_report_columns() {
-		$table_name = self::get_db_table_name();
+		$table_name           = self::get_db_table_name();
 		$this->report_columns = array(
 			'product_id'   => 'product_id',
 			'variation_id' => 'variation_id',
@@ -96,7 +96,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @param array  $query_args Parameters supplied by the user.
 	 * @param string $arg_name   Target of the JOIN sql param.
 	 */
-	protected function get_from_sql_params( $query_args, $arg_name ) {
+	protected function add_from_sql_params( $query_args, $arg_name ) {
 		global $wpdb;
 
 		if ( 'sku' !== $query_args['orderby'] ) {
@@ -118,18 +118,18 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @param array $query_args Query arguments supplied by the user.
 	 */
-	protected function get_sql_query_params( $query_args ) {
+	protected function add_sql_query_params( $query_args ) {
 		global $wpdb;
 		$order_product_lookup_table = self::get_db_table_name();
 
-		$this->get_time_period_sql_params( $query_args, $order_product_lookup_table );
+		$this->add_time_period_sql_params( $query_args, $order_product_lookup_table );
 		$this->get_limit_sql_params( $query_args );
-		$this->get_order_by_sql_params( $query_args );
+		$this->add_order_by_sql_params( $query_args );
 
 		if ( count( $query_args['variations'] ) > 0 ) {
-			$this->get_from_sql_params( $query_args, 'outer' );
+			$this->add_from_sql_params( $query_args, 'outer' );
 		} else {
-			$this->get_from_sql_params( $query_args, 'inner' );
+			$this->add_from_sql_params( $query_args, 'inner' );
 		}
 
 		$included_products = $this->get_included_products( $query_args );
@@ -270,7 +270,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 			$included_products = $this->get_included_products_array( $query_args );
 
-			$this->get_sql_query_params( $query_args );
+			$this->add_sql_query_params( $query_args );
 			$params = $this->get_limit_params( $query_args );
 			if ( count( $included_products ) > 0 && count( $query_args['variations'] ) > 0 ) {
 				$this->subquery->add_sql_clause( 'select', $this->selected_columns( $query_args ) );


### PR DESCRIPTION
Fixes #3111

This PR renames data store `get_*` functions to `add_*` where the function does not return a value. It's a follow up to #2961 .

It also contains quite a few PHPCS fixes.

### Detailed test instructions:

- Check the dashboard analytics to ensure all screens continue to function.

### Changelog Note:

Dev: rename data store get_* to add_* functions where function does not return values