### PR TITLE
Component styles: Explicitly import from Gutenberg

### DIFF
--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -1,12 +1,5 @@
 /** @format */
 
-@import 'node_modules/@wordpress/base-styles/colors';
-@import 'node_modules/@wordpress/base-styles/variables';
-@import 'node_modules/@wordpress/base-styles/mixins';
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/animations';
-@import 'node_modules/@wordpress/base-styles/z-index';
-
 $fallback-gutter: 24px;
 $fallback-gutter-large: 40px;
 $gutter: var(--main-gap);

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -29,20 +29,7 @@ $sidebar-width: 272px;
 // @todo Remove this spacing variable
 $spacing: 16px;
 
-// Gutenberg variables. These are temporary until Gutenberg's variables are exposed.
-$break-huge: 1440px;
-$break-wide: 1280px;
-$break-xlarge: 1080px;
-$break-large: 960px; // admin sidebar auto folds
-$break-medium: 782px; // adminbar goes big
-$break-small: 600px;
-$break-mobile: 480px;
-$break-zoomed-in: 280px;
-$border-width: 1px;
-$default-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
-	'Helvetica Neue', sans-serif;
-$default-font-size: 13px;
-$default-line-height: 1.4;
+// Gutenberg variable overrides.
 $white: $studio-white;
 $black: $studio-black;
 $light-gray-100: $core-grey-light-100;

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -1,5 +1,12 @@
 /** @format */
 
+@import 'node_modules/@wordpress/base-styles/colors';
+@import 'node_modules/@wordpress/base-styles/variables';
+@import 'node_modules/@wordpress/base-styles/mixins';
+@import 'node_modules/@wordpress/base-styles/breakpoints';
+@import 'node_modules/@wordpress/base-styles/animations';
+@import 'node_modules/@wordpress/base-styles/z-index';
+
 $fallback-gutter: 24px;
 $fallback-gutter-large: 40px;
 $gutter: var(--main-gap);
@@ -38,17 +45,17 @@ $default-font-size: 13px;
 $default-line-height: 1.4;
 $white: $studio-white;
 $black: $studio-black;
-$blue-medium-900: #006589;
-$blue-medium-800: #00739c;
-$blue-medium-700: #007fac;
-$blue-medium-600: #008dbe;
-$blue-medium-500: #00a0d2;
-$blue-medium-400: #33b3db;
-$blue-medium-300: #66c6e4;
-$blue-medium-200: #bfe7f3;
-$blue-medium-100: #e5f5fa;
-$blue-medium-highlight: #b3e7fe;
-$blue-medium-focus: #007cba;
+//$blue-medium-900: #006589;
+//$blue-medium-800: #00739c;
+//$blue-medium-700: #007fac;
+//$blue-medium-600: #008dbe;
+//$blue-medium-500: #00a0d2;
+//$blue-medium-400: #33b3db;
+//$blue-medium-300: #66c6e4;
+//$blue-medium-200: #bfe7f3;
+//$blue-medium-100: #e5f5fa;
+//$blue-medium-highlight: #b3e7fe;
+//$blue-medium-focus: #007cba;
 $light-gray-100: $core-grey-light-100;
 $light-gray-200: $core-grey-light-200;
 $light-gray-300: $core-grey-light-300;
@@ -71,13 +78,50 @@ $alert-red: $error-red;
 $alert-yellow: $notice-yellow;
 $alert-green: $valid-green;
 $toggle-border-width: 2px;
-$radius-round-rectangle: 4px;
-$icon-button-size: 36px;
-$icon-button-size-small: 24px;
-$grid-size-small: 4px;
-$grid-size: 8px;
-$grid-size-large: 16px;
-$grid-size-xlarge: 24px;
+//$radius-round-rectangle: 4px;
+//$icon-button-size: 36px;
+//$icon-button-size-small: 24px;
+//$grid-size-small: 4px;
+//$grid-size: 8px;
+//$grid-size-large: 16px;
+//$grid-size-xlarge: 24px;
+//$shadow-popover: 0 3px 30px rgba($dark-gray-900, 0.1);
+//$panel-header-height: 50px;
+//$panel-padding: 16px;
+//$shadow-modal: 0 3px 30px rgba($dark-gray-900, 0.2);
+//$modal-min-width: 360px;
+//$radius-round: 50%;
+
+// Gutenberg mixins, also temporary until we use base-styles
+//@mixin menu-style__neutral() {
+//	border: none;
+//	box-shadow: none;
+//}
+//@mixin menu-style__hover() {
+//	color: $dark-gray-900;
+//	border: none;
+//	box-shadow: none;
+//	background: $light-gray-200;
+//}
+//@mixin menu-style__focus() {
+//	color: $dark-gray-900;
+//	border: none;
+//	box-shadow: none;
+//	outline-offset: -2px;
+//	outline: 1px dotted $dark-gray-500;
+//}
+@mixin edit-post__fade-in-animation($speed: 0.2s, $delay: 0s) {
+	animation: edit-post__fade-in-animation $speed ease-out $delay;
+	animation-fill-mode: forwards;
+	@include reduce-motion('animation');
+}
+//@mixin input-style__neutral() {
+//	box-shadow: 0 0 0 transparent;
+//	transition: box-shadow 0.1s linear;
+//	border-radius: $radius-round-rectangle;
+//	border: $border-width solid $dark-gray-200;
+//	@include reduce-motion("transition");
+//}
 
 // Newspack variables. These are temporary until we move away from Newspack components.
 $muriel-white: $studio-white;

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -45,17 +45,6 @@ $default-font-size: 13px;
 $default-line-height: 1.4;
 $white: $studio-white;
 $black: $studio-black;
-//$blue-medium-900: #006589;
-//$blue-medium-800: #00739c;
-//$blue-medium-700: #007fac;
-//$blue-medium-600: #008dbe;
-//$blue-medium-500: #00a0d2;
-//$blue-medium-400: #33b3db;
-//$blue-medium-300: #66c6e4;
-//$blue-medium-200: #bfe7f3;
-//$blue-medium-100: #e5f5fa;
-//$blue-medium-highlight: #b3e7fe;
-//$blue-medium-focus: #007cba;
 $light-gray-100: $core-grey-light-100;
 $light-gray-200: $core-grey-light-200;
 $light-gray-300: $core-grey-light-300;
@@ -77,51 +66,6 @@ $dark-gray-900: $core-grey-dark-900;
 $alert-red: $error-red;
 $alert-yellow: $notice-yellow;
 $alert-green: $valid-green;
-$toggle-border-width: 2px;
-//$radius-round-rectangle: 4px;
-//$icon-button-size: 36px;
-//$icon-button-size-small: 24px;
-//$grid-size-small: 4px;
-//$grid-size: 8px;
-//$grid-size-large: 16px;
-//$grid-size-xlarge: 24px;
-//$shadow-popover: 0 3px 30px rgba($dark-gray-900, 0.1);
-//$panel-header-height: 50px;
-//$panel-padding: 16px;
-//$shadow-modal: 0 3px 30px rgba($dark-gray-900, 0.2);
-//$modal-min-width: 360px;
-//$radius-round: 50%;
-
-// Gutenberg mixins, also temporary until we use base-styles
-//@mixin menu-style__neutral() {
-//	border: none;
-//	box-shadow: none;
-//}
-//@mixin menu-style__hover() {
-//	color: $dark-gray-900;
-//	border: none;
-//	box-shadow: none;
-//	background: $light-gray-200;
-//}
-//@mixin menu-style__focus() {
-//	color: $dark-gray-900;
-//	border: none;
-//	box-shadow: none;
-//	outline-offset: -2px;
-//	outline: 1px dotted $dark-gray-500;
-//}
-@mixin edit-post__fade-in-animation($speed: 0.2s, $delay: 0s) {
-	animation: edit-post__fade-in-animation $speed ease-out $delay;
-	animation-fill-mode: forwards;
-	@include reduce-motion('animation');
-}
-//@mixin input-style__neutral() {
-//	box-shadow: 0 0 0 transparent;
-//	transition: box-shadow 0.1s linear;
-//	border-radius: $radius-round-rectangle;
-//	border: $border-width solid $dark-gray-200;
-//	@include reduce-motion("transition");
-//}
 
 // Newspack variables. These are temporary until we move away from Newspack components.
 $muriel-white: $studio-white;

--- a/client/stylesheets/shared/_gutenberg-components.scss
+++ b/client/stylesheets/shared/_gutenberg-components.scss
@@ -17,9 +17,6 @@ allows Woo themed components based on the config found in postcss.config.js
 @import 'gutenberg-components/tooltip/style.scss';
 @import 'gutenberg-components/popover/style.scss';
 @import 'gutenberg-components/radio-control/style.scss';
-@import 'gutenberg-components/checkbox-control/style.scss';
-@import 'gutenberg-components/dashicon/style.scss';
-@import 'gutenberg-components/snackbar/style.scss';
 @import 'gutenberg-components/menu-group/style.scss';
 @import 'gutenberg-components/menu-item/style.scss';
 @import 'gutenberg-components/modal/style.scss';

--- a/client/stylesheets/shared/_gutenberg-components.scss
+++ b/client/stylesheets/shared/_gutenberg-components.scss
@@ -15,3 +15,15 @@ allows Woo themed components based on the config found in postcss.config.js
 @import 'gutenberg-components/spinner/style.scss';
 @import 'gutenberg-components/text-control/style.scss';
 @import 'gutenberg-components/tooltip/style.scss';
+@import 'gutenberg-components/popover/style.scss';
+@import 'gutenberg-components/radio-control/style.scss';
+@import 'gutenberg-components/checkbox-control/style.scss';
+@import 'gutenberg-components/dashicon/style.scss';
+@import 'gutenberg-components/snackbar/style.scss';
+@import 'gutenberg-components/menu-group/style.scss';
+@import 'gutenberg-components/menu-item/style.scss';
+@import 'gutenberg-components/modal/style.scss';
+@import 'gutenberg-components/base-control/style.scss';
+@import 'gutenberg-components/date-time/style.scss';
+@import 'gutenberg-components/drop-zone/style.scss';
+@import 'gutenberg-components/form-file-upload/style.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3438,27 +3438,33 @@
         "babel-core": "^7.0.0-bridge.0"
       }
     },
+    "@wordpress/base-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.0.0.tgz",
+      "integrity": "sha512-Cfq3jlDqOSeclqT8aFgY9SdnJlKu0gZFyGtXVfHc2xCYJtkK9Xw4zW2u4RTtGuaKKm4RhgFhls+NaSVFguOIrQ==",
+      "dev": true
+    },
     "@wordpress/browserslist-config": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.6.0.tgz",
       "integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA=="
     },
     "@wordpress/components": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.3.1.tgz",
-      "integrity": "sha512-0E5RImfAC5MjKJNYDZyE/B0+e5oTImf56xSgTAdYtMzS4WuPrPfjR+hyL4JX+b6X298PtpfC/C8xDQtYmzaKRQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.4.0.tgz",
+      "integrity": "sha512-Fr2L8b8RxUC6hPiN2pMVKGaeB25RA+g4ENpA32LzmuEGd0ITBXtZfFUv3+5FMcUe4y9KFQZbXxBRElBf4xA+SQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/a11y": "^2.5.0",
-        "@wordpress/compose": "^3.7.1",
-        "@wordpress/deprecated": "^2.6.0",
-        "@wordpress/dom": "^2.5.1",
-        "@wordpress/element": "^2.8.1",
+        "@wordpress/a11y": "^2.5.1",
+        "@wordpress/compose": "^3.8.0",
+        "@wordpress/deprecated": "^2.6.1",
+        "@wordpress/dom": "^2.6.0",
+        "@wordpress/element": "^2.9.0",
         "@wordpress/hooks": "^2.6.0",
-        "@wordpress/i18n": "^3.6.1",
-        "@wordpress/is-shallow-equal": "^1.6.0",
-        "@wordpress/keycodes": "^2.6.1",
-        "@wordpress/rich-text": "^3.7.1",
+        "@wordpress/i18n": "^3.7.0",
+        "@wordpress/is-shallow-equal": "^1.6.1",
+        "@wordpress/keycodes": "^2.7.0",
+        "@wordpress/rich-text": "^3.8.0",
         "classnames": "^2.2.5",
         "clipboard": "^2.0.1",
         "dom-scroll-into-view": "^1.2.1",
@@ -3472,6 +3478,110 @@
         "rememo": "^3.0.0",
         "tinycolor2": "^1.4.1",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.8.0.tgz",
+          "integrity": "sha512-n22OFDcwoMZ+/GAjVCd28cwlN6NHslTy4eONLLS7tOrdMKYl4wQ3cFLzxu8XHgf1Pt14ogGyOaJqvdEGbBGrsw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/element": "^2.9.0",
+            "@wordpress/is-shallow-equal": "^1.6.1",
+            "lodash": "^4.17.15"
+          }
+        },
+        "@wordpress/data": {
+          "version": "4.10.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.10.0.tgz",
+          "integrity": "sha512-MDab2ePxLDkBJQ/Dxw1oYHpRGEmDzublBgo5ShTEhfPu14zj5fJhq2mnO7uH3A7s93/a2ZyjSn4h2fc8QJvb6w==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/compose": "^3.8.0",
+            "@wordpress/deprecated": "^2.6.1",
+            "@wordpress/element": "^2.9.0",
+            "@wordpress/is-shallow-equal": "^1.6.1",
+            "@wordpress/priority-queue": "^1.3.1",
+            "@wordpress/redux-routine": "^3.6.2",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^2.1.0",
+            "lodash": "^4.17.15",
+            "redux": "^4.0.0",
+            "turbo-combine-reducers": "^1.0.2"
+          }
+        },
+        "@wordpress/dom": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.6.0.tgz",
+          "integrity": "sha512-ERti77Y7Y0Oix7jfvIvBRX6Jx7hTvg6k6ke6LmeuMo+V7g5abmNEHLU4tL/dGSLNw9/SShStTIPu9Vg2IL44WA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "lodash": "^4.17.15"
+          }
+        },
+        "@wordpress/element": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.9.0.tgz",
+          "integrity": "sha512-IohEi9EkT+jnZof35l5PxDAHaBZXOcZzFS14B4cBt1eKFjbd5C54b8lHbifaL8b82S26ggMdA44sEoXVutdC0g==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/escape-html": "^1.6.0",
+            "lodash": "^4.17.15",
+            "react": "^16.9.0",
+            "react-dom": "^16.9.0"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.6.0.tgz",
+          "integrity": "sha512-PD4fEg7qIB2l8+buuRmYJ5edQhvUzydu6XoCigV2G4rju3BI+MO57BcEZf1LSPfbrYqTJCca3ElNW9nNbSQthQ==",
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.7.0.tgz",
+          "integrity": "sha512-yavu3yAKbSkEosQvEd0lCa064SdFFb8i6f7RfZGDq/TQfJHBaJQvRA4Hd/CtrOXqS6DLjw2rLNrVG4XcJFss1A==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.15",
+            "memize": "^1.0.5",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.1.0"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.7.0.tgz",
+          "integrity": "sha512-FPOFKSPY5WrvQuNr1l/WYn/ey+NoRO+RKQTlGR2EgpfWonqVGpV+CfEVyvgPVj8BBVcQHVDJYGkNEKDsoZ5l+g==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/i18n": "^3.7.0",
+            "lodash": "^4.17.15"
+          }
+        },
+        "@wordpress/rich-text": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.8.0.tgz",
+          "integrity": "sha512-vvPNCq15g7FnS3/vT2n6F0efo32fmlEZWjgDA23mmUWyTXcMx0zPchCfRU7qGVrUm8Ht7wdKUilDkF7oMLt8Cg==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/compose": "^3.8.0",
+            "@wordpress/data": "^4.10.0",
+            "@wordpress/deprecated": "^2.6.1",
+            "@wordpress/element": "^2.9.0",
+            "@wordpress/escape-html": "^1.6.0",
+            "@wordpress/hooks": "^2.6.0",
+            "@wordpress/is-shallow-equal": "^1.6.1",
+            "@wordpress/keycodes": "^2.7.0",
+            "classnames": "^2.2.5",
+            "lodash": "^4.17.15",
+            "memize": "^1.0.5",
+            "rememo": "^3.0.0"
+          }
+        }
       }
     },
     "@wordpress/compose": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@fresh-data/framework": "0.6.1",
     "@wordpress/api-fetch": "2.2.8",
-    "@wordpress/components": "8.3.1",
+    "@wordpress/components": "8.4.0",
     "@wordpress/data": "4.9.1",
     "@wordpress/date": "3.5.0",
     "@wordpress/element": "2.8.1",
@@ -118,6 +118,7 @@
     "@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
     "@wordpress/babel-plugin-makepot": "2.1.3",
     "@wordpress/babel-preset-default": "3.0.2",
+    "@wordpress/base-styles": "^1.0.0",
     "@wordpress/browserslist-config": "2.6.0",
     "@wordpress/custom-templated-path-webpack-plugin": "1.5.0",
     "@wordpress/jest-preset-default": "5.1.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,7 +26,7 @@
     "@woocommerce/currency": "1.1.1",
     "@woocommerce/date": "1.0.7",
     "@woocommerce/navigation": "2.1.0",
-    "@wordpress/components": "8.3.1",
+    "@wordpress/components": "8.4.0",
     "@wordpress/compose": "3.7.1",
     "@wordpress/date": "3.5.0",
     "@wordpress/element": "2.8.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -144,6 +144,12 @@ const webpackConfig = {
 						query: {
 							includePaths: [ 'client/stylesheets/abstracts' ],
 							data:
+								'@import "node_modules/@wordpress/base-styles/_colors.scss"; ' +
+								'@import "node_modules/@wordpress/base-styles/_variables.scss"; ' +
+								'@import "node_modules/@wordpress/base-styles/_mixins.scss"; ' +
+								'@import "node_modules/@wordpress/base-styles/_breakpoints.scss"; ' +
+								'@import "node_modules/@wordpress/base-styles/_animations.scss"; ' +
+								'@import "node_modules/@wordpress/base-styles/_z-index.scss"; ' +
 								'@import "_colors"; ' +
 								'@import "_variables"; ' +
 								'@import "_breakpoints"; ' +


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3120

https://github.com/woocommerce/woocommerce-admin/pull/3253 removed enqueued styles for Gutenberg components since we were bundling those components anyways.

This PR adds those styles back explicitly. They are also run through our post-css process so variables needed to be added. Since the [Base Styles](https://github.com/WordPress/gutenberg/tree/master/packages/base-styles) package is out, we can simply use import those variables and remove the ones we copy/pasted.

### Detailed test instructions:

1. Use the app and ensure no styles look off.

