### PR TITLE
scroll to notices when made visible while scrolled down

### DIFF
--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -10,6 +10,9 @@ import { IconButton } from '@wordpress/components';
 import { intersection, noop, partial } from 'lodash';
 import PropTypes from 'prop-types';
 
+// Height of the activity header in px.
+const HEADER_HEIGHT = 56;
+
 class WordPressNotices extends Component {
 	constructor() {
 		super();
@@ -176,6 +179,12 @@ class WordPressNotices extends Component {
 		notices.classList.remove( 'woocommerce-layout__notice-list-hide' );
 		screenMeta && screenMeta.classList.add( 'is-hidden-by-notices' );
 		screenLinks && screenLinks.classList.add( 'is-hidden-by-notices' );
+
+		const noticePosition = notices.getBoundingClientRect();
+		if ( noticePosition.y < HEADER_HEIGHT ) {
+			window.scrollBy( 0, noticePosition.y - HEADER_HEIGHT );
+		}
+		this.setState( { noticesOpen: true } );
 	}
 
 	hideNotices() {
@@ -184,6 +193,8 @@ class WordPressNotices extends Component {
 		notices.classList.remove( 'woocommerce-layout__notice-list-show' );
 		screenMeta && screenMeta.classList.remove( 'is-hidden-by-notices' );
 		screenLinks && screenLinks.classList.remove( 'is-hidden-by-notices' );
+
+		this.setState( { noticesOpen: false } );
 	}
 
 	render() {

--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -10,9 +10,6 @@ import { IconButton } from '@wordpress/components';
 import { intersection, noop, partial } from 'lodash';
 import PropTypes from 'prop-types';
 
-// Height of the activity header in px.
-const HEADER_HEIGHT = 56;
-
 class WordPressNotices extends Component {
 	constructor() {
 		super();
@@ -180,10 +177,7 @@ class WordPressNotices extends Component {
 		screenMeta && screenMeta.classList.add( 'is-hidden-by-notices' );
 		screenLinks && screenLinks.classList.add( 'is-hidden-by-notices' );
 
-		const noticePosition = notices.getBoundingClientRect();
-		if ( noticePosition.y < HEADER_HEIGHT ) {
-			window.scrollBy( 0, noticePosition.y - HEADER_HEIGHT );
-		}
+		window.scrollBy( 0, window.scrollY * -1 );
 		this.setState( { noticesOpen: true } );
 	}
 


### PR DESCRIPTION
Fixes #3127

This PR will cause the browser to scroll up to the notices when the activity button is clicked and the page is scrolled down where they wouldn't be seen.

### Detailed test instructions:

- Ensure you have a admin notice that is visible on all dashboard pages
- Go to any Analytics page
- While scrolled up show notices
- Scroll down until all notices are hidden
- Hide then show notices
- Repeat on a WooCommerce page (eg. Orders) where the WC Admin header is shown

### Changelog Note:

Tweak: Scroll to notices when displayed while the notice area is scrolled out of view.