### PR TITLE
Fix CompareFilter selected value format.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.1.0 (Unreleased)
 - Added `<ImageUpload />` component.
 - Style form components for WordPress 5.3.
+- Fix CompareFilter options format (key prop vs. id).
 
 # 4.0.0
 

--- a/packages/components/src/compare-filter/index.js
+++ b/packages/components/src/compare-filter/index.js
@@ -73,7 +73,7 @@ export class CompareFilter extends Component {
 	updateQuery() {
 		const { param, path, query } = this.props;
 		const { selected } = this.state;
-		const idList = selected.map( p => p.id );
+		const idList = selected.map( p => p.key );
 		updateQueryString( { [ param ]: idList.join( ',' ) }, path, query );
 	}
 


### PR DESCRIPTION
Fixes #3407.

Look for `key` instead of `id` property. _(This was missed in https://github.com/woocommerce/woocommerce-admin/pull/3036)_

### Detailed test instructions:

- Ensure your date range includes the sale of multiple products
- View the product report
- Select "Comparison" from the filter to the right of the date range picker
- Search for and include at least two products to compare, then click compare
- Note that the comparison contains only the products selected

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: `CompareFilter` functionality regression.