### PR TITLE
Include out of stock products in low_in_stock product filter

### DIFF
--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -168,7 +168,7 @@ class Products extends \WC_REST_Products_Controller {
 			$low_stock_amount = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 			$where           .= "
 			AND wc_product_meta_lookup.stock_quantity IS NOT NULL
-			AND wc_product_meta_lookup.stock_status = 'instock'
+			AND wc_product_meta_lookup.stock_status IN('instock','outofstock')
 			AND (
 				(
 					low_stock_amount_meta.meta_value > ''


### PR DESCRIPTION
Fixes #2466

Adds out of stock products to the `low_in_stock` filter for products (not the stock API).

**Question:** Will the `low_in_stock` filter naming be potentially confusing since this only reports items low in stock and not out of stock in the stock API?  We could potentially change this to `needs_stocking` or `below_stock_threshold` of this to avoid confusion.

### Screenshots
<img width="515" alt="Screen Shot 2019-11-27 at 1 27 21 PM" src="https://user-images.githubusercontent.com/10561050/69696150-be226080-1119-11ea-873d-1fea223f227a.png">

### Detailed test instructions:

1. Create at least 3 products: one with adequate stock, one with stock but below the low stock threshold, and one that has 0 or less stock.

### Changelog Note:

Fix: Add out of stock products to the activity panel "Stock" tab.