### PR TITLE
Decouple date package from `wcSettings`.

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -19,7 +19,7 @@ import {
 	getIntervalForQuery,
 	getChartTypeForQuery,
 	getPreviousDate,
-} from '@woocommerce/date';
+} from 'lib/date';
 import { Chart } from '@woocommerce/components';
 import { CURRENCY } from '@woocommerce/wc-admin-settings';
 

--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -17,7 +17,7 @@ import { LOCALE } from '@woocommerce/wc-admin-settings';
  */
 import { recordEvent } from 'lib/tracks';
 import { Currency } from 'lib/currency-format';
-import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
+import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from 'lib/date';
 
 export default class ReportFilters extends Component {
 	constructor() {
@@ -88,6 +88,7 @@ export default class ReportFilters extends Component {
 				onFilterSelect={ this.trackFilterSelect }
 				onAdvancedFilterAction={ this.trackAdvancedFilterAction }
 				dateQuery={ dateQuery }
+				isoDateFormat={ isoDateFormat }
 			/>
 		);
 	}

--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -17,7 +17,7 @@ import { LOCALE } from '@woocommerce/wc-admin-settings';
  */
 import { recordEvent } from 'lib/tracks';
 import { Currency } from 'lib/currency-format';
-import * as storeDate from 'lib/date';
+import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
 
 export default class ReportFilters extends Component {
 	constructor() {
@@ -65,6 +65,16 @@ export default class ReportFilters extends Component {
 
 	render() {
 		const { advancedFilters, filters, path, query, showDatePicker } = this.props;
+		const { period, compare, before, after } = getDateParamsFromQuery( query );
+		const { primary: primaryDate, secondary: secondaryDate } = getCurrentDates( query );
+		const dateQuery = {
+			period,
+			compare,
+			before,
+			after,
+			primaryDate,
+			secondaryDate,
+		};
 		return (
 			<Filters
 				query={ query }
@@ -77,7 +87,7 @@ export default class ReportFilters extends Component {
 				onDateSelect={ this.trackDateSelect }
 				onFilterSelect={ this.trackFilterSelect }
 				onAdvancedFilterAction={ this.trackAdvancedFilterAction }
-				storeDate={ storeDate }
+				dateQuery={ dateQuery }
 			/>
 		);
 	}

--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -17,6 +17,7 @@ import { LOCALE } from '@woocommerce/wc-admin-settings';
  */
 import { recordEvent } from 'lib/tracks';
 import { Currency } from 'lib/currency-format';
+import * as storeDate from 'lib/date';
 
 export default class ReportFilters extends Component {
 	constructor() {
@@ -76,6 +77,7 @@ export default class ReportFilters extends Component {
 				onDateSelect={ this.trackDateSelect }
 				onFilterSelect={ this.trackFilterSelect }
 				onAdvancedFilterAction={ this.trackAdvancedFilterAction }
+				storeDate={ storeDate }
 			/>
 		);
 	}

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * WooCommerce dependencies
  */
-import { getDateParamsFromQuery } from '@woocommerce/date';
+import { getDateParamsFromQuery } from 'lib/date';
 import { getNewPath } from '@woocommerce/navigation';
 import { SummaryList, SummaryListPlaceholder, SummaryNumber } from '@woocommerce/components';
 import { calculateDelta, formatValue } from 'lib/number-format';

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -10,7 +10,7 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { Date, Link } from '@woocommerce/components';
-import { defaultTableDateFormat } from '@woocommerce/date';
+import { defaultTableDateFormat } from 'lib/date';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { formatValue } from 'lib/number-format';

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -9,7 +9,7 @@ import { Tooltip } from '@wordpress/components';
 /**
  * WooCommerce dependencies
  */
-import { defaultTableDateFormat } from '@woocommerce/date';
+import { defaultTableDateFormat } from 'lib/date';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { Date, Link } from '@woocommerce/components';
 import { formatValue } from 'lib/number-format';

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -10,7 +10,7 @@ import moment from 'moment';
 /**
  * WooCommerce dependencies
  */
-import { defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
+import { defaultTableDateFormat, getCurrentDates } from 'lib/date';
 import { Date, Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { formatValue } from 'lib/number-format';

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -10,7 +10,7 @@ import { map } from 'lodash';
  * WooCommerce dependencies
  */
 import { Date, Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
-import { defaultTableDateFormat } from '@woocommerce/date';
+import { defaultTableDateFormat } from 'lib/date';
 import { formatCurrency, renderCurrency } from 'lib/currency-format';
 import { formatValue } from 'lib/number-format';
 import { getSetting } from '@woocommerce/wc-admin-settings';

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from '@woocommerce/date';
+import { appendTimestamp, defaultTableDateFormat, getCurrentDates } from 'lib/date';
 import { Date, Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/currency-format';
 import { formatValue } from 'lib/number-format';

--- a/client/analytics/settings/default-date.js
+++ b/client/analytics/settings/default-date.js
@@ -3,6 +3,12 @@
  * External dependencies
  */
 import { parse, stringify } from 'qs';
+
+/**
+ * Internal dependencies
+ */
+import * as storeDate from 'lib/date';
+
 /**
  * WooCommerce dependencies
  */
@@ -18,7 +24,7 @@ const DefaultDate = ( { value, onChange } ) => {
 		} );
 	};
 	const query = parse( value.replace( /&amp;/g, '&' ) );
-	return <DateRangeFilterPicker query={ query } onRangeSelect={ change } />;
+	return <DateRangeFilterPicker query={ query } onRangeSelect={ change } storeDate={ storeDate } />;
 };
 
 export default DefaultDate;

--- a/client/analytics/settings/default-date.js
+++ b/client/analytics/settings/default-date.js
@@ -7,7 +7,7 @@ import { parse, stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import * as storeDate from 'lib/date';
+import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
 
 /**
  * WooCommerce dependencies
@@ -24,7 +24,17 @@ const DefaultDate = ( { value, onChange } ) => {
 		} );
 	};
 	const query = parse( value.replace( /&amp;/g, '&' ) );
-	return <DateRangeFilterPicker query={ query } onRangeSelect={ change } storeDate={ storeDate } />;
+	const { period, compare, before, after } = getDateParamsFromQuery( query );
+	const { primary: primaryDate, secondary: secondaryDate } = getCurrentDates( query );
+	const dateQuery = {
+		period,
+		compare,
+		before,
+		after,
+		primaryDate,
+		secondaryDate,
+	};
+	return <DateRangeFilterPicker query={ query } onRangeSelect={ change } dateQuery={ dateQuery } />;
 };
 
 export default DefaultDate;

--- a/client/analytics/settings/default-date.js
+++ b/client/analytics/settings/default-date.js
@@ -7,7 +7,7 @@ import { parse, stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
+import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from 'lib/date';
 
 /**
  * WooCommerce dependencies
@@ -34,7 +34,14 @@ const DefaultDate = ( { value, onChange } ) => {
 		primaryDate,
 		secondaryDate,
 	};
-	return <DateRangeFilterPicker query={ query } onRangeSelect={ change } dateQuery={ dateQuery } />;
+	return (
+		<DateRangeFilterPicker
+			query={ query }
+			onRangeSelect={ change }
+			dateQuery={ dateQuery }
+			isoDateFormat={ isoDateFormat }
+		/>
+	);
 };
 
 export default DefaultDate;

--- a/client/analytics/settings/historical-data/period-selector.js
+++ b/client/analytics/settings/historical-data/period-selector.js
@@ -10,7 +10,7 @@ import { SelectControl } from '@wordpress/components';
  * WooCommerce dependencies
  */
 import { DatePicker } from '@woocommerce/components';
-import { dateValidationMessages } from '@woocommerce/date';
+import { dateValidationMessages } from 'lib/date';
 
 function HistoricalDataPeriodSelector( {
 	dateFormat,

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -25,7 +25,7 @@ import { recordEvent } from 'lib/tracks';
 import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
 import { isOnboardingEnabled } from 'dashboard/utils';
-import * as storeDate from 'lib/date';
+import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -208,6 +208,17 @@ class CustomizableDashboard extends Component {
 			return <TaskList query={ query } />;
 		}
 
+		const { period, compare, before, after } = getDateParamsFromQuery( query );
+		const { primary: primaryDate, secondary: secondaryDate } = getCurrentDates( query );
+		const dateQuery = {
+			period,
+			compare,
+			before,
+			after,
+			primaryDate,
+			secondaryDate,
+		};
+
 		return (
 			<Fragment>
 				{ isOnboardingEnabled() &&
@@ -215,7 +226,7 @@ class CustomizableDashboard extends Component {
 					! taskListHidden &&
 					taskListCompleted && <TaskList query={ query } inline /> }
 
-				<ReportFilters query={ query } path={ path } storeDate={ storeDate } />
+				<ReportFilters query={ query } path={ path } dateQuery={ dateQuery } />
 				{ sections.map( ( section, index ) => {
 					if ( section.isVisible ) {
 						return (

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -25,6 +25,7 @@ import { recordEvent } from 'lib/tracks';
 import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
 import { isOnboardingEnabled } from 'dashboard/utils';
+import * as storeDate from 'lib/date';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -214,7 +215,7 @@ class CustomizableDashboard extends Component {
 					! taskListHidden &&
 					taskListCompleted && <TaskList query={ query } inline /> }
 
-				<ReportFilters query={ query } path={ path } />
+				<ReportFilters query={ query } path={ path } storeDate={ storeDate } />
 				{ sections.map( ( section, index ) => {
 					if ( section.isVisible ) {
 						return (

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -25,7 +25,7 @@ import { recordEvent } from 'lib/tracks';
 import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
 import { isOnboardingEnabled } from 'dashboard/utils';
-import { getCurrentDates, getDateParamsFromQuery } from 'lib/date';
+import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from 'lib/date';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -226,7 +226,7 @@ class CustomizableDashboard extends Component {
 					! taskListHidden &&
 					taskListCompleted && <TaskList query={ query } inline /> }
 
-				<ReportFilters query={ query } path={ path } dateQuery={ dateQuery } />
+				<ReportFilters query={ query } path={ path } dateQuery={ dateQuery } isoDateFormat={ isoDateFormat } />
 				{ sections.map( ( section, index ) => {
 					if ( section.isVisible ) {
 						return (

--- a/client/dashboard/dashboard-charts/index.js
+++ b/client/dashboard/dashboard-charts/index.js
@@ -15,7 +15,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { EllipsisMenu, MenuItem, MenuTitle, SectionHeader } from '@woocommerce/components';
-import { getAllowedIntervalsForQuery } from '@woocommerce/date';
+import { getAllowedIntervalsForQuery } from 'lib/date';
 
 /**
  * Internal dependencies

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -12,7 +12,7 @@ import { find } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { getCurrentDates, appendTimestamp, getDateParamsFromQuery } from '@woocommerce/date';
+import { getCurrentDates, appendTimestamp, getDateParamsFromQuery } from 'lib/date';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { calculateDelta, formatValue } from 'lib/number-format';
 import { formatCurrency } from 'lib/currency-format';

--- a/client/lib/date.js
+++ b/client/lib/date.js
@@ -1,0 +1,75 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { partialRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+/**
+ * WooCommerce dependencies
+ */
+import {
+	isoDateFormat,
+	presetValues,
+	periods,
+	appendTimestamp,
+	toMoment,
+	getRangeLabel,
+	getLastPeriod,
+	getCurrentPeriod,
+	getDateParamsFromQuery,
+	getCurrentDates,
+	getDateDifferenceInDays,
+	getPreviousDate,
+	getAllowedIntervalsForQuery,
+	getIntervalForQuery,
+	getChartTypeForQuery,
+	dayTicksThreshold,
+	weekTicksThreshold,
+	defaultTableDateFormat,
+	getDateFormatsForInterval,
+	loadLocaleData,
+	dateValidationMessages,
+	validateDateInputForRange,
+} from '@woocommerce/date';
+
+// Load the store's locale.
+const localeSettings = getSetting( 'locale' );
+loadLocaleData( localeSettings );
+
+// Compose methods with store settings.
+const {
+	woocommerce_default_date_range: defaultDateRange = 'period=month&compare=previous_year',
+} = getSetting( 'wcAdminSettings', {} );
+const storeGetDateParamsFromQuery = partialRight( getDateParamsFromQuery, defaultDateRange );
+const storeGetCurrentDates = partialRight( getCurrentDates, defaultDateRange );
+
+// Export the expected API for the consuming app.
+export {
+	isoDateFormat,
+	presetValues,
+	periods,
+	appendTimestamp,
+	toMoment,
+	getRangeLabel,
+	getLastPeriod,
+	getCurrentPeriod,
+	storeGetDateParamsFromQuery as getDateParamsFromQuery,
+	storeGetCurrentDates as getCurrentDates,
+	getDateDifferenceInDays,
+	getPreviousDate,
+	getAllowedIntervalsForQuery,
+	getIntervalForQuery,
+	getChartTypeForQuery,
+	dayTicksThreshold,
+	weekTicksThreshold,
+	defaultTableDateFormat,
+	getDateFormatsForInterval,
+	loadLocaleData,
+	dateValidationMessages,
+	validateDateInputForRange,
+};

--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -7,7 +7,7 @@
 /**
  * WooCommerce dependencies
  */
-import { appendTimestamp, getCurrentDates } from '@woocommerce/date';
+import { appendTimestamp, getCurrentDates } from 'lib/date';
 
 /**
  * Returns leaderboard data to render a leaderboard table.

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -9,7 +9,7 @@ import moment from 'moment';
 /**
  * WooCommerce dependencies
  */
-import { appendTimestamp, getCurrentDates, getIntervalForQuery } from '@woocommerce/date';
+import { appendTimestamp, getCurrentDates, getIntervalForQuery } from 'lib/date';
 import { flattenFilters, getActiveFiltersFromQuery, getUrlKey } from '@woocommerce/navigation';
 import { formatCurrency } from 'lib/currency-format';
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `<TextControl />` component.
 - Require `currency` prop in `<AdvancedFilters />` component.
 - Remove call to `getAdminLink()` inside the `<Link />` component.
+- Add `storeDate` prop to `<ReportFilters />` and `<DateRangeFilterPicker />` components.
 
 # 4.0.0
 - Added a new `<ScrollTo />` component.

--- a/packages/components/src/date-range-filter-picker/README.md
+++ b/packages/components/src/date-range-filter-picker/README.md
@@ -15,12 +15,11 @@ Select a range of dates or single dates
 
 ### Props
 
-Required props are marked with `*`.
-
 Name    | Type     | Default | Description
 ------- | -------- | ------- | ---
 `query` | Object | `{}` | The query string represented in object form
 `onRangeSelect` | Function | `null` | Callback called when selection is made
+`storeDate` | object | `null` | (required) Date utility function object bound to store settings.
 
 ## URL as the source of truth
 

--- a/packages/components/src/date-range-filter-picker/README.md
+++ b/packages/components/src/date-range-filter-picker/README.md
@@ -6,10 +6,46 @@ Select a range of dates or single dates
 ## Usage
 
 ```jsx
+import {
+	getDateParamsFromQuery,
+	getCurrentDates,
+	isoDateFormat,
+	loadLocaleData,
+} from '@woocommerce/date';
+
+/**
+ * External dependencies
+ */
+import { partialRight } from 'lodash';
+
+const query = {};
+
+// Fetch locale from store settings and load for date functions.
+const localeSettings = {
+	userLocale: 'fr_FR',
+	weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
+};
+loadLocaleData( localeSettings );
+
+const defaultDateRange = 'period=month&compare=previous_year';
+const storeGetDateParamsFromQuery = partialRight( getDateParamsFromQuery, defaultDateRange );
+const storeGetCurrentDates = partialRight( getCurrentDates, defaultDateRange );
+const { period, compare, before, after } = storeGetDateParamsFromQuery( query );
+const { primary: primaryDate, secondary: secondaryDate } = storeGetCurrentDates( query );
+const dateQuery = {
+	period,
+	compare,
+	before,
+	after,
+	primaryDate,
+	secondaryDate,
+};
 
 <DateRangeFilterPicker
 	key="daterange"
 	onRangeSelect={ () => {} }
+	dateQuery={ dateQuery }
+	isoDateFormat={ isoDateFormat }
 />
 ```
 
@@ -17,9 +53,9 @@ Select a range of dates or single dates
 
 Name    | Type     | Default | Description
 ------- | -------- | ------- | ---
-`query` | Object | `{}` | The query string represented in object form
+`isDateFormat` | string | `null` | (required) ISO date format string
 `onRangeSelect` | Function | `null` | Callback called when selection is made
-`storeDate` | object | `null` | (required) Date utility function object bound to store settings.
+`dateQuery` | object | `null` | (required) Date initialization object
 
 ## URL as the source of truth
 

--- a/packages/components/src/date-range-filter-picker/docs/example.js
+++ b/packages/components/src/date-range-filter-picker/docs/example.js
@@ -6,6 +6,7 @@ import { DateRangeFilterPicker } from '@woocommerce/components';
 import {
 	getDateParamsFromQuery,
 	getCurrentDates,
+	isoDateFormat,
 	loadLocaleData,
 } from '@woocommerce/date';
 
@@ -43,5 +44,6 @@ export default () => (
 		query={ query }
 		onRangeSelect={ () => {} }
 		dateQuery={ dateQuery }
+		isoDateFormat={ isoDateFormat }
 	/>
 );

--- a/packages/components/src/date-range-filter-picker/docs/example.js
+++ b/packages/components/src/date-range-filter-picker/docs/example.js
@@ -3,13 +3,44 @@
  * Internal dependencies
  */
 import { DateRangeFilterPicker } from '@woocommerce/components';
+import {
+	getDateParamsFromQuery,
+	getCurrentDates,
+	isoDateFormat,
+	loadLocaleData,
+} from '@woocommerce/date';
+
+/**
+ * External dependencies
+ */
+import { partialRight } from 'lodash';
 
 const query = {};
+
+// Fetch locale from store settings and load for date functions.
+const localeSettings = {
+	userLocale: 'fr_FR',
+	weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
+};
+loadLocaleData( localeSettings );
+
+// Fetch store default date range and compose with date utility functions.
+const defaultDateRange = 'period=month&compare=previous_year';
+const storeGetDateParamsFromQuery = partialRight( getDateParamsFromQuery, defaultDateRange );
+const storeGetCurrentDates = partialRight( getCurrentDates, defaultDateRange );
+
+// Package date utilities for filter picker component.
+const storeDate = {
+	getDateParamsFromQuery: storeGetDateParamsFromQuery,
+	getCurrentDates: storeGetCurrentDates,
+	isoDateFormat,
+};
 
 export default () => (
 	<DateRangeFilterPicker
 		key="daterange"
 		query={ query }
 		onRangeSelect={ () => {} }
+		storeDate={ storeDate }
 	/>
 );

--- a/packages/components/src/date-range-filter-picker/docs/example.js
+++ b/packages/components/src/date-range-filter-picker/docs/example.js
@@ -6,7 +6,6 @@ import { DateRangeFilterPicker } from '@woocommerce/components';
 import {
 	getDateParamsFromQuery,
 	getCurrentDates,
-	isoDateFormat,
 	loadLocaleData,
 } from '@woocommerce/date';
 
@@ -24,16 +23,18 @@ const localeSettings = {
 };
 loadLocaleData( localeSettings );
 
-// Fetch store default date range and compose with date utility functions.
 const defaultDateRange = 'period=month&compare=previous_year';
 const storeGetDateParamsFromQuery = partialRight( getDateParamsFromQuery, defaultDateRange );
 const storeGetCurrentDates = partialRight( getCurrentDates, defaultDateRange );
-
-// Package date utilities for filter picker component.
-const storeDate = {
-	getDateParamsFromQuery: storeGetDateParamsFromQuery,
-	getCurrentDates: storeGetCurrentDates,
-	isoDateFormat,
+const { period, compare, before, after } = storeGetDateParamsFromQuery( query );
+const { primary: primaryDate, secondary: secondaryDate } = storeGetCurrentDates( query );
+const dateQuery = {
+	period,
+	compare,
+	before,
+	after,
+	primaryDate,
+	secondaryDate,
 };
 
 export default () => (
@@ -41,6 +42,6 @@ export default () => (
 		key="daterange"
 		query={ query }
 		onRangeSelect={ () => {} }
-		storeDate={ storeDate }
+		dateQuery={ dateQuery }
 	/>
 );

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -6,7 +6,6 @@ import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Dropdown } from '@wordpress/components';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -32,16 +31,25 @@ class DateRangeFilterPicker extends Component {
 		this.resetCustomValues = this.resetCustomValues.bind( this );
 	}
 
+	formatDate( date, format ) {
+		if ( date.isMoment && date.isMoment() ) {
+			return date.format( format );
+		}
+
+		return '';
+	}
+
 	getResetState() {
 		const { period, compare, before, after } = this.props.dateQuery;
+
 		return {
 			period,
 			compare,
 			before,
 			after,
 			focusedInput: 'startDate',
-			afterText: after ? after.format( shortDateFormat ) : '',
-			beforeText: before ? before.format( shortDateFormat ) : '',
+			afterText: this.formatDate( after, shortDateFormat ),
+			beforeText: this.formatDate( before, shortDateFormat ),
 			afterError: null,
 			beforeError: null,
 		};
@@ -60,8 +68,8 @@ class DateRangeFilterPicker extends Component {
 				compare,
 			};
 			if ( 'custom' === selectedTab ) {
-				data.after = after ? after.format( isoDateFormat ) : '';
-				data.before = before ? before.format( isoDateFormat ) : '';
+				data.after = this.formatDate( after, isoDateFormat );
+				data.before = this.formatDate( before, isoDateFormat );
 			} else {
 				data.after = undefined;
 				data.before = undefined;
@@ -162,8 +170,8 @@ DateRangeFilterPicker.propTypes = {
 	dateQuery: PropTypes.shape( {
 		period: PropTypes.string.isRequired,
 		compare: PropTypes.string.isRequired,
-		before: PropTypes.instanceOf( moment ),
-		after: PropTypes.instanceOf( moment ),
+		before: PropTypes.object,
+		after: PropTypes.object,
 		primaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -32,7 +32,7 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	formatDate( date, format ) {
-		if ( date.isMoment && date.isMoment() ) {
+		if ( date && date.isMoment && date.isMoment() ) {
 			return date.format( format );
 		}
 

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -32,7 +32,7 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	formatDate( date, format ) {
-		if ( date && date.isMoment && date.isMoment() ) {
+		if ( date && date._isAMomentObject && ( 'function' === typeof date.format ) ) {
 			return date.format( format );
 		}
 

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -167,14 +167,10 @@ DateRangeFilterPicker.propTypes = {
 		primaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,
-			after: PropTypes.instanceOf( moment ).isRequired,
-			before: PropTypes.instanceOf( moment ).isRequired,
 		} ).isRequired,
 		secondaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,
-			after: PropTypes.instanceOf( moment ).isRequired,
-			before: PropTypes.instanceOf( moment ).isRequired,
 		} ).isRequired,
 	} ).isRequired,
 };

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -8,11 +8,6 @@ import { Dropdown } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
- * WooCommerce dependencies
- */
-import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from '@woocommerce/date';
-
-/**
  * Internal dependencies
  */
 import DatePickerContent from './content';
@@ -37,7 +32,9 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	getResetState() {
-		const { period, compare, before, after } = getDateParamsFromQuery( this.props.query );
+		const { storeDate, query } = this.props;
+		const { getDateParamsFromQuery } = storeDate;
+		const { period, compare, before, after } = getDateParamsFromQuery( query );
 		return {
 			period,
 			compare,
@@ -56,7 +53,7 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	onSelect( selectedTab, onClose ) {
-		const { onRangeSelect } = this.props;
+		const { isoDateFormat, onRangeSelect } = this.props;
 		return event => {
 			const { period, compare, after, before } = this.state;
 			const data = {
@@ -76,7 +73,9 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	getButtonLabel() {
-		const { primary, secondary } = getCurrentDates( this.props.query );
+		const { storeDate, query } = this.props;
+		const { getCurrentDates } = storeDate;
+		const { primary, secondary } = getCurrentDates( query );
 		return [
 			`${ primary.label } (${ primary.range })`,
 			`${ __( 'vs.', 'woocommerce-admin' ) } ${ secondary.label } (${ secondary.range })`,
@@ -164,6 +163,14 @@ DateRangeFilterPicker.propTypes = {
 	 * The query string represented in object form.
 	 */
 	query: PropTypes.object,
+	/**
+	 * Store date utility instance.
+	 */
+	storeDate: PropTypes.shape( {
+		isoDateFormat: PropTypes.string.isRequired,
+		getDateParamsFromQuery: PropTypes.func.isRequired,
+		getCurrentDates: PropTypes.func.isRequired,
+	} ).isRequired,
 };
 
 DateRangeFilterPicker.defaultProps = {

--- a/packages/components/src/date-range-filter-picker/index.js
+++ b/packages/components/src/date-range-filter-picker/index.js
@@ -6,6 +6,7 @@ import { Component, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Dropdown } from '@wordpress/components';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -32,9 +33,7 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	getResetState() {
-		const { storeDate, query } = this.props;
-		const { getDateParamsFromQuery } = storeDate;
-		const { period, compare, before, after } = getDateParamsFromQuery( query );
+		const { period, compare, before, after } = this.props.dateQuery;
 		return {
 			period,
 			compare,
@@ -73,12 +72,10 @@ class DateRangeFilterPicker extends Component {
 	}
 
 	getButtonLabel() {
-		const { storeDate, query } = this.props;
-		const { getCurrentDates } = storeDate;
-		const { primary, secondary } = getCurrentDates( query );
+		const { primaryDate, secondaryDate } = this.props.dateQuery;
 		return [
-			`${ primary.label } (${ primary.range })`,
-			`${ __( 'vs.', 'woocommerce-admin' ) } ${ secondary.label } (${ secondary.range })`,
+			`${ primaryDate.label } (${ primaryDate.range })`,
+			`${ __( 'vs.', 'woocommerce-admin' ) } ${ secondaryDate.label } (${ secondaryDate.range })`,
 		];
 	}
 
@@ -160,21 +157,26 @@ DateRangeFilterPicker.propTypes = {
 	 */
 	onRangeSelect: PropTypes.func.isRequired,
 	/**
-	 * The query string represented in object form.
+	 * The date query string represented in object form.
 	 */
-	query: PropTypes.object,
-	/**
-	 * Store date utility instance.
-	 */
-	storeDate: PropTypes.shape( {
-		isoDateFormat: PropTypes.string.isRequired,
-		getDateParamsFromQuery: PropTypes.func.isRequired,
-		getCurrentDates: PropTypes.func.isRequired,
+	dateQuery: PropTypes.shape( {
+		period: PropTypes.string.isRequired,
+		compare: PropTypes.string.isRequired,
+		before: PropTypes.instanceOf( moment ),
+		after: PropTypes.instanceOf( moment ),
+		primaryDate: PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			range: PropTypes.string.isRequired,
+			after: PropTypes.instanceOf( moment ).isRequired,
+			before: PropTypes.instanceOf( moment ).isRequired,
+		} ).isRequired,
+		secondaryDate: PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			range: PropTypes.string.isRequired,
+			after: PropTypes.instanceOf( moment ).isRequired,
+			before: PropTypes.instanceOf( moment ).isRequired,
+		} ).isRequired,
 	} ).isRequired,
-};
-
-DateRangeFilterPicker.defaultProps = {
-	query: {},
 };
 
 export default DateRangeFilterPicker;

--- a/packages/components/src/filters/README.md
+++ b/packages/components/src/filters/README.md
@@ -18,3 +18,4 @@ Name | Type | Default | Description
 `onDateSelect` | Function | `() => {}` | Function to be called after date selection
 `onFilterSelect` | Function | `null` | Function to be called after filter selection
 `onAdvancedFilterAction` | Function | `null` | Function to be called after an advanced filter action has been taken
+`storeDate` | object | `null` | (required) Date utility function object bound to store settings.

--- a/packages/components/src/filters/docs/example.js
+++ b/packages/components/src/filters/docs/example.js
@@ -9,6 +9,17 @@ import {
 	ReportFilters,
 	Section,
 } from '@woocommerce/components';
+import {
+	getDateParamsFromQuery,
+	getCurrentDates,
+	isoDateFormat,
+	loadLocaleData,
+} from '@woocommerce/date';
+
+/**
+ * External dependencies
+ */
+import { partialRight } from 'lodash';
 
 const ORDER_STATUSES = {
 	cancelled: 'Cancelled',
@@ -18,6 +29,25 @@ const ORDER_STATUSES = {
 	pending: 'Pending payment',
 	processing: 'Processing',
 	refunded: 'Refunded',
+};
+
+// Fetch locale from store settings and load for date functions.
+const localeSettings = {
+	userLocale: 'fr_FR',
+	weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
+};
+loadLocaleData( localeSettings );
+
+// Fetch store default date range and compose with date utility functions.
+const defaultDateRange = 'period=month&compare=previous_year';
+const storeGetDateParamsFromQuery = partialRight( getDateParamsFromQuery, defaultDateRange );
+const storeGetCurrentDates = partialRight( getCurrentDates, defaultDateRange );
+
+// Package date utilities for filter picker component.
+const storeDate = {
+	getDateParamsFromQuery: storeGetDateParamsFromQuery,
+	getCurrentDates: storeGetCurrentDates,
+	isoDateFormat,
 };
 
 const siteLocale = 'en_US';
@@ -180,7 +210,7 @@ export default () => (
 	<div>
 		<H>Date picker only</H>
 		<Section component={ false }>
-			<ReportFilters path={ path } query={ query } />
+			<ReportFilters path={ path } query={ query } storeDate={ storeDate } />
 		</Section>
 
 		<H>Date picker & more filters</H>
@@ -189,6 +219,7 @@ export default () => (
 				filters={ filters }
 				path={ path }
 				query={ query }
+				storeDate={ storeDate }
 			/>
 		</Section>
 

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 
 /**
  * WooCommerce dependencies
@@ -84,12 +85,12 @@ class ReportFilters extends Component {
 
 	render() {
 		const {
+			dateQuery,
 			filters,
 			query,
 			path,
 			showDatePicker,
 			onFilterSelect,
-			storeDate,
 		} = this.props;
 		return (
 			<Fragment>
@@ -99,9 +100,8 @@ class ReportFilters extends Component {
 						{ showDatePicker && (
 							<DateRangeFilterPicker
 								key={ JSON.stringify( query ) }
-								query={ query }
+								dateQuery={ dateQuery }
 								onRangeSelect={ this.onRangeSelect }
-								storeDate={ storeDate }
 							/>
 						) }
 						{ filters.map( config => {
@@ -167,12 +167,25 @@ ReportFilters.propTypes = {
 	 */
 	currency: PropTypes.object.isRequired,
 	/**
-	 * Store date utility instance.
+	 * The date query string represented in object form.
 	 */
-	storeDate: PropTypes.shape( {
-		isoDateFormat: PropTypes.string.isRequired,
-		getDateParamsFromQuery: PropTypes.func.isRequired,
-		getCurrentDates: PropTypes.func.isRequired,
+	dateQuery: PropTypes.shape( {
+		period: PropTypes.string.isRequired,
+		compare: PropTypes.string.isRequired,
+		before: PropTypes.instanceOf( moment ),
+		after: PropTypes.instanceOf( moment ),
+		primaryDate: PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			range: PropTypes.string.isRequired,
+			after: PropTypes.instanceOf( moment ).isRequired,
+			before: PropTypes.instanceOf( moment ).isRequired,
+		} ).isRequired,
+		secondaryDate: PropTypes.shape( {
+			label: PropTypes.string.isRequired,
+			range: PropTypes.string.isRequired,
+			after: PropTypes.instanceOf( moment ).isRequired,
+			before: PropTypes.instanceOf( moment ).isRequired,
+		} ).isRequired,
 	} ).isRequired,
 };
 

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 
 /**
  * WooCommerce dependencies
@@ -172,8 +171,8 @@ ReportFilters.propTypes = {
 	dateQuery: PropTypes.shape( {
 		period: PropTypes.string.isRequired,
 		compare: PropTypes.string.isRequired,
-		before: PropTypes.instanceOf( moment ),
-		after: PropTypes.instanceOf( moment ),
+		before: PropTypes.object,
+		after: PropTypes.object,
 		primaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -90,6 +90,7 @@ class ReportFilters extends Component {
 			path,
 			showDatePicker,
 			onFilterSelect,
+			isoDateFormat,
 		} = this.props;
 		return (
 			<Fragment>
@@ -101,6 +102,7 @@ class ReportFilters extends Component {
 								key={ JSON.stringify( query ) }
 								dateQuery={ dateQuery }
 								onRangeSelect={ this.onRangeSelect }
+								isoDateFormat={ isoDateFormat }
 							/>
 						) }
 						{ filters.map( config => {
@@ -182,6 +184,10 @@ ReportFilters.propTypes = {
 			range: PropTypes.string.isRequired,
 		} ).isRequired,
 	} ).isRequired,
+	/**
+	 * ISO date format string.
+	 */
+	isoDateFormat: PropTypes.string.isRequired,
 };
 
 ReportFilters.defaultProps = {

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -83,7 +83,14 @@ class ReportFilters extends Component {
 	}
 
 	render() {
-		const { filters, query, path, showDatePicker, onFilterSelect } = this.props;
+		const {
+			filters,
+			query,
+			path,
+			showDatePicker,
+			onFilterSelect,
+			storeDate,
+		} = this.props;
 		return (
 			<Fragment>
 				<H className="screen-reader-text">{ __( 'Filters', 'woocommerce-admin' ) }</H>
@@ -94,6 +101,7 @@ class ReportFilters extends Component {
 								key={ JSON.stringify( query ) }
 								query={ query }
 								onRangeSelect={ this.onRangeSelect }
+								storeDate={ storeDate }
 							/>
 						) }
 						{ filters.map( config => {
@@ -158,6 +166,14 @@ ReportFilters.propTypes = {
 	 * The currency formatting instance for the site.
 	 */
 	currency: PropTypes.object.isRequired,
+	/**
+	 * Store date utility instance.
+	 */
+	storeDate: PropTypes.shape( {
+		isoDateFormat: PropTypes.string.isRequired,
+		getDateParamsFromQuery: PropTypes.func.isRequired,
+		getCurrentDates: PropTypes.func.isRequired,
+	} ).isRequired,
 };
 
 ReportFilters.defaultProps = {

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -177,14 +177,10 @@ ReportFilters.propTypes = {
 		primaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,
-			after: PropTypes.instanceOf( moment ).isRequired,
-			before: PropTypes.instanceOf( moment ).isRequired,
 		} ).isRequired,
 		secondaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,
-			after: PropTypes.instanceOf( moment ).isRequired,
-			before: PropTypes.instanceOf( moment ).isRequired,
 		} ).isRequired,
 	} ).isRequired,
 };

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Decouple from global wcSettings object.
+
 # 1.2.1
 
 - Update dependencies.

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -8,7 +8,6 @@ import moment from 'moment';
  * WooCommerce settings
  */
 import {
-	setSetting,
 	getSetting,
 } from '@woocommerce/wc-admin-settings';
 
@@ -511,24 +510,20 @@ describe( 'loadLocaleData', () => {
 	const originalLocale = getSetting( 'locale' );
 	beforeEach( () => {
 		// Reset to default settings
-		setSetting( 'locale', originalLocale );
+		loadLocaleData( originalLocale );
 	} );
 
 	it( 'should load locale data on user locale', () => {
-		setSetting(
-			'locale',
-			{
-				userLocale: 'fr_FR',
-				weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
-			}
-		);
-
 		// initialize locale. Gutenberg normaly does this, but not in test environment.
 		moment.locale( 'fr_FR', {} );
 
-		loadLocaleData();
-		expect( moment.localeData().weekdaysMin() )
-			.toEqual( getSetting( 'locale' ).weekdaysShort );
+		const weekdaysShort = [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ];
+
+		loadLocaleData( {
+			userLocale: 'fr_FR',
+			weekdaysShort,
+		} );
+		expect( moment.localeData().weekdaysMin() ).toEqual( weekdaysShort );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #3030.

This PR seeks to remove the `wcSettings` dependency from the Date package.

### `Date`

The exported methods of the date package that depended on `getSetting()` have been rewritten to accept a configuration object as their second parameter - this allows for composition using lodash's `partialRight()` - which is done in the new `lib/date` module.

`loadLocaleData()` is also no longer called within the date package, but in the `lib/date` module instead.

A new `lib/date` module has been introduced that exports the same API as the previous version of `@woocommerce/date` so that the consuming parts of the WC-Admin app don't need to change (too much).

### `AdvancedFilters` and `ReportFilters`

Add a new required `storeDate` prop as a means to pass down date initialization values from `@woocommerce/date`, but from `lib/date` in the app.

### Detailed test instructions:

- Verify that date values are properly formatted on all WC-Admin screens (check activity panels, reports, filters, etc)
- Verify that the default date range analytics setting functions
- Review changes to documentation

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: decouple Date package from global wcSettings object.