### PR TITLE
Bump version to 0.23.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/admin-library",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "homepage": "https://woocommerce.github.io/woocommerce-admin/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,15 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Changelog ==
 
+= 0.23.2 2019-12-19 =
+
+- Enhancement: allow filtering of hidden WP notices. #3391 (Activity Panel, Extensibility)
+- Fix: error when trying to download report data. #3429 (Analytics)
+- Bug: Fix user data fields filter name. #3428 (Dashboard)
+- Fix: `CompareFilter` functionality regression. #3421 (Analytics, Components, Packages)
+- Fix: Time zone offset calculation on customer last active date. #3388 (Analytics)
+- Fix: remove the header when user doesn't have required permissions #3386 (Activity Panel)
+
 = 0.23.1 2019-12-08 =
 
 - Fix: undefined function error.

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,10 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Changelog ==
 
+= 0.23.1 2019-12-08 =
+
+- Fix: undefined function error.
+
 = 0.23.0 2019-12-06 =
 
 - Dev: Add currency extension #3328 (Packages)

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -142,7 +142,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.23.1' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.23.2' );
 	}
 
 	/**

--- a/src/Package.php
+++ b/src/Package.php
@@ -19,7 +19,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '0.23.1';
+	const VERSION = '0.23.2';
 
 	/**
 	 * Init the package.

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 0.23.1
+ * Version: 0.23.2
  * Requires at least: 5.3.0
  * Requires PHP: 5.6.20
  *


### PR DESCRIPTION
Just bumps the version after the `0.23.2` release. See #3451 for details.