### PR TITLE
Invalidate cache on settings change

### DIFF
--- a/src/API/SettingOptions.php
+++ b/src/API/SettingOptions.php
@@ -11,6 +11,8 @@ namespace Automattic\WooCommerce\Admin\API;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
+
 /**
  * Setting Options controller.
  *
@@ -25,4 +27,18 @@ class SettingOptions extends \WC_REST_Setting_Options_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc-analytics';
+
+	/**
+	 * Invalidates API cache when updating settings options.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return array Of WP_Error or WP_REST_Response.
+	 */
+	public function batch_items( $request ) {
+		// Invalidate the API cache.
+		ReportsCache::invalidate();
+
+		// Process the request.
+		return parent::batch_items( $request );
+	}
 }


### PR DESCRIPTION
Fixes #3431 

This PR seeks to invalidate the current cache version number when Analytics Settings are updated.

Without doing so, changes in excluded order statuses won't be reflected on already-cached reports.

### Detailed test instructions:

1. Go to Orders Report and note a status that you see.
1. Add that status as an excluded status on the Settings page.
1. Return to the Orders Report and refresh. You will see that status correctly being excluded.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: invalidate Reports cache when changing Analytics settings.