### PR TITLE
Onboarding: Allow logo to be removed via customize appearance task

### DIFF
--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -172,7 +172,7 @@ class Appearance extends Component {
 	updateLogo() {
 		const { options, themeMods, updateOptions } = this.props;
 		const { logo } = this.state;
-		const updateThemeMods = logo ? { ...themeMods, custom_logo: logo.id } : themeMods;
+		const updateThemeMods = { ...themeMods, custom_logo: logo ? logo.id : null };
 
 		recordEvent( 'tasklist_appearance_upload_logo' );
 

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -54,7 +54,11 @@ class Appearance extends Component {
 		const step = this.getSteps()[ stepIndex ].key;
 		const isRequestSuccessful = ! isRequesting && prevProps.isRequesting && ! hasErrors;
 
-		if ( themeMods && prevProps.themeMods.custom_logo !== themeMods.custom_logo ) {
+		if (
+			themeMods &&
+			themeMods.custom_logo &&
+			prevProps.themeMods.custom_logo !== themeMods.custom_logo
+		) {
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( { isPending: true } );
 			wp.media


### PR DESCRIPTION
Fixes #3322

Fixes a bug where the logo could not be removed in this task.

### Screenshots
<img width="488" alt="Screen Shot 2019-11-29 at 12 10 50 PM" src="https://user-images.githubusercontent.com/10561050/69843171-4c751e80-12a1-11ea-91ee-2cfaf10461b7.png">

### Detailed test instructions:

1. Go to the onboarding task list "Customize Appearance" task.
2. Add a logo and save if it doesn't exist.
3. Revisit the step and remove the logo and click "Proceed."
4. Refresh the page to make sure the logo was updated in theme mods and changes persist.