### PR TITLE
Add remaining onboarding documentation

### DIFF
--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -37,7 +37,7 @@ To power the new onboarding flow client side, new REST API endpoints have been i
 
 ## Onboarding filters
 
-* `woocommerce_onboarding_profile_properties` filters the properties we track as part of the profile wizard (such as information from store/business details steps).
+* `woocommerce_onboarding_profile_properties` filters the properties we track as part of the profile wizard (such as information from store/business details steps). When the `completed` property is set to true, the profile wizard is completely dismissed and hidden.
 * `woocommerce_rest_onboarding_profile_object_query` filters the query arguments for requests to `/wc-admin/onboarding/profile`.
 * `woocommerce_rest_prepare_onboarding_profile` filters the response for requests to `/wc-admin/onboarding/profile`.
 * `rest_onboarding_profile_collection_params` filters the collection parameters for requests to  `/wc-admin/onboarding/profile`.
@@ -46,7 +46,7 @@ To power the new onboarding flow client side, new REST API endpoints have been i
 * `woocommerce_admin_onboarding_product_types` filters the product types displayed in the profile wizard.
 * `woocommerce_onboarding_plugins_whitelist` filters the list of plugins that can installed & activated via onboarding. This acts as a whitelist so only certain plugins can be used via the `/wc-admin/onboarding/profile/install` and `/wc-admin/onboarding/profile/activate` endpoints.
 * `woocommerce_admin_onboarding_themes` filters the themes displayed in the profile wizard.
-* `woocommerce_onboarding_jetpack_connect_redirect_url` filters the Jetpack connection URL outlined in the Jetpack connection section below.
+* `woocommerce_onboarding_jetpack_connect_redirect_url` filters the Jetpack connection redirect URL outlined in the Jetpack connection section below.
 * `woocommerce_onboarding_task_list` filters the list of tasks on the task list dashboard. This allows extensions to add new tasks. See [the extension docs](https://github.com/woocommerce/woocommerce-admin/tree/42015d17a919e8f9e54ba75869c50b04b8dc9241/docs/examples/extensions) for an example of how to do this.
 
 
@@ -54,9 +54,11 @@ To power the new onboarding flow client side, new REST API endpoints have been i
 
 A few new WordPress options have been introduced to store information and settings during setup. It may be necessary to manual delete these options from your `wp_options` database to test a certain task or feature.
 
-* `woocommerce_onboarding_payments`. Since the payments step requires multiple redirects to payment providers to setup accounts, we cache the current progress of the payments step in an option, so that we can quickly drop users back into the correct part of the task.
+
+* `woocommerce_task_list_hidden`. This option is used to conditionally show the entire task list. The task list can be hidden by the user after they have completed all tasks. Hiding the wizard stops it from showing in both full screen mode, and the collapsed inline version that shows above the dashboard analytics cards.
 * `woocommerce_task_list_welcome_modal_dismissed`. This option is used to show a congratulations modal during the transition between the profile wizard and task list.
 * `woocommerce_task_list_prompt_shown`. This option is used to conditionally show the "Is this card useful?" snackbar notice, shown once right after a user completes all the task list tasks.
+* `woocommerce_onboarding_payments`. Since the payments step requires multiple redirects to payment providers to setup accounts, we cache the current progress of the payments step in an option, so that we can quickly drop users back into the correct part of the task.
 
 We also use existing options from WooCommerce Core or extensions like WooCommerce Services or Stripe. The list below may not be complete, as new tasks are introduced, but you can generally find usage of these by searching for the [getOptions selector](https://github.com/woocommerce/woocommerce-admin/search?q=getOptions&unscoped_q=getOptions).
 

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -29,25 +29,61 @@ You can also set the following configuration flag in your `wp-config.php`:
 
 @todo
 
-## WooCommerce.com connection and redirection
+## WooCommerce.com Connection
 
 During the profile wizard, merchants can select paid product type extensions (like WooCommerce Memberships) or a paid theme. To make installation easier and to finish purchasing, it is necessary to make a [WooCommerce.com connection](https://docs.woocommerce.com/document/managing-woocommerce-com-subscriptions/). We also prompt users to connect on the task list if they chose extensions in the profile wizard, but did not finish connecting.
 
 To make the connection from the new oboarding experience possible, we build our own connection endpoints [/wc-admin/onboarding/plugins/request-wccom-connect](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L298-L355) and [/wc-admin/onboarding/plugins/finish-wccom-connect](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L357-L417).
 
-Both of these endpoints use WooCommerce Core's `WC_Helper_API` directly. The main difference with our connection (compared to the connection on the subscriptions page) is the addition of two additional query strings: `wccom-from=onboarding` and `calypso_env`.
+Both of these endpoints use WooCommerce Core's `WC_Helper_API` directly. The main difference with our connection (compared to the connection on the subscriptions page) is the addition of two additional query string parameters:
 
-`wccom-from=onboarding` is used to tell WooCommerce.com & WordPress.com that we are connecting from the new onboarding flow. This parameter is passed from the user's site to WooCommerce.com and finally into Calypso, so that the Calypso login and sign-up screens match the rest of the profile wizard (https://github.com/Automattic/wp-calypso/pull/35193). Without this parameter, you would end up on the existing WooCommerce OAuth screen. Calypso's sign-up and login is spread throughout a few different files, but searching for `wccom-from` [shows where this logic lives](https://github.com/Automattic/wp-calypso/search?q=wccom-from&unscoped_q=wccom-from).
-
-`calypso_env` allows us to load different versions of Calypso when testing.  By default, a merchant will end up on a production version of Calypso. If we make changes to the Calypso part of the flow and want to test them, we could pass `calypso_env=development` and to be redirected to `http://calypso.localhost:3000/` instead of `https://wordpress.com`.
-
-To change the value of `calypso_env`, set `WOOCOMMERCE_CALYPSO_ENVIRONMENT` in your `wp-config.php`. It accepts the following values: `'development', 'wpcalypso', 'horizon', 'stage'`.
+* `wccom-from=onboarding`, which is used to tell WooCommerce.com & WordPress.com that we are connecting from the new onboarding flow. This parameter is passed from the user's site to WooCommerce.com and finally into Calypso, so that the Calypso login and sign-up screens match the rest of the profile wizard (https://github.com/Automattic/wp-calypso/pull/35193). Without this parameter, you would end up on the existing WooCommerce OAuth screen.
+* `calypso_env` allows us to load different versions of Calypso when testing.  See the Calypso section below.
 
 To disconnect from WooCommerce.com, go to `WooCommerce > Extensions > WooCommerce.com Subscriptions > Connected to WooCommerce.com > Disconnect`.
 
-## Calypso and Jetpack Connections
+## Jetpack Connection
 
-@todo
+Using Jetpack & WooCommerce Services allows us to offer additional features to new WooCommerce users as well as simplifiy parts of the setup process. For example, we can do automated tax calculations for certain countries, significantly simplifing the tax task. To make this work, the user needs to be connected to a WordPress.com account. This also means development and testing of these features needs to be done on a Jetpack connected site. Search the MGS & the Feld  Guide for additional resources on testing Jetpack with local setups.
+
+We have a special Jetpack connection flow designed specifically for WooCommerce onboarding, so that the user feels that they are connecting as part of a coheisive experience. To access this flow, we have a custom Jetpack connection endpoint [/wc-admin/onboarding/plugins/connect-jetpack](https://github.com/woocommerce/woocommerce-admin/blob/61b771c2643c24334ea062ab3521073beaf50019/src/API/OnboardingPlugins.php#L273-L296).
+
+We use Jetpack's `build_connect_url` function directly, but add the following two query parameters:
+
+* `calypso_env`, which allows us to load different versions of Calypso when testing. See the Calypso section below.
+* `from=woocommerce-onboarding`, which is used to conditionally show the WooCommerce themed Jetpack authorization process (https://github.com/Automattic/wp-calypso/pull/34380). Without this parameter, you would end up in the normal Jetpack authorization flow.
+
+The user is prompted to install and connect to Jetpack as the first step of the profile wizard. If the user hasn't connected when they arrive at the task list, we also prompt them on certain tasks to make the setup process easier, such as the shipping and tax steps.
+
+To disconnect from Jetpack, go to `Jetpack > Dashboard > Connections > Site connection > Manage site connection > Disconnect`.
+
+## Calypso
+
+### `calypso_env`
+
+Both the WooCommerce.com & Jetpack connection processes (outlined below) send the user to [Calypso](https://github.com/Automattic/wp-calypso), the interface that powers WordPress.com, to signup or login.
+
+By default, a merchant will end up on a production version of Calypso (https://worddpress.com). If we make changes to the Calypso part of the flow and want to test them, we can do so with a `calypso_env` query parameter passed by both of our connection methods.
+
+To change the value of `calypso_env`, set `WOOCOMMERCE_CALYPSO_ENVIRONMENT` to one of the following values in your `wp-config.php`:
+
+* `production` which will send you to `https://wordpress.com`
+* `development` which will send you to `http://calypso.localhost:3000/`
+* `wpcalypso` which will send you to `http://wpcalypso.wordpress.com/`
+* `horizon` which will send you to `https://horizon.wordpress.com`
+* `stage` which will send you to `https://wordpress.com` (you must be proxied)
+
+### Feature Flags
+
+Logic for the Calypso flows are gated behind two separate [Calypso feature flags](https://github.com/Automattic/wp-calypso/tree/master/config#feature-flags). Since Calypso's login, signup, and Jetpack authentication is spread throughout a few different files, searching for these feature flags is the best way to locate logic.
+
+* [`woocommerce/onboarding-oauth`](https://github.com/Automattic/wp-calypso/search?q=woocommerce%2Fonboarding-oauth&unscoped_q=woocommerce%2Fonboarding-oauth), which enables the updated WooCommerce.com connection flow.
+* [`jetpack/connect/woocommerce`](https://github.com/Automattic/wp-calypso/search?q=%22jetpack%2Fconnect%2Fwoocommerce%22&unscoped_q=%22jetpack%2Fconnect%2Fwoocommerce%22), which enables the updated Jetpack connection flow.
+
+
+### Testing
+
+If you are running the development version of WooCommerce Admin, and have [`WP_DEBUG`](https://codex.wordpress.org/WP_DEBUG) set to `true`, two Calypso connection buttons are displayed under the `WooCommerce > Settings > Help > Setup Wizard` menu, making it easier to access and test the flows.
 
 ## Building the onboarding feature plugin
 


### PR DESCRIPTION
Closes #3198. This PR adds the rest if the onboarding dev documentation outlined in that issue. 

### Detailed test instructions:

* Review the onboard.md changes. [GitHub View](https://github.com/woocommerce/woocommerce-admin/blob/3d3c7d23a4ab0801cde3db806fc8e42caf193181/docs/features/onboarding.md).
