### PR TITLE
Fix user data fields filter name.

### DIFF
--- a/src/Features/ActivityPanels.php
+++ b/src/Features/ActivityPanels.php
@@ -36,10 +36,10 @@ class ActivityPanels {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
-		add_filter( 'wc_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
+		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		// Run after Automattic\WooCommerce\Admin\Loader.
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
-		// new settings injection
+		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
 		add_action( 'woocommerce_updated', array( $this, 'woocommerce_updated_note' ) );
 	}

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -34,7 +34,7 @@ class Analytics {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
-		add_filter( 'wc_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
+		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_pages' ) );
 	}
 

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -39,7 +39,7 @@ class AnalyticsDashboard {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
-		add_filter( 'wc_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
+		add_filter( 'woocommerce_admin_get_user_data_fields', array( $this, 'add_user_data_fields' ) );
 		add_action( 'admin_menu', array( $this, 'register_page' ) );
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( $this, 'update_link_structure' ), 20 );


### PR DESCRIPTION
The `wc_admin_get_user_data_fields` filter was renamed to `woocommerce_admin_get_user_data_fields ` in #3339, but the internal usage of the filter was missed.

This PR updates our usage to the new filter name.

### Detailed test instructions:

- Go to WooCommerce > Dashboard (not tasklist or OBW)
- Verify that changing visible indicators, changing section order and titles persists

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

_No changelog needed - unreleased regression_
