### PR TITLE
Fix checkout of master branch in CI environment.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -193,7 +193,7 @@ install_deps() {
 		git clone https://github.com/woocommerce/woocommerce-admin.git
 		cd woocommerce-admin
 		git fetch origin $BRANCH
-		git checkout -b $BRANCH origin/$BRANCH
+		git checkout -B $BRANCH origin/$BRANCH
 		# Activate the plugin
 		cd "$WP_CORE_DIR"
 		php wp-cli.phar plugin activate woocommerce-admin


### PR DESCRIPTION
Fixes `master` merge commit builds failing. See: https://travis-ci.org/woocommerce/woocommerce-admin/jobs/615647552

Use the `-B` flag in `git checkout` instead of `-b` to allow for existing branches, like `master`.