### PR TITLE
AssetDataRegistry: update SQL example

### DIFF
--- a/docs/examples/extensions/README.md
+++ b/docs/examples/extensions/README.md
@@ -26,3 +26,4 @@ You can make changes to Javascript and PHP files in the example and see changes 
 - `add-task` - Create a custom task for the onboarding task list.
 - `dashboard-section` - Adding a custom "section" to the new dashboard area.
 - `table-column` - An example of how to add column(s) to any report.
+- `sql-modification` - An example of how to modify SQL statements.

--- a/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
+++ b/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
@@ -8,6 +8,38 @@
 /**
  * Make the currency settings available to the javascript client using
  * AssetDataRegistry, available in WooCommerce 3.9.
+ *
+ * The add_currency_settings function is a most basic example, but below is
+ * a more elaborate example of how one might use AssetDataRegistry in classes.
+ *
+	```php
+	<?php
+
+	class MyClassWithAssetData {
+		private $asset_data_registry;
+		public function __construct( Automattic\WooCommerce\Blocks\AssetDataRegistry $asset_data_registry ) {
+			$this->asset_data_registry = $asset_data_registry;
+		}
+
+		protected function some_method_adding_assets() {
+			$this->asset_data_registry->add( 'myData', [ 'foo' => 'bar' ] );
+		}
+	}
+
+	// somewhere in the extensions bootstrap
+	class Bootstrap {
+		protected $container;
+		public function __construct( Automattic\WooCommerce\Blocks\Container $container ) {
+			$this->container = $container;
+			$this->container->register( MyClassWithAssetData::class, function( $blocks_container ) => {
+				return new MyClassWithAssetData( $blocks_container->get( Automattic\WooCommerce\Blocks\AssetDataRegistry::class ) );
+			} );
+		}
+	}
+
+	// now anywhere MyClassWithAssetData is instantiated it will automatically be
+	// constructed with the AssetDataRegistry
+	```
  */
 function add_currency_settings() {
 	$currencies = array(

--- a/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
+++ b/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
@@ -52,6 +52,7 @@ function add_report_register_script() {
 			'wp-i18n',
 			'wp-plugins',
 			'wc-components',
+			'wc-settings',
 		),
 		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
 		true

--- a/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
+++ b/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
@@ -6,12 +6,11 @@
  */
 
 /**
- * Get the currencies available.
- *
- * @return array
+ * Make the currency settings available to the javascript client using
+ * AssetDataRegistry, available in WooCommerce 3.9.
  */
-function get_currencies() {
-	return array(
+function add_currency_settings() {
+	$currencies = array(
 		array(
 			'label' => __( 'United States Dollar', 'woocommerce-admin' ),
 			'value' => 'USD',
@@ -25,6 +24,12 @@ function get_currencies() {
 			'value' => 'ZAR',
 		),
 	);
+
+	$data_registry = Automattic\WooCommerce\Blocks\Package::container()->get(
+		Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class
+	);
+
+	$data_registry->add( 'multiCurrency', $currencies );
 }
 
 /**
@@ -35,6 +40,8 @@ function add_report_register_script() {
 	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
 		return;
 	}
+
+	add_currency_settings();
 
 	wp_register_script(
 		'sql-modification',
@@ -51,15 +58,6 @@ function add_report_register_script() {
 	);
 
 	wp_enqueue_script( 'sql-modification' );
-
-	// todo: This is not the right way to interact with wcSettings. Update once WooCommerce 3.9 is available.
-	wp_add_inline_script(
-		'sql-modification',
-		"wcSettings.multiCurrency = JSON.parse( decodeURIComponent( '"
-		. esc_js( rawurlencode( wp_json_encode( get_currencies() ) ) )
-		. "' ) );",
-		'before'
-	);
 }
 add_action( 'admin_enqueue_scripts', 'add_report_register_script' );
 


### PR DESCRIPTION
The SQL Modification example previously used `wp_add_inline_script` to add data to the `wcSettings` object.

This PR updates that logic to use `AssetDataRegistry` instead.

### Detailed test instructions:

1. `npm run example -- --ext=sql-modification`
2. Activate the SQL Modification Example plugin
3. Visit a report with currencies, such as Revenue
4. Ensure the currency dropdown is functional

![Screen Shot 2019-12-13 at 12 51 57 PM](https://user-images.githubusercontent.com/1922453/70758300-6a657780-1da7-11ea-8504-1136edc72aaa.png)
