### PR TITLE
Fix the "is this card useful" prompt display

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -123,18 +123,18 @@ class TaskDashboard extends Component {
 
 		return (
 			<Snackbar className="woocommerce-task-card__prompt">
-				<div>
-					<div className="woocommerce-task-card__prompt-pointer" />
+				<div className="woocommerce-task-card__prompt-pointer" />
+				<div className="woocommerce-task-card__prompt-content">
 					<span>{ __( 'Is this card useful?', 'woocommerce-admin' ) }</span>
-				</div>
-				<div className="woocommerce-task-card__prompt-actions">
-					<Button isLink onClick={ () => this.hideTaskCard( 'hide_card' ) }>
-						{ __( 'No, hide it', 'woocommerce-admin' ) }
-					</Button>
+					<div className="woocommerce-task-card__prompt-actions">
+						<Button isLink onClick={ () => this.hideTaskCard( 'hide_card' ) }>
+							{ __( 'No, hide it', 'woocommerce-admin' ) }
+						</Button>
 
-					<Button isLink onClick={ () => this.keepTaskCard() }>
-						{ __( 'Yes, keep it', 'woocommerce-admin' ) }
-					</Button>
+						<Button isLink onClick={ () => this.keepTaskCard() }>
+							{ __( 'Yes, keep it', 'woocommerce-admin' ) }
+						</Button>
+					</div>
 				</div>
 			</Snackbar>
 		);

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -30,6 +30,12 @@
 		}
 	}
 
+	.woocommerce-task-dashboard__container
+		.woocommerce-task-card__prompt-actions
+		.components-button:not(.components-icon-button) {
+		color: $studio-white;
+	}
+
 	.woocommerce-list {
 		margin: 0;
 
@@ -383,8 +389,13 @@
 	margin-top: -$gap-smallest;
 	cursor: default;
 
-	.components-snackbar__content span {
-		margin-left: -$gap-large;
+	.components-snackbar__content {
+		display: block;
+		align-items: unset;
+		justify-content: unset;
+		span {
+			margin-left: -$gap-large;
+		}
 	}
 
 	.woocommerce-task-card__prompt-actions {
@@ -410,6 +421,20 @@
 		height: 0;
 		display: inline-block;
 		top: -30px;
+	}
+
+	.woocommerce-task-card__prompt-content {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		max-height: 10px;
+		margin-left: $gap-large;
+		position: relative;
+		top: -40px;
+	}
+
+	.woocommerce-task-card__prompt-actions {
+		margin-right: -$gap;
 	}
 
 	&:hover {

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -30,10 +30,12 @@
 		}
 	}
 
-	.woocommerce-task-dashboard__container
-		.woocommerce-task-card__prompt-actions
-		.components-button:not(.components-icon-button) {
-		color: $studio-white;
+	.woocommerce-task-dashboard__container {
+		.woocommerce-task-card__prompt-actions {
+			.components-button:not(.components-icon-button) {
+				color: $studio-white;
+			}
+		}
 	}
 
 	.woocommerce-list {


### PR DESCRIPTION
Fixes #3412 

This PR fixes the task lists "is this prompt useful?" notice. 

### Screenshots

<img width="1484" alt="Screen Shot 2019-12-16 at 12 17 15 PM" src="https://user-images.githubusercontent.com/689165/70928039-27511180-1ffe-11ea-8e31-6b9108fff953.png">

### Detailed test instructions:

* Delete the `woocommerce_task_list_prompt_shown` option.
* Enable the task list.
* Complete all the tasks, so you get the minified task view about analytics.
* See that the notice displays correctly.