### PR TITLE
Onboarding: Add option to track appearance completion

### DIFF
--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -27,15 +27,15 @@ import Payments from './tasks/payments';
 
 export function getAllTasks( { profileItems, options, query, toggleCartModal } ) {
 	const {
-		hasHomepage,
 		hasPhysicalProducts,
 		hasProducts,
+		isAppearanceComplete,
 		isTaxComplete,
 		shippingZonesCount,
 	} = getSetting( 'onboarding', {
-		hasHomepage: false,
 		hasPhysicalProducts: false,
 		hasProducts: false,
+		isAppearanceComplete: false,
 		isTaxComplete: false,
 		shippingZonesCount: 0,
 	} );
@@ -93,7 +93,7 @@ export function getAllTasks( { profileItems, options, query, toggleCartModal } )
 			content: __( 'Create a custom homepage and upload your logo', 'wooocommerce-admin' ),
 			icon: 'palette',
 			container: <Appearance />,
-			completed: hasHomepage,
+			completed: isAppearanceComplete,
 			visible: true,
 		},
 		{

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -35,6 +35,7 @@ class Appearance extends Component {
 		};
 
 		this.state = {
+			isDirty: false,
 			isPending: false,
 			logo: null,
 			stepIndex: 0,
@@ -210,7 +211,7 @@ class Appearance extends Component {
 	}
 
 	getSteps() {
-		const { isPending, logo, storeNoticeText } = this.state;
+		const { isDirty, isPending, logo, storeNoticeText } = this.state;
 		const { isRequesting } = this.props;
 
 		const steps = [
@@ -263,8 +264,16 @@ class Appearance extends Component {
 				description: __( 'Ensure your store is on-brand by adding your logo', 'woocommerce-admin' ),
 				content: isPending ? null : (
 					<Fragment>
-						<ImageUpload image={ logo } onChange={ image => this.setState( { logo: image } ) } />
-						<Button onClick={ this.updateLogo } isBusy={ isRequesting } isPrimary>
+						<ImageUpload
+							image={ logo }
+							onChange={ image => this.setState( { isDirty: true, logo: image } ) }
+						/>
+						<Button
+							disabled={ ! logo && ! isDirty }
+							onClick={ this.updateLogo }
+							isBusy={ isRequesting }
+							isPrimary
+						>
 							{ __( 'Proceed', 'woocommerce-admin' ) }
 						</Button>
 						<Button onClick={ () => this.completeStep() }>

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -197,7 +197,13 @@ class Appearance extends Component {
 			added_text: Boolean( storeNoticeText.length ),
 		} );
 
+		setSetting( 'onboarding', {
+			...getSetting( 'onboarding', {} ),
+			isAppearanceComplete: true,
+		} );
+
 		updateOptions( {
+			woocommerce_task_list_appearance_complete: true,
 			woocommerce_demo_store: storeNoticeText.length ? 'yes' : 'no',
 			woocommerce_demo_store_notice: storeNoticeText,
 		} );
@@ -337,7 +343,11 @@ export default compose(
 		const isRequesting =
 			Boolean( isUpdateOptionsRequesting( [ `theme_mods_${ stylesheet }` ] ) ) ||
 			Boolean(
-				isUpdateOptionsRequesting( [ 'woocommerce_demo_store', 'woocommerce_demo_store_notice' ] )
+				isUpdateOptionsRequesting( [
+					'woocommerce_task_list_appearance_complete',
+					'woocommerce_demo_store',
+					'woocommerce_demo_store_notice',
+				] )
 			);
 
 		return { errors, getOptionsError, hasErrors, isRequesting, options };

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -94,6 +94,7 @@ class OnboardingTasks {
 			)
 		) > 0;
 		$settings['onboarding']['hasProducts']                    = self::check_task_completion( 'products' );
+		$settings['onboarding']['isAppearanceComplete']           = get_option( 'woocommerce_task_list_appearance_complete' );
 		$settings['onboarding']['isTaxComplete']                  = self::check_task_completion( 'tax' );
 		$settings['onboarding']['shippingZonesCount']             = count( \WC_Shipping_Zones::get_zones() );
 		$settings['onboarding']['stylesheet']                     = get_option( 'stylesheet' );


### PR DESCRIPTION
Fixes #3458 

Allow the "Customize Appearance" step to be completed without creating a homepage.

### Screenshots
<img width="775" alt="Screen Shot 2020-01-02 at 4 18 03 PM" src="https://user-images.githubusercontent.com/10561050/71657574-78416380-2d7b-11ea-8793-e47800ed22b4.png">

### Detailed test instructions:

1.  Delete any homepages created from the task list appearance task.
2. Walk through the steps, skipping each, and completing at the end.
3. Make sure the appearance task is complete and persists on refresh.
4. Delete the `woocommerce_task_list_appearance_complete` option if you need to retest this.