### PR TITLE
Onboarding: Fix exception when task list is not shown.

### DIFF
--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -49,6 +49,12 @@ export function getProductIdsForCart( profileItems, includeInstalledItems = fals
 	const onboarding = getSetting( 'onboarding', {} );
 	const productTypes = profileItems.product_types || [];
 
+	// The population of onboarding.productTypes only happens if the task list should be shown
+	// so bail early if it isn't present.
+	if ( ! onboarding.productTypes ) {
+		return productIds;
+	}
+
 	productTypes.forEach( productType => {
 		if (
 			onboarding.productTypes[ productType ] &&


### PR DESCRIPTION
Not entirely certain how I got my local install to find this bug so kind of unsure on how to outline steps to reproduce. But here is a quick run-down of what was causing the bug:

- `getAllTasks()` is [called from the Dashboard](https://github.com/woocommerce/woocommerce-admin/blob/master/client/dashboard/customizable.js#L280) when onBoarding is enabled
- Which in-turn calls `getAllProductIdsForCart()` [here](https://github.com/woocommerce/woocommerce-admin/blob/master/client/dashboard/task-list/tasks.js#L43)
- This method anticipates an object of allowed `productTypes` [to be populated](https://github.com/woocommerce/woocommerce-admin/blob/master/src/Features/Onboarding.php#L378)
- But that list is only populated [if the task list should still be shown](https://github.com/woocommerce/woocommerce-admin/blob/master/src/Features/Onboarding.php#L370)

Which leads to my local hitting this bug as I have onboarding enabled, but the task list completed. In lieu of adding code to prevent this state from being reached, it seems like just adding a check in the `getProductIdsForCart()` util method not only fixes the bug but ensures no other component that might use the util from hitting the same state in the future.

### Screenshots

Complete the task list, then hide the card when you see this screen:
<img width="1436" alt="Dashboard ‹ Just another WordPress site — WooCommerce 2020-01-02 14-10-20" src="https://user-images.githubusercontent.com/22080/71739287-dae33f80-2e0d-11ea-9449-6115636e0936.png">

Error:
<img width="831" alt="Dashboard ‹ bend outdoors — WooCommerce 2020-01-03 09-13-04" src="https://user-images.githubusercontent.com/22080/71739423-41685d80-2e0e-11ea-9f38-8e26a240c0d8.png">

### Detailed test instructions:
I think you could try to reproduce the bug by enabling the task list on your site, and subsequently completing all items in the list. I haven't tried this yet, but you could do that on `master` first, then apply this branch.

### Changelog Note:

Fix: Exception on dashboard once Onboarding tasks are complete
