### PR TITLE
Show pending review regardless of comment moderation settings

### DIFF
--- a/client/header/activity-panel/panels/reviews.js
+++ b/client/header/activity-panel/panels/reviews.js
@@ -162,7 +162,7 @@ class ReviewsPanel extends Component {
 					</Fragment>
 				);
 			} else {
-				buttonUrl = getAdminLink( 'edit-comments.php' );
+				buttonUrl = getAdminLink( 'edit-comments.php?comment_type=review' );
 				buttonText = __( 'View all Reviews', 'woocommerce-admin' );
 				content = (
 					<p>

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -67,8 +67,7 @@ export function getUnreadOrders( select ) {
 export function getUnapprovedReviews( select ) {
 	const { getReviewsTotalCount, getReviewsError, isGetReviewsRequesting } = select( 'wc-api' );
 	const reviewsEnabled = getSetting( 'reviewsEnabled' );
-	const commentModeration = getSetting( 'commentModeration' );
-	if ( 'yes' === reviewsEnabled && '1' === commentModeration ) {
+	if ( 'yes' === reviewsEnabled ) {
 		const actionableReviewsQuery = {
 			page: 1,
 			// @todo we are not using this review, so when the endpoint supports it,


### PR DESCRIPTION
Fixes #2795

A store can have pending comments and choose to change their comment moderation settings. Additionally, comments can be disabled without affecting product reviews - so we shouldn't be tying review functionality to comments.

This PR:
- Removes the check on the `commentModeration` setting when determining if there are pending reviews
- Changes the "view all reviews" button link to filter comments by review type

### Detailed test instructions:

- Ensure product reviews are enabled (WooCommerce > Settings > Products)
- Ensure you have at least one pending product review
- Turn off comment moderation (Settings > Discussion > Before a comment appears)
- Open WooCommerce > Dashboard or any other WC-Admin screen
- Verify that the pending review is shown
- Approve the review
- Refresh WC-Admin page
- Verify the "view all reviews" button takes you to a comments page where only reviews are shown

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: show pending product reviews when comment moderation is disabled.