### PR TITLE
Add SelectControl debouncing and keyboard fixes

### DIFF
--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -153,6 +153,7 @@ class Search extends Component {
 					onFilter={ this.appendFreeTextSearch }
 					onSearch={ this.fetchOptions }
 					options={ options }
+					searchDebounceTime={ 500 }
 					searchInputType={ inputType }
 					selected={ selected }
 					showClearButton={ showClearButton }

--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -87,6 +87,10 @@ class Search extends Component {
 	}
 
 	fetchOptions( previousOptions, query ) {
+		if ( ! query ) {
+			return [];
+		}
+
 		const autocompleter = this.getAutocompleter();
 		return autocompleter.options( query ).then( async response => {
 			const options = this.getFormattedOptions( response, query );

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -149,7 +149,7 @@ class Control extends Component {
 		}
 
 		// Show the search query when focused on searchable controls.
-		if ( isSearchable && isFocused ) {
+		if ( isSearchable && isFocused && query ) {
 			return query;
 		}
 
@@ -169,7 +169,7 @@ class Control extends Component {
 			/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
 			<div
 				className={ classnames( 'components-base-control', 'woocommerce-select-control__control', className, {
-					empty: ! query.length,
+					empty: ! query || 0 === query.length,
 					'is-active': isActive,
 					'has-tags': inlineTags && hasTags,
 					'with-value': this.getInputValue().length,

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -42,7 +42,7 @@ export class SelectControl extends Component {
 		this.decrementSelectedIndex = this.decrementSelectedIndex.bind( this );
 		this.incrementSelectedIndex = this.incrementSelectedIndex.bind( this );
 		this.onAutofillChange = this.onAutofillChange.bind( this );
-		this.updateFilteredOptions = debounce( this.updateFilteredOptions, 500 );
+		this.updateFilteredOptions = debounce( this.updateFilteredOptions, props.searchDebounceTime );
 		this.search = this.search.bind( this );
 		this.selectOption = this.selectOption.bind( this );
 		this.setExpanded = this.setExpanded.bind( this );
@@ -389,6 +389,10 @@ SelectControl.propTypes = {
 	 */
 	placeholder: PropTypes.string,
 	/**
+	 * Time in milliseconds to debounce the search function after typing.
+	 */
+	searchDebounceTime: PropTypes.number,
+	/**
 	 * An array of objects describing selected values or optionally a string for a single value.
 	 * If the label of the selected value is omitted, the Tag of that value will not
 	 * be rendered inside the search box.
@@ -439,6 +443,7 @@ SelectControl.defaultProps = {
 	onSearch: options => Promise.resolve( options ),
 	maxResults: 0,
 	multiple: false,
+	searchDebounceTime: 0,
 	searchInputType: 'search',
 	selected: [],
 	showClearButton: false,

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -5,7 +5,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
-import { escapeRegExp, findIndex, identity, noop } from 'lodash';
+import { debounce, escapeRegExp, findIndex, identity, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withFocusOutside, withSpokenMessages } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
@@ -42,6 +42,7 @@ export class SelectControl extends Component {
 		this.decrementSelectedIndex = this.decrementSelectedIndex.bind( this );
 		this.incrementSelectedIndex = this.incrementSelectedIndex.bind( this );
 		this.onAutofillChange = this.onAutofillChange.bind( this );
+		this.updateFilteredOptions = debounce( this.updateFilteredOptions, 500 );
 		this.search = this.search.bind( this );
 		this.selectOption = this.selectOption.bind( this );
 		this.setExpanded = this.setExpanded.bind( this );
@@ -199,8 +200,12 @@ export class SelectControl extends Component {
 	}
 
 	search( query ) {
-		const { hideBeforeSearch, onSearch, options } = this.props;
 		this.setState( { query, isFocused: true } );
+		this.updateFilteredOptions( query );
+	}
+
+	updateFilteredOptions( query ) {
+		const { hideBeforeSearch, options, onSearch } = this.props;
 
 		const promise = ( this.activePromise = Promise.resolve( onSearch( options, query ) ).then(
 			searchOptions => {

--- a/packages/components/src/select-control/list.js
+++ b/packages/components/src/select-control/list.js
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component, createRef } from '@wordpress/element';
 import { isEqual } from 'lodash';
-import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
+import { ENTER, ESCAPE, UP, DOWN, LEFT, RIGHT, TAB } from '@wordpress/keycodes';
 import PropTypes from 'prop-types';
 
 /**
@@ -112,6 +112,7 @@ class List extends Component {
 				break;
 
 			case ESCAPE:
+			case TAB:
 				setExpanded( false );
 				onSearch( null );
 				return;

--- a/packages/components/src/select-control/list.js
+++ b/packages/components/src/select-control/list.js
@@ -112,7 +112,12 @@ class List extends Component {
 				break;
 
 			case ESCAPE:
+				setExpanded( false );
+				onSearch( null );
+				return;
+
 			case TAB:
+				this.select( options[ selectedIndex ] );
 				setExpanded( false );
 				onSearch( null );
 				return;


### PR DESCRIPTION
Fixes #3424 

* Adds a debouncing prop to `SelectControl` for typed queries.
* Fixes the escape key.
* Tab key now closes the list

### Screenshots
<img width="432" alt="Screen Shot 2020-01-03 at 12 48 05 PM" src="https://user-images.githubusercontent.com/10561050/71707903-53ef9080-2e28-11ea-8448-a171f417c890.png">


### Detailed test instructions:

1. Open the Product comparison or any other `Search` component.
2. Check that typed queries are debounced (500ms).
3. Hit the escape key and make sure no console error is logged.
4. Search for an item and select it.
5. Search again, but hit tab while still focused in the search control.
6. Make sure the options list is closed and the first selected item's close button is focused.
7. Make sure there are no regressions in other implementations of `SelectControl` (onboarding and devdocs).