### PR TITLE
DataStores: normalize contexts to plural

### DIFF
--- a/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
+++ b/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
@@ -113,12 +113,12 @@ function add_join_subquery( $clauses ) {
 }
 
 add_filter( 'woocommerce_analytics_clauses_join_orders_subquery', 'add_join_subquery' );
-add_filter( 'woocommerce_analytics_clauses_join_order_stats_total', 'add_join_subquery' );
-add_filter( 'woocommerce_analytics_clauses_join_order_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_orders_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_orders_stats_interval', 'add_join_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_join_products_subquery', 'add_join_subquery' );
-add_filter( 'woocommerce_analytics_clauses_join_product_stats_total', 'add_join_subquery' );
-add_filter( 'woocommerce_analytics_clauses_join_product_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_products_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_products_stats_interval', 'add_join_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_join_categories_subquery', 'add_join_subquery' );
 
@@ -127,8 +127,8 @@ add_filter( 'woocommerce_analytics_clauses_join_coupons_stats_total', 'add_join_
 add_filter( 'woocommerce_analytics_clauses_join_coupons_stats_interval', 'add_join_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_join_taxes_subquery', 'add_join_subquery' );
-add_filter( 'woocommerce_analytics_clauses_join_tax_stats_total', 'add_join_subquery' );
-add_filter( 'woocommerce_analytics_clauses_join_tax_stats_interval', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_taxes_stats_total', 'add_join_subquery' );
+add_filter( 'woocommerce_analytics_clauses_join_taxes_stats_interval', 'add_join_subquery' );
 
 /**
  * Add a WHERE clause.
@@ -148,12 +148,12 @@ function add_where_subquery( $clauses ) {
 	return $clauses;
 }
 add_filter( 'woocommerce_analytics_clauses_where_orders_subquery', 'add_where_subquery' );
-add_filter( 'woocommerce_analytics_clauses_where_order_stats_total', 'add_where_subquery' );
-add_filter( 'woocommerce_analytics_clauses_where_order_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_orders_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_orders_stats_interval', 'add_where_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_where_products_subquery', 'add_where_subquery' );
-add_filter( 'woocommerce_analytics_clauses_where_product_stats_total', 'add_where_subquery' );
-add_filter( 'woocommerce_analytics_clauses_where_product_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_products_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_products_stats_interval', 'add_where_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_where_categories_subquery', 'add_where_subquery' );
 
@@ -162,8 +162,8 @@ add_filter( 'woocommerce_analytics_clauses_where_coupons_stats_total', 'add_wher
 add_filter( 'woocommerce_analytics_clauses_where_coupons_stats_interval', 'add_where_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_where_taxes_subquery', 'add_where_subquery' );
-add_filter( 'woocommerce_analytics_clauses_where_tax_stats_total', 'add_where_subquery' );
-add_filter( 'woocommerce_analytics_clauses_where_tax_stats_interval', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_taxes_stats_total', 'add_where_subquery' );
+add_filter( 'woocommerce_analytics_clauses_where_taxes_stats_interval', 'add_where_subquery' );
 
 /**
  * Add a SELECT clause.
@@ -178,12 +178,12 @@ function add_select_subquery( $clauses ) {
 }
 
 add_filter( 'woocommerce_analytics_clauses_select_orders_subquery', 'add_select_subquery' );
-add_filter( 'woocommerce_analytics_clauses_select_order_stats_total', 'add_select_subquery' );
-add_filter( 'woocommerce_analytics_clauses_select_order_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_orders_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_orders_stats_interval', 'add_select_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_select_products_subquery', 'add_select_subquery' );
-add_filter( 'woocommerce_analytics_clauses_select_product_stats_total', 'add_select_subquery' );
-add_filter( 'woocommerce_analytics_clauses_select_product_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_products_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_products_stats_interval', 'add_select_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_select_categories_subquery', 'add_select_subquery' );
 
@@ -192,5 +192,5 @@ add_filter( 'woocommerce_analytics_clauses_select_coupons_stats_total', 'add_sel
 add_filter( 'woocommerce_analytics_clauses_select_coupons_stats_interval', 'add_select_subquery' );
 
 add_filter( 'woocommerce_analytics_clauses_select_taxes_subquery', 'add_select_subquery' );
-add_filter( 'woocommerce_analytics_clauses_select_tax_stats_total', 'add_select_subquery' );
-add_filter( 'woocommerce_analytics_clauses_select_tax_stats_interval', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_taxes_stats_total', 'add_select_subquery' );
+add_filter( 'woocommerce_analytics_clauses_select_taxes_stats_interval', 'add_select_subquery' );

--- a/src/API/Reports/Coupons/Stats/DataStore.php
+++ b/src/API/Reports/Coupons/Stats/DataStore.php
@@ -44,7 +44,7 @@ class DataStore extends CouponsDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'coupon_stats';
+	protected $context = 'coupons_stats';
 
 	/**
 	 * Cache identifier.

--- a/src/API/Reports/Customers/Stats/DataStore.php
+++ b/src/API/Reports/Customers/Stats/DataStore.php
@@ -40,7 +40,7 @@ class DataStore extends CustomersDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'customer_stats';
+	protected $context = 'customers_stats';
 
 	/**
 	 * Assign report columns once full table name has been assigned.

--- a/src/API/Reports/Downloads/Stats/DataStore.php
+++ b/src/API/Reports/Downloads/Stats/DataStore.php
@@ -40,7 +40,7 @@ class DataStore extends DownloadsDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'download_stats';
+	protected $context = 'downloads_stats';
 
 	/**
 	 * Assign report columns once full table name has been assigned.

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -68,7 +68,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'order_stats';
+	protected $context = 'orders_stats';
 
 	/**
 	 * Assign report columns once full table name has been assigned.

--- a/src/API/Reports/Products/Stats/DataStore.php
+++ b/src/API/Reports/Products/Stats/DataStore.php
@@ -40,7 +40,7 @@ class DataStore extends ProductsDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'product_stats';
+	protected $context = 'products_stats';
 
 	/**
 	 * Assign report columns once full table name has been assigned.

--- a/src/API/Reports/Taxes/Stats/DataStore.php
+++ b/src/API/Reports/Taxes/Stats/DataStore.php
@@ -51,7 +51,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 *
 	 * @var string
 	 */
-	protected $context = 'tax_stats';
+	protected $context = 'taxes_stats';
 
 	/**
 	 * Assign report columns once full table name has been assigned.


### PR DESCRIPTION
Follow up to https://github.com/woocommerce/woocommerce-admin/pull/3328

The contexts in DataStores for stats were singular, which made for construction of SQL hook names to be different between stats queries and regular queries.

In making #3328 I found this to be a source of errors and it was difficult to keep straight while adding filters. Changes here do introduce a discrepancy between the table name and the hook, ie `wp_wc_order_stats` v. `woocommerce_analytics_clauses_join_orders_stats_total`.

Short of renaming table columns, I think its ok because it allow either programatically adding filters or easy detection of typos.

```php
// This

add_filter( 'woocommerce_analytics_clauses_join_orders_subquery', 'add_join_subquery' );
add_filter( 'woocommerce_analytics_clauses_join_order_stats_total', 'add_join_subquery' );
add_filter( 'woocommerce_analytics_clauses_join_order_stats_interval', 'add_join_subquery' );

// becomes this

add_filter( 'woocommerce_analytics_clauses_join_orders_subquery', 'add_join_subquery' );
add_filter( 'woocommerce_analytics_clauses_join_orders_stats_total', 'add_join_subquery' );
add_filter( 'woocommerce_analytics_clauses_join_orders_stats_interval', 'add_join_subquery' );
```

### Detailed test instructions:

1. Create two or more orders for today.
1. On the last order, change the postmeta value for key `_order_currency` to `NZD` or `ZAR`. If you are using vvv, you can go to the last page of the `wp_postmeta` table and edit the key value pair directly in phpmyadmin.
1. You may need to clear your cache `wp transient delete woocommerce_reports-transient-version`.
1. `npm run example -- --ext=sql-modification`
2. Activate WooCommerce Admin SQL modification Example
3. Go to any report and change the time to "today"
4. Manipulate the currency dropdown to see the results update accordingly.
5. Check all the reports.
