### PR TITLE
Add/disable plugin filter

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -59,7 +59,7 @@ class FeaturePlugin {
 		 *
 		 * @param bool $disabled False.
 		 */
-		if ( apply_filters( 'woocommerce_analytics_disabled', false ) ) {
+		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
 			return;
 		}
 

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -54,6 +54,15 @@ class FeaturePlugin {
 	 * Init the feature plugin, only if we can detect both Gutenberg and WooCommerce.
 	 */
 	public function init() {
+		/**
+		 * Filter allowing WooCommerce Admin to be disabled.
+		 *
+		 * @param bool $disabled False.
+		 */
+		if ( apply_filters( 'woocommerce_analytics_disabled', false ) ) {
+			return;
+		}
+
 		$this->define_constants();
 
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';


### PR DESCRIPTION
Follow up to #3350 

Per @justinshreve's comment, this PR updates the filter name to better represent the effect of using it.

### Detailed test instructions:

- Add the filter add_filter( 'woocommerce_admin_disabled', '__return_true' );
