### PR TITLE
Stardardize hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,10 @@ There are a number of helper scripts exposed via our `package.json` (below list 
 
 ### Debugging synced lookup information:
 
-To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_disable_order_scheduling` hook.
+To debug synced lookup information in the database, you can bypass the action scheduler and immediately sync order and customer information by using the `woocommerce_analytics_disable_order_scheduling` hook.
 
 ```php
-add_filter( 'woocommerce_disable_order_scheduling', '__return_true' );
+add_filter( 'woocommerce_analytics_disable_order_scheduling', '__return_true' );
 ```
 
 ### Using `debug` package.

--- a/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
+++ b/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
@@ -82,21 +82,21 @@ function apply_currency_arg( $args ) {
 	return $args;
 }
 
-add_filter( 'woocommerce_reports_revenue_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_revenue_query_args', 'apply_currency_arg' );
 
-add_filter( 'woocommerce_reports_orders_query_args', 'apply_currency_arg' );
-add_filter( 'woocommerce_reports_orders_stats_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_orders_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_orders_stats_query_args', 'apply_currency_arg' );
 
-add_filter( 'woocommerce_reports_products_query_args', 'apply_currency_arg' );
-add_filter( 'woocommerce_reports_products_stats_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_products_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_products_stats_query_args', 'apply_currency_arg' );
 
-add_filter( 'woocommerce_reports_categories_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_categories_query_args', 'apply_currency_arg' );
 
-add_filter( 'woocommerce_reports_coupons_query_args', 'apply_currency_arg' );
-add_filter( 'woocommerce_reports_coupons_stats_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_coupons_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_coupons_stats_query_args', 'apply_currency_arg' );
 
-add_filter( 'woocommerce_reports_taxes_query_args', 'apply_currency_arg' );
-add_filter( 'woocommerce_reports_taxes_stats_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_taxes_query_args', 'apply_currency_arg' );
+add_filter( 'woocommerce_analytics_taxes_stats_query_args', 'apply_currency_arg' );
 
 /**
  * Add a JOIN clause.
@@ -112,23 +112,23 @@ function add_join_subquery( $clauses ) {
 	return $clauses;
 }
 
-add_filter( 'wc_admin_clauses_join_orders_subquery', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_order_stats_total', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_order_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_orders_subquery', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_order_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_order_stats_interval', 'add_join_subquery' );
 
-add_filter( 'wc_admin_clauses_join_products_subquery', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_product_stats_total', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_product_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_products_subquery', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_product_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_product_stats_interval', 'add_join_subquery' );
 
-add_filter( 'wc_admin_clauses_join_categories_subquery', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_categories_subquery', 'add_join_subquery' );
 
-add_filter( 'wc_admin_clauses_join_coupons_subquery', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_coupons_stats_total', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_coupons_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_coupons_subquery', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_coupons_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_coupons_stats_interval', 'add_join_subquery' );
 
-add_filter( 'wc_admin_clauses_join_taxes_subquery', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_tax_stats_total', 'add_join_subquery' );
-add_filter( 'wc_admin_clauses_join_tax_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_taxes_subquery', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_tax_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_tax_stats_interval', 'add_join_subquery' );
 
 /**
  * Add a WHERE clause.
@@ -147,23 +147,23 @@ function add_where_subquery( $clauses ) {
 
 	return $clauses;
 }
-add_filter( 'wc_admin_clauses_where_orders_subquery', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_order_stats_total', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_order_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_orders_subquery', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_order_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_order_stats_interval', 'add_where_subquery' );
 
-add_filter( 'wc_admin_clauses_where_products_subquery', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_product_stats_total', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_product_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_products_subquery', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_product_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_product_stats_interval', 'add_where_subquery' );
 
-add_filter( 'wc_admin_clauses_where_categories_subquery', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_categories_subquery', 'add_where_subquery' );
 
-add_filter( 'wc_admin_clauses_where_coupons_subquery', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_coupons_stats_total', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_coupons_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_coupons_subquery', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_coupons_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_coupons_stats_interval', 'add_where_subquery' );
 
-add_filter( 'wc_admin_clauses_where_taxes_subquery', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_tax_stats_total', 'add_where_subquery' );
-add_filter( 'wc_admin_clauses_where_tax_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_taxes_subquery', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_tax_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_tax_stats_interval', 'add_where_subquery' );
 
 /**
  * Add a SELECT clause.
@@ -177,20 +177,20 @@ function add_select_subquery( $clauses ) {
 	return $clauses;
 }
 
-add_filter( 'wc_admin_clauses_select_orders_subquery', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_order_stats_total', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_order_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_orders_subquery', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_order_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_order_stats_interval', 'add_select_subquery' );
 
-add_filter( 'wc_admin_clauses_select_products_subquery', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_product_stats_total', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_product_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_products_subquery', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_product_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_product_stats_interval', 'add_select_subquery' );
 
-add_filter( 'wc_admin_clauses_select_categories_subquery', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_categories_subquery', 'add_select_subquery' );
 
-add_filter( 'wc_admin_clauses_select_coupons_subquery', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_coupons_stats_total', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_coupons_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_coupons_subquery', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_coupons_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_coupons_stats_interval', 'add_select_subquery' );
 
-add_filter( 'wc_admin_clauses_select_taxes_subquery', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_tax_stats_total', 'add_select_subquery' );
-add_filter( 'wc_admin_clauses_select_tax_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_taxes_subquery', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_tax_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_tax_stats_interval', 'add_select_subquery' );

--- a/src/API/NoteActions.php
+++ b/src/API/NoteActions.php
@@ -92,7 +92,7 @@ class NoteActions extends Notes {
 		 * @param string        $name The triggered action name.
 		 * @param WC_Admin_Note $note The corresponding Note.
 		 */
-		do_action( 'woocommerce_admin_note_action', $triggered_action->name, $note );
+		do_action( 'woocommerce_note_action', $triggered_action->name, $note );
 
 		/**
 		 * Fires when an admin note action is taken.
@@ -100,7 +100,7 @@ class NoteActions extends Notes {
 		 *
 		 * @param WC_Admin_Note $note The corresponding Note.
 		 */
-		do_action( 'woocommerce_admin_note_action_' . $triggered_action->name, $note );
+		do_action( 'woocommerce_note_action_' . $triggered_action->name, $note );
 
 		// Update the note with the status for this action.
 		if ( ! empty( $triggered_action->status ) ) {

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -159,7 +159,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		 * @param array           $args    Key value array of query var to query value.
 		 * @param WP_REST_Request $request The request used.
 		 */
-		$args = apply_filters( 'woocommerce_rest_admin_notes_object_query', $args, $request );
+		$args = apply_filters( 'woocommerce_rest_notes_object_query', $args, $request );
 
 		return $args;
 	}
@@ -308,7 +308,7 @@ class Notes extends \WC_REST_CRUD_Controller {
 		 * @param array            $data The original note.
 		 * @param WP_REST_Request  $request  Request used to generate the response.
 		 */
-		return apply_filters( 'woocommerce_rest_prepare_admin_note', $response, $data, $request );
+		return apply_filters( 'woocommerce_rest_prepare_note', $response, $data, $request );
 	}
 
 	/**

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -358,7 +358,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			),
 		);
 
-		return apply_filters( 'woocommerce_admin_onboarding_profile_properties', $properties );
+		return apply_filters( 'woocommerce_rest_onboarding_profile_properties', $properties );
 	}
 
 	/**

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -270,7 +270,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $categories_data ) {
-				return new \WP_Error( 'woocommerce_reports_categories_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ), array( 'status' => 500 ) );
+				return new \WP_Error( 'woocommerce_analytics_categories_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ), array( 'status' => 500 ) );
 			}
 
 			$record_count = count( $categories_data );

--- a/src/API/Reports/Categories/Query.php
+++ b/src/API/Reports/Categories/Query.php
@@ -44,8 +44,8 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args    = apply_filters( 'woocommerce_reports_categories_query_args', $this->get_query_vars() );
+		$args    = apply_filters( 'woocommerce_analytics_categories_query_args', $this->get_query_vars() );
 		$results = \WC_Data_Store::load( self::REPORT_NAME )->get_data( $args );
-		return apply_filters( 'woocommerce_reports_categories_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_categories_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -68,7 +68,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 5 );
+		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 5 );
 		add_action( 'delete_post', array( __CLASS__, 'delete_coupon' ) );
 	}
 
@@ -379,7 +379,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			 * @param int $coupon_id Coupon ID.
 			 * @param int $order_id  Order ID.
 			 */
-			do_action( 'woocommerce_reports_update_coupon', $coupon_id, $order_id );
+			do_action( 'woocommerce_analytics_update_coupon', $coupon_id, $order_id );
 
 			// Sum the rows affected. Using REPLACE can affect 2 rows if the row already exists.
 			$num_updated += 2 === intval( $result ) ? 1 : intval( $result );
@@ -417,7 +417,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $coupon_id Coupon ID.
 		 * @param int $order_id  Order ID.
 		 */
-		do_action( 'woocommerce_reports_delete_coupon', 0, $order_id );
+		do_action( 'woocommerce_analytics_delete_coupon', 0, $order_id );
 
 		ReportsCache::invalidate();
 	}

--- a/src/API/Reports/Coupons/Query.php
+++ b/src/API/Reports/Coupons/Query.php
@@ -41,11 +41,11 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_coupons_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_coupons_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-coupons' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_coupons_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_coupons_select_query', $results, $args );
 	}
 
 }

--- a/src/API/Reports/Coupons/Stats/Query.php
+++ b/src/API/Reports/Coupons/Stats/Query.php
@@ -41,11 +41,11 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_coupons_stats_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_coupons_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-coupons-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_coupons_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_coupons_select_query', $results, $args );
 	}
 
 }

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -662,7 +662,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return false;
 		}
 
-		$customer_roles = (array) apply_filters( 'woocommerce_admin_customer_roles', array( 'customer' ) );
+		$customer_roles = (array) apply_filters( 'woocommerce_analytics_customer_roles', array( 'customer' ) );
 		if ( $customer->get_order_count() < 1 && ! in_array( $customer->get_role(), $customer_roles, true ) ) {
 			return false;
 		}

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -502,7 +502,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 *
 		 * @param int $customer_id Customer ID.
 		 */
-		do_action( 'woocommerce_reports_new_customer', $customer_id );
+		do_action( 'woocommerce_analytics_new_customer', $customer_id );
 
 		return $result ? $customer_id : false;
 	}
@@ -642,7 +642,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 *
 		 * @param int $customer_id Customer ID.
 		 */
-		do_action( 'woocommerce_reports_update_customer', $customer_id );
+		do_action( 'woocommerce_analytics_update_customer', $customer_id );
 
 		ReportsCache::invalidate();
 
@@ -686,7 +686,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 *
 		 * @param int $order_id Order ID.
 		 */
-		do_action( 'woocommerce_reports_delete_customer', $customer_id );
+		do_action( 'woocommerce_analytics_delete_customer', $customer_id );
 	}
 
 	/**

--- a/src/API/Reports/Customers/Query.php
+++ b/src/API/Reports/Customers/Query.php
@@ -48,10 +48,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_customers_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_customers_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-customers' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_customers_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_customers_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Customers/Stats/Query.php
+++ b/src/API/Reports/Customers/Stats/Query.php
@@ -48,10 +48,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_customers_stats_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_customers_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-customers-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_customers_stats_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_customers_stats_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -546,7 +546,7 @@ class DataStore extends SqlQuery {
 	protected static function get_excluded_report_order_statuses() {
 		$excluded_statuses = \WC_Admin_Settings::get_option( 'woocommerce_excluded_report_order_statuses', array( 'pending', 'failed', 'cancelled' ) );
 		$excluded_statuses = array_merge( array( 'trash' ), $excluded_statuses );
-		return apply_filters( 'woocommerce_reports_excluded_order_statuses', $excluded_statuses );
+		return apply_filters( 'woocommerce_analytics_excluded_order_statuses', $excluded_statuses );
 	}
 
 	/**

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -1190,7 +1190,7 @@ class DataStore extends SqlQuery {
 		 * @param string $field      The object type.
 		 * @param string $context    The data store context.
 		 */
-		$ids = apply_filters( 'wc_admin_reports_ ' . $field, $ids, $query_args, $field, $this->context );
+		$ids = apply_filters( 'woocommerce_analytics_ ' . $field, $ids, $query_args, $field, $this->context );
 
 		if ( ! empty( $ids ) ) {
 			$ids_str = implode( $separator, $ids );

--- a/src/API/Reports/Downloads/Query.php
+++ b/src/API/Reports/Downloads/Query.php
@@ -41,10 +41,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_downloads_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_downloads_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-downloads' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_downloads_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_downloads_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -117,7 +117,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_reports_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
 			}
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
@@ -133,7 +133,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_reports_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_downloads_stats_result_failed', __( 'Sorry, fetching downloads data failed.', 'woocommerce-admin' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/src/API/Reports/Downloads/Stats/Query.php
+++ b/src/API/Reports/Downloads/Stats/Query.php
@@ -31,10 +31,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_downloads_stats_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_downloads_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-downloads-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_downloads_stats_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_downloads_stats_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Orders/Query.php
+++ b/src/API/Reports/Orders/Query.php
@@ -36,9 +36,9 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args       = apply_filters( 'woocommerce_reports_orders_query_args', $this->get_query_vars() );
+		$args       = apply_filters( 'woocommerce_analytics_orders_query_args', $this->get_query_vars() );
 		$data_store = \WC_Data_Store::load( 'report-orders' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_orders_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_orders_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -295,7 +295,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				ARRAY_A
 			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 			if ( null === $totals ) {
-				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new WP_Error( 'woocommerce_analytics_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
 			}
 
 			// @todo Remove these assignements when refactoring segmenter classes to use query objects.
@@ -348,7 +348,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // phpcs:ignore cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
 			}
 
 			if ( isset( $intervals[0] ) ) {
@@ -510,7 +510,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 *
 		 * @param int $order_id Order ID.
 		 */
-		do_action( 'woocommerce_reports_update_order_stats', $order->get_id() );
+		do_action( 'woocommerce_analytics_update_order_stats', $order->get_id() );
 
 		// Check the rows affected for success. Using REPLACE can affect 2 rows if the row already exists.
 		return ( 1 === $result || 2 === $result );
@@ -535,7 +535,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 *
 		 * @param int $order_id Order ID.
 		 */
-		do_action( 'woocommerce_reports_delete_order_stats', $order_id );
+		do_action( 'woocommerce_analytics_delete_order_stats', $order_id );
 
 		ReportsCache::invalidate();
 	}

--- a/src/API/Reports/Orders/Stats/Query.php
+++ b/src/API/Reports/Orders/Stats/Query.php
@@ -55,10 +55,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_orders_stats_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_orders_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-orders-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_orders_stats_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_orders_stats_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -127,7 +127,7 @@ class Controller extends \WC_REST_Reports_Controller {
 		}
 
 		if ( 200 !== $response->get_status() ) {
-			return new \WP_Error( 'woocommerce_reports_performance_indicators_result_failed', __( 'Sorry, fetching performance indicators failed.', 'woocommerce-admin' ) );
+			return new \WP_Error( 'woocommerce_analytics_performance_indicators_result_failed', __( 'Sorry, fetching performance indicators failed.', 'woocommerce-admin' ) );
 		}
 
 		$endpoints     = $response->get_data();
@@ -275,7 +275,7 @@ class Controller extends \WC_REST_Reports_Controller {
 
 		$query_args = $this->prepare_reports_query( $request );
 		if ( empty( $query_args['stats'] ) ) {
-			return new \WP_Error( 'woocommerce_reports_performance_indicators_empty_query', __( 'A list of stats to query must be provided.', 'woocommerce-admin' ), 400 );
+			return new \WP_Error( 'woocommerce_analytics_performance_indicators_empty_query', __( 'A list of stats to query must be provided.', 'woocommerce-admin' ), 400 );
 		}
 
 		$stats = array();

--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -102,7 +102,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 10 );
+		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 10 );
 	}
 
 	/**
@@ -474,7 +474,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			 * @param int $order_item_id Order Item ID.
 			 * @param int $order_id      Order ID.
 			 */
-			do_action( 'woocommerce_reports_update_product', $order_item_id, $order->get_id() );
+			do_action( 'woocommerce_analytics_update_product', $order_item_id, $order->get_id() );
 
 			// Sum the rows affected. Using REPLACE can affect 2 rows if the row already exists.
 			$num_updated += 2 === intval( $result ) ? 1 : intval( $result );
@@ -513,7 +513,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $product_id Product ID.
 		 * @param int $order_id   Order ID.
 		 */
-		do_action( 'woocommerce_reports_delete_product', 0, $order_id );
+		do_action( 'woocommerce_analytics_delete_product', 0, $order_id );
 
 		ReportsCache::invalidate();
 	}

--- a/src/API/Reports/Products/Query.php
+++ b/src/API/Reports/Products/Query.php
@@ -42,10 +42,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_products_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_products_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-products' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_products_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_products_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Products/Stats/Controller.php
+++ b/src/API/Reports/Products/Stats/Controller.php
@@ -48,7 +48,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'woocommerce_reports_products_stats_select_query', array( $this, 'set_default_report_data' ) );
+		add_filter( 'woocommerce_analytics_products_stats_select_query', array( $this, 'set_default_report_data' ) );
 	}
 
 	/**

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -178,7 +178,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 			$totals[0]['segments'] = $segmenter->get_totals_segments( $totals_query, $table_name );
 
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_reports_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
 			}
 
 			$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );
@@ -194,7 +194,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_reports_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_products_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/src/API/Reports/Products/Stats/Query.php
+++ b/src/API/Reports/Products/Stats/Query.php
@@ -42,11 +42,11 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_products_stats_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_products_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-products-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_products_stats_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_products_stats_select_query', $results, $args );
 	}
 
 }

--- a/src/API/Reports/Revenue/Query.php
+++ b/src/API/Reports/Revenue/Query.php
@@ -60,10 +60,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_revenue_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-revenue-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_revenue_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_revenue_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/SqlQuery.php
+++ b/src/API/Reports/SqlQuery.php
@@ -113,13 +113,13 @@ class SqlQuery {
 		 * @param array  $clauses The original arguments for the request.
 		 * @param string $context The data store context.
 		 */
-		$clauses = apply_filters( "wc_admin_clauses_{$type}", $clauses, $this->context );
+		$clauses = apply_filters( "woocommerce_analytics_clauses_{$type}", $clauses, $this->context );
 		/**
 		 * Filter SQL clauses by type and context.
 		 *
 		 * @param array  $clauses The original arguments for the request.
 		 */
-		$clauses = apply_filters( "wc_admin_clauses_{$type}_{$this->context}", $clauses );
+		$clauses = apply_filters( "woocommerce_analytics_clauses_{$type}_{$this->context}", $clauses );
 		return implode( ' ', $clauses );
 	}
 

--- a/src/API/Reports/Stock/Stats/Query.php
+++ b/src/API/Reports/Stock/Stats/Query.php
@@ -27,6 +27,6 @@ class Query extends ReportsQuery {
 	public function get_data() {
 		$data_store = \WC_Data_Store::load( 'report-stock-stats' );
 		$results    = $data_store->get_data();
-		return apply_filters( 'woocommerce_reports_stock_stats_query', $results );
+		return apply_filters( 'woocommerce_analytics_stock_stats_query', $results );
 	}
 }

--- a/src/API/Reports/Taxes/DataStore.php
+++ b/src/API/Reports/Taxes/DataStore.php
@@ -82,7 +82,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_reports_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15 );
+		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15 );
 	}
 
 	/**
@@ -307,7 +307,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			 * @param int $tax_rate_id Tax Rate ID.
 			 * @param int $order_id    Order ID.
 			 */
-			do_action( 'woocommerce_reports_update_tax', $tax_item->get_rate_id(), $order->get_id() );
+			do_action( 'woocommerce_analytics_update_tax', $tax_item->get_rate_id(), $order->get_id() );
 
 			// Sum the rows affected. Using REPLACE can affect 2 rows if the row already exists.
 			$num_updated += 2 === intval( $result ) ? 1 : intval( $result );
@@ -332,7 +332,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		 * @param int $tax_rate_id Tax Rate ID.
 		 * @param int $order_id    Order ID.
 		 */
-		do_action( 'woocommerce_reports_delete_tax', 0, $order_id );
+		do_action( 'woocommerce_analytics_delete_tax', 0, $order_id );
 
 		ReportsCache::invalidate();
 	}

--- a/src/API/Reports/Taxes/Query.php
+++ b/src/API/Reports/Taxes/Query.php
@@ -41,10 +41,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_taxes_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_taxes_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-taxes' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_taxes_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_taxes_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Taxes/Stats/Controller.php
+++ b/src/API/Reports/Taxes/Stats/Controller.php
@@ -37,7 +37,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'woocommerce_reports_taxes_stats_select_query', array( $this, 'set_default_report_data' ) );
+		add_filter( 'woocommerce_analytics_taxes_stats_select_query', array( $this, 'set_default_report_data' ) );
 	}
 
 	/**

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -188,7 +188,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $totals ) {
-				return new \WP_Error( 'woocommerce_reports_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_taxes_stats_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce-admin' ) );
 			}
 
 			// @todo remove these assignements when refactoring segmenter classes to use query objects.
@@ -222,7 +222,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
-				return new \WP_Error( 'woocommerce_reports_taxes_stats_result_failed', __( 'Sorry, fetching tax data failed.', 'woocommerce-admin' ) );
+				return new \WP_Error( 'woocommerce_analytics_taxes_stats_result_failed', __( 'Sorry, fetching tax data failed.', 'woocommerce-admin' ) );
 			}
 
 			$totals = (object) $this->cast_numbers( $totals[0] );

--- a/src/API/Reports/Taxes/Stats/Query.php
+++ b/src/API/Reports/Taxes/Stats/Query.php
@@ -42,10 +42,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_taxes_stats_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_taxes_stats_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-taxes-stats' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_taxes_stats_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_taxes_stats_select_query', $results, $args );
 	}
 }

--- a/src/API/Reports/Variations/Query.php
+++ b/src/API/Reports/Variations/Query.php
@@ -42,10 +42,10 @@ class Query extends ReportsQuery {
 	 * @return array
 	 */
 	public function get_data() {
-		$args = apply_filters( 'woocommerce_reports_variations_query_args', $this->get_query_vars() );
+		$args = apply_filters( 'woocommerce_analytics_variations_query_args', $this->get_query_vars() );
 
 		$data_store = \WC_Data_Store::load( 'report-variations' );
 		$results    = $data_store->get_data( $args );
-		return apply_filters( 'woocommerce_reports_variations_select_query', $results, $args );
+		return apply_filters( 'woocommerce_analytics_variations_select_query', $results, $args );
 	}
 }

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -315,7 +315,7 @@ class FeaturePlugin {
 	 * @param array $features Array of feature slugs.
 	 */
 	public function replace_supported_features( $features ) {
-		$feature_config = apply_filters( 'wc_admin_get_feature_config', wc_admin_get_feature_config() );
+		$feature_config = apply_filters( 'woocommerce_admin_get_feature_config', wc_admin_get_feature_config() );
 		$features       = array_keys( array_filter( $feature_config ) );
 		return $features;
 	}

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -145,7 +145,7 @@ class Analytics {
 			),
 		);
 
-		$report_pages = apply_filters( 'woocommerce_admin_report_menu_items', $report_pages );
+		$report_pages = apply_filters( 'woocommerce_analytics_report_menu_items', $report_pages );
 
 		foreach ( $report_pages as $report_page ) {
 			if ( ! is_null( $report_page ) ) {

--- a/src/Install.php
+++ b/src/Install.php
@@ -69,7 +69,7 @@ class Install {
 		 */
 		if ( ! $version_option || $requires_update ) {
 			self::install();
-			do_action( 'wc_admin_updated' );
+			do_action( 'woocommerce_admin_updated' );
 		}
 
 		/*
@@ -108,7 +108,7 @@ class Install {
 		// Use add_option() here to avoid overwriting this value with each
 		// plugin version update. We base plugin age off of this value.
 		add_option( 'wc_admin_install_timestamp', time() );
-		do_action( 'wc_admin_installed' );
+		do_action( 'woocommerce_admin_installed' );
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -204,7 +204,7 @@ class Loader {
 	 * @todo The entry point for the embed needs moved to this class as well.
 	 */
 	public static function register_page_handler() {
-		$analytics_cap = apply_filters( 'woocommerce_admin_analytics_menu_capability', 'view_woocommerce_reports' );
+		$analytics_cap = apply_filters( 'woocommerce_analytics_menu_capability', 'view_woocommerce_reports' );
 		wc_admin_register_page(
 			array(
 				'id'         => 'woocommerce-dashboard', // Expected to be overridden if dashboard is enabled.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -855,7 +855,7 @@ class Loader {
 	 * @return array Fields to expose over the WP user endpoint.
 	 */
 	public static function get_user_data_fields() {
-		return apply_filters( 'wc_admin_get_user_data_fields', array() );
+		return apply_filters( 'woocommerce_admin_get_user_data_fields', array() );
 	}
 
 	/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -52,7 +52,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		 *
 		 * @param int $note_id Note ID.
 		 */
-		do_action( 'woocommerce_new_note', $note_id );
+		do_action( 'woocommerce_note_created', $note_id );
 	}
 
 	/**
@@ -87,7 +87,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			 *
 			 * @param int $note_id Note ID.
 			 */
-			do_action( 'woocommerce_admin_note_loaded', $note );
+			do_action( 'woocommerce_note_loaded', $note );
 		} elseif ( $note_row ) {
 			$note->set_name( $note_row->name );
 			$note->set_type( $note_row->type );
@@ -110,7 +110,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			 *
 			 * @param int $note_id Note ID.
 			 */
-			do_action( 'woocommerce_admin_note_loaded', $note );
+			do_action( 'woocommerce_note_loaded', $note );
 		} else {
 			throw new \Exception( __( 'Invalid data store for admin note.', 'woocommerce-admin' ) );
 		}
@@ -166,7 +166,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		 *
 		 * @param int $note_id Note ID.
 		 */
-		do_action( 'woocommerce_update_note', $note->get_id() );
+		do_action( 'woocommerce_note_updated', $note->get_id() );
 	}
 
 	/**
@@ -185,11 +185,11 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		}
 
 		/**
-		 * Fires when an admin note is updated.
+		 * Fires when an admin note is deleted.
 		 *
 		 * @param int $note_id Note ID.
 		 */
-		do_action( 'woocommerce_delete_note', $note_id );
+		do_action( 'woocommerce_note_deleted', $note_id );
 	}
 
 	/**
@@ -407,7 +407,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		 * @param string $where_clauses The generated WHERE clause.
 		 * @param array  $args          The original arguments for the request.
 		 */
-		return apply_filters( 'woocommerce_admin_notes_where_clauses', $where_clauses, $args );
+		return apply_filters( 'woocommerce_notes_where_clauses', $where_clauses, $args );
 	}
 
 	/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -407,7 +407,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		 * @param string $where_clauses The generated WHERE clause.
 		 * @param array  $args          The original arguments for the request.
 		 */
-		return apply_filters( 'woocommerce_notes_where_clauses', $where_clauses, $args );
+		return apply_filters( 'woocommerce_note_where_clauses', $where_clauses, $args );
 	}
 
 	/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -19,7 +19,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 * @param WC_Admin_Note $note Admin note.
 	 */
 	public function create( &$note ) {
-		$date_created = current_time( 'timestamp', 1 );
+		$date_created = time();
 		$note->set_date_created( $date_created );
 
 		global $wpdb;
@@ -257,7 +257,8 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		}
 
 		$clear_actions_query = $wpdb->prepare(
-			"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id = %d", $note->get_id()
+			"DELETE FROM {$wpdb->prefix}wc_admin_note_actions WHERE note_id = %d",
+			$note->get_id()
 		);
 
 		if ( $actions_to_keep ) {
@@ -405,7 +406,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		 * @param string $where_clauses The generated WHERE clause.
 		 * @param array  $args          The original arguments for the request.
 		 */
-		return apply_filters( 'wc_admin_notes_where_clauses', $where_clauses, $args );
+		return apply_filters( 'woocommerce_admin_notes_where_clauses', $where_clauses, $args );
 	}
 
 	/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -59,7 +59,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 	 * Method to read a note.
 	 *
 	 * @param WC_Admin_Note $note Admin note.
-	 * @throws Exception Throws exception when invalid data is found.
+	 * @throws \Exception Throws exception when invalid data is found.
 	 */
 	public function read( &$note ) {
 		global $wpdb;
@@ -265,7 +265,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$clear_actions_query .= sprintf( ' AND action_id NOT IN (%s)', implode( ',', $actions_to_keep ) );
 		}
 
-		$wpdb->query( $clear_actions_query );
+		$wpdb->query( $clear_actions_query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		// Update/insert the actions in this changeset.
 		foreach ( $changed_actions as $action ) {
@@ -324,10 +324,11 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		$where_clauses = $this->get_notes_where_clauses( $args );
 
 		$query = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"SELECT note_id, title, content FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
 			$offset,
 			$args['per_page']
-		); // WPCS: unprepared SQL ok.
+		);
 
 		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
@@ -350,7 +351,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		);
 
 		if ( ! empty( $where_clauses ) ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses}" );
 		}
 

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -123,7 +123,7 @@ class WC_Admin_Note extends \WC_Data {
 			self::E_WC_ADMIN_NOTE_INFORMATIONAL,
 		);
 
-		return apply_filters( 'woocommerce_admin_note_types', $allowed_types );
+		return apply_filters( 'woocommerce_note_types', $allowed_types );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class WC_Admin_Note extends \WC_Data {
 			self::E_WC_ADMIN_NOTE_SNOOZED,
 		);
 
-		return apply_filters( 'woocommerce_admin_note_statuses', $allowed_statuses );
+		return apply_filters( 'woocommerce_note_statuses', $allowed_statuses );
 	}
 
 

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -89,7 +89,7 @@ class PageController {
 		 *   @type boolean      js_page      If this is a JS-powered page.
 		 * }
 		 */
-		$options = apply_filters( 'wc_admin_connect_page_options', $options );
+		$options = apply_filters( 'woocommerce_navigation_connect_page_options', $options );
 
 		// @todo check for null ID, or collision.
 		$this->pages[ $options['id'] ] = $options;
@@ -147,7 +147,7 @@ class PageController {
 		// Bail if this isn't a page registered with this controller.
 		if ( false === $current_page ) {
 			// Filter documentation below.
-			return apply_filters( 'wc_admin_get_breadcrumbs', array( '' ), $current_page );
+			return apply_filters( 'woocommerce_navigation_get_breadcrumbs', array( '' ), $current_page );
 		}
 
 		if ( 1 === count( $current_page['title'] ) ) {
@@ -182,7 +182,7 @@ class PageController {
 		 * @param array         $breadcrumbs Navigation pieces (breadcrumbs).
 		 * @param array|boolean $current_page The connected page data or false if not identified.
 		 */
-		return apply_filters( 'wc_admin_get_breadcrumbs', $breadcrumbs, $current_page );
+		return apply_filters( 'woocommerce_navigation_get_breadcrumbs', $breadcrumbs, $current_page );
 	}
 
 	/**
@@ -224,7 +224,7 @@ class PageController {
 		$current_screen = get_current_screen();
 		if ( ! $current_screen ) {
 			// Filter documentation below.
-			return apply_filters( 'wc_admin_current_screen_id', false, $current_screen );
+			return apply_filters( 'woocommerce_navigation_current_screen_id', false, $current_screen );
 		}
 
 		$screen_pieces = array( $current_screen->id );
@@ -251,7 +251,7 @@ class PageController {
 
 		// Pages with default tab values.
 		$pages_with_tabs = apply_filters(
-			'wc_admin_pages_with_tabs',
+			'woocommerce_navigation_pages_with_tabs',
 			array(
 				'wc-reports'  => 'orders',
 				'wc-settings' => 'general',
@@ -265,7 +265,7 @@ class PageController {
 		$wc_email_ids = array_map( 'sanitize_title', array_keys( $wc_emails->get_emails() ) );
 
 		$tabs_with_sections = apply_filters(
-			'wc_admin_page_tab_sections',
+			'woocommerce_navigation_page_tab_sections',
 			array(
 				'products'          => array( '', 'inventory', 'downloadable' ),
 				'shipping'          => array( '', 'options', 'classes' ),
@@ -316,7 +316,7 @@ class PageController {
 		 * @param string|boolean $screen_id The screen id or false if not identified.
 		 * @param WP_Screen      $current_screen The current WP_Screen.
 		 */
-		return apply_filters( 'wc_admin_current_screen_id', implode( '-', $screen_pieces ), $current_screen );
+		return apply_filters( 'woocommerce_navigation_current_screen_id', implode( '-', $screen_pieces ), $current_screen );
 	}
 
 	/**
@@ -360,7 +360,7 @@ class PageController {
 		 * @param boolean       $is_connected_page True if the current page is connected.
 		 * @param array|boolean $current_page The connected page data or false if not identified.
 		 */
-		return apply_filters( 'woocommerce_page_is_connected_page', $is_connected_page, $current_page );
+		return apply_filters( 'woocommerce_navigation_is_connected_page', $is_connected_page, $current_page );
 	}
 
 	/**
@@ -385,7 +385,7 @@ class PageController {
 		 * @param boolean       $is_registered_page True if the current page was registered with this controller.
 		 * @param array|boolean $current_page The registered page data or false if not identified.
 		 */
-		return apply_filters( 'woocommerce_page_is_registered_page', $is_registered_page, $current_page );
+		return apply_filters( 'woocommerce_navigation_is_registered_page', $is_registered_page, $current_page );
 	}
 
 	/**

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -185,7 +185,7 @@ class ReportsSync {
 	 */
 	public static function get_import_totals( $days, $skip_existing ) {
 		$orders         = self::get_orders( 1, 1, $days, $skip_existing );
-		$customer_roles = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
+		$customer_roles = apply_filters( 'woocommerce_analytics_import_customer_roles', array( 'customer' ) );
 		$customer_query = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
@@ -286,7 +286,7 @@ class ReportsSync {
 			return;
 		}
 
-		if ( apply_filters( 'woocommerce_disable_order_scheduling', false ) ) {
+		if ( apply_filters( 'woocommerce_analytics_disable_order_scheduling', false ) ) {
 			self::orders_lookup_import_order( $order_id );
 			return;
 		}
@@ -678,7 +678,7 @@ class ReportsSync {
 	 */
 	public static function customer_lookup_import_batch_init( $days, $skip_existing ) {
 		$batch_size      = self::get_batch_size( self::CUSTOMERS_IMPORT_BATCH_ACTION );
-		$customer_roles  = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
+		$customer_roles  = apply_filters( 'woocommerce_analytics_import_customer_roles', array( 'customer' ) );
 		$customer_query  = self::get_user_ids_for_batch(
 			$days,
 			$skip_existing,
@@ -717,7 +717,7 @@ class ReportsSync {
 		);
 		wc_admin_record_tracks_event( 'import_job_start', $properties );
 
-		$customer_roles = apply_filters( 'woocommerce_admin_import_customer_roles', array( 'customer' ) );
+		$customer_roles = apply_filters( 'woocommerce_analytics_import_customer_roles', array( 'customer' ) );
 		// When we are skipping already imported customers, the table of customers to import gets smaller in
 		// every batch, so we want to always import the first page.
 		$page           = $skip_existing ? 1 : $batch_number;

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -528,7 +528,7 @@ class ReportsSync {
 		 * @param int    $batch_size Batch size.
 		 * @param string $action Batch action name.
 		 */
-		return apply_filters( 'wc_admin_report_regenerate_batch_size', $batch_size, $action );
+		return apply_filters( 'woocommerce_analytics_regenerate_batch_size', $batch_size, $action );
 	}
 
 	/**

--- a/tests/api/onboarding-profile.php
+++ b/tests/api/onboarding-profile.php
@@ -123,7 +123,7 @@ class WC_Tests_API_Onboarding_Profiles extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		add_filter(
-			'woocommerce_admin_onboarding_profile_properties',
+			'woocommerce_rest_onboarding_profile_properties',
 			function( $properties ) {
 				$properties['test_profile_datum'] = array(
 					'type'        => 'array',


### PR DESCRIPTION
Fixes #3301

*Note* The unit test issue is the `date()` calls in `ReportSync.php`. I've left those to be addressed in #3285 

Once WC Admin is merged into WC core, users and third party developers will see it as part of WooCommerce. With that in mind, this PR eliminates the use of `woocommerce_admin_` as a hook/filter prefix except plugin functions (eg. update routines) and onboarding (as WC core currently has an onboarding feature). 

At a later date when the core onboarding is eliminated we can look at renaming `woocommerce_admin_onboarding_` hooks/filters to `woocommerce_onboarding`.

This PR updates the hook/filter names as follows:

- renames `woocommerce_reports_` hook prefix with `woocommerce_analytics_`
- adds `woocommerce_navigation_` hook prefix
- updates `wc_admin_` hooks to `woocommerce_admin_` or one of the above two prefixes
- standardizes `woocommerce_note_` prefix 

### Detailed test instructions:

- Check that the dashboard and Analytics continue to function.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Dev: Standardize hook and filter prefixes.