### PR TITLE
Fix errant DB migrations.

### DIFF
--- a/src/Install.php
+++ b/src/Install.php
@@ -308,7 +308,7 @@ class Install {
 	 * @return boolean
 	 */
 	public static function needs_db_update() {
-		$current_db_version = get_option( self::VERSION_OPTION );
+		$current_db_version = get_option( self::VERSION_OPTION, null );
 		$updates            = self::get_db_update_callbacks();
 		$update_versions    = array_keys( $updates );
 		usort( $update_versions, 'version_compare' );


### PR DESCRIPTION
@timmyc noticed the following error on a fresh test site install:

```
WordPress database error Unknown column 'gross_total' in 'wp_wc_order_stats' for query ALTER TABLE wp_wc_order_stats CHANGE COLUMN `gross_total` `total_sales` double DEFAULT 0 NOT NULL made by do_action_ref_array('action_scheduler_run_queue'), WP_Hook->do_action, WP_Hook->apply_filters, ActionScheduler_QueueRunner->run, ActionScheduler_QueueRunner->do_batch, ActionScheduler_Abstract_QueueRunner->process_action, ActionScheduler_Action->execute, do_action_ref_array('woocommerce_run_update_callback'), WP_Hook->do_action, WP_Hook->apply_filters, WC_Install::run_update_callback, wc_admin_update_0230_rename_gross_total
```

None of the migration queries should run on a new install. The test for an unset DB version value is expecting a `NULL`, but we weren't passing `NULL` as the default value to `get_option()` (it defaults to `false`).

This PR sets the default value to `NULL`, like https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-install.php#L323 - missed in https://github.com/woocommerce/woocommerce-admin/pull/3299.
### Detailed test instructions:

- Launch a new test site on Jurassic.ninja, or use a fresh database in your local environment
- Install and activate WooCommerce
- Install and activate WooCommerce Admin (this branch)
- Verify that no DB migrations are scheduled (Tools > Scheduled Actions)
- Verify that no DB errors have occurred in the debug/error log

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: don't run database migrations on new installs.