### PR TITLE
Allow report caching layer to be filtered off.

### DIFF
--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -120,6 +120,23 @@ class DataStore extends SqlQuery {
 	}
 
 	/**
+	 * Whether or not the report should use the caching layer.
+	 *
+	 * Provides an opportunity for plugins to prevent reports from using cache.
+	 *
+	 * @return boolean Whether or not to utilize caching.
+	 */
+	protected function should_use_cache() {
+		/**
+		 * Determines if a report will utilize caching.
+		 *
+		 * @param bool $use_cache Whether or not to use cache.
+		 * @param string $cache_key The report's cache key. Used to identify the report.
+		 */
+		return (bool) apply_filters( 'woocommerce_analytics_report_should_use_cache', true, $this->cache_key );
+	}
+
+	/**
 	 * Returns string to be used as cache key for the data.
 	 *
 	 * @param array $params Query parameters.
@@ -143,7 +160,11 @@ class DataStore extends SqlQuery {
 	 * @return mixed
 	 */
 	protected function get_cached_data( $cache_key ) {
-		return Cache::get( $cache_key );
+		if ( $this->should_use_cache() ) {
+			return Cache::get( $cache_key );
+		}
+
+		return false;
 	}
 
 	/**
@@ -154,7 +175,11 @@ class DataStore extends SqlQuery {
 	 * @return bool
 	 */
 	protected function set_cached_data( $cache_key, $value ) {
-		return Cache::set( $cache_key, $value );
+		if ( $this->should_use_cache() ) {
+			return Cache::set( $cache_key, $value );
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/reports/class-wc-tests-reports-orders-stats.php
+++ b/tests/reports/class-wc-tests-reports-orders-stats.php
@@ -13,6 +13,19 @@ use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
  * Class WC_Tests_Reports_Orders_Stats
  */
 class WC_Tests_Reports_Orders_Stats extends WC_Unit_Test_Case {
+	/**
+	 * Don't cache report data during these tests.
+	 */
+	public static function setUpBeforeClass() {
+		add_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
+	}
+
+	/**
+	 * Restore cache for other tests.
+	 */
+	public static function tearDownAfterClass() {
+		remove_filter( 'woocommerce_analytics_report_should_use_cache', '__return_false' );
+	}
 
 	/**
 	 * Test the calculations and querying works correctly for the base case of 1 order.


### PR DESCRIPTION
Fixes #3072.

This PR seeks to restore the last query output in unit test failures for the Order Stats tests.

It does so by adding a filter to allow report caching to be conditionally disabled. It introduces the `woocommerce_analytics_report_should_use_cache` filter, which short circuits caching (by returning `false`).

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: allow report cache layer to be turned off.
