### PR TITLE
Onboarding: Add error styling and text to country state dropdown

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -179,6 +179,7 @@ export function StoreAddress( props ) {
 				options={ countryStateOptions }
 				isSearchable
 				{ ...getInputProps( 'countryState' ) }
+				controlClassName={ getInputProps( 'countryState' ).className }
 			>
 				{ getCountryStateAutofill(
 					countryStateOptions,

--- a/client/dashboard/style.scss
+++ b/client/dashboard/style.scss
@@ -115,6 +115,7 @@
 
 		.components-base-control__help {
 			top: 100%;
+			left: $gap-small;
 			position: absolute;
 			margin-top: $gap-smallest;
 			font-size: 12px;

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -157,7 +157,7 @@ class Control extends Component {
 	}
 
 	render() {
-		const { hasTags, help, inlineTags, instanceId, isSearchable, label, query } = this.props;
+		const { className, hasTags, help, inlineTags, instanceId, isSearchable, label, query } = this.props;
 		const { isActive } = this.state;
 
 		return (
@@ -168,7 +168,7 @@ class Control extends Component {
 			// for the benefit of sighted users.
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			<div
-				className={ classnames( 'components-base-control', 'woocommerce-select-control__control', {
+				className={ classnames( 'components-base-control', 'woocommerce-select-control__control', className, {
 					empty: ! query.length,
 					'is-active': isActive,
 					'has-tags': inlineTags && hasTags,

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -51,6 +51,12 @@ class Control extends Component {
 	}
 
 	onBlur() {
+		const { onBlur } = this.props;
+
+		if ( 'function' === typeof onBlur ) {
+			onBlur();
+		}
+
 		this.setState( { isActive: false } );
 	}
 
@@ -234,6 +240,10 @@ Control.propTypes = {
 	 * ID used for a11y in the listbox.
 	 */
 	listboxId: PropTypes.string,
+	/**
+	 * Function called when the input is blurred.
+	 */
+	onBlur: PropTypes.func,
 	/**
 	 * Function called when selected results change, passed result list.
 	 */

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -242,6 +242,7 @@ export class SelectControl extends Component {
 			autofill,
 			children,
 			className,
+			controlClassName,
 			inlineTags,
 			instanceId,
 			isSearchable,
@@ -279,6 +280,7 @@ export class SelectControl extends Component {
 					{ ...this.props }
 					{ ...this.state }
 					activeId={ activeId }
+					className={ controlClassName }
 					hasTags={ hasTags }
 					isExpanded={ isExpanded }
 					listboxId={ listboxId }
@@ -322,6 +324,10 @@ SelectControl.propTypes = {
 	 * Class name applied to parent div.
 	 */
 	className: PropTypes.string,
+	/**
+	 * Class name applied to control wrapper.
+	 */
+	controlClassName: PropTypes.string,
 	/**
 	 * Exclude already selected options from the options list.
 	 */


### PR DESCRIPTION
Fixes #3462

* Adds a class name option to the control wrapper inside `SelectControl`.
* Adds an `onBlur` prop for the control inside `SelectControl`.

### Screenshots
<img width="521" alt="Screen Shot 2019-12-30 at 11 39 39 PM" src="https://user-images.githubusercontent.com/10561050/71588894-0fc96b00-2b5e-11ea-8c21-735489dcdd42.png">

### Detailed test instructions:

1. Visit anywhere with the `SelectControl` component and validation (i.e., store details step of the profiler).
2. Remove the country manually by backspacing if necessary (may require backspacing all the way plus one more backspace).
3. Blur the control.
4. Note the error shows for the country state dropdown.