### PR TITLE
Onboarding: Update the tracking usage modal copy

### DIFF
--- a/client/dashboard/profile-wizard/steps/usage-modal.js
+++ b/client/dashboard/profile-wizard/steps/usage-modal.js
@@ -64,7 +64,8 @@ class UsageModal extends Component {
 		const { isRequesting } = this.props;
 		const trackingMessage = interpolateComponents( {
 			mixedString: __(
-				"Learn more about how usage tracking works, and how you'll be helping {{link}}here{{/link}}.",
+				'Get improved features and faster fixes by sharing non-sensitive data via {{link}}usage tracking{{/link}} ' +
+					'that shows us how WooCommerce is used. No personal data is tracked or stored.',
 				'woocommerce-admin'
 			),
 			components: {
@@ -76,7 +77,7 @@ class UsageModal extends Component {
 
 		return (
 			<Modal
-				title={ __( 'Help improve WooCommerce with usage tracking', 'woocommerce-admin' ) }
+				title={ __( 'Build a Better WooCommerce', 'woocommerce-admin' ) }
 				onRequestClose={ () => this.props.onClose() }
 				className="woocommerce-profile-wizard__usage-modal"
 			>
@@ -86,10 +87,7 @@ class UsageModal extends Component {
 						<CheckboxControl
 							className="woocommerce-profile-wizard__tracking-checkbox"
 							checked={ allowTracking }
-							label={ __(
-								'Enable usage tracking and help improve WooCommerce',
-								'woocommerce-admin'
-							) }
+							label={ __( 'Yes, count me in!', 'woocommerce-admin' ) }
 							onChange={ this.onTrackingChange }
 						/>
 


### PR DESCRIPTION
Fixes #3348

Updates the text in the tracking usage modal.

### Screenshots
<img width="632" alt="Screen Shot 2019-12-09 at 2 37 38 PM" src="https://user-images.githubusercontent.com/10561050/70416526-d7b89600-1a91-11ea-9c8d-c476ea2eeea8.png">

### Detailed test instructions:

1. Enable the onboarding profiler.
2. Visit the first step of the profiler and click "Get started."
3. Note the text matches the expected text in the modal.