### PR TITLE
Decouple currency and numbers packages from `wcSettings`.

### DIFF
--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -8,8 +8,8 @@ import { mount, shallow } from 'enzyme';
 /**
  * WooCommerce dependencies
  */
-import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
-import { numberFormat } from '@woocommerce/number';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
+import { numberFormat } from 'lib/number-format';
 
 /**
  * Internal dependencies

--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -10,12 +10,13 @@ import { omitBy, isUndefined, snakeCase } from 'lodash';
  * WooCommerce dependencies
  */
 import { ReportFilters as Filters } from '@woocommerce/components';
-import { LOCALE, CURRENCY } from '@woocommerce/wc-admin-settings';
+import { LOCALE } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
  */
 import { recordEvent } from 'lib/tracks';
+import { Currency } from 'lib/currency-format';
 
 export default class ReportFilters extends Component {
 	constructor() {
@@ -67,7 +68,7 @@ export default class ReportFilters extends Component {
 			<Filters
 				query={ query }
 				siteLocale={ LOCALE.siteLocale }
-				currency={ CURRENCY }
+				currency={ Currency }
 				path={ path }
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -13,8 +13,8 @@ import PropTypes from 'prop-types';
 import { getDateParamsFromQuery } from '@woocommerce/date';
 import { getNewPath } from '@woocommerce/navigation';
 import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce/components';
-import { calculateDelta, formatValue } from '@woocommerce/number';
-import { formatCurrency } from '@woocommerce/currency';
+import { calculateDelta, formatValue } from 'lib/number-format';
+import { formatCurrency } from 'lib/currency-format';
 
 /**
  * Internal dependencies

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -10,10 +10,10 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from '@woocommerce/currency';
+import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 
 /**
  * Internal dependencies

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -13,7 +13,7 @@ import { map } from 'lodash';
 import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 
 /**
  * Internal dependencies
@@ -82,7 +82,7 @@ class CategoriesReportTable extends Component {
 					value: category && category.name,
 				},
 				{
-					display: numberFormat( items_sold ),
+					display: formatValue( 'number', items_sold ),
 					value: items_sold,
 				},
 				{
@@ -98,13 +98,13 @@ class CategoriesReportTable extends Component {
 							} ) }
 							type="wc-admin"
 						>
-							{ numberFormat( products_count ) }
+							{ formatValue( 'number', products_count ) }
 						</Link>
 					),
 					value: products_count,
 				},
 				{
-					display: numberFormat( orders_count ),
+					display: formatValue( 'number', orders_count ),
 					value: orders_count,
 				},
 			];
@@ -116,11 +116,11 @@ class CategoriesReportTable extends Component {
 		return [
 			{
 				label: _n( 'category', 'categories', totalResults, 'woocommerce-admin' ),
-				value: numberFormat( totalResults ),
+				value: formatValue( 'number', totalResults ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', items_sold, 'woocommerce-admin' ),
-				value: numberFormat( items_sold ),
+				value: formatValue( 'number', items_sold ),
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
@@ -128,7 +128,7 @@ class CategoriesReportTable extends Component {
 			},
 			{
 				label: _n( 'order', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 		];
 	}

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -11,9 +11,9 @@ import { map } from 'lodash';
  */
 import { Date, Link } from '@woocommerce/components';
 import { defaultTableDateFormat } from '@woocommerce/date';
-import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 
 /**
  * Internal dependencies

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -13,7 +13,7 @@ import { Date, Link } from '@woocommerce/components';
 import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 
 /**
  * Internal dependencies
@@ -92,7 +92,7 @@ export default class CouponsReportTable extends Component {
 			} );
 			const ordersLink = (
 				<Link href={ ordersUrl } type="wc-admin">
-					{ numberFormat( orders_count ) }
+					{ formatValue( 'number', orders_count ) }
 				</Link>
 			);
 
@@ -134,11 +134,11 @@ export default class CouponsReportTable extends Component {
 		return [
 			{
 				label: _n( 'coupon', 'coupons', coupons_count, 'woocommerce-admin' ),
-				value: numberFormat( coupons_count ),
+				value: formatValue( 'number', coupons_count ),
 			},
 			{
 				label: _n( 'order', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 			{
 				label: __( 'amount discounted', 'woocommerce-admin' ),

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -10,9 +10,9 @@ import { Tooltip } from '@wordpress/components';
  * WooCommerce dependencies
  */
 import { defaultTableDateFormat } from '@woocommerce/date';
-import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { Date, Link } from '@woocommerce/components';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 const { countries } = getSetting( 'dataEndpoints', { countries: {} } );

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -12,7 +12,7 @@ import { Tooltip } from '@wordpress/components';
 import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { Date, Link } from '@woocommerce/components';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
@@ -178,7 +178,7 @@ export default class CustomersReportTable extends Component {
 					value: email,
 				},
 				{
-					display: numberFormat( orders_count ),
+					display: formatValue( 'number', orders_count ),
 					value: orders_count,
 				},
 				{
@@ -219,11 +219,11 @@ export default class CustomersReportTable extends Component {
 		return [
 			{
 				label: _n( 'customer', 'customers', customers_count, 'woocommerce-admin' ),
-				value: numberFormat( customers_count ),
+				value: formatValue( 'number', customers_count ),
 			},
 			{
 				label: _n( 'average order', 'average orders', avg_orders_count, 'woocommerce-admin' ),
-				value: numberFormat( avg_orders_count ),
+				value: formatValue( 'number', avg_orders_count ),
 			},
 			{
 				label: __( 'average lifetime spend', 'woocommerce-admin' ),

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -13,7 +13,7 @@ import moment from 'moment';
 import { defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Date, Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 
 /**
  * Internal dependencies

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -13,7 +13,7 @@ import moment from 'moment';
 import { defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Date, Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 
 /**
  * Internal dependencies
@@ -140,11 +140,11 @@ export default class CouponsReportTable extends Component {
 		return [
 			{
 				label: _n( 'day', 'days', days, 'woocommerce-admin' ),
-				value: numberFormat( days ),
+				value: formatValue( 'number', days ),
 			},
 			{
 				label: _n( 'download', 'downloads', download_count, 'woocommerce-admin' ),
-				value: numberFormat( download_count ),
+				value: formatValue( 'number', download_count ),
 			},
 		];
 	}

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -11,8 +11,8 @@ import { map } from 'lodash';
  */
 import { Date, Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { defaultTableDateFormat } from '@woocommerce/date';
-import { formatCurrency, renderCurrency } from '@woocommerce/currency';
-import { numberFormat } from '@woocommerce/number';
+import { formatCurrency, renderCurrency } from 'lib/currency-format';
+import { numberFormat } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -12,7 +12,7 @@ import { map } from 'lodash';
 import { Date, Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { defaultTableDateFormat } from '@woocommerce/date';
 import { formatCurrency, renderCurrency } from 'lib/currency-format';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -193,7 +193,7 @@ export default class OrdersReportTable extends Component {
 						.join( ', ' ),
 				},
 				{
-					display: numberFormat( num_items_sold ),
+					display: formatValue( 'number', num_items_sold ),
 					value: num_items_sold,
 				},
 				{
@@ -224,11 +224,11 @@ export default class OrdersReportTable extends Component {
 		return [
 			{
 				label: _n( 'order', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 			{
 				label: _n( 'new customer', 'new customers', num_new_customers, 'woocommerce-admin' ),
-				value: numberFormat( num_new_customers ),
+				value: formatValue( 'number', num_new_customers ),
 			},
 			{
 				label: _n(
@@ -237,19 +237,19 @@ export default class OrdersReportTable extends Component {
 					num_returning_customers,
 					'woocommerce-admin'
 				),
-				value: numberFormat( num_returning_customers ),
+				value: formatValue( 'number', num_returning_customers ),
 			},
 			{
 				label: _n( 'product', 'products', products, 'woocommerce-admin' ),
-				value: numberFormat( products ),
+				value: formatValue( 'number', products ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', num_items_sold, 'woocommerce-admin' ),
-				value: numberFormat( num_items_sold ),
+				value: formatValue( 'number', num_items_sold ),
 			},
 			{
 				label: _n( 'coupon', 'coupons', coupons_count, 'woocommerce-admin' ),
-				value: numberFormat( coupons_count ),
+				value: formatValue( 'number', coupons_count ),
 			},
 			{
 				label: __( 'net revenue', 'woocommerce-admin' ),

--- a/client/analytics/report/orders/utils.js
+++ b/client/analytics/report/orders/utils.js
@@ -6,7 +6,7 @@
 /**
  * WooCommerce dependencies
  */
-import { getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getOrderRefundTotal } from 'lib/order-values';
 
 export function formatTableOrders( orders ) {

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -12,7 +12,7 @@ import { map, get } from 'lodash';
 import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -113,7 +113,7 @@ export default class VariationsReportTable extends Component {
 					value: sku,
 				},
 				{
-					display: numberFormat( items_sold ),
+					display: formatValue( 'number', items_sold ),
 					value: items_sold,
 				},
 				{
@@ -155,11 +155,11 @@ export default class VariationsReportTable extends Component {
 		return [
 			{
 				label: _n( 'variation sold', 'variations sold', variations_count, 'woocommerce-admin' ),
-				value: numberFormat( variations_count ),
+				value: formatValue( 'number', variations_count ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', items_sold, 'woocommerce-admin' ),
-				value: numberFormat( items_sold ),
+				value: formatValue( 'number', items_sold ),
 			},
 			{
 				label: __( 'net revenue', 'woocommerce-admin' ),
@@ -167,7 +167,7 @@ export default class VariationsReportTable extends Component {
 			},
 			{
 				label: _n( 'orders', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 		];
 	}

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -10,9 +10,9 @@ import { map, get } from 'lodash';
  * WooCommerce dependencies
  */
 import { Link } from '@woocommerce/components';
-import { formatCurrency, getCurrencyFormatDecimal } from '@woocommerce/currency';
+import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -13,7 +13,7 @@ import { map } from 'lodash';
 import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { Link, Tag } from '@woocommerce/components';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -152,7 +152,7 @@ class ProductsReportTable extends Component {
 					value: sku,
 				},
 				{
-					display: numberFormat( items_sold ),
+					display: formatValue( 'number', items_sold ),
 					value: items_sold,
 				},
 				{
@@ -194,7 +194,7 @@ class ProductsReportTable extends Component {
 					value: productCategories.map( category => category.name ).join( ', ' ),
 				},
 				{
-					display: numberFormat( variations.length ),
+					display: formatValue( 'number', variations.length ),
 					value: variations.length,
 				},
 				'yes' === manageStock
@@ -206,7 +206,7 @@ class ProductsReportTable extends Component {
 				'yes' === manageStock
 					? {
 							display: manage_stock
-								? numberFormat( stock_quantity )
+								? formatValue( 'number', stock_quantity )
 								: __( 'N/A', 'woocommerce-admin' ),
 							value: stock_quantity,
 						}
@@ -220,11 +220,11 @@ class ProductsReportTable extends Component {
 		return [
 			{
 				label: _n( 'product', 'products', products_count, 'woocommerce-admin' ),
-				value: numberFormat( products_count ),
+				value: formatValue( 'number', products_count ),
 			},
 			{
 				label: _n( 'item sold', 'items sold', items_sold, 'woocommerce-admin' ),
-				value: numberFormat( items_sold ),
+				value: formatValue( 'number', items_sold ),
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
@@ -232,7 +232,7 @@ class ProductsReportTable extends Component {
 			},
 			{
 				label: _n( 'orders', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 		];
 	}

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -10,10 +10,10 @@ import { map } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from '@woocommerce/currency';
+import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { Link, Tag } from '@woocommerce/components';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -14,7 +14,7 @@ import { get } from 'lodash';
 import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Date, Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 
 /**
  * Internal dependencies
@@ -113,7 +113,7 @@ class RevenueReportTable extends Component {
 					href={ 'edit.php?post_type=shop_order&m=' + formatDate( 'Ymd', row.date_start ) }
 					type="wp-admin"
 				>
-					{ numberFormat( orders_count ) }
+					{ formatValue( 'number', orders_count ) }
 				</Link>
 			);
 			return [
@@ -166,11 +166,11 @@ class RevenueReportTable extends Component {
 		return [
 			{
 				label: _n( 'day', 'days', totalResults, 'woocommerce-admin' ),
-				value: numberFormat( totalResults ),
+				value: formatValue( 'number', totalResults ),
 			},
 			{
 				label: _n( 'order', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 			{
 				label: __( 'gross revenue', 'woocommerce-admin' ),

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -13,8 +13,8 @@ import { get } from 'lodash';
  */
 import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
 import { Date, Link } from '@woocommerce/components';
-import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from '@woocommerce/currency';
-import { numberFormat } from '@woocommerce/number';
+import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
+import { numberFormat } from 'lib/number-format';
 
 /**
  * Internal dependencies

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -10,7 +10,7 @@ import { Component } from '@wordpress/element';
  */
 import { Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -10,7 +10,7 @@ import { Component } from '@wordpress/element';
  */
 import { Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -109,7 +109,9 @@ export default class StockReportTable extends Component {
 					value: stock_status,
 				},
 				{
-					display: manage_stock ? numberFormat( stock_quantity ) : __( 'N/A', 'woocommerce-admin' ),
+					display: manage_stock
+						? formatValue( 'number', stock_quantity )
+						: __( 'N/A', 'woocommerce-admin' ),
 					value: stock_quantity,
 				},
 			];
@@ -121,23 +123,23 @@ export default class StockReportTable extends Component {
 		return [
 			{
 				label: _n( 'product', 'products', products, 'woocommerce-admin' ),
-				value: numberFormat( products ),
+				value: formatValue( 'number', products ),
 			},
 			{
 				label: __( 'out of stock', outofstock, 'woocommerce-admin' ),
-				value: numberFormat( outofstock ),
+				value: formatValue( 'number', outofstock ),
 			},
 			{
 				label: __( 'low stock', lowstock, 'woocommerce-admin' ),
-				value: numberFormat( lowstock ),
+				value: formatValue( 'number', lowstock ),
 			},
 			{
 				label: __( 'on backorder', onbackorder, 'woocommerce-admin' ),
-				value: numberFormat( onbackorder ),
+				value: formatValue( 'number', onbackorder ),
 			},
 			{
 				label: __( 'in stock', instock, 'woocommerce-admin' ),
-				value: numberFormat( instock ),
+				value: formatValue( 'number', instock ),
 			},
 		];
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -13,7 +13,7 @@ import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { getTaxCode } from './utils';
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 
 /**
  * Internal dependencies
@@ -109,7 +109,7 @@ export default class TaxesReportTable extends Component {
 					value: getCurrencyFormatDecimal( shipping_tax ),
 				},
 				{
-					display: numberFormat( orders_count ),
+					display: formatValue( 'number', orders_count ),
 					value: orders_count,
 				},
 			];
@@ -127,7 +127,7 @@ export default class TaxesReportTable extends Component {
 		return [
 			{
 				label: _n( 'tax code', 'tax codes', tax_codes, 'woocommerce-admin' ),
-				value: numberFormat( tax_codes ),
+				value: formatValue( 'number', tax_codes ),
 			},
 			{
 				label: __( 'total tax', 'woocommerce-admin' ),
@@ -143,7 +143,7 @@ export default class TaxesReportTable extends Component {
 			},
 			{
 				label: _n( 'order', 'orders', orders_count, 'woocommerce-admin' ),
-				value: numberFormat( orders_count ),
+				value: formatValue( 'number', orders_count ),
 			},
 		];
 	}

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -10,10 +10,10 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { Link } from '@woocommerce/components';
-import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from '@woocommerce/currency';
+import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { getTaxCode } from './utils';
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 
 /**
  * Internal dependencies

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -13,7 +13,7 @@ import { keys, get, pickBy } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { numberFormat } from '@woocommerce/number';
+import { numberFormat } from 'lib/number-format';
 import { getSetting, CURRENCY as currency } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -22,7 +22,7 @@ import { getSetting, CURRENCY as currency } from '@woocommerce/wc-admin-settings
 import { H, Card, SelectControl, Form } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
-import { formatCurrency } from '@woocommerce/currency';
+import { formatCurrency } from 'lib/currency-format';
 import Plugins from 'dashboard/task-list/tasks/steps/plugins';
 import { pluginNames } from 'wc-api/onboarding/constants';
 

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -14,8 +14,8 @@ import { find } from 'lodash';
  */
 import { getCurrentDates, appendTimestamp, getDateParamsFromQuery } from '@woocommerce/date';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
-import { calculateDelta, formatValue } from '@woocommerce/number';
-import { formatCurrency } from '@woocommerce/currency';
+import { calculateDelta, formatValue } from 'lib/number-format';
+import { formatCurrency } from 'lib/currency-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -15,7 +15,7 @@ import { keyBy, map, merge } from 'lodash';
  * WooCommerce dependencies
  */
 import { EmptyContent, Flag, Link, OrderStatus, Section } from '@woocommerce/components';
-import { formatCurrency } from '@woocommerce/currency';
+import { formatCurrency } from 'lib/currency-format';
 import { getAdminLink, getNewPath } from '@woocommerce/navigation';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 

--- a/client/lib/currency-format.js
+++ b/client/lib/currency-format.js
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { CURRENCY } from '@woocommerce/wc-admin-settings';
+
+/**
+ * WooCommerce dependencies
+ */
+import Currency from '@woocommerce/currency';
+
+// Pass the site currency settings to our instance.
+const storeCurrency = new Currency( CURRENCY );
+
+// Allow our exported API to be called without knowing about the Currency instance.
+const formatCurrency = storeCurrency.formatCurrency.bind( storeCurrency );
+const formatDecimal = storeCurrency.formatDecimal.bind( storeCurrency );
+const formatDecimalString = storeCurrency.formatDecimalString.bind( storeCurrency );
+const render = storeCurrency.render.bind( storeCurrency );
+
+// Export the expected API for the consuming app, along with the instance.
+export {
+	storeCurrency as Currency,
+	formatCurrency,
+	formatDecimal as getCurrencyFormatDecimal,
+	formatDecimalString as getCurrencyFormatString,
+	render as renderCurrency,
+};

--- a/client/lib/number-format.js
+++ b/client/lib/number-format.js
@@ -1,0 +1,18 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { partial } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { CURRENCY } from '@woocommerce/wc-admin-settings';
+import { numberFormat, formatValue, calculateDelta } from '@woocommerce/number';
+
+// Compose the site currency settings with the format functions.
+const storeNumberFormat = partial( numberFormat, CURRENCY );
+const storeFormatValue = partial( formatValue, CURRENCY );
+
+// Export the expected API for the consuming app.
+export { storeNumberFormat as numberFormat, storeFormatValue as formatValue, calculateDelta };

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -11,7 +11,7 @@ import moment from 'moment';
  */
 import { appendTimestamp, getCurrentDates, getIntervalForQuery } from '@woocommerce/date';
 import { flattenFilters, getActiveFiltersFromQuery, getUrlKey } from '@woocommerce/navigation';
-import { formatCurrency } from '@woocommerce/currency';
+import { formatCurrency } from 'lib/currency-format';
 
 /**
  * Internal dependencies

--- a/docs/examples/extensions/dashboard-section/js/global-prices.js
+++ b/docs/examples/extensions/dashboard-section/js/global-prices.js
@@ -8,7 +8,10 @@ import moment from 'moment';
  * WooCommerce dependencies
  */
 import { Card, Chart } from '@woocommerce/components';
-import { formatCurrency } from '@woocommerce/currency';
+import Currency from '@woocommerce/currency';
+
+const storeCurrency = new Currency(); // give this store settings.
+const formatCurrency = storeCurrency.formatCurrency.bind( storeCurrency );
 
 const data = [];
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,7 +4,7 @@ Currently we have a small set of public-facing packages that can be dowloaded fr
 
 - `@woocommerce/components`: A library of components that can be used to create pages in the WooCommerce dashboard and reports pages.
 - `@woocommerce/csv-export`: A set of functions to convert data into CSV values, and enable a browser download of the CSV data.
-- `@woocommerce/currency`: A collection of utilities to display and work with currency values.
+- `@woocommerce/currency`: A class to display and work with currency values.
 - `@woocommerce/date`: A collection of utilities to display and work with date values.
 - `@woocommerce/navigation`: A collection of navigation-related functions for handling query parameter objects, serializing query parameters, updating query parameters, and triggering path changes.
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Removed WC-Admin specific actions from `<TableCard />` component.
 - Export the `<CompareButton />` component.
 - Add `<TextControl />` component.
+- Require `currency` prop in `<AdvancedFilters />` component.
 
 # 4.0.0
 - Added a new `<ScrollTo />` component.

--- a/packages/components/src/advanced-filters/README.md
+++ b/packages/components/src/advanced-filters/README.md
@@ -67,7 +67,7 @@ Name | Type | Default | Description
 `query` | Object | `null` | The query string represented in object form.
 `onAdvancedFilterAction` | Function | `null` | Function to be called after an advanced filter action has been taken.
 `siteLocale` | string | `'en_US'` | The siteLocale for the site.
-`currency` | Object | `{}` | The currency info for the site.
+`currency` | Object | `null` | (required) The currency instance for the site (@woocommerce/currency).
 
 
 ## Input Components

--- a/packages/components/src/advanced-filters/docs/example.js
+++ b/packages/components/src/advanced-filters/docs/example.js
@@ -3,6 +3,7 @@
  * Internal dependencies
  */
 import { AdvancedFilters } from '@woocommerce/components';
+import Currency from '@woocommerce/currency';
 
 const ORDER_STATUSES = {
 	cancelled: 'Cancelled',
@@ -15,6 +16,7 @@ const ORDER_STATUSES = {
 };
 
 const siteLocale = 'en_US';
+const siteCurrency = new Currency(); // pass site currency settings.
 
 const path = ( new URL( document.location ) ).searchParams.get( 'path' ) || '/devdocs';
 const query = {
@@ -153,5 +155,6 @@ export default () => (
         query={ query }
         filterTitle="Orders"
 		config={ advancedFilters }
+		currency={ siteCurrency }
     />
 );

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -203,7 +203,6 @@ class AdvancedFilters extends Component {
 		const updateHref = this.getUpdateHref( activeFilters, match );
 		const updateDisabled = ( 'admin.php' + window.location.search === updateHref ) || 0 === activeFilters.length;
 		const isEnglish = this.isEnglish();
-		const { symbol: currencySymbol, symbolPosition } = currency;
 		return (
 			<Card className="woocommerce-filters-advanced woocommerce-analytics__card" title={ this.getTitle() }>
 				<ul className="woocommerce-filters-advanced__list" ref={ this.filterListRef }>
@@ -239,8 +238,7 @@ class AdvancedFilters extends Component {
 										onFilterChange={ this.onFilterChange }
 										isEnglish={ isEnglish }
 										query={ query }
-										currencySymbol={ currencySymbol }
-										symbolPosition={ symbolPosition }
+										currency={ currency }
 									/>
 								) }
 								{ 'Currency' === input.component && (
@@ -251,8 +249,7 @@ class AdvancedFilters extends Component {
 										onFilterChange={ this.onFilterChange }
 										isEnglish={ isEnglish }
 										query={ query }
-										currencySymbol={ currencySymbol }
-										symbolPosition={ symbolPosition }
+										currency={ currency }
 									/>
 								) }
 								{ 'Date' === input.component && (
@@ -373,19 +370,15 @@ AdvancedFilters.propTypes = {
 	 */
 	siteLocale: PropTypes.string,
 	/**
-	 * The currency settings for the site.
+	 * The currency formatting instance for the site.
 	 */
-	currency: PropTypes.object,
+	currency: PropTypes.object.isRequired,
 };
 
 AdvancedFilters.defaultProps = {
 	query: {},
 	onAdvancedFilterAction: () => {},
 	siteLocale: 'en_US',
-	currency: {
-		symbol: '$',
-		symbolPosition: 'left',
-	},
 };
 
 export default AdvancedFilters;

--- a/packages/components/src/advanced-filters/number-filter.js
+++ b/packages/components/src/advanced-filters/number-filter.js
@@ -15,11 +15,6 @@ import { sprintf, __, _x } from '@wordpress/i18n';
 import TextControlWithAffixes from '../text-control-with-affixes';
 import { textContent } from './utils';
 
-/**
- * WooCommerce dependencies
- */
-import { formatCurrency } from '@woocommerce/currency';
-
 class NumberFilter extends Component {
 	getBetweenString() {
 		return _x(
@@ -30,6 +25,7 @@ class NumberFilter extends Component {
 	}
 
 	getScreenReaderText( filter, config ) {
+		const { currency } = this.props;
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 		const rule = find( config.rules, { value: filter.rule } ) || {};
 		let [ rangeStart, rangeEnd ] = isArray( filter.value ) ? filter.value : [ filter.value ];
@@ -43,8 +39,8 @@ class NumberFilter extends Component {
 		}
 
 		if ( 'currency' === inputType ) {
-			rangeStart = formatCurrency( rangeStart );
-			rangeEnd = formatCurrency( rangeEnd );
+			rangeStart = currency.formatCurrency( rangeStart );
+			rangeEnd = currency.formatCurrency( rangeEnd );
 		}
 
 		let filterStr = rangeStart;
@@ -115,9 +111,12 @@ class NumberFilter extends Component {
 			config,
 			filter,
 			onFilterChange,
-			currencySymbol,
-			symbolPosition,
+			currency,
 		} = this.props;
+		const {
+			symbol: currencySymbol,
+			symbolPosition,
+		} = currency;
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 
 		if ( 'between' === filter.rule ) {
@@ -158,9 +157,12 @@ class NumberFilter extends Component {
 			config,
 			filter,
 			onFilterChange,
-			currencySymbol,
-			symbolPosition,
+			currency,
 		} = this.props;
+		const {
+			symbol: currencySymbol,
+			symbolPosition,
+		} = currency;
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 		const [ rangeStart, rangeEnd ] = isArray( filter.value ) ? filter.value : [ filter.value ];
 

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -155,17 +155,13 @@ ReportFilters.propTypes = {
 	 */
 	onAdvancedFilterAction: PropTypes.func,
 	/**
-	 * The currency settings for the site.
+	 * The currency formatting instance for the site.
 	 */
-	currency: PropTypes.object,
+	currency: PropTypes.object.isRequired,
 };
 
 ReportFilters.defaultProps = {
 	siteLocale: 'en_US',
-	currency: {
-		symbol: '$',
-		symbolPosition: 'left',
-	},
 	advancedFilters: {},
 	filters: [],
 	query: {},

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove lodash dependency.
 - Added getCurrencyData, for returning code, position, thousands separator, decimal separator, and precision information by region.
+- Decouple from global wcSettings object.
 
 # 1.1.3
 

--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -15,17 +15,19 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ## Usage
 
 ```JS
-import { formatCurrency, getCurrencyFormatDecimal, getCurrencyFormatString } from '@woocommerce/currency';
+import Currency from '@woocommerce/currency';
+
+const storeCurrency = new Currency(); // pass store settings into constructor.
 
 // Formats money with a given currency symbol. Uses site's currency settings for formatting,
 // from the settings api. Defaults to symbol=`$`, precision=2, decimalSeparator=`.`, thousandSeparator=`,`
-const total = formatCurrency( 20.923, '$' ); // '$20.92'
+const total = storeCurrency.formatCurrency( 20.923 ); // '$20.92'
 
 // Get the rounded decimal value of a number at the precision used for the current currency,
 // from the settings api. Defaults to 2.
-const total = getCurrencyFormatDecimal( '6.2892' ); // 6.29 https://google.com/?q=test
+const total = storeCurrency.formatDecimal( '6.2892' ); // 6.29 https://google.com/?q=test
 
 // Get the string representation of a floating point number to the precision used by the current
 // currency. This is different from `formatCurrency` by not returning the currency symbol.
-const total = getCurrencyFormatString( 1088.478 ); // '1088.48'
+const total = storeCurrency.formatDecimalString( 1088.478 ); // '1088.48'
 ```

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -10,43 +10,25 @@ import { isNumber, isString } from 'lodash';
  */
 import { numberFormat } from '@woocommerce/number';
 
+const DEFAULTS = {
+	code: 'USD',
+	precision: 2,
+	symbol: '$',
+	symbolPosition: 'left',
+	decimalSeparator: '.',
+	priceFormat: '%1$s%2$s',
+	thousandSeparator: ',',
+};
+
 export default class Currency {
-	code = 'USD';
-	precision = 2;
-	symbol = '$';
-	symbolPosition = 'left';
-	decimalSeparator = '.';
-	priceFormat = '%1$s%2$s';
-	thousandSeparator = ',';
-
 	constructor( config = {} ) {
-		if ( isString( config.code ) ) {
-			this.code = config.code;
-		}
-
-		if ( isNumber( config.precision ) ) {
-			this.precision = config.precision;
-		}
-
-		if ( isString( config.symbol ) ) {
-			this.symbol = config.symbol;
-		}
-
-		if ( isString( config.symbolPosition ) ) {
-			this.symbolPosition = config.symbolPosition;
-		}
-
-		if ( isString( config.decimalSeparator ) ) {
-			this.decimalSeparator = config.decimalSeparator;
-		}
-
-		if ( isString( config.priceFormat ) ) {
-			this.priceFormat = config.priceFormat;
-		}
-
-		if ( isString( config.thousandSeparator ) ) {
-			this.thousandSeparator = config.thousandSeparator;
-		}
+		this.code = isString( config.code ) ? config.code : DEFAULTS.code;
+		this.precision = isNumber( config.precision ) ? config.precision : DEFAULTS.precision;
+		this.symbol = isString( config.symbol ) ? config.symbol : DEFAULTS.symbol;
+		this.symbolPosition = isString( config.symbolPosition ) ? config.symbolPosition : DEFAULTS.symbolPosition;
+		this.decimalSeparator = isString( config.decimalSeparator ) ? config.decimalSeparator : DEFAULTS.decimalSeparator;
+		this.priceFormat = isString( config.priceFormat ) ? config.priceFormat : DEFAULTS.priceFormat;
+		this.thousandSeparator = isString( config.thousandSeparator ) ? config.thousandSeparator : DEFAULTS.thousandSeparator;
 	}
 
 	/**

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { sprintf } from '@wordpress/i18n';
-import { isNumber, isString } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -22,13 +21,15 @@ const DEFAULTS = {
 
 export default class Currency {
 	constructor( config = {} ) {
-		this.code = isString( config.code ) ? config.code : DEFAULTS.code;
-		this.precision = isNumber( config.precision ) ? config.precision : DEFAULTS.precision;
-		this.symbol = isString( config.symbol ) ? config.symbol : DEFAULTS.symbol;
-		this.symbolPosition = isString( config.symbolPosition ) ? config.symbolPosition : DEFAULTS.symbolPosition;
-		this.decimalSeparator = isString( config.decimalSeparator ) ? config.decimalSeparator : DEFAULTS.decimalSeparator;
-		this.priceFormat = isString( config.priceFormat ) ? config.priceFormat : DEFAULTS.priceFormat;
-		this.thousandSeparator = isString( config.thousandSeparator ) ? config.thousandSeparator : DEFAULTS.thousandSeparator;
+		this.code = ( config.code || DEFAULTS.code ).toString();
+		this.symbol = ( config.symbol || DEFAULTS.symbol ).toString();
+		this.symbolPosition = ( config.symbolPosition || DEFAULTS.symbolPosition ).toString();
+		this.decimalSeparator = ( config.decimalSeparator || DEFAULTS.decimalSeparator ).toString();
+		this.priceFormat = ( config.priceFormat || DEFAULTS.priceFormat ).toString();
+		this.thousandSeparator = ( config.thousandSeparator || DEFAULTS.thousandSeparator ).toString();
+
+		const precisionNumber = parseInt( config.precision, 10 );
+		this.precision = isNaN( precisionNumber ) ? DEFAULTS.precision : precisionNumber;
 	}
 
 	/**

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -30,6 +30,8 @@ export default class Currency {
 
 		const precisionNumber = parseInt( config.precision, 10 );
 		this.precision = isNaN( precisionNumber ) ? DEFAULTS.precision : precisionNumber;
+
+		Object.freeze( this );
 	}
 
 	/**

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -3,80 +3,117 @@
  * External dependencies
  */
 import { sprintf } from '@wordpress/i18n';
+import { isNumber, isString } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
 import { numberFormat } from '@woocommerce/number';
-import { CURRENCY as currency } from '@woocommerce/wc-admin-settings';
 
-/**
- * Formats money with a given currency code. Uses site's currency settings for formatting.
- *
- * @param   {Number|String} number number to format
- * @param   {String}        currencySymbol currency code e.g. '$'
- * @returns {?String} A formatted string.
- */
-export function formatCurrency( number, currencySymbol ) {
-	if ( ! currencySymbol ) {
-		currencySymbol = currency.symbol;
+export default class Currency {
+	code = 'USD';
+	precision = 2;
+	symbol = '$';
+	symbolPosition = 'left';
+	decimalSeparator = '.';
+	priceFormat = '%1$s%2$s';
+	thousandSeparator = ',';
+
+	constructor( config = {} ) {
+		if ( isString( config.code ) ) {
+			this.code = config.code;
+		}
+
+		if ( isNumber( config.precision ) ) {
+			this.precision = config.precision;
+		}
+
+		if ( isString( config.symbol ) ) {
+			this.symbol = config.symbol;
+		}
+
+		if ( isString( config.symbolPosition ) ) {
+			this.symbolPosition = config.symbolPosition;
+		}
+
+		if ( isString( config.decimalSeparator ) ) {
+			this.decimalSeparator = config.decimalSeparator;
+		}
+
+		if ( isString( config.priceFormat ) ) {
+			this.priceFormat = config.priceFormat;
+		}
+
+		if ( isString( config.thousandSeparator ) ) {
+			this.thousandSeparator = config.thousandSeparator;
+		}
 	}
 
-	const precision = currency.precision;
-	const formattedNumber = numberFormat( number, precision );
-	const priceFormat = currency.priceFormat;
+	/**
+	 * Formats money value.
+	 *
+	 * @param   {Number|String} number number to format
+	 * @returns {?String} A formatted string.
+	 */
+	formatCurrency( number ) {
+		const formattedNumber = numberFormat( this, number );
 
-	if ( '' === formattedNumber ) {
-		return formattedNumber;
+		if ( '' === formattedNumber ) {
+			return formattedNumber;
+		}
+
+		return sprintf( this.priceFormat, this.symbol, formattedNumber );
 	}
 
-	return sprintf( priceFormat, currencySymbol, formattedNumber );
-}
+	/**
+	 * Get the rounded decimal value of a number at the precision used for the current currency.
+	 * This is a work-around for fraction-cents, meant to be used like `wc_format_decimal`
+	 *
+	 * @param {Number|String} number A floating point number (or integer), or string that converts to a number
+	 * @return {Number} The original number rounded to a decimal point
+	 */
+	formatDecimal( number ) {
+		if ( 'number' !== typeof number ) {
+			number = parseFloat( number );
+		}
+		if ( Number.isNaN( number ) ) {
+			return 0;
+		}
+		return Math.round( number * Math.pow( 10, this.precision ) ) / Math.pow( 10, this.precision );
+	}
 
-/**
- * Get the rounded decimal value of a number at the precision used for the current currency.
- * This is a work-around for fraction-cents, meant to be used like `wc_format_decimal`
- *
- * @param {Number|String} number A floating point number (or integer), or string that converts to a number
- * @return {Number} The original number rounded to a decimal point
- */
-export function getCurrencyFormatDecimal( number ) {
-	const { precision = 2 } = currency;
-	if ( 'number' !== typeof number ) {
-		number = parseFloat( number );
+	/**
+	 * Get the string representation of a floating point number to the precision used by the current currency.
+	 * This is different from `formatCurrency` by not returning the currency symbol.
+	 *
+	 * @param  {Number|String} number A floating point number (or integer), or string that converts to a number
+	 * @return {String}               The original number rounded to a decimal point
+	 */
+	formatDecimalString( number ) {
+		if ( 'number' !== typeof number ) {
+			number = parseFloat( number );
+		}
+		if ( Number.isNaN( number ) ) {
+			return '';
+		}
+		return number.toFixed( this.precision );
 	}
-	if ( Number.isNaN( number ) ) {
-		return 0;
-	}
-	return Math.round( number * Math.pow( 10, precision ) ) / Math.pow( 10, precision );
-}
 
-/**
- * Get the string representation of a floating point number to the precision used by the current currency.
- * This is different from `formatCurrency` by not returning the currency symbol.
- *
- * @param  {Number|String} number A floating point number (or integer), or string that converts to a number
- * @return {String}               The original number rounded to a decimal point
- */
-export function getCurrencyFormatString( number ) {
-	const { precision = 2 } = currency;
-	if ( 'number' !== typeof number ) {
-		number = parseFloat( number );
+	/**
+	 * Render a currency for display in a component.
+	 *
+	 * @param  {Number|String} number A floating point number (or integer), or string that converts to a number
+	 * @return {Node|String} The number formatted as currency and rendered for display.
+	 */
+	render( number ) {
+		if ( 'number' !== typeof number ) {
+			number = parseFloat( number );
+		}
+		if ( number < 0 ) {
+			return <span className="is-negative">{ this.formatCurrency( number ) }</span>;
+		}
+		return this.formatCurrency( number );
 	}
-	if ( Number.isNaN( number ) ) {
-		return '';
-	}
-	return number.toFixed( precision );
-}
-
-export function renderCurrency( number, currencySymbol ) {
-	if ( 'number' !== typeof number ) {
-		number = parseFloat( number );
-	}
-	if ( number < 0 ) {
-		return <span className="is-negative">{ formatCurrency( number, currencySymbol ) }</span>;
-	}
-	return formatCurrency( number, currencySymbol );
 }
 
 /**

--- a/packages/currency/test/index.js
+++ b/packages/currency/test/index.js
@@ -2,110 +2,89 @@
 /**
  * Internal dependencies
  */
-import {
-	formatCurrency,
-	getCurrencyFormatDecimal,
-	getCurrencyFormatString,
-} from '../src';
-
-/**
- * WooCommerce dependencies
- * Note: setCurrencyProp doesn't exist on the module alias, it's used for mocking
- * values.
- */
-import { setCurrencyProp, resetMock } from '@woocommerce/wc-admin-settings';
-
-beforeEach( () => {
-	resetMock();
-} );
-
-jest.mock( '@woocommerce/wc-admin-settings', () => {
-	let mockedCurrency = jest.requireActual( '@woocommerce/wc-admin-settings' ).CURRENCY;
-	const originalCurrency = {
-		...mockedCurrency,
-	};
-	const reset = () => {
-		mockedCurrency = Object.assign( mockedCurrency, originalCurrency );
-	};
-	return {
-		setCurrencyProp: ( prop, value ) => {
-			mockedCurrency[ prop ] = value;
-		},
-		resetMock: reset,
-		CURRENCY: mockedCurrency,
-	};
-} );
+import Currency from '../src';
 
 describe( 'formatCurrency', () => {
 	it( 'should use defaults (USD) when currency not passed in', () => {
-		expect( formatCurrency( 9.99 ) ).toBe( '$9.99' );
-		expect( formatCurrency( 30 ) ).toBe( '$30.00' );
+		const currency = new Currency();
+		expect( currency.formatCurrency( 9.99 ) ).toBe( '$9.99' );
+		expect( currency.formatCurrency( 30 ) ).toBe( '$30.00' );
 	} );
 
 	it( 'should uses store currency settings, not locale-based', () => {
-		setCurrencyProp( 'code', 'JPY' );
-		setCurrencyProp( 'precision', 3 );
-		setCurrencyProp( 'priceFormat', '%2$s%1$s' );
-		setCurrencyProp( 'thousandSeparator', '.' );
-		setCurrencyProp( 'decimalSeparator', ',' );
-		expect( formatCurrency( 9.49258, '¥' ) ).toBe( '9,493¥' );
-		expect( formatCurrency( 3000, '¥' ) ).toBe( '3.000,000¥' );
-		expect( formatCurrency( 3.0002, '¥' ) ).toBe( '3,000¥' );
+		const currency = new Currency( {
+			code: 'JPY',
+			symbol: '¥',
+			precision: 3,
+			priceFormat: '%2$s%1$s',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+		} );
+		expect( currency.formatCurrency( 9.49258 ) ).toBe( '9,493¥' );
+		expect( currency.formatCurrency( 3000 ) ).toBe( '3.000,000¥' );
+		expect( currency.formatCurrency( 3.0002 ) ).toBe( '3,000¥' );
 	} );
 
 	it( "should return empty string when given an input that isn't a number", () => {
-		expect( formatCurrency( 'abc' ) ).toBe( '' );
-		expect( formatCurrency( false ) ).toBe( '' );
-		expect( formatCurrency( null ) ).toBe( '' );
+		const currency = new Currency();
+		expect( currency.formatCurrency( 'abc' ) ).toBe( '' );
+		expect( currency.formatCurrency( false ) ).toBe( '' );
+		expect( currency.formatCurrency( null ) ).toBe( '' );
 	} );
 } );
 
-describe( 'getCurrencyFormatDecimal', () => {
+describe( 'currency.formatDecimal', () => {
 	it( 'should round a number to 2 decimal places in USD', () => {
-		expect( getCurrencyFormatDecimal( 9.49258 ) ).toBe( 9.49 );
-		expect( getCurrencyFormatDecimal( 30 ) ).toBe( 30 );
-		expect( getCurrencyFormatDecimal( 3.0002 ) ).toBe( 3 );
+		const currency = new Currency();
+		expect( currency.formatDecimal( 9.49258 ) ).toBe( 9.49 );
+		expect( currency.formatDecimal( 30 ) ).toBe( 30 );
+		expect( currency.formatDecimal( 3.0002 ) ).toBe( 3 );
 	} );
 
 	it( 'should round a number to 0 decimal places in JPY', () => {
-		setCurrencyProp( 'precision', 0 );
-		expect( getCurrencyFormatDecimal( 1239.88 ) ).toBe( 1240 );
-		expect( getCurrencyFormatDecimal( 1500 ) ).toBe( 1500 );
-		expect( getCurrencyFormatDecimal( 33715.02 ) ).toBe( 33715 );
+		const currency = new Currency( { precision: 0 } );
+		expect( currency.formatDecimal( 1239.88 ) ).toBe( 1240 );
+		expect( currency.formatDecimal( 1500 ) ).toBe( 1500 );
+		expect( currency.formatDecimal( 33715.02 ) ).toBe( 33715 );
 	} );
 
 	it( 'should correctly convert and round a string', () => {
-		expect( getCurrencyFormatDecimal( '19.80' ) ).toBe( 19.8 );
+		const currency = new Currency();
+		expect( currency.formatDecimal( '19.80' ) ).toBe( 19.8 );
 	} );
 
 	it( "should return 0 when given an input that isn't a number", () => {
-		expect( getCurrencyFormatDecimal( 'abc' ) ).toBe( 0 );
-		expect( getCurrencyFormatDecimal( false ) ).toBe( 0 );
-		expect( getCurrencyFormatDecimal( null ) ).toBe( 0 );
+		const currency = new Currency();
+		expect( currency.formatDecimal( 'abc' ) ).toBe( 0 );
+		expect( currency.formatDecimal( false ) ).toBe( 0 );
+		expect( currency.formatDecimal( null ) ).toBe( 0 );
 	} );
 } );
 
-describe( 'getCurrencyFormatString', () => {
+describe( 'currency.formatDecimalString', () => {
 	it( 'should round a number to 2 decimal places in USD', () => {
-		expect( getCurrencyFormatString( 9.49258 ) ).toBe( '9.49' );
-		expect( getCurrencyFormatString( 30 ) ).toBe( '30.00' );
-		expect( getCurrencyFormatString( 3.0002 ) ).toBe( '3.00' );
+		const currency = new Currency();
+		expect( currency.formatDecimalString( 9.49258 ) ).toBe( '9.49' );
+		expect( currency.formatDecimalString( 30 ) ).toBe( '30.00' );
+		expect( currency.formatDecimalString( 3.0002 ) ).toBe( '3.00' );
 	} );
 
 	it( 'should round a number to 0 decimal places in JPY', () => {
-		setCurrencyProp( 'precision', 0 );
-		expect( getCurrencyFormatString( 1239.88 ) ).toBe( '1240' );
-		expect( getCurrencyFormatString( 1500 ) ).toBe( '1500' );
-		expect( getCurrencyFormatString( 33715.02 ) ).toBe( '33715' );
+		const currency = new Currency( { precision: 0 } );
+		expect( currency.formatDecimalString( 1239.88 ) ).toBe( '1240' );
+		expect( currency.formatDecimalString( 1500 ) ).toBe( '1500' );
+		expect( currency.formatDecimalString( 33715.02 ) ).toBe( '33715' );
 	} );
 
 	it( 'should correctly convert and round a string', () => {
-		expect( getCurrencyFormatString( '19.80' ) ).toBe( '19.80' );
+		const currency = new Currency();
+		expect( currency.formatDecimalString( '19.80' ) ).toBe( '19.80' );
 	} );
 
 	it( "should return empty string when given an input that isn't a number", () => {
-		expect( getCurrencyFormatString( 'abc' ) ).toBe( '' );
-		expect( getCurrencyFormatString( false ) ).toBe( '' );
-		expect( getCurrencyFormatString( null ) ).toBe( '' );
+		const currency = new Currency();
+		expect( currency.formatDecimalString( 'abc' ) ).toBe( '' );
+		expect( currency.formatDecimalString( false ) ).toBe( '' );
+		expect( currency.formatDecimalString( null ) ).toBe( '' );
 	} );
 } );

--- a/packages/number/CHANGELOG.md
+++ b/packages/number/CHANGELOG.md
@@ -1,5 +1,6 @@
 # (unreleased)
 - Remove lodash dependency.
+- Decouple from global wcSettings object.
 
 # 1.0.4
 

--- a/packages/number/README.md
+++ b/packages/number/README.md
@@ -17,14 +17,26 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```JS
 import { formatNumber, formatValue, calculateDelta } from '@woocommerce/number';
 
-// Formats a number using site's current locale.
-// Defaults to en-US localization
-const localizedNumber = formatNumber( 1337 ); // '1,377'
+// It's best to retrieve the site currency settings and compose them with the format functions.
+import { partial } from 'lodash';
+// Retrieve this from the API or a global settings object.
+const siteNumberOptions = {
+    precision: 2,
+	decimalSeparator: '.',
+	thousandSeparator: ',',
+};
+// Compose.
+const formatStoreNumber = partial( siteNumberOptions, formatNumber );
+const formatStoreValue = partial( siteNumberOptions, formatValue );
 
-// formatValue's first argument is a type: average, or number
-// The second argument is the number/value to format
-const formattedAverage = formatValue( 'average', '10.5' ); // 11 just uses Math.round
-const formattedNumber = formatValue( 'number', '1337' ); // 1,337 calls formatNumber ( see above )
+// Formats a number using site's current locale.
+const localizedNumber = formatStoreNumber( 1337 ); // '1,377'
+
+// formatValue's second argument is a type: average, or number
+// The third argument is the number/value to format
+// (The first argument is the config object we composed with earlier)
+const formattedAverage = formatStoreValue( 'average', '10.5' ); // 11 just uses Math.round
+const formattedNumber = formatStoreValue( 'number', '1337' ); // 1,337 calls formatNumber ( see above )
 
 // Get a rounded percent change/delta between two numbers
 const delta = calculateDelta( 10, 8 ); // '25'

--- a/packages/number/src/index.js
+++ b/packages/number/src/index.js
@@ -51,7 +51,7 @@ export function formatValue( numberConfig, type, value ) {
 		case 'average':
 			return Math.round( value );
 		case 'number':
-			return numberFormat( numberConfig, value );
+			return numberFormat( { ...numberConfig, precision: null }, value );
 	}
 }
 

--- a/packages/number/src/index.js
+++ b/packages/number/src/index.js
@@ -1,22 +1,21 @@
 /** @format */
 /* eslint-disable wpcalypso/import-docblock */
 
-/**
- * WooCommerce dependencies
- */
-import { CURRENCY } from '@woocommerce/wc-admin-settings';
-
 const number_format = require( 'locutus/php/strings/number_format' );
 
 /**
  * Formats a number using site's current locale
  *
  * @see http://locutus.io/php/strings/number_format/
+ * @param {Object} numberConfig number formatting configuration object.
  * @param {Number|String} number number to format
- * @param {int|null} [precision=null] optional decimal precision
  * @returns {?String} A formatted string.
  */
-export function numberFormat( number, precision = null ) {
+export function numberFormat( {
+	precision = null,
+	decimalSeparator = '.',
+	thousandSeparator = ',',
+}, number ) {
 	if ( 'number' !== typeof number ) {
 		number = parseFloat( number );
 	}
@@ -25,10 +24,6 @@ export function numberFormat( number, precision = null ) {
 		return '';
 	}
 
-	const {
-		decimalSeparator,
-		thousandSeparator,
-	} = CURRENCY;
 	precision = parseInt( precision );
 
 	if ( isNaN( precision ) ) {
@@ -42,11 +37,12 @@ export function numberFormat( number, precision = null ) {
 /**
  * Formats a number string based on type of `average` or `number`.
  *
+ * @param {Object} numberConfig number formatting configuration object.
  * @param {String} type of number to format, average or number
  * @param {int} value to format.
  * @returns {?String} A formatted string.
  */
-export function formatValue( type, value ) {
+export function formatValue( numberConfig, type, value ) {
 	if ( ! Number.isFinite( value ) ) {
 		return null;
 	}
@@ -55,7 +51,7 @@ export function formatValue( type, value ) {
 		case 'average':
 			return Math.round( value );
 		case 'number':
-			return numberFormat( value );
+			return numberFormat( numberConfig, value );
 	}
 }
 

--- a/packages/number/src/test/index.js
+++ b/packages/number/src/test/index.js
@@ -1,64 +1,47 @@
 /** @format */
 /**
+ * External dependencies
+ */
+import { partial } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { numberFormat } from '../index';
 
-/**
- * WooCommerce dependencies
- * Note: setCurrencyProp doesn't exist on the module alias, it's used for mocking
- * values.
- */
-import { setCurrencyProp, resetMock } from '@woocommerce/wc-admin-settings';
-
-jest.mock( '@woocommerce/wc-admin-settings', () => {
-	let mockedCurrency = jest.requireActual( '@woocommerce/wc-admin-settings' ).CURRENCY;
-	const originalCurrency = {
-		...mockedCurrency,
-	};
-	const reset = () => {
-		mockedCurrency = Object.assign( mockedCurrency, originalCurrency );
-	};
-	return {
-		setCurrencyProp: ( prop, value ) => {
-			mockedCurrency[ prop ] = value;
-		},
-		resetMock: reset,
-		CURRENCY: mockedCurrency,
-	};
-} );
+const defaultNumberFormat = partial( numberFormat, {} );
 
 describe( 'numberFormat', () => {
-	beforeEach( () => {
-		resetMock();
-	} );
 	it( 'should default to precision=null decimal=. thousands=,', () => {
-		expect( numberFormat( 1000 ) ).toBe( '1,000' );
+		expect( defaultNumberFormat( 1000 ) ).toBe( '1,000' );
 	} );
 
 	it( 'should return an empty string if no argument is passed', () => {
-		expect( numberFormat() ).toBe( '' );
+		expect( defaultNumberFormat() ).toBe( '' );
 	} );
 
 	it( 'should accept a string', () => {
-		expect( numberFormat( '10000' ) ).toBe( '10,000' );
+		expect( defaultNumberFormat( '10000' ) ).toBe( '10,000' );
 	} );
 
 	it( 'maintains all decimals if no precision specified', () => {
-		expect( numberFormat( '10000.123456' ) ).toBe( '10,000.123456' );
+		expect( defaultNumberFormat( '10000.123456' ) ).toBe( '10,000.123456' );
 	} );
 
 	it( 'maintains all decimals if invalid precision specified', () => {
-		expect( numberFormat( '10000.123456', 'not a number' ) ).toBe( '10,000.123456' );
+		expect( numberFormat( { precision: 'not a number' }, '10000.123456' ) ).toBe( '10,000.123456' );
 	} );
 
 	it( 'calculates the correct decimals based on precision passed in', () => {
-		expect( numberFormat( '1337.4498', 2 ) ).toBe( '1,337.45' );
+		expect( numberFormat( { precision: 2 }, '1337.4498' ) ).toBe( '1,337.45' );
 	} );
 
 	it( 'uses store currency settings, not locale', () => {
-		setCurrencyProp( 'decimalSeparator', ',' );
-		setCurrencyProp( 'thousandSeparator', '.' );
-		expect( numberFormat( '12345.6789', 3 ) ).toBe( '12.345,679' );
+		const config = {
+			decimalSeparator: ',',
+			thousandSeparator: '.',
+			precision: 3,
+		};
+		expect( numberFormat( config, '12345.6789' ) ).toBe( '12.345,679' );
 	} );
 } );


### PR DESCRIPTION
Fixes #3029.
Fixes #3032.

This PR seeks to remove the `wcSettings` dependency from the Currency and Number packages.

### `Currency`

The currency package has been rewritten to export a `Currency` class instead of several utility functions. It takes an object in the constructor for configuration - which matches the structure of the `wcSettings` currency options.

A new `lib/currency-format` module has been introduced that exports the same API as the previous version of `@woocommerce/currency` so that the consuming parts of the WC-Admin app don't need to change (too much).

### `Number`

The exported methods of the number package have been rewritten to accept a configuration object as their first parameter - this allows for composition using lodash's `partial()` - which is done in the new `lib/number-format` module.

A new `lib/number-format` module has been introduced that exports the same API as the previous version of `@woocommerce/number` so that the consuming parts of the WC-Admin app don't need to change (too much).

### `AdvancedFilters`

Make the `currency` prop required, and expect an instance of the new `Currency` object.

### Detailed test instructions:

- Verify that numbers and monetary values are properly formatted on all WC-Admin screens (check activity panels, reports, filters, etc)
- Verify that changing store currency settings changes the formatting
- Review changes to documentation

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: decouple Currency and Number packages from global wcSettings object.
