### PR TITLE
DB Updates: invalidate cache after update

### DIFF
--- a/src/Install.php
+++ b/src/Install.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\API\Reports\Cache;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Historical_Data;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Welcome_Message;
 
@@ -352,6 +353,7 @@ class Install {
 							array( $update_callback ),
 							'woocommerce-db-updates'
 						);
+						Cache::invalidate();
 					}
 
 					$loop++;


### PR DESCRIPTION
After running a database update, I noticed data was being served from a cache because no new or updated orders were made. So I think its a good idea to invalidate our caches when a database update is about to run. 

### Detailed test instructions:

This one is hard to test. You can try forcing an update and seeing that no errors are produced.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
