### PR TITLE
Onboarding: Fix error if product types are missing

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -10,8 +10,8 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { getSetting } from '@woocommerce/wc-admin-settings';
-import { updateQueryString } from '@woocommerce/navigation';
+import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { getNewPath, updateQueryString } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -63,6 +63,9 @@ class Dashboard extends Component {
 		}
 
 		const productIds = this.getProductIds();
+		const backUrl = getAdminLink( getNewPath( {}, '/', {} ) );
+		const { connectNonce } = getSetting( 'onboarding', {} );
+
 		if ( ! productIds.length ) {
 			return;
 		}
@@ -70,8 +73,11 @@ class Dashboard extends Component {
 		document.body.classList.add( 'woocommerce-admin-is-loading' );
 
 		const url = addQueryArgs( 'https://woocommerce.com/cart', {
-			'wccom-back': window.location.href,
+			'wccom-site': getSetting( 'siteUrl' ),
+			'wccom-woo-version': getSetting( 'wcVersion' ),
 			'wccom-replace-with': productIds.join( ',' ),
+			'wccom-connect-nonce': connectNonce,
+			'wccom-back': backUrl,
 		} );
 		window.location = url;
 	}

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -37,13 +37,14 @@ class Dashboard extends Component {
 		const productIds = [];
 		const profileItems = get( this.props, 'profileItems', {} );
 		const onboarding = getSetting( 'onboarding', {} );
+		const productTypes = profileItems.product_types || [];
 
-		profileItems.product_types.forEach( product_type => {
+		productTypes.forEach( productType => {
 			if (
-				onboarding.productTypes[ product_type ] &&
-				onboarding.productTypes[ product_type ].product
+				onboarding.productTypes[ productType ] &&
+				onboarding.productTypes[ productType ].product
 			) {
-				productIds.push( onboarding.productTypes[ product_type ].product );
+				productIds.push( onboarding.productTypes[ productType ].product );
 			}
 		} );
 

--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -10,7 +10,7 @@ import { get } from 'lodash';
 /**
  * WooCommerce dependencies
  */
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { getSetting } from '@woocommerce/wc-admin-settings';
 import { getNewPath, updateQueryString } from '@woocommerce/navigation';
 
 /**
@@ -63,7 +63,7 @@ class Dashboard extends Component {
 		}
 
 		const productIds = this.getProductIds();
-		const backUrl = getAdminLink( getNewPath( {}, '/', {} ) );
+		const backPath = getNewPath( {}, '/', {} );
 		const { connectNonce } = getSetting( 'onboarding', {} );
 
 		if ( ! productIds.length ) {
@@ -77,7 +77,7 @@ class Dashboard extends Component {
 			'wccom-woo-version': getSetting( 'wcVersion' ),
 			'wccom-replace-with': productIds.join( ',' ),
 			'wccom-connect-nonce': connectNonce,
-			'wccom-back': backUrl,
+			'wccom-back': backPath,
 		} );
 		window.location = url;
 	}


### PR DESCRIPTION
Fixes #3330

* Fixes an error that occurs if the product types step was somehow skipped. 
* Also removes duplicated efforts to redirect to the cart if purchasable items exist.

### Detailed test instructions:

1. Delete `wc_onboarding_profile` from `wp_options`.
2. Go to the profiler/dashboard.
3. Skip to the final step without completing the others using this URL: `wp-admin/admin.php?page=wc-admin&step=theme`
4. Choose the currently installed theme.
5. Make sure no error occurs and you see the task list.
6. Delete `wc_onboarding_profile` from `wp_options`.
7. Walk through the profiler, selecting product types and/or a theme that requires purchase.
8. Make sure you’re redirected to the cart as expected.