### PR TITLE
Onboarding: Redirect to task list after shipping step connection

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -231,6 +231,7 @@ class Shipping extends Component {
 				),
 				content: (
 					<Connect
+						redirectUrl={ getNewPath( {}, '/', {} ) }
 						completeStep={ this.completeStep }
 						{ ...this.props }
 						onConnect={ () => {

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -14,8 +14,8 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Card, Link, Stepper } from '@woocommerce/components';
+import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import { getHistory, getNewPath } from '@woocommerce/navigation';
-import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -231,7 +231,7 @@ class Shipping extends Component {
 				),
 				content: (
 					<Connect
-						redirectUrl={ getNewPath( {}, '/', {} ) }
+						redirectUrl={ getAdminLink( 'admin.php?page=wc-admin' ) }
 						completeStep={ this.completeStep }
 						{ ...this.props }
 						onConnect={ () => {

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import PropTypes from 'prop-types';
 import { withDispatch } from '@wordpress/data';
 
 /**
@@ -52,6 +53,33 @@ class Connect extends Component {
 		);
 	}
 }
+
+Connect.propTypes = {
+	/**
+	 * Method to create a displayed notice.
+	 */
+	createNotice: PropTypes.func.isRequired,
+	/**
+	 * Human readable error message.
+	 */
+	error: PropTypes.string,
+	/**
+	 * Bool to determine if the "Retry" button should be displayed.
+	 */
+	hasErrors: PropTypes.bool,
+	/**
+	 * Bool to check if the connection URL is still being requested.
+	 */
+	isRequesting: PropTypes.bool,
+	/**
+	 * Generated Jetpack connection URL.
+	 */
+	jetpackConnectUrl: PropTypes.string,
+	/**
+	 * Redirect URL to encode as a URL param for the connection path.
+	 */
+	redirectUrl: PropTypes.string,
+};
 
 export default compose(
 	withSelect( ( select, props ) => {

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -54,7 +54,7 @@ class Connect extends Component {
 }
 
 export default compose(
-	withSelect( select => {
+	withSelect( ( select, props ) => {
 		const {
 			getJetpackConnectUrl,
 			isGetJetpackConnectUrlRequesting,
@@ -62,7 +62,7 @@ export default compose(
 		} = select( 'wc-api' );
 
 		const queryArgs = {
-			redirect_url: window.location.href,
+			redirect_url: props.redirectUrl || window.location.href,
 		};
 		const isRequesting = isGetJetpackConnectUrlRequesting( queryArgs );
 		const error = getJetpackConnectUrlError( queryArgs );


### PR DESCRIPTION
Fixes #3326 

* Redirects back to the task list after connecting to a Jetpack account in the shipping step instead of redirecting back to the shipping step.
* Adds a `redirectUrl` to the `Connect` component as well as some prop info.

### Screenshots
<img width="563" alt="Screen Shot 2019-12-02 at 6 35 04 PM" src="https://user-images.githubusercontent.com/10561050/69952690-b22c0980-1532-11ea-9e57-7ce61511a1f6.png">


### Detailed test instructions:

1. Disconnect Jetpack.
2. Go to the shipping step.
3. Walk through all steps and click "Connect" on the final step.
4. Connect the account.
5. Note that you're redirected back to the task list and not the individual shipping task.