### PR TITLE
Add autocomplete props to address fields in onboarding and adjust country/state matching

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -86,20 +86,21 @@ export function getCountryStateAutofill( options, countryState, setValue ) {
 	useEffect(
 		() => {
 			let filteredOptions = [];
+			const countrySearch = new RegExp( escapeRegExp( autofillCountry ), 'i' );
 			if ( autofillState.length || autofillCountry.length ) {
-				const countrySearch = new RegExp(
-					escapeRegExp( autofillCountry.replace( /\s/g, '' ) ),
-					'i'
-				);
-				filteredOptions = options.filter( option =>
-					countrySearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
-				);
+				filteredOptions = options.filter( option => countrySearch.test( option.label ) );
 			}
 			if ( autofillCountry.length && autofillState.length ) {
 				const stateSearch = new RegExp( escapeRegExp( autofillState.replace( /\s/g, '' ) ), 'i' );
 				filteredOptions = filteredOptions.filter( option =>
 					stateSearch.test( option.label.replace( '-', '' ).replace( /\s/g, '' ) )
 				);
+
+				if ( filteredOptions.length > 1 ) {
+					filteredOptions = filteredOptions.filter(
+						option => countrySearch.test( option.key ) || stateSearch.test( option.key )
+					);
+				}
 			}
 			if ( 1 === filteredOptions.length && countryState !== filteredOptions[ 0 ].key ) {
 				setValue( 'countryState', filteredOptions[ 0 ].key );
@@ -117,6 +118,7 @@ export function getCountryStateAutofill( options, countryState, setValue ) {
 				type="text"
 				className="woocommerce-select-control__autofill-input"
 				tabIndex="-1"
+				autoComplete="country"
 			/>
 
 			<input
@@ -126,6 +128,7 @@ export function getCountryStateAutofill( options, countryState, setValue ) {
 				type="text"
 				className="woocommerce-select-control__autofill-input"
 				tabIndex="-1"
+				autoComplete="address-level1"
 			/>
 		</Fragment>
 	);

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -146,12 +146,14 @@ export function StoreAddress( props ) {
 			<TextControl
 				label={ __( 'Address line 1', 'woocommerce-admin' ) }
 				required
+				autoComplete="address-line1"
 				{ ...getInputProps( 'addressLine1' ) }
 			/>
 
 			<TextControl
 				label={ __( 'Address line 2 (optional)', 'woocommerce-admin' ) }
 				required
+				autoComplete="address-line2"
 				{ ...getInputProps( 'addressLine2' ) }
 			/>
 
@@ -173,11 +175,13 @@ export function StoreAddress( props ) {
 				label={ __( 'City', 'woocommerce-admin' ) }
 				required
 				{ ...getInputProps( 'city' ) }
+				autoComplete="address-level2"
 			/>
 
 			<TextControl
 				label={ __( 'Post code', 'woocommerce-admin' ) }
 				required
+				autoComplete="postal-code"
 				{ ...getInputProps( 'postCode' ) }
 			/>
 		</div>

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -97,11 +97,24 @@ export function getCountryStateAutofill( options, countryState, setValue ) {
 				);
 
 				if ( filteredOptions.length > 1 ) {
-					filteredOptions = filteredOptions.filter(
-						option => countrySearch.test( option.key ) || stateSearch.test( option.key )
-					);
+					let countryKeyOptions = [];
+					countryKeyOptions = filteredOptions.filter( option => countrySearch.test( option.key ) );
+
+					if ( countryKeyOptions.length > 0 ) {
+						filteredOptions = countryKeyOptions;
+					}
+				}
+
+				if ( filteredOptions.length > 1 ) {
+					let stateKeyOptions = [];
+					stateKeyOptions = filteredOptions.filter( option => stateSearch.test( option.key ) );
+
+					if ( 1 === stateKeyOptions.length ) {
+						filteredOptions = stateKeyOptions;
+					}
 				}
 			}
+
 			if ( 1 === filteredOptions.length && countryState !== filteredOptions[ 0 ].key ) {
 				setValue( 'countryState', filteredOptions[ 0 ].key );
 			}


### PR DESCRIPTION
From the internal testing thread:

> When using auto-fill on Chrome Address 2 was populated with the same content as Address 1.

This PR adds some autocomplete attributes to the store details page, so auto-fill knows how to use the fields.

It also adjusts the logic on the country/state autocomplete code, because I was having trouble consistently filling across Chrome & Safari. Also, if you prerefilled data was abbreviated `OH` for example instead of `Ohio`, results wouldn't always show up correctly.

### Detailed test instructions:

- Test using your browser's autofill feature. I tested in Safari & Chrome.
- Try editing your autofill data (for Safari this is in the `Contacts` app, for Chrome this is under Settings > Addresses) and use different formats for Country and State (for example US vs United States, OH vs Ohio).
