### PR TITLE
Settings: Persist date range selection

### DIFF
--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -148,6 +148,7 @@ class Settings extends Component {
 		// TODO: remove this optimistic set of isDirty to false once #2541 is resolved.
 		this.setState( { saving: true, isDirty: false } );
 
+		// On save, reset persisted query properties of Nav Menu links to default
 		query.period = undefined;
 		query.compare = undefined;
 		query.before = undefined;

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -117,13 +117,13 @@ class Settings extends Component {
 	 * @param {object} state - State
 	 */
 	persistChanges( state ) {
-		const settings = getSetting( 'wcAdminSetting', {} );
+		const settings = getSetting( 'wcAdminSettings', {} );
 		analyticsSettings.forEach( setting => {
 			const updatedValue = state.settings[ setting.name ];
 			settings[ setting.name ] = updatedValue;
 			setting.initialValue = updatedValue;
 		} );
-		setSetting( 'wcAdminSetting', settings );
+		setSetting( 'wcAdminSettings', settings );
 	}
 
 	saveChanges = source => {

--- a/client/analytics/settings/index.js
+++ b/client/analytics/settings/index.js
@@ -128,6 +128,7 @@ class Settings extends Component {
 
 	saveChanges = source => {
 		const { settings } = this.state;
+		const { query } = this.props;
 		this.persistChanges( this.state );
 		this.props.updateSettings( { wc_admin: settings } );
 
@@ -146,6 +147,14 @@ class Settings extends Component {
 
 		// TODO: remove this optimistic set of isDirty to false once #2541 is resolved.
 		this.setState( { saving: true, isDirty: false } );
+
+		query.period = undefined;
+		query.compare = undefined;
+		query.before = undefined;
+		query.after = undefined;
+		query.interval = undefined;
+		query.type = undefined;
+		window.wpNavMenuUrlUpdate( query );
 	};
 
 	handleInputChange( e ) {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -115,7 +115,7 @@ export class Controller extends Component {
 		const { url, params } = match;
 		const query = this.getQuery( location.search );
 
-		window.wpNavMenuUrlUpdate( page, query );
+		window.wpNavMenuUrlUpdate( query );
 		window.wpNavMenuClassChange( page, url );
 		return createElement( page.container, { params, path: url, pathMatch: page.path, query } );
 	}
@@ -154,7 +154,7 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 }
 
 // Update's wc-admin links in wp-admin menu
-window.wpNavMenuUrlUpdate = function( page, query ) {
+window.wpNavMenuUrlUpdate = function( query ) {
 	const excludedScreens = applyFilters( TIME_EXCLUDED_SCREENS_FILTER, [
 		'devdocs',
 		'stock',


### PR DESCRIPTION
Date range selections were not getting persisted on the global settings object due to a typo. The sidebar links were also not getting reset to defaults on save either.

### Screenshots

### Detailed test instructions:

1. Revenue Report > change the date range to something other than default
2. Go to Settings screen and confirm the selected date range is reflected in the Report links
3. Change the default date range and save
4. Confirm the sidebar links have no query parameters reflecting default date selections
5. Click on a Report and confirm the default is actually showing up in the report.

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
