### PR TITLE
Check if extended_info is set for order report items

### DIFF
--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -497,9 +497,9 @@ class Controller extends ReportsController implements ExportableInterface {
 			'order_number'   => $item['order_number'],
 			'status'         => $item['status'],
 			'customer_type'  => $item['customer_type'],
-			'products'       => $this->_get_products( $item['extended_info']['products'] ),
+			'products'       => isset( $item['extended_info']['products'] ) ? $this->_get_products( $item['extended_info']['products'] ) : null,
 			'num_items_sold' => $item['num_items_sold'],
-			'coupons'        => $this->_get_coupons( $item['extended_info']['coupons'] ),
+			'coupons'        => isset( $item['extended_info']['coupons'] ) ? $this->_get_coupons( $item['extended_info']['coupons'] ) : null,
 			'net_total'      => $item['net_total'],
 		);
 	}


### PR DESCRIPTION
Fixes #3314

Checks for existence of `extended_info` properties before setting the column values.

### Screenshots
<img width="282" alt="Screen Shot 2019-11-28 at 1 44 53 PM" src="https://user-images.githubusercontent.com/10561050/69781091-06a84f80-11e8-11ea-873e-a71215c3dbe7.png">

### Detailed test instructions:

1. Make sure `WP_DEBUG_LOG` is enabled.
2. Create some refunds.
3. Export an order via the REST API (post to `wp-json/wc-analytics/reports/orders/export?email=true`)
4. Make sure no warnings or errors exist.