### PR TITLE
Onboarding: Update shipping task button text

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -144,9 +144,12 @@ class Shipping extends Component {
 
 	getSteps() {
 		const { countryCode } = this.props;
-		const plugins = [ 'GB', 'CA', 'AU' ].includes( countryCode )
-			? [ 'woocommerce-shipstation-integration' ]
-			: [ 'jetpack', 'woocommerce-services' ];
+		let plugins = [];
+		if ( [ 'GB', 'CA', 'AU' ].includes( countryCode ) ) {
+			plugins = [ 'woocommerce-shipstation-integration' ];
+		} else if ( 'US' === countryCode ) {
+			plugins = [ 'jetpack', 'woocommerce-services' ];
+		}
 
 		const steps = [
 			{
@@ -175,7 +178,7 @@ class Shipping extends Component {
 				content: (
 					<ShippingRates
 						buttonText={
-							[ 'US', 'GB', 'CA', 'AU' ].includes( countryCode )
+							plugins.length
 								? __( 'Proceed', 'woocommerce-admin' )
 								: __( 'Complete task', 'woocommerce-admin' )
 						}
@@ -189,7 +192,7 @@ class Shipping extends Component {
 			{
 				key: 'label_printing',
 				label: __( 'Enable shipping label printing', 'woocommerce-admin' ),
-				description: [ 'GB', 'CA', 'AU' ].includes( countryCode )
+				description: plugins.includes( 'woocommerce-shipstation-integration' )
 					? interpolateComponents( {
 							mixedString: __(
 								'We recommend using ShipStation to save time at the post office by printing your shipping ' +
@@ -225,7 +228,7 @@ class Shipping extends Component {
 						{ ...this.props }
 					/>
 				),
-				visible: [ 'US', 'GB', 'CA', 'AU' ].includes( countryCode ),
+				visible: plugins.length,
 			},
 			{
 				key: 'connect',
@@ -244,7 +247,7 @@ class Shipping extends Component {
 						} }
 					/>
 				),
-				visible: 'US' === countryCode,
+				visible: plugins.includes( 'jetpack' ),
 			},
 		];
 

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -174,6 +174,11 @@ class Shipping extends Component {
 				),
 				content: (
 					<ShippingRates
+						buttonText={
+							[ 'US', 'GB', 'CA', 'AU' ].includes( countryCode )
+								? __( 'Proceed', 'woocommerce-admin' )
+								: __( 'Complete task', 'woocommerce-admin' )
+						}
 						shippingZones={ this.state.shippingZones }
 						onComplete={ this.completeStep }
 						{ ...this.props }

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -161,7 +161,7 @@ class ShippingRates extends Component {
 	}
 
 	render() {
-		const { shippingZones } = this.props;
+		const { buttonText, shippingZones } = this.props;
 
 		if ( ! shippingZones.length ) {
 			return null;
@@ -224,7 +224,7 @@ class ShippingRates extends Component {
 							</div>
 
 							<Button isPrimary onClick={ handleSubmit }>
-								{ __( 'Complete task', 'woocommerce-admin' ) }
+								{ buttonText || __( 'Update', 'woocommerce-admin' ) }
 							</Button>
 						</Fragment>
 					);
@@ -235,6 +235,10 @@ class ShippingRates extends Component {
 }
 
 ShippingRates.propTypes = {
+	/**
+	 * Text displayed on the primary button.
+	 */
+	buttonText: PropTypes.string,
 	/**
 	 * Function used to mark the step complete.
 	 */


### PR DESCRIPTION
Fixes #3399

Updates the button text depending on whether or not remaining steps in the task exist.

### Screenshots
<img width="742" alt="Screen Shot 2019-12-09 at 3 21 37 PM" src="https://user-images.githubusercontent.com/10561050/70419433-00438e80-1a98-11ea-88c1-134c21937c11.png">

<img width="566" alt="Screen Shot 2019-12-09 at 3 21 14 PM" src="https://user-images.githubusercontent.com/10561050/70419434-00438e80-1a98-11ea-8af3-7bf1bed9b2ba.png">

### Detailed test instructions:

1. Set your store default country to US, AU, CA, or GB.
2. Go to the shipping task and make sure that the 2nd step button text reads "Proceed."
3. Set your store to a country not listed above.
4. Make sure the 2nd step of the shipping task button text reads "Complete task."
