### PR TITLE
Onboarding: Skip Shipping connect step if Jetpack is already connected

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -143,12 +143,16 @@ class Shipping extends Component {
 	}
 
 	getSteps() {
-		const { countryCode } = this.props;
+		const { countryCode, isJetpackConnected } = this.props;
 		let plugins = [];
 		if ( [ 'GB', 'CA', 'AU' ].includes( countryCode ) ) {
 			plugins = [ 'woocommerce-shipstation-integration' ];
 		} else if ( 'US' === countryCode ) {
-			plugins = [ 'jetpack', 'woocommerce-services' ];
+			plugins = [ 'woocommerce-services' ];
+
+			if ( ! isJetpackConnected ) {
+				plugins.push( 'jetpack' );
+			}
 		}
 
 		const steps = [
@@ -275,7 +279,9 @@ class Shipping extends Component {
 
 export default compose(
 	withSelect( select => {
-		const { getSettings, getSettingsError, isGetSettingsRequesting } = select( 'wc-api' );
+		const { getSettings, getSettingsError, isGetSettingsRequesting, isJetpackConnected } = select(
+			'wc-api'
+		);
 
 		const settings = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );
@@ -287,7 +293,14 @@ export default compose(
 		const country = countryCode ? countries.find( c => c.code === countryCode ) : null;
 		const countryName = country ? country.name : null;
 
-		return { countryCode, countryName, isSettingsError, isSettingsRequesting, settings };
+		return {
+			countryCode,
+			countryName,
+			isJetpackConnected: isJetpackConnected(),
+			isSettingsError,
+			isSettingsRequesting,
+			settings,
+		};
 	} ),
 	withDispatch( dispatch => {
 		const { createNotice } = dispatch( 'core/notices' );


### PR DESCRIPTION
Fixes #3468

Doesn't show the "Connect" step if Jetpack is already connected in the Shipping task.

### Screenshots
<img width="729" alt="Screen Shot 2019-12-26 at 6 52 21 PM" src="https://user-images.githubusercontent.com/10561050/71473312-6575de80-2811-11ea-9e13-6c06acb578cf.png">


### Detailed test instructions:

1. Disconnect Jetpack.
2. Visit the Shipping task from the task list.
3. Walk through the steps, connecting Jetpack.
4. Revisit the Shipping step.
5. Make sure the "Connect" step is not shown.