### PR TITLE
Fix revenue question translation with currency conversion

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -141,6 +141,11 @@ class BusinessDetails extends Component {
 	}
 
 	convertCurrency( value ) {
+		const region = getCurrencyRegion( this.props.settings.woocommerce_default_country );
+		if ( 'US' === region ) {
+			return value;
+		}
+
 		// These are rough exchange rates from USD.  Precision is not paramount.
 		// The keys here should match the keys in `getCurrencyData`.
 		const exchangeRates = {
@@ -159,10 +164,11 @@ class BusinessDetails extends Component {
 			CA: 1.32,
 		};
 
-		const region = getCurrencyRegion( this.props.settings.woocommerce_default_country );
 		const exchangeRate = exchangeRates[ region ] || exchangeRates.US;
+		const digits = exchangeRate.toString().split( '.' )[ 0 ].length;
+		const multiplier = Math.pow( 10, 2 + digits );
 
-		return Math.round( value * exchangeRate / 1000 ) * 1000;
+		return Math.round( value * exchangeRate / multiplier ) * multiplier;
 	}
 
 	numberFormat( value ) {

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -24,6 +24,7 @@ import { recordEvent } from 'lib/tracks';
 import { formatCurrency } from 'lib/currency-format';
 import Plugins from 'dashboard/task-list/tasks/steps/plugins';
 import { pluginNames } from 'wc-api/onboarding/constants';
+import { getCurrencyRegion } from 'dashboard/utils';
 
 const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
 
@@ -139,18 +140,47 @@ class BusinessDetails extends Component {
 		return keys( pickBy( values ) ).filter( name => this.extensions.includes( name ) );
 	}
 
-	getNumberRangeString( min, max = false ) {
+	convertCurrency( value ) {
+		// These are rough exchange rates from USD.  Precision is not paramount.
+		// The keys here should match the keys in `getCurrencyData`.
+		const exchangeRates = {
+			US: 1,
+			EU: 0.9,
+			IN: 71.24,
+			GB: 0.76,
+			BR: 4.19,
+			VN: 23172.5,
+			ID: 14031.0,
+			BD: 84.87,
+			PK: 154.8,
+			RU: 63.74,
+			TR: 5.75,
+			MX: 19.37,
+			CA: 1.32,
+		};
+
+		const region = getCurrencyRegion( this.props.settings.woocommerce_default_country );
+		const exchangeRate = exchangeRates[ region ] || exchangeRates.US;
+
+		return Math.round( value * exchangeRate / 1000 ) * 1000;
+	}
+
+	numberFormat( value ) {
+		return formatValue( 'number', value );
+	}
+
+	getNumberRangeString( min, max = false, format = this.numberFormat ) {
 		if ( ! max ) {
 			return sprintf(
 				_x( '%s+', 'store product count or revenue', 'woocommerce-admin' ),
-				formatValue( 'number', min )
+				format( min )
 			);
 		}
 
 		return sprintf(
 			_x( '%1$s - %2$s', 'store product count or revenue range', 'woocommerce-admin' ),
-			formatValue( 'number', min ),
-			formatValue( 'number', max )
+			format( min ),
+			format( max )
 		);
 	}
 
@@ -287,27 +317,39 @@ class BusinessDetails extends Component {
 				label: sprintf(
 					/* translators: %s: A given revenue amount, e.g., $2500 */
 					__( 'Up to %s', 'woocommerce-admin' ),
-					formatCurrency( 2500 )
+					formatCurrency( this.convertCurrency( 2500 ) )
 				),
 			},
 			{
 				key: '2500-10000',
-				label: this.getNumberRangeString( 2500, 10000, formatCurrency ),
+				label: this.getNumberRangeString(
+					this.convertCurrency( 2500 ),
+					this.convertCurrency( 10000 ),
+					formatCurrency
+				),
 			},
 			{
 				key: '10000-50000',
-				label: this.getNumberRangeString( 10000, 50000, formatCurrency ),
+				label: this.getNumberRangeString(
+					this.convertCurrency( 10000 ),
+					this.convertCurrency( 50000 ),
+					formatCurrency
+				),
 			},
 			{
 				key: '50000-250000',
-				label: this.getNumberRangeString( 50000, 250000, formatCurrency ),
+				label: this.getNumberRangeString(
+					this.convertCurrency( 50000 ),
+					this.convertCurrency( 250000 ),
+					formatCurrency
+				),
 			},
 			{
 				key: 'more-than-250000',
 				label: sprintf(
 					/* translators: %s: A given revenue amount, e.g., $250000 */
 					__( 'More than %s', 'woocommerce-admin' ),
-					formatCurrency( 250000 )
+					formatCurrency( this.convertCurrency( 250000 ) )
 				),
 			},
 		];
@@ -440,11 +482,14 @@ class BusinessDetails extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getProfileItems, getProfileItemsError } = select( 'wc-api' );
+		const { getProfileItems, getProfileItemsError, getSettings } = select( 'wc-api' );
+
+		const settings = getSettings( 'general' );
 
 		return {
 			isError: Boolean( getProfileItemsError() ),
 			profileItems: getProfileItems(),
+			settings,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -9,12 +9,11 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { recordEvent } from 'lib/tracks';
-import { without, get } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WooCommerce dependencies
  */
-import { getSetting } from '@woocommerce/wc-admin-settings';
 import { H, Card, Form } from '@woocommerce/components';
 import { getCurrencyData } from '@woocommerce/currency';
 
@@ -22,7 +21,7 @@ import { getCurrencyData } from '@woocommerce/currency';
  * Internal dependencies
  */
 import { setCurrency } from 'lib/currency-format';
-import { getCountryCode } from 'dashboard/utils';
+import { getCountryCode, getCurrencyRegion } from 'dashboard/utils';
 import {
 	StoreAddress,
 	validateStoreAddress,
@@ -68,15 +67,7 @@ class StoreDetails extends Component {
 			return null;
 		}
 
-		let region = getCountryCode( countryState );
-		const euCountries = without(
-			getSetting( 'onboarding', { euCountries: [] } ).euCountries,
-			'GB'
-		);
-		if ( euCountries.includes( region ) ) {
-			region = 'EU';
-		}
-
+		const region = getCurrencyRegion( countryState );
 		const currencyData = getCurrencyData();
 		return currencyData[ region ] || currencyData.US;
 	}

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -1,8 +1,13 @@
 /** @format */
+
+/**
+ * External dependencies
+ */
+import { without } from 'lodash';
+
 /**
  * Internal dependencies
  */
-
 import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -19,6 +24,16 @@ export function getCountryCode( countryState ) {
 	}
 
 	return countryState.split( ':' )[ 0 ];
+}
+
+export function getCurrencyRegion( countryState ) {
+	let region = getCountryCode( countryState );
+	const euCountries = without( getSetting( 'onboarding', { euCountries: [] } ).euCountries, 'GB' );
+	if ( euCountries.includes( region ) ) {
+		region = 'EU';
+	}
+
+	return region;
 }
 
 /**

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -127,6 +127,7 @@ export default class Currency {
 /**
  * Returns currency data by country/region. Contains code, symbol, position, thousands separator, decimal separator, and precision.
  *
+ * Dev Note: When adding new currencies below, the exchange rate array should also be updated in WooCommerce Admin's `business-details.js`.
  * @format
  * @return {object} Curreny data.
  */


### PR DESCRIPTION
Closes #2768.

This PR implements @joshuatf's idea for solving the revenue translation issue:

> My current thought is that if we really want to solve this we can go back to getting a rough range based on the currency. Since @justinshreve has added currency data for the most commonly selected countries, we could create an exchange rate value which we can then round to the nearest nth number.

I didn't end up storing the exchange rates with the rest of the currency info. That info is in an exportable public currency package, and I worry about the rates getting used the wrong way if we expose them there. They are meant to be rough and not useful in most situations, so I opted to just include them in the conversion function, inside the dashboard.

### Screenshots

France:

<img width="552" alt="Screen Shot 2019-12-05 at 12 36 35 PM" src="https://user-images.githubusercontent.com/689165/70259397-154cb480-175c-11ea-86be-82502f32c4a1.png">

United States:

<img width="690" alt="Screen Shot 2019-12-05 at 12 36 03 PM" src="https://user-images.githubusercontent.com/689165/70259410-1da4ef80-175c-11ea-8be7-3dd7a30a82aa.png">

### Detailed test instructions:

* Enable the profile wizard, and select a non-US country. We currently only set smart currency defaults for the top countries + EU, so select one of the following regions: https://github.com/woocommerce/woocommerce-admin/blob/master/packages/currency/src/index.js#L133
* Continue through to the business details page, and expose the revenue question (Yes, I'm currently selling elsewhere).
* Confirm that the revenue question has been translated and converted to use a rough range in the correct currency.