### PR TITLE
Onboarding -  Add button to continue setup after importing products

### DIFF
--- a/client/dashboard/task-list/tasks/products.js
+++ b/client/dashboard/task-list/tasks/products.js
@@ -37,7 +37,7 @@ const subTasks = [
 		after: <i className="material-icons-outlined">chevron_right</i>,
 		onClick: () => recordEvent( 'tasklist_add_product', { method: 'import' } ),
 		href: getAdminLink(
-			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=products'
+			'edit.php?post_type=product&page=product_importer&wc_onboarding_active_task=product-import'
 		),
 	},
 	{

--- a/client/wp-admin-scripts/onboarding-product-import-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-product-import-notice/index.js
@@ -1,0 +1,31 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
+
+domReady( () => {
+	const actionButtons = document.querySelector( '.wc-actions' );
+	if ( actionButtons ) {
+		const primaryButton = document.querySelector( '.wc-actions .button-primary' );
+		if ( primaryButton ) {
+			primaryButton.classList.remove( 'button' );
+			primaryButton.classList.remove( 'button-primary' );
+		}
+
+		const continueButton = document.createElement( 'a' );
+		continueButton.classList.add( 'button' );
+		continueButton.classList.add( 'button-primary' );
+		continueButton.setAttribute( 'href', getAdminLink( 'admin.php?page=wc-admin' ) );
+		continueButton.innerText = __( 'Continue setup', 'woocommerce-admin' );
+
+		actionButtons.appendChild( continueButton );
+	}
+} );

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -62,6 +62,7 @@ class OnboardingTasks {
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_homepage_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_import_notice_admin_script' ) );
 	}
 
 	/**
@@ -219,6 +220,19 @@ class OnboardingTasks {
 			! self::is_active_task_complete()
 		) {
 			wp_enqueue_script( 'onboarding-tax-notice', Loader::get_url( 'wp-admin-scripts/onboarding-tax-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
+		}
+	}
+
+	/**
+	 * Adds a notice to return to the task list when the product importeris done running.
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function add_onboarding_product_import_notice_admin_script( $hook ) {
+		$step = isset( $_GET['step'] ) ? $_GET['step'] : ''; // phpcs:ignore csrf ok, sanitization ok.
+		if ( 'product_page_product_importer' === $hook && 'done' === $step && 'product-import' === self::get_active_task() ) {
+			delete_transient( self::ACTIVE_TASK_TRANSIENT );
+			wp_enqueue_script( 'onboarding-product-import-notice', Loader::get_url( 'wp-admin-scripts/onboarding-product-import-notice.js' ), array( 'wc-navigation', 'wp-i18n', 'wp-data' ), WC_ADMIN_VERSION_NUMBER, true );
 		}
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,7 @@ wcAdminPackages.forEach( name => {
 const wpAdminScripts = [
 	'onboarding-homepage-notice',
 	'onboarding-product-notice',
+	'onboarding-product-import-notice',
 	'onboarding-tax-notice',
 ];
 wpAdminScripts.forEach( name => {


### PR DESCRIPTION
Fixes #3235.

This PR adds a button to the product import page to continue setup, if the user entered the import flow through onboarding.

### Screenshots

<img width="882" alt="Screen Shot 2019-12-09 at 2 12 21 PM" src="https://user-images.githubusercontent.com/689165/70465377-d043bd80-1a8e-11ea-867b-1bc5996c9313.png">

### Detailed test instructions:

* Delete your products
* Enable the task list and go to the products task and select import
* Walk through the importer steps (you can use [this CSV file for testing](https://docs.woocommerce.com/document/product-csv-importer-exporter/dummy-data/))
* Verify you see the continue setup button
* Leave, and import products the normal way (`Tools > Import`) and notice the primary button is just "Add Products"

