### PR TITLE
Sync refactor tweaks

### DIFF
--- a/src/Schedulers/ImportScheduler.php
+++ b/src/Schedulers/ImportScheduler.php
@@ -38,8 +38,20 @@ abstract class ImportScheduler {
 				'group'    => self::$group,
 			)
 		);
+		if ( empty( $pending_jobs ) ) {
+			$in_progress = self::queue()->search(
+				array(
+					'status'   => 'in-progress',
+					'per_page' => 1,
+					'search'   => 'import',
+					'group'    => self::$group,
+				)
+			);
+		} else {
+			$in_progress = true;
+		}
 
-		return ! empty( $pending_jobs );
+		return ! empty( $in_progress );
 	}
 
 	/**

--- a/src/Schedulers/ImportScheduler.php
+++ b/src/Schedulers/ImportScheduler.php
@@ -47,8 +47,6 @@ abstract class ImportScheduler {
 					'group'    => self::$group,
 				)
 			);
-		} else {
-			$in_progress = true;
 		}
 
 		return ! empty( $pending_jobs ) || ! empty( $in_progress );

--- a/src/Schedulers/ImportScheduler.php
+++ b/src/Schedulers/ImportScheduler.php
@@ -51,7 +51,7 @@ abstract class ImportScheduler {
 			$in_progress = true;
 		}
 
-		return ! empty( $in_progress );
+		return ! empty( $pending_jobs ) || ! empty( $in_progress );
 	}
 
 	/**

--- a/src/Schedulers/SchedulerTraits.php
+++ b/src/Schedulers/SchedulerTraits.php
@@ -234,7 +234,11 @@ trait SchedulerTraits {
 		if ( is_array( $blocking_jobs ) ) {
 			foreach ( $blocking_jobs as $blocking_job ) {
 				$blocking_job_hook = $blocking_job->get_hook();
-				$next_job_schedule = $blocking_job->get_schedule()->next();
+				if ( method_exists( $blocking_job->get_schedule(), 'get_date' ) ) {
+					$next_job_schedule = $blocking_job->get_schedule()->get_date();
+				} else {
+					$next_job_schedule = $blocking_job->get_schedule()->next();
+				}
 
 				// Ensure that the next schedule is a DateTime (it can be null).
 				if ( is_a( $next_job_schedule, 'DateTime' ) ) {


### PR DESCRIPTION
Fixes #3496 

This is a followup PR to #3285. With AS 2.2.X, the probability of the import status api call occurring while actions are in progress is about 5% (3/60). With AS 3.0, that probability is much closer to 100% when the last import actions are processing. This PR adds a check for `in-progress` actions if there are no remaining `pending` actions.

### Detailed test instructions:

- Activate Action Scheduler 3.0
- Delete existing imported analytics data
- Import analytics data
- Remain on screen to verify that 
- The `Finalizing ...` message appears
- The import ends with the message `Historical data from onward imported`
