### PR TITLE
update customer rest controller for last active date in local time

### DIFF
--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -166,12 +166,14 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $report, $request ) {
-		$context                      = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data                         = $this->add_additional_fields_to_object( $report, $request );
-		$data['date_registered_gmt']  = wc_rest_prepare_date_response( $data['date_registered'] );
-		$data['date_registered']      = wc_rest_prepare_date_response( $data['date_registered'], false );
-		$data['date_last_active_gmt'] = wc_rest_prepare_date_response( $data['date_last_active'] );
-		$data['date_last_active']     = wc_rest_prepare_date_response( $data['date_last_active'], false );
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $report, $request );
+		// Registered date is UTC.
+		$data['date_registered_gmt'] = wc_rest_prepare_date_response( $data['date_registered'] );
+		$data['date_registered']     = wc_rest_prepare_date_response( $data['date_registered'], false );
+		// Last active date is local time.
+		$data['date_last_active_gmt'] = wc_rest_prepare_date_response( $data['date_last_active'], false );
+		$data['date_last_active']     = wc_rest_prepare_date_response( $data['date_last_active'] );
 		$data                         = $this->filter_response_by_context( $data, $context );
 
 		// Wrap the data in a response object.


### PR DESCRIPTION
Fixes #2815 

I apologize for the branch name. This PR changes the customers REST controller to process the last active date as a local date instead of as UTC. WordPress controls the user registered date field and stores it as UTC.

### Detailed test instructions:

- Set your time zone to `America/New York`.
- Use `wc-smooth-generator` to create 10 orders in the last week.
- In `master` load the customers report to see that the new users created have a last active date of the day before they were registered.
- Clear transients
- Switch to this branch & verify that registered and last active are the same day

### Changelog Note:

Fix: Time zone offset calculation on customer last active date.