### PR TITLE
Onboarding: Reduce number of queries needed to update logo

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -83,7 +83,6 @@ class OnboardingTasks {
 		// @todo We may want to consider caching some of these and use to check against
 		// task completion along with cache busting for active tasks.
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
-		$settings['onboarding']['customLogo']                     = get_theme_mod( 'custom_logo', false );
 		$settings['onboarding']['hasHomepage']                    = self::check_task_completion( 'homepage' ) || 'classic' === get_option( 'classic-editor-replace' );
 		$settings['onboarding']['hasPhysicalProducts']            = count(
 			wc_get_products(
@@ -96,7 +95,9 @@ class OnboardingTasks {
 		$settings['onboarding']['hasProducts']                    = self::check_task_completion( 'products' );
 		$settings['onboarding']['isTaxComplete']                  = self::check_task_completion( 'tax' );
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
+		$settings['onboarding']['stylesheet']                     = get_option( 'stylesheet' );
 		$settings['onboarding']['taxJarActivated']                = class_exists( 'WC_Taxjar' );
+		$settings['onboarding']['themeMods']                      = get_theme_mods();
 
 		return $settings;
 	}


### PR DESCRIPTION
Fixes #3334

Adds `themeMods` and `stylesheet` to preloaded settings so fetching is not needed during the customize appearance task of the task list.

@mikejolley Can you take a look and see if this performs better in your environment?

### Screenshots
<img width="507" alt="Screen Shot 2019-12-09 at 2 27 56 PM" src="https://user-images.githubusercontent.com/10561050/70415875-4268d200-1a90-11ea-94d7-fd6ddd7b0d9a.png">


### Detailed test instructions:

1. Go to the customize appearance task in the task list.
2. Test adding and removing the logo and updating.
3. Try refreshing the page to make sure the logo persists.
4. Add a logo, update, and without refreshing the page, visit another route and return to this task to make sure the logo still exists.