### PR TITLE
Onboarding: Add another option to platforms.

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -370,6 +370,10 @@ class BusinessDetails extends Component {
 				label: __( 'Yes, on another platform', 'woocommerce-admin' ),
 			},
 			{
+				key: 'other-woocommerce',
+				label: __( 'Yes, I own a different store powered by WooCommerce', 'woocommerce-admin' ),
+			},
+			{
 				key: 'brick-mortar',
 				label: __( 'Yes, in person at physical stores and/or events', 'woocommerce-admin' ),
 			},

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -124,7 +124,9 @@ class BusinessDetails extends Component {
 			} else if ( 'revenue' === name ) {
 				if (
 					! values.revenue.length &&
-					[ 'other', 'brick-mortar', 'brick-mortar-other' ].includes( values.selling_venues )
+					[ 'other', 'brick-mortar', 'brick-mortar-other', 'other-woocommerce' ].includes(
+						values.selling_venues
+					)
 				) {
 					errors.revenue = __( 'This field is required', 'woocommerce-admin' );
 				}
@@ -445,7 +447,7 @@ class BusinessDetails extends Component {
 										{ ...getInputProps( 'selling_venues' ) }
 									/>
 
-									{ [ 'other', 'brick-mortar', 'brick-mortar-other' ].includes(
+									{ [ 'other', 'brick-mortar', 'brick-mortar-other', 'other-woocommerce' ].includes(
 										values.selling_venues
 									) && (
 										<SelectControl

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -284,6 +284,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'other',
 					'brick-mortar',
 					'brick-mortar-other',
+					'other-woocommerce',
 				),
 			),
 			'revenue'             => array(


### PR DESCRIPTION
Fixes #3449

This change adds another option to the business details step of the OBW which allows users to select that they have another WooCommerce store:

![Dashboard ‹ bend outdoors — WooCommerce 2019-12-23 10-40-22](https://user-images.githubusercontent.com/22080/71374810-f8441e00-2570-11ea-925a-67a0bcac3a82.png)

__To Test__
- If you have yet to do so, opt-in to the new Site Profiler / OBW via the "Help" menu in WooCommerce Orders. While there you can also launch the Site Profiler.
- On the business profile page, verify the new option for other platforms is shown as seen above