### PR TITLE
Add purchase modal at the end of the profile wizard

### DIFF
--- a/client/dashboard/index.js
+++ b/client/dashboard/index.js
@@ -4,7 +4,6 @@
  */
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,42 +11,15 @@ import { get } from 'lodash';
 import './style.scss';
 import CustomizableDashboard from './customizable';
 import ProfileWizard from './profile-wizard';
-import CartModal from './profile-wizard/cart-modal';
 import withSelect from 'wc-api/with-select';
-import { isOnboardingEnabled, getProductIdsForCart } from 'dashboard/utils';
+import { isOnboardingEnabled } from 'dashboard/utils';
 
 class Dashboard extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			showCartModal: false,
-		};
-	}
-	componentDidUpdate( prevProps ) {
-		const profileItems = get( this.props, 'profileItems', {} );
-		const prevProfileItems = get( prevProps, 'profileItems', {} );
-
-		// We only want to show the modal during the transition between the profile wizard and dashboard and if products were selected.
-		if ( profileItems.completed && ! prevProfileItems.completed ) {
-			const productIds = getProductIdsForCart( profileItems );
-			if ( productIds.length ) {
-				/* eslint-disable react/no-did-update-set-state */
-				this.setState( { showCartModal: true } );
-				/* eslint-enable react/nod-ddi-update-set-state */
-			}
-		}
-	}
-
 	render() {
 		const { path, profileItems, query } = this.props;
-		const { showCartModal } = this.state;
 
 		if ( isOnboardingEnabled() && ! profileItems.completed ) {
 			return <ProfileWizard query={ query } />;
-		}
-
-		if ( isOnboardingEnabled() && showCartModal ) {
-			return <CartModal onClose={ () => this.setState( { showCartModal: false } ) } />;
 		}
 
 		if ( window.wcAdminFeatures[ 'analytics-dashboard/customizable' ] ) {

--- a/client/dashboard/profile-wizard/cart-modal.js
+++ b/client/dashboard/profile-wizard/cart-modal.js
@@ -25,18 +25,16 @@ import { getProductIdsForCart } from 'dashboard/utils';
 import sanitizeHTML from 'lib/sanitize-html';
 
 class CartModal extends Component {
-	componentDidMount() {
-		document.body.classList.add( 'woocommerce-admin-full-screen' );
-		document.body.classList.add( 'woocommerce-profile-wizard__body' );
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isRedirecting: false,
+		};
 	}
 
-	componentWillUnmount() {
-		document.body.classList.remove( 'woocommerce-admin-full-screen' );
-		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
-	}
-
-	redirectToCart() {
-		const { productIds } = this.props;
+	onClickNow() {
+		const { productIds, onClickNow } = this.props;
+		this.setState( { isRedirecting: true } );
 		const backPath = getNewPath( {}, '/', {} );
 		const { connectNonce } = getSetting( 'onboarding', {} );
 
@@ -51,6 +49,12 @@ class CartModal extends Component {
 			'wccom-connect-nonce': connectNonce,
 			'wccom-back': backPath,
 		} );
+
+		if ( onClickNow ) {
+			onClickNow( url );
+			return;
+		}
+
 		window.location = url;
 	}
 
@@ -75,7 +79,7 @@ class CartModal extends Component {
 				return theme.id === productId;
 			} );
 
-			if ( themeInfo && themeInfo.slug !== 'Storefront' ) {
+			if ( themeInfo ) {
 				listItems.push( {
 					title: sprintf(
 						__( '%s — %s per year', 'woocommerce-admin' ),
@@ -91,6 +95,7 @@ class CartModal extends Component {
 	}
 
 	render() {
+		const { isRedirecting } = this.state;
 		return (
 			<Modal
 				title={ __(
@@ -102,7 +107,7 @@ class CartModal extends Component {
 			>
 				{ this.renderProducts() }
 
-				<p>
+				<p className="woocommerce-cart-modal__help-text">
 					{ __(
 						"You won't have access to this functionality until the extensions have been purchased and installed.",
 						'woocommerce-admin'
@@ -110,11 +115,11 @@ class CartModal extends Component {
 				</p>
 
 				<div className="woocommerce-cart-modal__actions">
-					<Button isLink onClick={ () => this.props.onClose() }>
+					<Button isLink onClick={ () => this.props.onClickLater() }>
 						{ __( "I'll do it later", 'woocommerce-admin' ) }
 					</Button>
 
-					<Button isPrimary isDefault onClick={ () => this.redirectToCart() }>
+					<Button isPrimary isDefault isBusy={ isRedirecting } onClick={ () => this.onClickNow() }>
 						{ __( 'Purchase & install now', 'woocommerce-admin' ) }
 					</Button>
 				</div>

--- a/client/dashboard/profile-wizard/cart-modal.js
+++ b/client/dashboard/profile-wizard/cart-modal.js
@@ -1,0 +1,134 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { Button, Modal } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { find } from 'lodash';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+import { getNewPath } from '@woocommerce/navigation';
+import { List } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import withSelect from 'wc-api/with-select';
+import { getProductIdsForCart } from 'dashboard/utils';
+import sanitizeHTML from 'lib/sanitize-html';
+
+class CartModal extends Component {
+	componentDidMount() {
+		document.body.classList.add( 'woocommerce-admin-full-screen' );
+		document.body.classList.add( 'woocommerce-profile-wizard__body' );
+	}
+
+	componentWillUnmount() {
+		document.body.classList.remove( 'woocommerce-admin-full-screen' );
+		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
+	}
+
+	redirectToCart() {
+		const { productIds } = this.props;
+		const backPath = getNewPath( {}, '/', {} );
+		const { connectNonce } = getSetting( 'onboarding', {} );
+
+		if ( ! productIds.length ) {
+			return;
+		}
+
+		const url = addQueryArgs( 'https://woocommerce.com/cart', {
+			'wccom-site': getSetting( 'siteUrl' ),
+			'wccom-woo-version': getSetting( 'wcVersion' ),
+			'wccom-replace-with': productIds.join( ',' ),
+			'wccom-connect-nonce': connectNonce,
+			'wccom-back': backPath,
+		} );
+		window.location = url;
+	}
+
+	renderProducts() {
+		const { productIds } = this.props;
+		const { productTypes = {}, themes = [] } = getSetting( 'onboarding', {} );
+		const listItems = [];
+
+		productIds.forEach( productId => {
+			const productInfo = find( productTypes, productType => {
+				return productType.product === productId;
+			} );
+
+			if ( productInfo ) {
+				listItems.push( {
+					title: productInfo.label,
+					content: productInfo.description,
+				} );
+			}
+
+			const themeInfo = find( themes, theme => {
+				return theme.id === productId;
+			} );
+
+			if ( themeInfo && themeInfo.slug !== 'Storefront' ) {
+				listItems.push( {
+					title: sprintf(
+						__( '%s — %s per year', 'woocommerce-admin' ),
+						themeInfo.title,
+						decodeEntities( themeInfo.price )
+					),
+					content: <span dangerouslySetInnerHTML={ sanitizeHTML( themeInfo.excerpt ) } />,
+				} );
+			}
+		} );
+
+		return <List items={ listItems } />;
+	}
+
+	render() {
+		return (
+			<Modal
+				title={ __(
+					'Would you like to purchase and install the following features now?',
+					'woocommerce-admin'
+				) }
+				onRequestClose={ () => this.props.onClose() }
+				className="woocommerce-cart-modal"
+			>
+				{ this.renderProducts() }
+
+				<p>
+					{ __(
+						"You won't have access to this functionality until the extensions have been purchased and installed.",
+						'woocommerce-admin'
+					) }
+				</p>
+
+				<div className="woocommerce-cart-modal__actions">
+					<Button isLink onClick={ () => this.props.onClose() }>
+						{ __( "I'll do it later", 'woocommerce-admin' ) }
+					</Button>
+
+					<Button isPrimary isDefault onClick={ () => this.redirectToCart() }>
+						{ __( 'Purchase & install now', 'woocommerce-admin' ) }
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+}
+
+export default compose(
+	withSelect( select => {
+		const { getProfileItems } = select( 'wc-api' );
+		const profileItems = getProfileItems();
+		const productIds = getProductIdsForCart( profileItems );
+
+		return { profileItems, productIds };
+	} )
+)( CartModal );

--- a/client/dashboard/profile-wizard/cart-modal.js
+++ b/client/dashboard/profile-wizard/cart-modal.js
@@ -28,13 +28,14 @@ class CartModal extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isRedirecting: false,
+			purchaseNowButtonBusy: false,
+			purchaseLaterButtonBusy: false,
 		};
 	}
 
-	onClickNow() {
-		const { productIds, onClickNow } = this.props;
-		this.setState( { isRedirecting: true } );
+	onClickPurchaseNow() {
+		const { productIds, onClickPurchaseNow } = this.props;
+		this.setState( { purchaseNowButtonBusy: true } );
 		const backPath = getNewPath( {}, '/', {} );
 		const { connectNonce } = getSetting( 'onboarding', {} );
 
@@ -50,12 +51,17 @@ class CartModal extends Component {
 			'wccom-back': backPath,
 		} );
 
-		if ( onClickNow ) {
-			onClickNow( url );
+		if ( onClickPurchaseNow ) {
+			onClickPurchaseNow( url );
 			return;
 		}
 
 		window.location = url;
+	}
+
+	onClickPurchaseLater() {
+		this.setState( { purchaseLaterButtonBusy: true } );
+		this.props.onClickPurchaseLater();
 	}
 
 	renderProducts() {
@@ -95,7 +101,7 @@ class CartModal extends Component {
 	}
 
 	render() {
-		const { isRedirecting } = this.state;
+		const { purchaseNowButtonBusy, purchaseLaterButtonBusy } = this.state;
 		return (
 			<Modal
 				title={ __(
@@ -115,11 +121,20 @@ class CartModal extends Component {
 				</p>
 
 				<div className="woocommerce-cart-modal__actions">
-					<Button isLink onClick={ () => this.props.onClickLater() }>
+					<Button
+						isLink
+						isBusy={ purchaseLaterButtonBusy }
+						onClick={ () => this.onClickPurchaseLater() }
+					>
 						{ __( "I'll do it later", 'woocommerce-admin' ) }
 					</Button>
 
-					<Button isPrimary isDefault isBusy={ isRedirecting } onClick={ () => this.onClickNow() }>
+					<Button
+						isPrimary
+						isDefault
+						isBusy={ purchaseNowButtonBusy }
+						onClick={ () => this.onClickPurchaseNow() }
+					>
 						{ __( 'Purchase & install now', 'woocommerce-admin' ) }
 					</Button>
 				</div>

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -17,6 +17,7 @@ import { updateQueryString } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import BusinessDetails from './steps/business-details';
+import CartModal from './cart-modal';
 import Industry from './steps/industry';
 import Plugins from './steps/plugins';
 import ProductTypes from './steps/product-types';
@@ -25,17 +26,31 @@ import Start from './steps/start';
 import StoreDetails from './steps/store-details';
 import Theme from './steps/theme';
 import withSelect from 'wc-api/with-select';
+import { getProductIdsForCart } from 'dashboard/utils';
 import './style.scss';
 
 class ProfileWizard extends Component {
 	constructor() {
 		super( ...arguments );
+		this.state = {
+			showCartModal: false,
+			cartRedirect: false,
+		};
 		this.goToNextStep = this.goToNextStep.bind( this );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const { step: prevStep } = prevProps.query;
 		const { step } = this.props.query;
+		const { isError, isGetProfileItemsRequesting, createNotice } = this.props;
+
+		const isRequestError = ! isGetProfileItemsRequesting && prevProps.isRequesting && isError;
+		if ( isRequestError ) {
+			createNotice(
+				'error',
+				__( 'There was a problem finishing the profile wizard.', 'woocommerce-admin' )
+			);
+		}
 
 		if ( prevStep !== step ) {
 			window.document.documentElement.scrollTop = 0;
@@ -50,6 +65,13 @@ class ProfileWizard extends Component {
 	}
 
 	componentWillUnmount() {
+		const { cartRedirect } = this.state;
+
+		if ( cartRedirect ) {
+			document.body.classList.add( 'woocommerce-admin-is-loading' );
+			window.location = cartRedirect;
+		}
+
 		document.documentElement.classList.add( 'wp-toolbar' );
 		document.body.classList.remove( 'woocommerce-onboarding' );
 		document.body.classList.remove( 'woocommerce-profile-wizard__body' );
@@ -117,28 +139,40 @@ class ProfileWizard extends Component {
 	}
 
 	async goToNextStep() {
-		const { createNotice, isError, updateProfileItems } = this.props;
 		const currentStep = this.getCurrentStep();
 		const currentStepIndex = this.getSteps().findIndex( s => s.key === currentStep.key );
 		const nextStep = this.getSteps()[ currentStepIndex + 1 ];
 
 		if ( 'undefined' === typeof nextStep ) {
-			await updateProfileItems( { completed: true } );
-
-			if ( isError ) {
-				createNotice(
-					'error',
-					__( 'There was a problem completing the profiler.', 'woocommerce-admin' )
-				);
-			}
+			this.finishWizard();
 			return;
 		}
 
 		return updateQueryString( { step: nextStep.key } );
 	}
 
+	finishWizard() {
+		const { profileItems, updateProfileItems } = this.props;
+
+		// @todo This should also send profile information to woocommerce.com.
+
+		const productIds = getProductIdsForCart( profileItems );
+		if ( productIds.length ) {
+			this.setState( { showCartModal: true } );
+		} else {
+			updateProfileItems( { completed: true } );
+		}
+	}
+
+	markCompleteAndPurchase( cartRedirect ) {
+		const { updateProfileItems } = this.props;
+		this.setState( { cartRedirect } );
+		updateProfileItems( { completed: true } );
+	}
+
 	render() {
 		const { query } = this.props;
+		const { showCartModal } = this.state;
 		const step = this.getCurrentStep();
 
 		const container = createElement( step.container, {
@@ -150,6 +184,13 @@ class ProfileWizard extends Component {
 
 		return (
 			<Fragment>
+				{ showCartModal && (
+					<CartModal
+						onClose={ () => this.setState( { showCartModal: false } ) }
+						onClickNow={ cartRedirect => this.markCompleteAndPurchase( cartRedirect ) }
+						onClickLater={ () => this.props.updateProfileItems( { completed: true } ) }
+					/>
+				) }
 				<ProfileWizardHeader currentStep={ step.key } steps={ steps } />
 				<div className="woocommerce-profile-wizard__container">{ container }</div>
 			</Fragment>

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -34,7 +34,7 @@ class ProfileWizard extends Component {
 		super( ...arguments );
 		this.state = {
 			showCartModal: false,
-			cartRedirect: false,
+			cartRedirectUrl: null,
 		};
 		this.goToNextStep = this.goToNextStep.bind( this );
 	}
@@ -65,11 +65,11 @@ class ProfileWizard extends Component {
 	}
 
 	componentWillUnmount() {
-		const { cartRedirect } = this.state;
+		const { cartRedirectUrl } = this.state;
 
-		if ( cartRedirect ) {
+		if ( cartRedirectUrl ) {
 			document.body.classList.add( 'woocommerce-admin-is-loading' );
-			window.location = cartRedirect;
+			window.location = cartRedirectUrl;
 		}
 
 		document.documentElement.classList.add( 'wp-toolbar' );
@@ -164,9 +164,9 @@ class ProfileWizard extends Component {
 		}
 	}
 
-	markCompleteAndPurchase( cartRedirect ) {
+	markCompleteAndPurchase( cartRedirectUrl ) {
 		const { updateProfileItems } = this.props;
-		this.setState( { cartRedirect } );
+		this.setState( { cartRedirectUrl } );
 		updateProfileItems( { completed: true } );
 	}
 
@@ -187,8 +187,10 @@ class ProfileWizard extends Component {
 				{ showCartModal && (
 					<CartModal
 						onClose={ () => this.setState( { showCartModal: false } ) }
-						onClickNow={ cartRedirect => this.markCompleteAndPurchase( cartRedirect ) }
-						onClickLater={ () => this.props.updateProfileItems( { completed: true } ) }
+						onClickPurchaseNow={ cartRedirectUrl =>
+							this.markCompleteAndPurchase( cartRedirectUrl )
+						}
+						onClickPurchaseLater={ () => this.props.updateProfileItems( { completed: true } ) }
 					/>
 				) }
 				<ProfileWizardHeader currentStep={ step.key } steps={ steps } />

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -44,23 +44,29 @@ class Theme extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isGetProfileItemsRequesting, isError, createNotice, goToNextStep } = this.props;
+		const { isError, isGetProfileItemsRequesting, createNotice } = this.props;
 		const { chosen } = this.state;
+		const isRequestSuccessful =
+			! isGetProfileItemsRequesting && prevProps.isGetProfileItemsRequesting && ! isError && chosen;
+		const isRequestError = ! isGetProfileItemsRequesting && prevProps.isRequesting && isError;
 
-		/* eslint-disable react/no-did-update-set-state */
-		if ( prevProps.isGetProfileItemsRequesting && ! isGetProfileItemsRequesting && chosen ) {
-			if ( ! isError ) {
-				// @todo This should send profile information to woocommerce.com.
-				goToNextStep();
-			} else {
-				this.setState( { chosen: null } );
-				createNotice(
-					'error',
-					__( 'There was a problem selecting your store theme.', 'woocommerce-admin' )
-				);
-			}
+		if ( isRequestSuccessful ) {
+			// @todo This should send profile information to woocommerce.com.
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( { chosen: null } );
+			/* eslint-enable react/no-did-update-set-state */
+			this.props.goToNextStep();
 		}
-		/* eslint-enable react/no-did-update-set-state */
+
+		if ( isRequestError ) {
+			/* eslint-disable react/no-did-update-set-state */
+			this.setState( { chosen: null } );
+			/* eslint-enable react/no-did-update-set-state */
+			createNotice(
+				'error',
+				__( 'There was a problem selecting your store theme.', 'woocommerce-admin' )
+			);
+		}
 	}
 
 	async onChoose( theme, location = '' ) {

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -51,7 +51,6 @@ class Theme extends Component {
 		const isRequestError = ! isGetProfileItemsRequesting && prevProps.isRequesting && isError;
 
 		if ( isRequestSuccessful ) {
-			// @todo This should send profile information to woocommerce.com.
 			/* eslint-disable react/no-did-update-set-state */
 			this.setState( { chosen: null } );
 			/* eslint-enable react/no-did-update-set-state */

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -179,3 +179,44 @@
 		/* stylelint-enable */
 	}
 }
+
+.components-modal__frame.woocommerce-cart-modal {
+	width: 600px;
+	max-width: 100%;
+
+	.components-modal__header {
+		border-bottom: 0;
+		margin-bottom: 0;
+
+		button {
+			display: none;
+		}
+	}
+
+	.woocommerce-list {
+		margin-top: $gap-smallest;
+	}
+
+	.woocommerce-list .woocommerce-list__item:first-child {
+		border-top: 1px solid $studio-gray-5;
+	}
+
+	.woocommerce-list__item {
+		border-bottom: 1px solid $studio-gray-5;
+	}
+
+	.woocommerce-cart-modal__actions {
+		text-align: right;
+
+		button.is-link {
+			color: $studio-pink;
+			font-weight: bold;
+			margin-right: $gap;
+			text-decoration: none;
+		}
+
+		button.is-primary {
+			align-self: flex-end;
+		}
+	}
+}

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -186,11 +186,19 @@
 
 	.components-modal__header {
 		border-bottom: 0;
-		margin-bottom: 0;
+		margin-bottom: $gap;
+		margin-top: $gap;
 
 		button {
 			display: none;
 		}
+	}
+
+	.components-modal__header-heading {
+		font-style: normal;
+		font-weight: normal;
+		font-size: 24px;
+		line-height: 32px;
 	}
 
 	.woocommerce-list {
@@ -205,14 +213,20 @@
 		border-bottom: 1px solid $studio-gray-5;
 	}
 
+	.woocommerce-cart-modal__help-text {
+		font-size: 16px;
+		line-height: 24px;
+	}
+
 	.woocommerce-cart-modal__actions {
 		text-align: right;
 
 		button.is-link {
 			color: $studio-pink;
-			font-weight: bold;
 			margin-right: $gap;
 			text-decoration: none;
+			font-weight: 600;
+			font-size: 14px;
 		}
 
 		button.is-primary {

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -37,6 +37,35 @@ export function getCurrencyRegion( countryState ) {
 }
 
 /**
+ * Gets the product IDs for items selected for purchase.
+ *
+ * @param {object} profileItems Onboarding profile.
+ * @return {array} Product Ids.
+ */
+export function getProductIdsForCart( profileItems ) {
+	const productIds = [];
+	const onboarding = getSetting( 'onboarding', {} );
+	const productTypes = profileItems.product_types || [];
+
+	productTypes.forEach( productType => {
+		if (
+			onboarding.productTypes[ productType ] &&
+			onboarding.productTypes[ productType ].product
+		) {
+			productIds.push( onboarding.productTypes[ productType ].product );
+		}
+	} );
+
+	const theme = onboarding.themes.find( themeData => themeData.slug === profileItems.theme );
+
+	if ( theme && theme.id && ! theme.is_installed ) {
+		productIds.push( theme.id );
+	}
+
+	return productIds;
+}
+
+/**
  * Returns if the onboarding feature of WooCommerce Admin should be enabled.
  *
  * While we preform an a/b test of onboarding, the feature will be enabled within the plugin build,

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -37,7 +37,7 @@ export function getCurrencyRegion( countryState ) {
 }
 
 /**
- * Gets the product IDs for items selected for purchase.
+ * Gets the product IDs for items based on the product types and theme selected in the onboarding profiler.
  *
  * @param {object} profileItems Onboarding profile.
  * @return {array} Product Ids.
@@ -58,6 +58,7 @@ export function getProductIdsForCart( profileItems ) {
 
 	const theme = onboarding.themes.find( themeData => themeData.slug === profileItems.theme );
 
+	// @todo -- Split out free themes so that they are not considered for purchase, and install those from WordPress.org on the theme step.
 	if ( theme && theme.id && ! theme.is_installed ) {
 		productIds.push( theme.id );
 	}

--- a/client/wc-api/onboarding/selectors.js
+++ b/client/wc-api/onboarding/selectors.js
@@ -24,7 +24,11 @@ const getProfileItems = ( getResource, requireResource ) => (
 	const { profile } = getSetting( 'onboarding', {} );
 
 	if ( ! ids.length ) {
-		return profile;
+		const data = {};
+		Object.keys( profile ).forEach( id => {
+			data[ id ] = getResource( getResourceName( resourceName, id ) ).data || profile[ id ];
+		} );
+		return data;
 	}
 
 	const items = {};

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -360,9 +360,7 @@ class Onboarding {
 
 		// Only fetch if the onboarding wizard is incomplete.
 		if ( self::should_show_profiler() ) {
-			$settings['onboarding']['productTypes'] = self::get_allowed_product_types();
-			$settings['onboarding']['themes']       = self::get_themes();
-			$settings['onboarding']['activeTheme']  = get_option( 'stylesheet' );
+			$settings['onboarding']['activeTheme'] = get_option( 'stylesheet' );
 		}
 
 		// Only fetch if the onboarding wizard OR the task list is incomplete.
@@ -373,6 +371,8 @@ class Onboarding {
 			$settings['onboarding']['connectNonce']             = wp_create_nonce( 'connect' );
 			$current_user                                       = wp_get_current_user();
 			$settings['onboarding']['userEmail']                = esc_html( $current_user->user_email );
+			$settings['onboarding']['productTypes']             = self::get_allowed_product_types();
+			$settings['onboarding']['themes']                   = self::get_themes();
 		}
 
 		return $settings;


### PR DESCRIPTION
Closes #3441.

This PR adds a modal at the end of the profile wizard that allows the user to confirm if they would like to purchase products now, or later (via the task list). I've tried to build this in a way that the modal can easily be used from the task as well.

It also fixes the intermittent bug we were seeing at the end of the theme step where the app would get stuck in a `updateProfileItems` loop.

One thing that I think needs further follow-up, is selecting Storefront or one of the other free themes still shows the dialog and redirects you to the cart (`master` also currently adds these items to the WC.com cart). I think we'll want to install the free themes from WordPress.org instead. cc @joshuatf.

### Screenshots

<img width="681" alt="Screen Shot 2019-12-18 at 3 15 09 PM" src="https://user-images.githubusercontent.com/689165/71120572-b1d67400-21aa-11ea-9fd2-1bfbd9d62164.png">

### Detailed test instructions:

* Enable the profile wizard
* Make a product type selection or theme selection that requires purchase
* Finish the theme step, and see the modal appear
* Walk through the profile wizard again and make selections that don't require purchase
* No modal should be displayed