### PR TITLE
make report filter date props optional

### DIFF
--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -183,11 +183,11 @@ ReportFilters.propTypes = {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,
 		} ).isRequired,
-	} ).isRequired,
+	} ),
 	/**
 	 * ISO date format string.
 	 */
-	isoDateFormat: PropTypes.string.isRequired,
+	isoDateFormat: PropTypes.string,
 };
 
 ReportFilters.defaultProps = {


### PR DESCRIPTION
While looking at https://github.com/woocommerce/action-scheduler-admin/pull/19 I was seeing React warnings that the date properties were not being provided. The AS Admin screen has the date picker disabled https://github.com/woocommerce/action-scheduler-admin/blob/master/js/src/as-report.js#L21. We shouldn't require the date props while having the date range selector optional.

### Detailed test instructions:

- This can be tested with the AS Admin plugin which doesn't pass either of the date related props.
- Use https://github.com/woocommerce/action-scheduler-admin/pull/19
- Verify that sorting & filter changes work without generating any console warnings or errors.

### Changelog Note:

Fix: make report filter date props optional