### PR TITLE
Fix error due to fallback not loading when needed for getAdminLink

### DIFF
--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -26,4 +26,7 @@ export const DEFAULT_DATE_RANGE = SOURCE.DEFAULT_DATE_RANGE;
 
 export const getSetting = SOURCE.getSetting;
 export const setSetting = SOURCE.setSetting;
-export const getAdminLink = SOURCE.getAdminLink;
+
+// this needs to be shimmed separately because WooCommerce Blocks plugin version
+// might have `SHARED.getSetting` and thus `fallbacks.js` will not get loaded.
+export const getAdminLink = SOURCE.getAdminLink || FALLBACKS.getAdminLink;


### PR DESCRIPTION
Master was broken due to `getAdminLink` being undefined in a certain environment.  Thus nothing for wc-admin would load.  

To reproduce:

- Make sure latest blocks plugin is active
- Load wc-admin and 💥 

The file `client/settings/index.js` loads fallback shims that it uses (for back-compat) when the expected shared settings is not available in the environment.  However, in the WooCommerce Blocks 2.5.0 (or master) environment, the check on line 16 does not shim the fallbacks because 2.5.0 has the shared settings in the environment:

```js
const SOURCE = ! SHARED || typeof SHARED.getSetting === 'undefined' ? FALLBACKS : SHARED;
```

Yet, the shared settings do _not_ yet have `getAdminLink` defined (which is coming with https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1244).  This pull fixes that so we _always_ use the fallback for that particular function if it's not present in `SOURCE`.
