### PR TITLE
Add moment dependency to script registration.

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -288,7 +288,7 @@ class Loader {
 		wp_register_script(
 			'wc-csv',
 			self::get_url( 'csv-export/index.js' ),
-			array(),
+			array( 'moment' ),
 			self::get_file_version( 'csv-export/index.js' ),
 			true
 		);
@@ -322,7 +322,7 @@ class Loader {
 		wp_register_script(
 			'wc-date',
 			self::get_url( 'date/index.js' ),
-			array( 'wp-date', 'wp-i18n' ),
+			array( 'moment', 'wp-date', 'wp-i18n' ),
 			self::get_file_version( 'date/index.js' ),
 			true
 		);
@@ -333,6 +333,7 @@ class Loader {
 			'wc-components',
 			self::get_url( 'components/index.js' ),
 			array(
+				'moment',
 				'wp-api-fetch',
 				'wp-data',
 				'wp-element',
@@ -371,7 +372,7 @@ class Loader {
 		wp_register_script(
 			WC_ADMIN_APP,
 			self::get_url( 'app/index.js' ),
-			array( 'wc-components', 'wc-navigation', 'wp-date', 'wp-html-entities', 'wp-keycodes', 'wp-i18n' ),
+			array( 'wc-components', 'wc-navigation', 'wp-date', 'wp-html-entities', 'wp-keycodes', 'wp-i18n', 'moment' ),
 			self::get_file_version( 'app/index.js' ),
 			true
 		);


### PR DESCRIPTION
Our app and packages expect momentjs as an external.

Fixes https://wordpress.org/support/topic/analytics-download-button-does-not-work/

The `client/` app, `components`, `csv-export`, and `date` packages all expect an external `moment` to be loaded.

It seems that we were relying on `moment` being enqueued by some other mechanism that no longer is working. This PR explicitly names `moment` as a dependency for the above scripts during their registration.

### Detailed test instructions:

- Open any report
- Set the date range such that there is only 1 page of results
- Click "download"
- Verify no console errors, and the report is downloaded in-browser

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: error when trying to download report data.
