### PR TITLE
add privacy erasure via woocommerce hook

### DIFF
--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\Schedulers;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\API\Reports\Cache as ReportsCache;
 use \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore as CustomersDataStore;
 use \Automattic\WooCommerce\Admin\Schedulers\OrdersScheduler;
 
@@ -29,6 +30,7 @@ class CustomersScheduler extends ImportScheduler {
 	public static function init() {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
 		add_action( 'woocommerce_update_customer', array( __CLASS__, 'schedule_import' ) );
+		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 
 		CustomersDataStore::init();
 		parent::init();
@@ -111,6 +113,18 @@ class CustomersScheduler extends ImportScheduler {
 	}
 
 	/**
+	 * Get all available scheduling actions.
+	 * Used to determine action hook names and clear events.
+	 *
+	 * @return array
+	 */
+	public static function get_scheduler_actions() {
+		$actions              = parent::get_scheduler_actions();
+		$actions['anonymize'] = 'wc-admin_anonymize_' . static::$name;
+		return $actions;
+	}
+
+	/**
 	 * Schedule import.
 	 *
 	 * @param int $user_id User ID.
@@ -118,6 +132,19 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function schedule_import( $user_id ) {
 		self::schedule_action( 'import', array( $user_id ) );
+	}
+
+	/**
+	 * Schedule an action to anonymize a single Order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @return void
+	 */
+	public static function schedule_anonymize( $order ) {
+		if ( is_a( $order, 'WC_Order' ) ) {
+			// Postpone until any pending updates are completed.
+			self::schedule_action( 'anonymize', array( $order->get_id() ), time() + MINUTE_IN_SECONDS + 5 );
+		}
 	}
 
 	/**
@@ -148,6 +175,57 @@ class CustomersScheduler extends ImportScheduler {
 
 		foreach ( $customer_ids as $customer_id ) {
 			CustomersDataStore::delete_customer( $customer_id );
+		}
+	}
+
+	/**
+	 * Anonymize the customer data for a single order.
+	 *
+	 * @param int $order_id Order id.
+	 * @return void
+	 */
+	public static function anonymize( $order_id ) {
+		global $wpdb;
+
+		$customer_id = $wpdb->get_var(
+			$wpdb->prepare( "SELECT customer_id FROM {$wpdb->prefix}wc_order_stats WHERE order_id = %d", $order_id )
+		);
+
+		if ( ! $customer_id ) {
+			return;
+		}
+
+		// Long form query because $wpdb->update rejects [deleted].
+		$updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->prefix}wc_customer_lookup
+					SET
+						username = %s,
+						first_name = %s,
+						last_name = %s,
+						email = %s,
+						country = %s,
+						postcode = %s,
+						city = %s,
+						state = %s
+					WHERE
+						customer_id = %d",
+				array(
+					'[deleted]',
+					'[deleted]',
+					'[deleted]',
+					'deleted@site.invald',
+					'[deleted]',
+					'[deleted]',
+					'[deleted]',
+					'[deleted]',
+					$customer_id,
+				)
+			)
+		);
+		// If the customer row was anonymized, flush the cache.
+		if ( $updated ) {
+			ReportsCache::invalidate();
 		}
 	}
 }

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -44,6 +44,7 @@ class CustomersScheduler extends ImportScheduler {
 	public static function get_dependencies() {
 		return array(
 			'delete_batch_init' => OrdersScheduler::get_action( 'delete_batch_init' ),
+			'anonymize'         => self::get_action( 'import' ),
 		);
 	}
 
@@ -143,7 +144,7 @@ class CustomersScheduler extends ImportScheduler {
 	public static function schedule_anonymize( $order ) {
 		if ( is_a( $order, 'WC_Order' ) ) {
 			// Postpone until any pending updates are completed.
-			self::schedule_action( 'anonymize', array( $order->get_id() ), time() + MINUTE_IN_SECONDS + 5 );
+			self::schedule_action( 'anonymize', array( $order->get_id() ) );
 		}
 	}
 

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -214,7 +214,7 @@ class CustomersScheduler extends ImportScheduler {
 					'[deleted]',
 					'[deleted]',
 					'[deleted]',
-					'deleted@site.invald',
+					'deleted@site.invalid',
 					'[deleted]',
 					'[deleted]',
 					'[deleted]',

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -196,29 +196,30 @@ class CustomersScheduler extends ImportScheduler {
 		}
 
 		// Long form query because $wpdb->update rejects [deleted].
-		$updated = $wpdb->query(
+		$deleted_text = __( '[deleted]', 'woocommerce-admin' );
+		$updated      = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->prefix}wc_customer_lookup
 					SET
+						user_id = NULL,
 						username = %s,
 						first_name = %s,
 						last_name = %s,
 						email = %s,
-						country = %s,
+						country = '',
 						postcode = %s,
 						city = %s,
 						state = %s
 					WHERE
 						customer_id = %d",
 				array(
-					'[deleted]',
-					'[deleted]',
-					'[deleted]',
+					$deleted_text,
+					$deleted_text,
+					$deleted_text,
 					'deleted@site.invalid',
-					'[deleted]',
-					'[deleted]',
-					'[deleted]',
-					'[deleted]',
+					$deleted_text,
+					$deleted_text,
+					$deleted_text,
 					$customer_id,
 				)
 			)

--- a/src/Schedulers/SchedulerTraits.php
+++ b/src/Schedulers/SchedulerTraits.php
@@ -274,9 +274,8 @@ trait SchedulerTraits {
 	 *
 	 * @param string $action_name Action name.
 	 * @param array  $args Array of arguments to pass to action.
-	 * @param int    $timestamp Time to schedule the action. Optional.
 	 */
-	public static function schedule_action( $action_name, $args = array(), $timestamp = null ) {
+	public static function schedule_action( $action_name, $args = array() ) {
 		// Check for existing jobs and bail if they already exist.
 		if ( static::has_existing_jobs( $action_name, $args ) ) {
 			return;
@@ -292,12 +291,7 @@ trait SchedulerTraits {
 			return;
 		}
 
-		if ( null === $timestamp ) {
-			$timestamp = time() + 5;
-		} else {
-			$timestamp = (int) $timestamp;
-		}
-		self::queue()->schedule_single( $timestamp, $action_hook, $args, static::$group );
+		self::queue()->schedule_single( time() + 5, $action_hook, $args, static::$group );
 	}
 
 	/**

--- a/src/Schedulers/SchedulerTraits.php
+++ b/src/Schedulers/SchedulerTraits.php
@@ -274,8 +274,9 @@ trait SchedulerTraits {
 	 *
 	 * @param string $action_name Action name.
 	 * @param array  $args Array of arguments to pass to action.
+	 * @param int    $timestamp Time to schedule the action. Optional.
 	 */
-	public static function schedule_action( $action_name, $args = array() ) {
+	public static function schedule_action( $action_name, $args = array(), $timestamp = null ) {
 		// Check for existing jobs and bail if they already exist.
 		if ( static::has_existing_jobs( $action_name, $args ) ) {
 			return;
@@ -291,7 +292,12 @@ trait SchedulerTraits {
 			return;
 		}
 
-		self::queue()->schedule_single( time() + 5, $action_hook, $args, static::$group );
+		if ( null === $timestamp ) {
+			$timestamp = time() + 5;
+		} else {
+			$timestamp = (int) $timestamp;
+		}
+		self::queue()->schedule_single( $timestamp, $action_hook, $args, static::$group );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3422

This PR adds erasure support to anonymize the analytics customer when the erasure request is processed. It has a delay in the action schedule to allow the update customer process to run. Analytics will pull the user's name fields from a user account if it exists. Store owners might question the anonymize process if the customer analytics still had some of the customer's identity data.

### Detailed test instructions:

- Create a customer with a fake email address
- Create an order for the customer
- Allow analytics to import the customer & order
- Enable erasure in the WC settings
- Request erasure of the customer using the email address
- Force immediate erasure
- Wait for scheduled action to process
- Check customer report to verify identity info removed

### Changelog Note:

Enhancement: add customer privacy erasure support.