### PR TITLE
Update task list success notices

### DIFF
--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -95,7 +95,13 @@ class Appearance extends Component {
 		}
 
 		if ( 'notice' === step && isRequestSuccessful ) {
-			createNotice( 'success', __( 'Store notice updated sucessfully.', 'woocommerce-admin' ) );
+			createNotice(
+				'success',
+				__(
+					"🎨 Your store is looking great! Don't forget to continue personalizing it.",
+					'woocommerce-admin'
+				)
+			);
 			this.completeStep();
 		}
 

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -92,11 +92,19 @@ class Payments extends Component {
 	}
 
 	completeTask() {
-		this.props.updateOptions( {
+		const { createNotice, updateOptions } = this.props;
+
+		updateOptions( {
 			[ 'woocommerce_task_list_payments' ]: {
 				completed: 1,
 			},
 		} );
+
+		createNotice(
+			'success',
+			__( '💰 Ka-ching! Your store can now accept payments 💳', 'woocommerce-admin' )
+		);
+
 		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
 

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -130,6 +130,7 @@ class Shipping extends Component {
 	}
 
 	completeStep() {
+		const { createNotice } = this.props;
 		const { step } = this.state;
 		const steps = this.getSteps();
 		const currentStepIndex = steps.findIndex( s => s.key === step );
@@ -138,6 +139,13 @@ class Shipping extends Component {
 		if ( nextStep ) {
 			this.setState( { step: nextStep.key } );
 		} else {
+			createNotice(
+				'success',
+				__(
+					"📦 Shipping is done! Don't worry, you can always change it later.",
+					'woocommerce-admin'
+				)
+			);
 			getHistory().push( getNewPath( {}, '/', {} ) );
 		}
 	}

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -164,7 +164,10 @@ class Tax extends Component {
 				...getSetting( 'onboarding', {} ),
 				isTaxComplete: true,
 			} );
-			createNotice( 'success', __( 'Your tax settings have been updated.', 'woocommerce-admin' ) );
+			createNotice(
+				'success',
+				__( "You're awesome! One less item on your to-do list ✅", 'woocommerce-admin' )
+			);
 			if ( automatedTaxEnabled ) {
 				getHistory().push( getNewPath( {}, '/', {} ) );
 			} else {

--- a/client/wp-admin-scripts/onboarding-product-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-product-notice/index.js
@@ -16,7 +16,7 @@ import { getAdminLink } from '@woocommerce/wc-admin-settings';
  */
 const showProductCompletionNotice = () => {
 	dispatch( 'core/notices' ).createSuccessNotice(
-		__( 'You created your first product!', 'woocommerce-admin' ),
+		__( '🎉 Congrats on adding your first product!', 'woocommerce-admin' ),
 		{
 			id: 'WOOCOMMERCE_ONBOARDING_PRODUCT_NOTICE',
 			actions: [


### PR DESCRIPTION
Fixes #3319

Updates the success notices to be a bit more positive.

**Question**: It's possible on some steps to hit multiple messages at once.  I updated the "Appearance" step and removed the last message about the updated store notice to be the new success message.  Should we do the same thing with shipping here so this doesn't happen?

<img width="566" alt="Screen Shot 2020-01-03 at 1 23 55 PM" src="https://user-images.githubusercontent.com/10561050/71708616-a97a6c00-2e2d-11ea-9ed1-74ee43b0b961.png">

### Screenshots
<img width="610" alt="Screen Shot 2020-01-03 at 1 34 32 PM" src="https://user-images.githubusercontent.com/10561050/71708686-ee060780-2e2d-11ea-9e6a-6d5595c6d01e.png">


### Detailed test instructions:

1. Go to the task list.
2. Complete the Shipping, Payments, Appearance, Product, and Tax tasks.
3. Note the success messages on each.