### PR TITLE
Fix button color when no demo present.

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -121,7 +121,7 @@ class Theme extends Component {
 					</p>
 					<div className="woocommerce-profile-wizard__theme-actions">
 						<Button
-							isPrimary={ Boolean( demo_url ) }
+							isPrimary
 							isDefault={ ! Boolean( demo_url ) }
 							onClick={ () => this.onChoose( slug, 'card' ) }
 							isBusy={ chosen === slug }

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -116,6 +116,10 @@
 				border-color: $studio-pink-50;
 				color: $studio-pink-50;
 			}
+
+			&.is-primary {
+				color: $studio-white;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3488

On the theme step of the Profiler, this PR fixes the theme buttons to show as primary/pink, when no demo button is present.

__before__
<img width="830" alt="Dashboard ‹ bend outdoors — WooCommerce 2019-12-27 09-17-09" src="https://user-images.githubusercontent.com/22080/71526259-e0c7a680-288a-11ea-8dbf-59942f5e89e2.png">

__after__
<img width="829" alt="Dashboard ‹ bend outdoors — WooCommerce 2019-12-27 09-24-03" src="https://user-images.githubusercontent.com/22080/71526264-e6bd8780-288a-11ea-9ac7-8ec198c4a6b1.png">

### Detailed test instructions:

- Visit the profiler via `wp-admin/admin.php?page=wc-admin&reset_profiler=1` proceed to the theme step
- Verify the buttons for Choose/Demo appear properly for themes with and without demo links. 

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Properly style theme selection button in Site Profiler
