### PR TITLE
Onboarding: Don't show skip link if no plugins exist to skip

### DIFF
--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -269,15 +269,17 @@ class Start extends Component {
 					</Button>
 				</Card>
 
-				<p>
-					<Button
-						isLink
-						className="woocommerce-profile-wizard__skip"
-						onClick={ () => this.setState( { showUsageModal: true, continueAction: 'skip' } ) }
-					>
-						{ sprintf( __( 'Proceed without %s', 'woocommerce-admin' ), pluginNamesString ) }
-					</Button>
-				</p>
+				{ pluginNamesString && (
+					<p>
+						<Button
+							isLink
+							className="woocommerce-profile-wizard__skip"
+							onClick={ () => this.setState( { showUsageModal: true, continueAction: 'skip' } ) }
+						>
+							{ sprintf( __( 'Proceed without %s', 'woocommerce-admin' ), pluginNamesString ) }
+						</Button>
+					</p>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/dashboard/profile-wizard/steps/start/index.js
+++ b/client/dashboard/profile-wizard/steps/start/index.js
@@ -269,7 +269,7 @@ class Start extends Component {
 					</Button>
 				</Card>
 
-				{ pluginNamesString && (
+				{ 0 !== pluginsToInstall.length && (
 					<p>
 						<Button
 							isLink


### PR DESCRIPTION
Fixes #3469

Removes a partial text string "Proceed without" when no plugins need to be installed.

### Screenshots
<img width="548" alt="Screen Shot 2019-12-26 at 3 52 11 PM" src="https://user-images.githubusercontent.com/10561050/71465589-08b9fa00-27f8-11ea-9b62-fd5ddbd55c50.png">


### Detailed test instructions:

1. Delete WCS and/or Jetpack.
2. Go to the profile wizard first step and continue to install WCS and Jetpack.
3. Connect Jetpack.
4. Delete `wc_connect_options` from `wp_options`.
5. Revisit the first step and make sure the skip link is not shown.