### PR TITLE
don't load analytics dashboard for users without needed capability

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -141,6 +141,15 @@ class Loader {
 	}
 
 	/**
+	 * Helper function indicating whether the current user has the required analytics capability.
+	 *
+	 * @return bool
+	 */
+	public static function user_can_analytics() {
+		return current_user_can( static::get_analytics_capability() );
+	}
+
+	/**
 	 * Returns if a specific wc-admin feature is enabled.
 	 *
 	 * @param  string $feature Feature slug.
@@ -401,7 +410,7 @@ class Loader {
 			return;
 		}
 
-		if ( ! current_user_can( static::get_analytics_capability() ) ) {
+		if ( ! static::user_can_analytics() ) {
 			return;
 		}
 
@@ -451,7 +460,7 @@ class Loader {
 	 * @param array $section Section to create breadcrumb from.
 	 */
 	private static function output_breadcrumbs( $section ) {
-		if ( ! current_user_can( static::get_analytics_capability() ) ) {
+		if ( ! static::user_can_analytics() ) {
 			return;
 		}
 		?>
@@ -474,7 +483,7 @@ class Loader {
 			return;
 		}
 
-		if ( ! current_user_can( static::get_analytics_capability() ) ) {
+		if ( ! static::user_can_analytics() ) {
 			return;
 		}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -34,6 +34,13 @@ class Loader {
 	protected static $classes = array();
 
 	/**
+	 * WordPress capability required to use analytics features.
+	 *
+	 * @var string
+	 */
+	protected static $required_capability = null;
+
+	/**
 	 * Get class instance.
 	 */
 	public static function get_instance() {
@@ -114,6 +121,23 @@ class Loader {
 	 */
 	public static function get_features() {
 		return apply_filters( 'woocommerce_admin_features', array() );
+	}
+
+	/**
+	 * Gets WordPress capability required to use analytics features.
+	 *
+	 * @return string
+	 */
+	public static function get_analytics_capability() {
+		if ( null === static::$required_capability ) {
+			/**
+			 * Filters the required capability to use the analytics features.
+			 *
+			 * @param string $capability WordPress capability.
+			 */
+			static::$required_capability = apply_filters( 'woocommerce_analytics_menu_capability', 'view_woocommerce_reports' );
+		}
+		return static::$required_capability;
 	}
 
 	/**
@@ -204,14 +228,13 @@ class Loader {
 	 * @todo The entry point for the embed needs moved to this class as well.
 	 */
 	public static function register_page_handler() {
-		$analytics_cap = apply_filters( 'woocommerce_analytics_menu_capability', 'view_woocommerce_reports' );
 		wc_admin_register_page(
 			array(
 				'id'         => 'woocommerce-dashboard', // Expected to be overridden if dashboard is enabled.
 				'parent'     => 'woocommerce',
 				'title'      => null,
 				'path'       => self::APP_ENTRY_POINT,
-				'capability' => $analytics_cap,
+				'capability' => static::get_analytics_capability(),
 			)
 		);
 
@@ -378,6 +401,10 @@ class Loader {
 			return;
 		}
 
+		if ( ! current_user_can( static::get_analytics_capability() ) ) {
+			return;
+		}
+
 		wp_enqueue_script( WC_ADMIN_APP );
 		wp_enqueue_style( WC_ADMIN_APP );
 		wp_enqueue_style( 'wc-material-icons' );
@@ -424,6 +451,9 @@ class Loader {
 	 * @param array $section Section to create breadcrumb from.
 	 */
 	private static function output_breadcrumbs( $section ) {
+		if ( ! current_user_can( static::get_analytics_capability() ) ) {
+			return;
+		}
 		?>
 		<span>
 		<?php if ( is_array( $section ) ) : ?>
@@ -441,6 +471,10 @@ class Loader {
 	 */
 	public static function embed_page_header() {
 		if ( ! self::is_embed_page() ) {
+			return;
+		}
+
+		if ( ! current_user_can( static::get_analytics_capability() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #3276 

This PR adds checks to the dashboard loader to ensure that the current user has the required WP capability to use the analytics functionality.

### Detailed test instructions:

- Install a role editing plugin
- Create a role that has `read` plus all `shop_order` post type caps
- Create a user with this role
- Log into the dashboard as a shop manager & verify that screens load & activity panel works
- Log in as test user
- Go to orders page
- Check that WCA scripts aren't included
- Check that `root` and `embedded-root` are not injected into the page

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: remove the header when user doesn't have required permissions