### PR TITLE
Analytics: Change Refunds to Returns

### DIFF
--- a/client/dashboard/dashboard-charts/config.js
+++ b/client/dashboard/dashboard-charts/config.js
@@ -54,7 +54,7 @@ const defaultCharts = [
 		key: 'items_sold',
 	},
 	{
-		label: __( 'Refunds', 'woocommerce-admin' ),
+		label: __( 'Returns', 'woocommerce-admin' ),
 		report: 'revenue',
 		key: 'refunds',
 	},

--- a/src/API/Reports/Revenue/Stats/Controller.php
+++ b/src/API/Reports/Revenue/Stats/Controller.php
@@ -450,7 +450,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'date'         => __( 'Date', 'woocommerce-admin' ),
 			'orders_count' => __( 'Orders', 'woocommerce-admin' ),
 			'total_sales'  => __( 'Total Sales', 'woocommerce-admin' ),
-			'refunds'      => __( 'Refunds', 'woocommerce-admin' ),
+			'refunds'      => __( 'Returns', 'woocommerce-admin' ),
 			'coupons'      => __( 'Coupons', 'woocommerce-admin' ),
 			'taxes'        => __( 'Taxes', 'woocommerce-admin' ),
 			'shipping'     => __( 'Shipping', 'woocommerce-admin' ),

--- a/src/API/Reports/Revenue/Stats/Controller.php
+++ b/src/API/Reports/Revenue/Stats/Controller.php
@@ -211,8 +211,8 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 				'format'      => 'currency',
 			),
 			'refunds'        => array(
-				'title'       => __( 'Refunds', 'woocommerce-admin' ),
-				'description' => __( 'Total of refunds.', 'woocommerce-admin' ),
+				'title'       => __( 'Returns', 'woocommerce-admin' ),
+				'description' => __( 'Total of returns.', 'woocommerce-admin' ),
 				'type'        => 'number',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,


### PR DESCRIPTION
While working through some docs and chatting with @LevinMedia - he pointed out that he was hoping to rename **Refunds** in the context of the Revenue report to be **Returns**. This PR does that. I opted to not rename the element in the REST API response here as I'm concerned this will cause some issues with the mobile apps ( /cc @astralbodies ) - and since we don't have versions on these endpoints, I'm just going with the labeling change for now.### Screenshots

### Detailed test instructions:

- Open the dashboard, verify Refunds now says returns in the Performance Indicator
- Also on the dashboard, verify the Refunds chart now says returns

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Tweak: Change Refunds to Returns on the dashboard.
