### PR TITLE
add filter to allow WC Admin to be disabled

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -54,6 +54,15 @@ class FeaturePlugin {
 	 * Init the feature plugin, only if we can detect both Gutenberg and WooCommerce.
 	 */
 	public function init() {
+		/**
+		 * Filter allowing WooCommerce Admin to be disabled.
+		 *
+		 * @param bool $disabled False.
+		 */
+		if ( apply_filters( 'woocommerce_analytics_disabled', false ) ) {
+			return;
+		}
+
 		$this->define_constants();
 
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';


### PR DESCRIPTION
Fixes #2223

After much discussion on the topic, this PR adds a filter that allows completely disabling WooCommerce Admin.


### Detailed test instructions:

- Add the filter `add_filter( 'woocommerce_analytics_disabled', '__return_true' );`

### Changelog Note:

Tweak: Add a filter that allows disabling WooCommerce Admin.