### PR TITLE
Update onboarding filters with a consistent prefix

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -255,7 +255,7 @@ export default compose(
 			const profileItems = getProfileItems();
 			const tasks = getTasks( {
 				profileItems,
-				options: getOptions( [ 'woocommerce_onboarding_payments' ] ),
+				options: getOptions( [ 'woocommerce_task_list_payments' ] ),
 				query: props.query,
 			} );
 			const visibleTasks = filter( tasks, task => task.visible );

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -276,7 +276,7 @@ export default compose(
 
 		const tasks = getTasks( {
 			profileItems,
-			options: getOptions( [ 'woocommerce_onboarding_payments' ] ),
+			options: getOptions( [ 'woocommerce_task_list_payments' ] ),
 			query: props.query,
 		} );
 

--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -43,7 +43,7 @@ export function getTasks( { profileItems, options, query } ) {
 
 	const paymentsCompleted = get(
 		options,
-		[ 'woocommerce_onboarding_payments', 'completed' ],
+		[ 'woocommerce_task_list_payments', 'completed' ],
 		false
 	);
 

--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -125,5 +125,5 @@ export function getTasks( { profileItems, options, query } ) {
 		},
 	];
 
-	return applyFilters( 'woocommerce_onboarding_task_list', tasks, query );
+	return applyFilters( 'woocommerce_admin_onboarding_task_list', tasks, query );
 }

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -90,7 +90,7 @@ class Payments extends Component {
 
 	completeTask() {
 		this.props.updateOptions( {
-			[ 'woocommerce_onboarding_payments' ]: {
+			[ 'woocommerce_task_list_payments' ]: {
 				completed: 1,
 			},
 		} );
@@ -139,7 +139,7 @@ class Payments extends Component {
 	completePluginInstall() {
 		const { completed } = this.props;
 		this.props.updateOptions( {
-			[ 'woocommerce_onboarding_payments' ]: {
+			[ 'woocommerce_task_list_payments' ]: {
 				completed: completed || false,
 				installed: 1,
 				methods: this.getMethodsToConfigure(),
@@ -155,8 +155,8 @@ class Payments extends Component {
 		const { options, methods, configured } = this.props;
 		configured.push( method );
 		this.props.updateOptions( {
-			[ 'woocommerce_onboarding_payments' ]: {
-				...options.woocommerce_onboarding_payments,
+			[ 'woocommerce_task_list_payments' ]: {
+				...options.woocommerce_task_list_payments,
 				configured,
 			},
 		} );
@@ -283,10 +283,10 @@ class Payments extends Component {
 		const { options } = this.props;
 		if (
 			options &&
-			options.woocommerce_onboarding_payments &&
-			options.woocommerce_onboarding_payments.methods
+			options.woocommerce_task_list_payments &&
+			options.woocommerce_task_list_payments.methods
 		) {
-			return options.woocommerce_onboarding_payments.methods;
+			return options.woocommerce_task_list_payments.methods;
 		}
 
 		const { values } = this.formData;
@@ -492,16 +492,16 @@ export default compose(
 		);
 
 		const options = getOptions( [
-			'woocommerce_onboarding_payments',
+			'woocommerce_task_list_payments',
 			'woocommerce_default_country',
 		] );
 		const countryCode = getCountryCode( options.woocommerce_default_country );
 
-		const methods = get( options, [ 'woocommerce_onboarding_payments', 'methods' ], [] );
-		const installed = get( options, [ 'woocommerce_onboarding_payments', 'installed' ], false );
-		const configured = get( options, [ 'woocommerce_onboarding_payments', 'configured' ], [] );
+		const methods = get( options, [ 'woocommerce_task_list_payments', 'methods' ], [] );
+		const installed = get( options, [ 'woocommerce_task_list_payments', 'installed' ], false );
+		const configured = get( options, [ 'woocommerce_task_list_payments', 'configured' ], [] );
 
-		const completed = get( options, [ 'woocommerce_onboarding_payments', 'completed' ], false );
+		const completed = get( options, [ 'woocommerce_task_list_payments', 'completed' ], false );
 
 		return {
 			countryCode,

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -69,9 +69,9 @@ const Task = () => {
 };
 
 /**
- * Use the 'woocommerce_onboarding_task_list' filter to add a task page.
+ * Use the 'woocommerce_admin_onboarding_task_list' filter to add a task page.
  */
-addFilter( 'woocommerce_onboarding_task_list', 'plugin-domain', tasks => {
+addFilter( 'woocommerce_admin_onboarding_task_list', 'plugin-domain', tasks => {
 	return [
 		...tasks,
 		{

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -21,9 +21,9 @@ You can also set the following configuration flag in your `wp-config.php`:
 
 To power the new onboarding flow client side, new REST API endpoints have been introduced. These are purpose built endpoints that exist under the `/wc-admin/onboarding/` namespace, and are not meant to be shipped in the core rest API package. The source is stored in `src/API/OnboardingPlugins.php`, `src/API/OnboardingProfile.php`, and `src/API/OnboardingTasks.php` respectively.
 
-* POST `/wc-admin/onboarding/plugins/install` - Installs a requested plugin, if present in the `woocommerce_onboarding_plugins_whitelist` array.
+* POST `/wc-admin/onboarding/plugins/install` - Installs a requested plugin, if present in the `woocommerce_admin_onboarding_plugins_whitelist` array.
 * GET `/wc-admin/onboarding/plugins/active` - Returns a list of the currently active plugins.
-* POST `/wc-admin/onboarding/plugins/activate` - Activates the requested plugins,  if present in the `woocommerce_onboarding_plugins_whitelist` array. Multiple plugins can be passed to activate at once.
+* POST `/wc-admin/onboarding/plugins/activate` - Activates the requested plugins,  if present in the `woocommerce_admin_onboarding_plugins_whitelist` array. Multiple plugins can be passed to activate at once.
 * GET `/wc-admin/onboarding/plugins/connect-jetpack` - Generates a URL for connecting to Jetpack. A `redirect_url` is accepted, which is used upon a successful connection.
 * POST `/wc-admin/onboarding/plugins/request-wccom-connect` - Generates a URL for the WooCommerce.com connection process.
 * POST `/wc-admin/onboarding/plugins/finish-wccom-connect` - Finishes the WooCommerce.com connection process by storing the received access token.
@@ -37,18 +37,17 @@ To power the new onboarding flow client side, new REST API endpoints have been i
 
 ## Onboarding filters
 
-* `woocommerce_onboarding_profile_properties` filters the properties we track as part of the profile wizard (such as information from store/business details steps). When the `completed` property is set to true, the profile wizard is completely dismissed and hidden.
-* `woocommerce_rest_onboarding_profile_object_query` filters the query arguments for requests to `/wc-admin/onboarding/profile`.
-* `woocommerce_rest_prepare_onboarding_profile` filters the response for requests to `/wc-admin/onboarding/profile`.
-* `rest_onboarding_profile_collection_params` filters the collection parameters for requests to  `/wc-admin/onboarding/profile`.
+* `woocommerce_admin_onboarding_profile_properties` filters the properties we track as part of the profile wizard (such as information from store/business details steps). When the `completed` property is set to true, the profile wizard is completely dismissed and hidden.
 * `woocommerce_admin_onboarding_industries` filters the list of allowed industries displayed in the profile wizard.
 * `woocommerce_admin_onboarding_industry_image` filters the images used for homepage templates in the appearance task. When creating a homepage, example images are used based on industry. These images are stored in `images/onboarding`.
 * `woocommerce_admin_onboarding_product_types` filters the product types displayed in the profile wizard.
-* `woocommerce_onboarding_plugins_whitelist` filters the list of plugins that can installed & activated via onboarding. This acts as a whitelist so only certain plugins can be used via the `/wc-admin/onboarding/profile/install` and `/wc-admin/onboarding/profile/activate` endpoints.
+* `woocommerce_admin_onboarding_plugins_whitelist` filters the list of plugins that can installed & activated via onboarding. This acts as a whitelist so only certain plugins can be used via the `/wc-admin/onboarding/profile/install` and `/wc-admin/onboarding/profile/activate` endpoints.
 * `woocommerce_admin_onboarding_themes` filters the themes displayed in the profile wizard.
-* `woocommerce_onboarding_jetpack_connect_redirect_url` filters the Jetpack connection redirect URL outlined in the Jetpack connection section below.
-* `woocommerce_onboarding_task_list` filters the list of tasks on the task list dashboard. This allows extensions to add new tasks. See [the extension docs](https://github.com/woocommerce/woocommerce-admin/tree/42015d17a919e8f9e54ba75869c50b04b8dc9241/docs/examples/extensions) for an example of how to do this.
-
+* `woocommerce_admin_onboarding_jetpack_connect_redirect_url` filters the Jetpack connection redirect URL outlined in the Jetpack connection section below.
+* `woocommerce_admin_onboarding_task_list` filters the list of tasks on the task list dashboard. This allows extensions to add new tasks. See [the extension docs](https://github.com/woocommerce/woocommerce-admin/tree/42015d17a919e8f9e54ba75869c50b04b8dc9241/docs/examples/extensions) for an example of how to do this.
+* `woocommerce_rest_onboarding_profile_collection_params` filters the collection parameters for requests to  `/wc-admin/onboarding/profile`.
+* `woocommerce_rest_onboarding_profile_object_query` filters the query arguments for requests to `/wc-admin/onboarding/profile`.
+* `woocommerce_rest_onboarding_prepare_onboarding_profile` filters the response for requests to `/wc-admin/onboarding/profile`.
 
 ## Options and settings
 

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -57,7 +57,7 @@ A few new WordPress options have been introduced to store information and settin
 * `woocommerce_task_list_hidden`. This option is used to conditionally show the entire task list. The task list can be hidden by the user after they have completed all tasks. Hiding the wizard stops it from showing in both full screen mode, and the collapsed inline version that shows above the dashboard analytics cards.
 * `woocommerce_task_list_welcome_modal_dismissed`. This option is used to show a congratulations modal during the transition between the profile wizard and task list.
 * `woocommerce_task_list_prompt_shown`. This option is used to conditionally show the "Is this card useful?" snackbar notice, shown once right after a user completes all the task list tasks.
-* `woocommerce_onboarding_payments`. Since the payments step requires multiple redirects to payment providers to setup accounts, we cache the current progress of the payments step in an option, so that we can quickly drop users back into the correct part of the task.
+* `woocommerce_task_list_payments`. Since the payments step requires multiple redirects to payment providers to setup accounts, we cache the current progress of the payments step in an option, so that we can quickly drop users back into the correct part of the task.
 
 We also use existing options from WooCommerce Core or extensions like WooCommerce Services or Stripe. The list below may not be complete, as new tasks are introduced, but you can generally find usage of these by searching for the [getOptions selector](https://github.com/woocommerce/woocommerce-admin/search?q=getOptions&unscoped_q=getOptions).
 

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -311,7 +311,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 			return new \WP_Error( 'woocommerce_rest_jetpack_not_active', __( 'Jetpack is not installed or active.', 'woocommerce-admin' ), 404 );
 		}
 
-		$redirect_url = apply_filters( 'woocommerce_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
+		$redirect_url = apply_filters( 'woocommerce_admin_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
 		$connect_url  = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
 
 		// @todo When implementing user-facing split testing, this should be abled to a default of 'production'.

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -192,7 +192,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		 * @param array            $item     The original item.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
-		return apply_filters( 'woocommerce_rest_prepare_onboarding_profile', $response, $item, $request );
+		return apply_filters( 'woocommerce_rest_onboarding_prepare_profile', $response, $item, $request );
 	}
 
 	/**
@@ -358,7 +358,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 		);
 
-		return apply_filters( 'woocommerce_onboarding_profile_properties', $properties );
+		return apply_filters( 'woocommerce_admin_onboarding_profile_properties', $properties );
 	}
 
 	/**
@@ -401,6 +401,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 
 		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 
-		return apply_filters( 'rest_onboarding_profile_collection_params', $params );
+		return apply_filters( 'woocommerce_rest_onboarding_profile_collection_params', $params );
 	}
 }

--- a/src/API/Options.php
+++ b/src/API/Options.php
@@ -136,7 +136,7 @@ class Options extends \WC_REST_Data_Controller {
 			'woocommerce_setup_jetpack_opted_in' => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_stripe_settings'        => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_ppec_paypal_settings'   => current_user_can( 'manage_woocommerce' ),
-			'woocommerce_onboarding_payments'    => current_user_can( 'manage_woocommerce' ),
+			'woocommerce_task_list_payments'     => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store'             => current_user_can( 'manage_woocommerce' ),
 			'woocommerce_demo_store_notice'      => current_user_can( 'manage_woocommerce' ),
 		);

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -475,7 +475,7 @@ class Onboarding {
 	 */
 	public static function get_allowed_plugins() {
 		return apply_filters(
-			'woocommerce_onboarding_plugins_whitelist',
+			'woocommerce_admin_onboarding_plugins_whitelist',
 			array(
 				'facebook-for-woocommerce'            => 'facebook-for-woocommerce/facebook-for-woocommerce.php',
 				'mailchimp-for-woocommerce'           => 'mailchimp-for-woocommerce/mailchimp-woocommerce.php',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -387,7 +387,7 @@ class Onboarding {
 		$options[] = 'wc_connect_options';
 		$options[] = 'woocommerce_task_list_welcome_modal_dismissed';
 		$options[] = 'woocommerce_task_list_prompt_shown';
-		$options[] = 'woocommerce_onboarding_payments';
+		$options[] = 'woocommerce_task_list_payments';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce_default_country';

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -123,7 +123,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		add_filter(
-			'woocommerce_onboarding_profile_properties',
+			'woocommerce_admin_onboarding_profile_properties',
 			function( $properties ) {
 				$properties['test_profile_datum'] = array(
 					'type'        => 'array',


### PR DESCRIPTION
Fixes #3288.

This PR updates the filter names used in onboarding to be more consistent. Per the short conversation in Slack ( p1574361629414700-slack-wc-admin ), General filters are prefixed with `woocommerce_admin_` and REST endpoints with `woocommerce_rest_`

### Detailed test instructions:

* Boot up the app and make sure everything looks OK.
* Bonus: Run the [add-task example extension](https://github.com/woocommerce/woocommerce-admin/tree/master/docs/examples/extensions) and make sure it works.

### Changelog Note:

Dev: Update onboarding filters with a consistent prefix