### PR TITLE
Onboarding: Update getCurrencyFormatString import to use wc-admin lib

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -14,12 +14,12 @@ import PropTypes from 'prop-types';
  * WooCommerce dependencies
  */
 import { Flag, Form, TextControl } from '@woocommerce/components';
-import { getCurrencyFormatString } from '@woocommerce/currency';
 import { CURRENCY, getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
  */
+import { getCurrencyFormatString } from 'lib/currency-format';
 import { recordEvent } from 'lib/tracks';
 
 const { symbol, symbolPosition } = CURRENCY;


### PR DESCRIPTION
Fixes #3329

Fixes the shipping task not loading on the latest build.

@msdesign21 would you mind checking to see if this PR works in your environment?  Here's the link to the release- https://github.com/woocommerce/woocommerce-admin/releases/tag/v0.22.0-onboarding-120219-plugin

### Detailed test instructions:

1. Spin up a new environment.
2. Install this build - https://github.com/woocommerce/woocommerce-admin/releases/tag/v0.22.0-onboarding-120219-plugin
3. Walk through the onboarding profiler and complete.
4. On the task list, go to the shipping step.
5. Make sure it loads and all steps work as expected.
