### PR TITLE
Use report filters with tracking, not one from packages

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -12,7 +12,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { H, ReportFilters } from '@woocommerce/components';
+import { H } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ import TaskList from './task-list';
 import { getTasks } from './task-list/tasks';
 import { isOnboardingEnabled } from 'dashboard/utils';
 import { getCurrentDates, getDateParamsFromQuery, isoDateFormat } from 'lib/date';
+import ReportFilters from 'analytics/components/report-filters';
 
 class CustomizableDashboard extends Component {
 	constructor( props ) {
@@ -226,7 +227,13 @@ class CustomizableDashboard extends Component {
 					! taskListHidden &&
 					taskListCompleted && <TaskList query={ query } inline /> }
 
-				<ReportFilters query={ query } path={ path } dateQuery={ dateQuery } isoDateFormat={ isoDateFormat } />
+				<ReportFilters
+					report="dashboard"
+					query={ query }
+					path={ path }
+					dateQuery={ dateQuery }
+					isoDateFormat={ isoDateFormat }
+				/>
 				{ sections.map( ( section, index ) => {
 					if ( section.isVisible ) {
 						return (


### PR DESCRIPTION
Fixes a React proptype warning

![Screen Shot 2019-11-27 at 4 51 49 PM](https://user-images.githubusercontent.com/1922453/69692766-ee78f780-1137-11ea-84ba-a5f7b31d1358.png)

And also introduces tracking for the datepicker on the Dashboard.

### Detailed test instructions:

1. Go to the Dashboard and check that no React warning appear.
2. If you have the debug log set, you can see a Tracks event fire with a change to the date range.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
