### PR TITLE
Onboarding: Add tracks to extension purchase task and modal

### DIFF
--- a/client/dashboard/components/cart-modal.js
+++ b/client/dashboard/components/cart-modal.js
@@ -23,6 +23,7 @@ import { List } from '@woocommerce/components';
 import withSelect from 'wc-api/with-select';
 import { getProductIdsForCart } from 'dashboard/utils';
 import sanitizeHTML from 'lib/sanitize-html';
+import { recordEvent } from 'lib/tracks';
 
 class CartModal extends Component {
 	constructor( props ) {
@@ -43,6 +44,11 @@ class CartModal extends Component {
 			return;
 		}
 
+		recordEvent( 'tasklist_modal_proceed_checkout', {
+			product_ids: productIds,
+			purchase_install: false,
+		} );
+
 		const url = addQueryArgs( 'https://woocommerce.com/cart', {
 			'wccom-site': getSetting( 'siteUrl' ),
 			'wccom-woo-version': getSetting( 'wcVersion' ),
@@ -60,6 +66,13 @@ class CartModal extends Component {
 	}
 
 	onClickPurchaseLater() {
+		const { productIds } = this.props;
+
+		recordEvent( 'tasklist_modal_proceed_checkout', {
+			product_ids: productIds,
+			purchase_install: false,
+		} );
+
 		this.setState( { purchaseLaterButtonBusy: true } );
 		this.props.onClickPurchaseLater();
 	}

--- a/client/dashboard/components/cart-modal.js
+++ b/client/dashboard/components/cart-modal.js
@@ -77,6 +77,17 @@ class CartModal extends Component {
 		this.props.onClickPurchaseLater();
 	}
 
+	onClose() {
+		const { onClose, productIds } = this.props;
+
+		recordEvent( 'tasklist_modal_proceed_checkout', {
+			product_ids: productIds,
+			purchase_install: false,
+		} );
+
+		onClose();
+	}
+
 	renderProducts() {
 		const { productIds } = this.props;
 		const { productTypes = {}, themes = [] } = getSetting( 'onboarding', {} );
@@ -121,7 +132,7 @@ class CartModal extends Component {
 					'Would you like to purchase and install the following features now?',
 					'woocommerce-admin'
 				) }
-				onRequestClose={ () => this.props.onClose() }
+				onRequestClose={ () => this.onClose() }
 				className="woocommerce-cart-modal"
 			>
 				{ this.renderProducts() }

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -172,7 +172,13 @@ class TaskDashboard extends Component {
 	}
 
 	toggleCartModal() {
-		this.setState( { isCartModalOpen: ! this.state.isCartModalOpen } );
+		const { isCartModalOpen } = this.state;
+
+		if ( ! isCartModalOpen ) {
+			recordEvent( 'tasklist_purchase_extensions' );
+		}
+
+		this.setState( { isCartModalOpen: ! isCartModalOpen } );
 	}
 
 	closeWelcomeModal() {

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -90,8 +90,10 @@ class TaskDashboard extends Component {
 		if ( this.getCurrentTask() ) {
 			return;
 		}
+
 		const { profileItems } = this.props;
 		const tasks = this.getTasks();
+
 		recordEvent( 'tasklist_view', {
 			number_tasks: tasks.length,
 			store_connected: profileItems.wccom_connected,


### PR DESCRIPTION
Fixes #3487

* Tracks when the purchase extensions task is clicked.
* Tracks when a user clicks purchase now or purchase later.

@pmcpinto I changed this a bit to track all of the product IDs needing purchase collectively since that most closely resembles how we track what needs to be purchased and should provide detail into specifics of the items on the WCCOM side.  But if you feel that product slugs and/or separating the theme would be better here, feel free to let me know and I'll modify accordingly.

### Screenshots
<img width="672" alt="Screen Shot 2019-12-30 at 8 24 00 PM" src="https://user-images.githubusercontent.com/10561050/71581859-54dfa400-2b42-11ea-824a-bc8202e2f0c5.png">

### Detailed test instructions:

1. Enter localStorage.setItem( 'debug', 'wc-admin:*' ); into your console. Leave your console open.
1. Enable the profiler if not enabled already.
1. Go through the profiler, selecting items that require purchase.
1. After choosing a theme, click purchase later and note the tracked event with product IDs in the console.
1. In the task list, click the purchase extensions task and note the tracked event.
1. Try clicking either button in the modal and note the tracked product IDs.