### PR TITLE
Added @woocommerce/wc-admin-settings as alias in examples.config.js

### DIFF
--- a/docs/examples/extensions/examples.config.js
+++ b/docs/examples/extensions/examples.config.js
@@ -79,7 +79,11 @@ const webpackConfig = {
 			'node_modules',
 		],
 		alias: {
-			'gutenberg-components': path.resolve( __dirname, 'node_modules/@wordpress/components/src' ),
+			'gutenberg-components': path.resolve( __dirname, '../../../node_modules/@wordpress/components/src' ),
+			'@woocommerce/wc-admin-settings': path.resolve(
+				__dirname,
+				'../../../client/settings/index.js'
+			),
 		},
 	},
 	plugins: [


### PR DESCRIPTION
Fixed gutenberg-components path & added @woocommerce/wc-admin-settings

### Accessibility

### Detailed test instructions:

- Now, we can use `@woocommerce/wc-admin-settings` package in the extensions of WooCommerce Admin.

### Changelog Note:
Dev: Fixed gutenberg-components path & added @woocommerce/wc-admin-settings
