### PR TITLE
Onboarding: Redirect the user to the task list if referer is wccom checkout

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -86,6 +86,7 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'reset_profiler' ) );
 		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
+		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
 	}
@@ -897,5 +898,22 @@ class Onboarding {
 		}
 
 		return $show;
+	}
+
+	/**
+	 * Redirects the user to the task list if the task list is enabled and finishing a wccom checkout.
+	 *
+	 * @todo Once URL params are added to the redirect, we can check those instead of the referer.
+	 */
+	public static function redirect_wccom_install() {
+		if (
+			! self::should_show_tasks() ||
+			! isset( $_SERVER['HTTP_REFERER'] ) ||
+			0 !== strpos( $_SERVER['HTTP_REFERER'], 'https://woocommerce.com/checkout' ) // phpcs:ignore sanitization ok.
+		) {
+			return;
+		}
+
+		wp_safe_redirect( wc_admin_url() );
 	}
 }


### PR DESCRIPTION
Fixes #3463

Redirects the user to the task list if referred from wccom checkout instead of the plugins page.

### Detailed test instructions:

1. Build this branch.
2. On a JN or other public facing site, run through the profiler, adding products that require purchase.
3. Go through the checkout process and purchase those products.
4. Make sure you're redirected to the task list instead of the plugins screen.