### PR TITLE
Fix onboarding product type notices

### DIFF
--- a/client/dashboard/profile-wizard/steps/product-types.js
+++ b/client/dashboard/profile-wizard/steps/product-types.js
@@ -100,25 +100,27 @@ class ProductTypes extends Component {
 				<Card>
 					<div className="woocommerce-profile-wizard__checkbox-group">
 						{ Object.keys( productTypes ).map( slug => {
-							const helpText = interpolateComponents( {
-								mixedString:
-									productTypes[ slug ].description +
-									( productTypes[ slug ].more_url ? ' {{moreLink/}}' : '' ),
-								components: {
-									moreLink: productTypes[ slug ].more_url ? (
-										<Link
-											href={ productTypes[ slug ].more_url }
-											target="_blank"
-											type="external"
-											onClick={ () => this.onLearnMore( slug ) }
-										>
-											{ __( 'Learn more', 'woocommerce-admin' ) }
-										</Link>
-									) : (
-										''
-									),
-								},
-							} );
+							const helpText =
+								productTypes[ slug ].description &&
+								interpolateComponents( {
+									mixedString:
+										productTypes[ slug ].description +
+										( productTypes[ slug ].more_url ? ' {{moreLink/}}' : '' ),
+									components: {
+										moreLink: productTypes[ slug ].more_url ? (
+											<Link
+												href={ productTypes[ slug ].more_url }
+												target="_blank"
+												type="external"
+												onClick={ () => this.onLearnMore( slug ) }
+											>
+												{ __( 'Learn more', 'woocommerce-admin' ) }
+											</Link>
+										) : (
+											''
+										),
+									},
+								} );
 
 							return (
 								<CheckboxControl

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -310,17 +310,24 @@ class Onboarding {
 		$products     = array();
 
 		// Map product data by ID.
-		foreach ( $product_data->products as $product_datum ) {
-			$products[ $product_datum->id ] = $product_datum;
+		if ( isset( $product_data ) && isset( $product_data->products ) ) {
+			foreach ( $product_data->products as $product_datum ) {
+				if ( isset( $product_datum->id ) ) {
+					$products[ $product_datum->id ] = $product_datum;
+				}
+			}
 		}
 
 		// Loop over product types and append data.
 		foreach ( $product_types as $key => $product_type ) {
-			if ( isset( $product_type['product'] ) ) {
+			if ( isset( $product_type['product'] ) && isset( $products[ $product_type['product'] ] ) ) {
 				/* translators: Amount of product per year (e.g. Bookings - $240.00 per year) */
 				$product_types[ $key ]['label']      .= sprintf( __( ' — %s per year', 'woocommerce-admin' ), html_entity_decode( $products[ $product_type['product'] ]->price ) );
 				$product_types[ $key ]['description'] = $products[ $product_type['product'] ]->excerpt;
 				$product_types[ $key ]['more_url']    = $products[ $product_type['product'] ]->link;
+			} elseif ( isset( $product_type['product'] ) ) {
+				/* translators: site currency symbol (used to show that the product costs money) */
+				$product_types[ $key ]['label'] .= sprintf( __( ' — %s', 'woocommerce-admin' ), html_entity_decode( get_woocommerce_currency_symbol() ) );
 			}
 		}
 


### PR DESCRIPTION
Fixes #3287.

Note that I wasn't able to reproduce the specific notices directly, but commenting out the `$woocommerce_products` block of code in `append_product_data` allows you to simulate a request failing and the product data / IDs not being set.

This PR adds some guards against that, and fixes an 'undefined' string that shows up if the description fails to load from a failed API request.

To Test:
* Open your debug log / enable error logging
* Go to `/wp-admin/admin.php?page=wc-admin&step=product-types` and verify there are no notices in the log, and the product types display OK
* Optional: Edit `append_product_data` and comment out the code that sets `$woocommerce_products` and the transient`, so that it is `false.
* Optional: Go to `/wp-admin/admin.php?page=wc-admin&step=product-types` and verify there are no notices in the log, and that at least the product title and a cost indicator are displayed.