### PR TITLE
Onboarding: Add in tracks for failed plugin installation

### DIFF
--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -201,10 +201,10 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 
 		if ( is_wp_error( $api ) ) {
 			$properties = array(
-				'slug'    => $slug,
 				/* translators: %s: plugin slug (example: woocommerce-services) */
-				'message' => __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce-admin' ),
-				'api'     => $api,
+				'error_message' => __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce-admin' ),
+				'api'           => $api,
+				'slug'          => $slug,
 			);
 			wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 
@@ -224,12 +224,12 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 
 		if ( is_wp_error( $result ) || is_null( $result ) ) {
 			$properties = array(
-				'slug'     => $slug,
 				/* translators: %s: plugin slug (example: woocommerce-services) */
-				'message'  => __( 'The requested plugin `%s` could not be installed.', 'woocommerce-admin' ),
-				'api'      => $api,
-				'upgrader' => $upgrader,
-				'result'   => $result,
+				'error_message' => __( 'The requested plugin `%s` could not be installed.', 'woocommerce-admin' ),
+				'slug'          => $slug,
+				'api'           => $api,
+				'upgrader'      => $upgrader,
+				'result'        => $result,
 			);
 			wc_admin_record_tracks_event( 'install_plugin_error', $properties );
 

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -200,6 +200,14 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		);
 
 		if ( is_wp_error( $api ) ) {
+			$properties = array(
+				'slug'    => $slug,
+				/* translators: %s: plugin slug (example: woocommerce-services) */
+				'message' => __( 'The requested plugin `%s` could not be installed. Plugin API call failed.', 'woocommerce-admin' ),
+				'api'     => $api,
+			);
+			wc_admin_record_tracks_event( 'install_plugin_error', $properties );
+
 			return new \WP_Error(
 				'woocommerce_rest_plugin_install',
 				sprintf(
@@ -215,6 +223,16 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		$result   = $upgrader->install( $api->download_link );
 
 		if ( is_wp_error( $result ) || is_null( $result ) ) {
+			$properties = array(
+				'slug'     => $slug,
+				/* translators: %s: plugin slug (example: woocommerce-services) */
+				'message'  => __( 'The requested plugin `%s` could not be installed.', 'woocommerce-admin' ),
+				'api'      => $api,
+				'upgrader' => $upgrader,
+				'result'   => $result,
+			);
+			wc_admin_record_tracks_event( 'install_plugin_error', $properties );
+
 			return new \WP_Error(
 				'woocommerce_rest_plugin_install',
 				sprintf(


### PR DESCRIPTION
Adds debugging to try and diagnose plugin installation described in #3446

### Detailed test instructions:

1. Force a failed installation.  For example, you could change `'slug' => sanitize_key( $slug )`, to `'slug' => ''`, in OnboardingPlugins.php.
2. Now delete WooCommerce Services, and enable the profile wizard.
3. Go to the first step of the profiler, and see the installation fail.
4. Watch live tracks events and note the data.