### PR TITLE
Included RegExp for JS files in examples.config.js

### DIFF
--- a/docs/examples/extensions/examples.config.js
+++ b/docs/examples/extensions/examples.config.js
@@ -55,6 +55,14 @@ const webpackConfig = {
 						plugins: [ 'transform-es2015-template-literals' ],
 					},
 				},
+				include: new RegExp( '/node_modules\/(' +
+					'|acorn-jsx' +
+					'|d3-array' +
+					'|debug' +
+					'|regexpu-core' +
+					'|unicode-match-property-ecmascript' +
+					'|unicode-match-property-value-ecmascript)/'
+				),
 			},
 			{
 				test: /\.s?css$/,


### PR DESCRIPTION
Fixes #3509 

Included RegExp for JS files in examples.config.js

### Detailed test instructions:

1. Go to 'docs/examples/extensions/' folder
2. Create a new folder for the add-on example 'new-addon'. Inside it create a new folder with name js, then inside it create a file index.js.
3. Write following lines:
var obj = {}; console.log( typeof obj );
4. Then run the following command in the root folder of WooCommerce admin plugin npm run example -- --ext=new-addon
5. Now 'object' will displayed in the console

### Changelog Note:
Tweak: Included RegExp for JS files in examples.config.js
