### PR TITLE
Onboarding: Format product count ranges numbers without decimals

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -139,18 +139,18 @@ class BusinessDetails extends Component {
 		return keys( pickBy( values ) ).filter( name => this.extensions.includes( name ) );
 	}
 
-	getNumberRangeString( min, max = false, format = formatValue ) {
+	getNumberRangeString( min, max = false ) {
 		if ( ! max ) {
 			return sprintf(
 				_x( '%s+', 'store product count or revenue', 'woocommerce-admin' ),
-				format( 'number', min )
+				formatValue( 'number', min )
 			);
 		}
 
 		return sprintf(
 			_x( '%1$s - %2$s', 'store product count or revenue range', 'woocommerce-admin' ),
-			format( 'number', min ),
-			format( 'number', max )
+			formatValue( 'number', min ),
+			formatValue( 'number', max )
 		);
 	}
 

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -13,7 +13,7 @@ import { keys, get, pickBy } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { numberFormat } from 'lib/number-format';
+import { formatValue } from 'lib/number-format';
 import { getSetting, CURRENCY as currency } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -139,18 +139,18 @@ class BusinessDetails extends Component {
 		return keys( pickBy( values ) ).filter( name => this.extensions.includes( name ) );
 	}
 
-	getNumberRangeString( min, max = false, format = numberFormat ) {
+	getNumberRangeString( min, max = false, format = formatValue ) {
 		if ( ! max ) {
 			return sprintf(
 				_x( '%s+', 'store product count or revenue', 'woocommerce-admin' ),
-				format( min )
+				format( 'number', min )
 			);
 		}
 
 		return sprintf(
 			_x( '%1$s - %2$s', 'store product count or revenue range', 'woocommerce-admin' ),
-			format( min ),
-			format( max )
+			format( 'number', min ),
+			format( 'number', max )
 		);
 	}
 


### PR DESCRIPTION
Fixes #3312

Fixes a change to the product count formatting since `numberFormat()` now includes precision by default.

### Before
<img width="555" alt="Screen Shot 2019-11-27 at 9 23 24 PM" src="https://user-images.githubusercontent.com/10561050/69781598-9dc1d700-11e9-11ea-81e8-0e743a11e7ae.png">

### After
<img width="586" alt="Screen Shot 2019-11-28 at 2 13 45 PM" src="https://user-images.githubusercontent.com/10561050/69781592-9ac6e680-11e9-11ea-8e0f-26d71502dafb.png">


### Detailed test instructions:

1. Open the onboarding profiler.
2. Go to the business details step.
3. Make sure dropdown numbers are formatted as expected.