### PR TITLE
Onboarding: Install free themes during profiler

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -25,6 +25,7 @@ import './style.scss';
 import { recordEvent } from 'lib/tracks';
 import ThemeUploader from './uploader';
 import ThemePreview from './preview';
+import { getPriceValue } from 'dashboard/utils';
 
 class Theme extends Component {
 	constructor() {
@@ -77,7 +78,7 @@ class Theme extends Component {
 		this.setState( { chosen: slug } );
 		recordEvent( 'storeprofiler_store_theme_choose', { theme: slug, location } );
 
-		if ( theme !== activeTheme && this.getPriceValue( price ) <= 0 ) {
+		if ( theme !== activeTheme && getPriceValue( price ) <= 0 ) {
 			this.installTheme( slug );
 		} else {
 			updateProfileItems( { theme: slug } );
@@ -193,7 +194,7 @@ class Theme extends Component {
 		}
 		if ( is_installed ) {
 			return __( 'Installed', 'woocommerce-admin' );
-		} else if ( this.getPriceValue( price ) <= 0 ) {
+		} else if ( getPriceValue( price ) <= 0 ) {
 			return __( 'Free', 'woocommerce-admin' );
 		}
 
@@ -217,9 +218,9 @@ class Theme extends Component {
 
 		switch ( activeTab ) {
 			case 'paid':
-				return allThemes.filter( theme => this.getPriceValue( theme.price ) > 0 );
+				return allThemes.filter( theme => getPriceValue( theme.price ) > 0 );
 			case 'free':
-				return allThemes.filter( theme => this.getPriceValue( theme.price ) <= 0 );
+				return allThemes.filter( theme => getPriceValue( theme.price ) <= 0 );
 			case 'all':
 			default:
 				return allThemes;

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -59,8 +59,7 @@ export function getProductIdsForCart( profileItems ) {
 
 	const theme = onboarding.themes.find( themeData => themeData.slug === profileItems.theme );
 
-	// @todo -- Split out free themes so that they are not considered for purchase, and install those from WordPress.org on the theme step.
-	if ( theme && theme.id && ! theme.is_installed ) {
+	if ( theme && theme.id && ! theme.is_installed && getPriceValue( theme.price ) > 0 ) {
 		productIds.push( theme.id );
 	}
 

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import { decodeEntities } from '@wordpress/html-entities';
 import { without } from 'lodash';
 
 /**
@@ -64,6 +65,16 @@ export function getProductIdsForCart( profileItems ) {
 	}
 
 	return productIds;
+}
+
+/**
+ * Get the value of a price from a string, removing any non-numeric characters.
+ *
+ * @param {string} string Price string.
+ * @return {number} Number value.
+ */
+export function getPriceValue( string ) {
+	return Number( decodeEntities( string ).replace( /[^0-9.-]+/g, '' ) );
 }
 
 /**

--- a/src/API/OnboardingThemes.php
+++ b/src/API/OnboardingThemes.php
@@ -182,6 +182,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 
 		return( array(
 			'slug'   => $theme,
+			'name'   => $installed_themes[ $theme ]->get( 'Name' ),
 			'status' => 'success',
 		) );
 	}


### PR DESCRIPTION
Fixes #3455

Installs free themes directly from wporg and activates during the onboarding profiler.

**Question:** The installation success notice shows up behind the cart modal if one exists.  Do we want to update this to appear above the modal?

### Screenshots
<img width="729" alt="Screen Shot 2019-12-26 at 2 19 09 PM" src="https://user-images.githubusercontent.com/10561050/71463637-005ec080-27f2-11ea-831d-a0cc7a3f0138.png">


### Detailed test instructions:

1. Go to the theme step of the profiler.
2. Click "Choose" on a free, uninstalled theme.
3. The cart modal should show up if purchasable products still exist, otherwise the task list should be shown.  Free items should not show in the cart.
4. Check that the theme is actually installed.
5. Run through this process again, selecting a paid theme.  Make sure there's no attempt to install the theme and it shows up in the cart modal.