### PR TITLE
account for time change when calculating next day start

### DIFF
--- a/src/API/Reports/TimeInterval.php
+++ b/src/API/Reports/TimeInterval.php
@@ -304,14 +304,18 @@ class TimeInterval {
 	 * @return DateTime
 	 */
 	public static function next_day_start( $datetime, $reversed = false ) {
-		$day_increment      = $reversed ? 0 : 1;
-		$timestamp          = (int) $datetime->format( 'U' );
-		$seconds_into_day   = (int) $datetime->format( 'H' ) * HOUR_IN_SECONDS + (int) $datetime->format( 'i' ) * MINUTE_IN_SECONDS + (int) $datetime->format( 's' );
-		$next_day_timestamp = $timestamp + ( $day_increment * DAY_IN_SECONDS - $seconds_into_day );
+		$seconds_into_day = (int) $datetime->format( 'H' ) * HOUR_IN_SECONDS + (int) $datetime->format( 'i' ) * MINUTE_IN_SECONDS + (int) $datetime->format( 's' );
 
 		// The day boundary is actually next midnight when going in reverse, so set it to day -1 at 23:59:59.
 		if ( $reversed ) {
-			$next_day_timestamp --;
+			$timestamp          = (int) $datetime->format( 'U' );
+			$next_day_timestamp = $timestamp - ( $seconds_into_day + 1 );
+		} else {
+			$day_increment = new \DateInterval( 'P1D' ); // Plus 1 Day.
+			$next_datetime = clone $datetime;
+			$next_datetime->add( $day_increment );
+			$timestamp          = (int) $next_datetime->format( 'U' );
+			$next_day_timestamp = $timestamp - $seconds_into_day;
 		}
 
 		$next_day = new \DateTime();


### PR DESCRIPTION
Fixes #3270 

This PR addresses the obscure issue where switching to or from daylight savings time makes a day 23 or 25 hours long. 

In North American time zones 24 hours after `2019-11-03T00:00:00` is `2019-11-03T23:00:00`. As a result, the interval sequencing was processing Nov 3 twice, then the code to remove extra segments was removing the `2019-11-03T00:00:00` segment. The chart was calculating the position using the `2019-11-03T23:00:00`.

### Detailed test instructions:

- Set you time zone to `America/New York`
- Ensure you have an order on Nov 3, 2019
- Load the last month revenue chart in `master`
- Clear your data cache
- Check the same month with this PR

### Changelog Note:

Fix: beginning of next day calculation on daylight saving time on the days the time changes.