### PR TITLE
Fix JS error on DevDocs

### DIFF
--- a/client/lib/date.js
+++ b/client/lib/date.js
@@ -32,14 +32,9 @@ import {
 	weekTicksThreshold,
 	defaultTableDateFormat,
 	getDateFormatsForInterval,
-	loadLocaleData,
 	dateValidationMessages,
 	validateDateInputForRange,
 } from '@woocommerce/date';
-
-// Load the store's locale.
-const localeSettings = getSetting( 'locale' );
-loadLocaleData( localeSettings );
 
 // Compose methods with store settings.
 const {
@@ -69,7 +64,6 @@ export {
 	weekTicksThreshold,
 	defaultTableDateFormat,
 	getDateFormatsForInterval,
-	loadLocaleData,
 	dateValidationMessages,
 	validateDateInputForRange,
 };

--- a/packages/components/src/date-range-filter-picker/docs/example.js
+++ b/packages/components/src/date-range-filter-picker/docs/example.js
@@ -7,7 +7,6 @@ import {
 	getDateParamsFromQuery,
 	getCurrentDates,
 	isoDateFormat,
-	loadLocaleData,
 } from '@woocommerce/date';
 
 /**
@@ -16,13 +15,6 @@ import {
 import { partialRight } from 'lodash';
 
 const query = {};
-
-// Fetch locale from store settings and load for date functions.
-const localeSettings = {
-	userLocale: 'fr_FR',
-	weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
-};
-loadLocaleData( localeSettings );
 
 const defaultDateRange = 'period=month&compare=previous_year';
 const storeGetDateParamsFromQuery = partialRight( getDateParamsFromQuery, defaultDateRange );

--- a/packages/components/src/filters/docs/example.js
+++ b/packages/components/src/filters/docs/example.js
@@ -13,7 +13,6 @@ import {
 	getDateParamsFromQuery,
 	getCurrentDates,
 	isoDateFormat,
-	loadLocaleData,
 } from '@woocommerce/date';
 
 /**
@@ -30,13 +29,6 @@ const ORDER_STATUSES = {
 	processing: 'Processing',
 	refunded: 'Refunded',
 };
-
-// Fetch locale from store settings and load for date functions.
-const localeSettings = {
-	userLocale: 'fr_FR',
-	weekdaysShort: [ 'dim', 'lun', 'mar', 'mer', 'jeu', 'ven', 'sam' ],
-};
-loadLocaleData( localeSettings );
 
 // Fetch store default date range and compose with date utility functions.
 const defaultDateRange = 'period=month&compare=previous_year';


### PR DESCRIPTION
### To reproduce:
* Go to DevDocs
* Open the Inbox panel
* 💥

The root of the issue is calling `moment.updateLocale()` with unregistered locales (for example, WP's `fr_FR`). See: https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/date-range-filter-picker/docs/example.js#L25

This PR seeks to remove unnecessary locale update call ultimately letting the `@wordpress/date` module handle it.

#### Question:

Should we remove the `loadLocaleData()` export from `@woocommerce/date`?

### Detailed test instructions:

* Go to DevDocs
* Open the Inbox panel
* Verify no explosions
* Check that `moment` is still loading the proper locale data:
  * This is best done on non-`en_US`
  * Open console, compare `wcSettings.locale.weekdaysShort` and `moment.localeData()._weekdaysShort`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: errant moment locale data loading.