### PR TITLE
Install latest stable WC for running builds.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -169,10 +169,11 @@ install_deps() {
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
 
-	# Install WooCommerce
+	# Install WooCommerce (latest non-hyphenated (beta, RC) tag)
+	LATEST_WC_TAG="$(git ls-remote --tags https://github.com/woocommerce/woocommerce.git | awk '{print $2}' | sed 's/^refs\/tags\///' | grep -E '^[0-9]\.[0-9]\.[0-9]$' | sort -V | tail -n 1)"
 	cd "wp-content/plugins/"
 	# As zip file does not include tests, we have to get it from git repo.
-	git clone --depth 1 https://github.com/woocommerce/woocommerce.git
+	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git
 
 	# Bring in WooCommerce Core dependencies
 	cd "woocommerce"


### PR DESCRIPTION
Occasionally, master breaks the build.

Several open PRs are failing on Travis CI, presumably because of a bug in the WooCommerce `master` right now.

This PR seeks to install the latest non-hyphenated tag, instead of `master`. Hopefully this mitigates the issue (it's fixing it currently).
