### PR TITLE
Onboarding: Fix disabled button hover state

### DIFF
--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -178,6 +178,10 @@
 		) !important; // Gutenberg & PostCSS Add the gradient late in output, based on the 'primary' color, which in our case is purple. Our busy state should be pink.
 		/* stylelint-enable */
 	}
+
+	&:disabled {
+		cursor: not-allowed;
+	}
 }
 
 .components-modal__frame.woocommerce-cart-modal {

--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -152,8 +152,12 @@ body.woocommerce-page {
 	.components-button.is-button.is-primary {
 		color: $studio-white;
 
-		&:hover {
-			color: $studio-white;
+		&:not(:disabled) {
+			&:hover,
+			&:active,
+			&:focus {
+				color: $studio-white;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #3457

Prevents the change to white on disabled button hover and adds a `not-allowed` value to the cursor for disabled buttons.

### Screenshots (hovered)
<img width="531" alt="Screen Shot 2019-12-30 at 7 11 15 PM" src="https://user-images.githubusercontent.com/10561050/71579814-2ad5b400-2b39-11ea-8de6-2cad755ade3c.png">

### Detailed test instructions:

1. View any disabled buttons in the onboarding profiler or task list (e.g., store details step and remove any required fields).
2. Make sure the button text color does not change on hover.
3. Make sure the cursor changes to `not-allowed` on hover.
4. Make sure other buttons are unaffected.