### PR TITLE
Add filters to WP notice collapsing behavior.

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -279,7 +279,16 @@
 }
 
 #wp__notice-list {
-	padding-right: 20px;
+	padding-left: 5px;
+	padding-right: 5px;
+
+	@include breakpoint( '<782px' ) {
+		padding-left: 20px;
+		padding-right: 20px;
+		& > div {
+			margin: 20px 0 10px 0;
+		}
+	}
 }
 
 .woocommerce-layout__notice-list .jitm-card {

--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -81,11 +81,9 @@ class WordPressNotices extends Component {
 			document.getElementById( 'woocommerce-layout__notice-list' );
 
 		let count = 0;
-		for ( let i = 0; i <= notices.children.length; i++ ) {
-			const notice = notices.children[ i ];
-			if ( ! notice ) {
-				continue;
-			} else if ( 0 === notice.innerHTML.length ) {
+
+		for ( const notice of Array.from( notices.children ) ) {
+			if ( 0 === notice.innerHTML.length ) {
 				// Ignore empty elements in this part of the DOM.
 				continue;
 			} else if ( ! this.shouldCollapseNotice( notice ) ) {

--- a/client/header/activity-panel/wordpress-notices.js
+++ b/client/header/activity-panel/wordpress-notices.js
@@ -9,6 +9,7 @@ import Gridicon from 'gridicons';
 import { IconButton } from '@wordpress/components';
 import { intersection, noop, partial } from 'lodash';
 import PropTypes from 'prop-types';
+import { applyFilters } from '@wordpress/hooks';
 
 class WordPressNotices extends Component {
 	constructor() {
@@ -117,16 +118,19 @@ class WordPressNotices extends Component {
 
 	// Some messages should not be displayed in the toggle, like Jetpack JITM messages or update/success messages
 	shouldCollapseNotice( element ) {
-		// element id, [ classes to include ], [ classes to exclude ]
-		const noticesToHide = [
-			[ null, [ 'jetpack-jitm-message' ] ],
-			[ 'woocommerce_errors', null ],
-			[ null, [ 'hidden' ] ],
-			[ 'message', [ 'notice', 'updated' ], [ 'woocommerce-message' ] ],
-		];
+		const noticesToShow = applyFilters(
+			'woocommerce_admin_notices_to_show',
+			// element id, [ classes to include ], [ classes to exclude ]
+			[
+				[ null, [ 'jetpack-jitm-message' ] ],
+				[ 'woocommerce_errors', null ],
+				[ null, [ 'hidden' ] ],
+				[ 'message', [ 'notice', 'updated' ], [ 'woocommerce-message' ] ],
+			]
+		);
 
-		for ( let i = 0; i < noticesToHide.length; i++ ) {
-			const [ id, includeClasses, excludeClasses ] = noticesToHide[ i ];
+		for ( let i = 0; i < noticesToShow.length; i++ ) {
+			const [ id, includeClasses, excludeClasses ] = noticesToShow[ i ];
 
 			const idMatch = null === id || id === element.id;
 			let classMatch = true;
@@ -140,11 +144,11 @@ class WordPressNotices extends Component {
 			}
 
 			if ( idMatch && classMatch ) {
-				return false;
+				return applyFilters( 'woocommerce_admin_should_hide_notice', false, element );
 			}
 		}
 
-		return true;
+		return applyFilters( 'woocommerce_admin_should_hide_notice', true, element );
 	}
 
 	updateCount() {

--- a/docs/examples/extensions/important-admin-notice/js/index.js
+++ b/docs/examples/extensions/important-admin-notice/js/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Use the 'woocommerce_admin_notices_to_show' filter to add notices to show.
+ */
+addFilter( 'woocommerce_admin_notices_to_show', 'plugin-domain', notices => {
+	return [
+        ...notices,
+        // element id, [ classes to include ], [ classes to exclude ]
+        [ null, [ 'woocommerce-admin' ], [ 'ok-to-hide' ] ],
+        [ 'woocommerce-admin-important-notice', null, null ],
+	];
+} );
+
+/**
+ * Use the 'woocommerce_admin_should_hide_notice' filter to show a specific notice by inspecting its children.
+ */
+addFilter( 'woocommerce_admin_should_hide_notice', 'plugin-domain', ( hide, notice ) => {
+    if ( hide && notice.querySelector( 'p.notice-text' ) ) {
+        return false;
+    }
+
+    return hide;
+} );

--- a/docs/examples/extensions/important-admin-notice/woocommerce-admin-important-admin-notice-example.php
+++ b/docs/examples/extensions/important-admin-notice/woocommerce-admin-important-admin-notice-example.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Admin Important Notice Example
+ *
+ * @package WC_Admin
+ */
+
+/**
+ * Register the JS.
+ */
+function wc_admin_important_notice_register_script() {
+	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) ) {
+		return;
+	}
+
+	if (
+		! \Automattic\WooCommerce\Admin\Loader::is_admin_page() &&
+		! \Automattic\WooCommerce\Admin\Loader::is_embed_page()
+	) {
+		return;
+	}
+
+	wp_register_script(
+		'wc-admin-important-notice',
+		plugins_url( '/dist/index.js', __FILE__ ),
+		array(
+			'wp-hooks',
+		),
+		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		true
+	);
+
+	wp_enqueue_script( 'wc-admin-important-notice' );
+}
+add_action( 'admin_enqueue_scripts', 'wc_admin_important_notice_register_script' );
+
+/**
+ * Create an Admin Notice we want to remain visible.
+ */
+function wc_admin_add_important_notice() {
+	?>
+	<div class="updated woocommerce-message">
+		<p class="notice-text">Important notice targeted by inspecting DOM.</p>
+	</div>
+	<div class="updated woocommerce-admin woocommerce-message">
+		<p>Impotant notice targeted by class.</p>
+	</div>
+	<div class="updated woocommerce-admin woocommerce-message ok-to-hide">
+		<p>Notice excluded from importance clause targeted by class.</p>
+	</div>
+	<div id="woocommerce-admin-important-notice" class="updated woocommerce-message">
+		<p>Important notice targeted by ID.</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'wc_admin_add_important_notice' );


### PR DESCRIPTION
Fixes #2909.

This PR seeks to allow 3PDs to filter the WordPress notice collapsing behavior.

It introduces two new filters: `woocommerce_admin_notices_to_show` and `woocommerce_admin_should_hide_notice`. Additionally, it corrects a variable name - `noticesToHide` is used for "notices to not collapse" so I renamed it to `noticesToShow`.

### Detailed test instructions:

- Verify that existing WP notice collapsing behavior remains unchanged
- Use the `woocommerce_admin_notices_to_show` filter to modify the notices to show, verify its function
- Use the `woocommerce_admin_should_hide_notice` filter to modify the result for an element, verify its function

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: allow filtering of hidden WP notices.