### PR TITLE
Bump minimum WP version to 5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[WordPress 5.2 or greater](https://wordpress.org/download/) and [WooCommerce 3.6.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.3 or greater](https://wordpress.org/download/) and [WooCommerce 3.6.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -19,8 +19,8 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 # Error if WP < 5
 if [[ $WP_VERSION =~ ^([0-9]+)[0-9\.]+\-? ]]; then
-	if [ "5.2" -gt "${BASH_REMATCH[1]}" ]; then
-		echo "You must use WordPress 5.2 or greater."
+	if [ "5.3" -gt "${BASH_REMATCH[1]}" ]; then
+		echo "You must use WordPress 5.3 or greater."
 		exit 1
 	fi
 fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[WordPress 5.2 or greater](https://wordpress.org/download/) and [WooCommerce 3.6.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.3 or greater](https://wordpress.org/download/) and [WooCommerce 3.6.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Admin ===
 Contributors: automattic
 Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activity, notices, insights, stats, woo commerce, woocommerce
-Requires at least: 5.2.0
+Requires at least: 5.3.0
 Tested up to: 5.3.0
 Requires PHP: 5.6.20
 Stable tag: 1.0.0
@@ -34,7 +34,7 @@ WooCommerce Admin also allows store owners to customize a new dashboard screen w
 
 = Minimum Requirements =
 
-* WordPress 5.2
+* WordPress 5.3
 * WooCommerce 3.6.0 or greater
 * PHP version 5.6.20 or greater. PHP 7.2 or greater is recommended
 * MySQL version 5.0 or greater. MySQL 5.6 or greater is recommended

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -235,7 +235,7 @@ class FeaturePlugin {
 	protected function get_dependency_errors() {
 		$errors                      = array();
 		$wordpress_version           = get_bloginfo( 'version' );
-		$minimum_wordpress_version   = '5.2';
+		$minimum_wordpress_version   = '5.3';
 		$minimum_woocommerce_version = '3.6';
 		$wordpress_minimum_met       = version_compare( $wordpress_version, $minimum_wordpress_version, '>=' );
 		$woocommerce_minimum_met     = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, $minimum_woocommerce_version, '>=' );

--- a/src/Package.php
+++ b/src/Package.php
@@ -24,10 +24,10 @@ class Package {
 	/**
 	 * Init the package.
 	 *
-	 * Only initialize for WP 5.2 or greater.
+	 * Only initialize for WP 5.3 or greater.
 	 */
 	public static function init() {
-		$wordpress_minimum_met = version_compare( get_bloginfo( 'version' ), '5.2', '>=' );
+		$wordpress_minimum_met = version_compare( get_bloginfo( 'version' ), '5.3', '>=' );
 		if ( ! $wordpress_minimum_met ) {
 			return;
 		}

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -8,7 +8,7 @@
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
  * Version: 0.23.1
- * Requires at least: 5.2.0
+ * Requires at least: 5.3.0
  * Requires PHP: 5.6.20
  *
  * WC requires at least: 3.6.0


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3372

Bumps version. 

### Testing

Double check that references to WP 5.2 have all been updated.