### PR TITLE
CI: use PR repo instead of main repo when checking out branches.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -191,7 +191,7 @@ install_deps() {
 		BRANCH="$(sed 's/#/%23/' <<<$BRANCH)"
 		# Checkout plugin via Git so all files are gathered.
 		cd "$WP_CORE_DIR/wp-content/plugins"
-		git clone https://github.com/woocommerce/woocommerce-admin.git
+		git clone https://github.com/$REPO.git
 		cd woocommerce-admin
 		git fetch origin $BRANCH
 		git checkout -B $BRANCH origin/$BRANCH


### PR DESCRIPTION
Fixes the CI builds when a PR is opened from a fork.

See: https://travis-ci.org/woocommerce/woocommerce-admin/jobs/632175029?utm_medium=notification&utm_source=github_status