### PR TITLE
Onboarding: Add Skip Step link on Themes Step

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -137,7 +137,8 @@ class Theme extends Component {
 	}
 
 	skipStep() {
-		recordEvent( 'storeprofiler_store_theme_skip_step' );
+		const { activeTheme = '' } = getSetting( 'onboarding', {} );
+		recordEvent( 'storeprofiler_store_theme_skip_step', { activeTheme } );
 		this.props.goToNextStep();
 	}
 
@@ -207,7 +208,7 @@ class Theme extends Component {
 		return sprintf( __( '%s per year', 'woocommerce-admin' ), decodeEntities( price ) );
 	}
 
-	doesCurrentThemeSupportWooCommerce() {
+	doesActiveThemeSupportWooCommerce() {
 		const { activeTheme = '' } = getSetting( 'onboarding', {} );
 		const allThemes = this.getThemes();
 		const currentTheme = allThemes.find( theme => theme.slug === activeTheme );
@@ -253,7 +254,7 @@ class Theme extends Component {
 	render() {
 		const { activeTab, chosen, demo } = this.state;
 		const themes = this.getThemes( activeTab );
-		const currentThemeSupportsWooCommerce = this.doesCurrentThemeSupportWooCommerce();
+		const activeThemeSupportsWooCommerce = this.doesActiveThemeSupportWooCommerce();
 
 		return (
 			<Fragment>
@@ -300,7 +301,7 @@ class Theme extends Component {
 						isBusy={ chosen === demo.slug }
 					/>
 				) }
-				{ currentThemeSupportsWooCommerce && (
+				{ activeThemeSupportsWooCommerce && (
 					<p>
 						<Button
 							isLink


### PR DESCRIPTION
Fixes #3460 

Sometimes things go sideways during the theme install step of the profiler. Typically this happens when a theme is already installed, and clicking on "Choose" doesn't do anything. I've only been able to reproduce this bug once, so @pmcpinto and I discussed in the issue that a good work-around for this would be to expose a "Skip this step" link if a theme is already chosen, and it supports WooCommerce. So that is the solution presented in this branch.
### Screenshots

<img width="836" alt="skip-step" src="https://user-images.githubusercontent.com/22080/71529764-4e7bce80-289b-11ea-8c3b-a75c07f218ed.png">

### Detailed test instructions:

- On your test site, have a theme selected that **does not** support Woo
- Visit the profiler theme step, and verify the "Skip this step" link pictured above is not shown.
- Also verify toggling between the All | Paid | Free theme tabs up top still function as expected since some of that logic was tweaked a bit in this branch.
- Activate a Woo-supported theme.
- Revisit the theme step and verify the skip link is shown.
- Click the "Skip this step" link and confirm you are then directed to the dashboard.
- Bonus points to watch for the track being recorded on your last action

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Tweak: Onboarding - Add Skip Step link on Themes Step.
