### PR TITLE
Update instructions for documenting new components.

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,23 +1,26 @@
 # How To Document Components
 
-We rely on inline documentation and a markdown example file for both [the docs site on github.io,](https://woocommerce.github.io/woocommerce-admin/#/) and the DevDocs section in wp-admin. This allows us to keep the docs site up-to-date if any components change, because the documentation is kept in the same place as the code. Read on for how to build out the docs files and devdocs section.
+We rely on a markdown documentation file for [the docs site on github.io,](https://woocommerce.github.io/woocommerce-admin/#/) and an example JavaScript file for the DevDocs section in wp-admin. Read on for how to build out the docs files and devdocs section.
 
-## 1. Add the inline documentation to generate a markdown file
+## 1. Create a markdown documentation file
 
-This consists of a docblock for a component description at the top of the component, correct `PropTypes` definitions for all props used, and docblocks for each prop in PropTypes. See [count/index.js](https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/count/index.js) for a simple example, or [table/table.js](https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/table/table.js) for a very detailed example.
+Create a `README.md` file in the component directory. You can start with the documentation for a simple component as a reference (we recommend the [Card component](https://raw.githubusercontent.com/woocommerce/woocommerce-admin/master/packages/components/src/card/README.md)). Typically the markdown file has a description of the component, example usage, and a table describing the available props.
 
-## 2. Generate the docs with `npm run docs`
+## 2. Create a JavaScript example file
 
-This creates the file in `/docs/components/` for your new component, or adds it to the existing component doc (if this is a sub-component, like TablePlaceholder).
+The JavaScript example will be rendered in the DevDocs section and serves as interactive documentation for the component. Create a `docs/example.js` file in the component directory.
+
+See [count/docs/example.js](https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/count/docs/example.js) for a simple example, or [table/docs/example.js](https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/table/docs/example.js) for a more detailed example.
+
+## 3. Generate the docs with `npm run docs`
+
+This creates the file in `/docs/components/` for your new component and builds the sidebar links for the documentation site.
 
 You can test this by running `npx docsify serve docs`, it will spin up a server at localhost:3000 to preview the docs. This also live-reloads as you're making changes.
 
-## 3. Add an `example.md` file
-
-You can use [`card/example.md`](https://raw.githubusercontent.com/woocommerce/woocommerce-admin/master/packages/components/src/card/example.md) as a simple example, or [`pagination/example.md`](https://raw.githubusercontent.com/woocommerce/woocommerce-admin/master/packages/components/src/pagination/example.md) as an example with state ([using `withState` HoC from gutenberg](https://github.com/WordPress/gutenberg/tree/master/packages/compose/src/with-state)).
 
 ## 4. Add your example to `client/devdocs/examples.json`
 
-Keep these alphabetized. Optional properties here are `render`, `filePath`, and `docPath`. `render` defaults to `My{ComponentName}`, and `filePath` defaults to `/docs/component/packages/{component-name-as-slug}`. `docPath` designates the origin of the component and efaults to `packages` for components from `/packages/components`.
+Keep these alphabetized. The `component` property is required. You can optionally provide a `filePath`, but it will default to `/docs/component/packages/{component-name-as-slug}`.
 
 Now you can visit `/wp-admin/admin.php?page=wc-admin&path=/devdocs` to see your component in action.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -4,7 +4,9 @@ We rely on a markdown documentation file for [the docs site on github.io,](https
 
 ## 1. Create a markdown documentation file
 
-Create a `README.md` file in the component directory. You can start with the documentation for a simple component as a reference (we recommend the [Card component](https://raw.githubusercontent.com/woocommerce/woocommerce-admin/master/packages/components/src/card/README.md)). Typically the markdown file has a description of the component, example usage, and a table describing the available props.
+Use `npm run docs` to generate a `README.md` for your new component. This will create a basic documentation file containing the component name, description comment, component props, and a placeholder section for example usage.
+
+Edit the documentation file for completeness. We recommend using a simple component as a reference (like the [Card component](https://raw.githubusercontent.com/woocommerce/woocommerce-admin/master/packages/components/src/card/README.md)).
 
 ## 2. Create a JavaScript example file
 
@@ -12,12 +14,9 @@ The JavaScript example will be rendered in the DevDocs section and serves as int
 
 See [count/docs/example.js](https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/count/docs/example.js) for a simple example, or [table/docs/example.js](https://github.com/woocommerce/woocommerce-admin/blob/master/packages/components/src/table/docs/example.js) for a more detailed example.
 
-## 3. Generate the docs with `npm run docs`
+## 3. Preview the documentation site
 
-This creates the file in `/docs/components/` for your new component and builds the sidebar links for the documentation site.
-
-You can test this by running `npx docsify serve docs`, it will spin up a server at localhost:3000 to preview the docs. This also live-reloads as you're making changes.
-
+You can test the documentation site by running `npx docsify serve docs`. It will spin up a server at localhost:3000 to preview the docs. This also live-reloads as you're making changes.
 
 ## 4. Add your example to `client/devdocs/examples.json`
 


### PR DESCRIPTION
Fixes #3026.

This PR seeks to update the component documentation process after it was changed in #2872.

### Detailed test instructions:

- Read `docs/documentation.md`
- Verify for accuracy

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
