### PR TITLE
Update date format for import status

### DIFF
--- a/client/analytics/settings/historical-data/status.js
+++ b/client/analytics/settings/historical-data/status.js
@@ -22,12 +22,15 @@ function HistoricalDataStatus( { importDate, status } ) {
 		customers: [ __( 'Importing Customers', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		orders: [ __( 'Importing Orders', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		finalizing: [ __( 'Finalizing', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
-		finished: sprintf(
-			__( 'Historical data from %s onward imported', 'woocommerce-admin' ),
-			// @todo The date formatting should be localized ( 'll' ), but this is currently broken in Gutenberg.
-			// See https://github.com/WordPress/gutenberg/issues/12626 for details.
-			importDate !== -1 ? moment( importDate ).format( 'YYYY-MM-DD' ) : ''
-		),
+		finished:
+			importDate === -1
+				? __( 'All historical data imported', 'woocommerce-admin' )
+				: sprintf(
+						__( 'Historical data from %s onward imported', 'woocommerce-admin' ),
+						// @todo The date formatting should be localized ( 'll' ), but this is currently broken in Gutenberg.
+						// See https://github.com/WordPress/gutenberg/issues/12626 for details.
+						moment( importDate ).format( 'YYYY-MM-DD' )
+					),
 	} );
 
 	return (

--- a/client/analytics/settings/historical-data/status.js
+++ b/client/analytics/settings/historical-data/status.js
@@ -24,7 +24,9 @@ function HistoricalDataStatus( { importDate, status } ) {
 		finalizing: [ __( 'Finalizing', 'woocommerce-admin' ), <Spinner key="spinner" /> ],
 		finished: sprintf(
 			__( 'Historical data from %s onward imported', 'woocommerce-admin' ),
-			importDate !== -1 ? moment( importDate ).format( 'll' ) : ''
+			// @todo The date formatting should be localized ( 'll' ), but this is currently broken in Gutenberg.
+			// See https://github.com/WordPress/gutenberg/issues/12626 for details.
+			importDate !== -1 ? moment( importDate ).format( 'YYYY-MM-DD' ) : ''
 		),
 	} );
 


### PR DESCRIPTION
Fixes #3505

Temporarily fixes the date formatting for the importer.

The moment package in Gutenberg appears to be broken for localized date formats (see - https://github.com/WordPress/gutenberg/issues/12626 )

This PR updates to the format `YYYY-MM-DD` until that is resolved.

### Screenshots

#### Before
<img width="617" alt="Screen Shot 2020-01-06 at 2 06 02 PM" src="https://user-images.githubusercontent.com/10561050/71799150-73d4bd80-308f-11ea-9449-2f75aa237e3a.png">

#### After
<img width="586" alt="Screen Shot 2020-01-06 at 2 05 32 PM" src="https://user-images.githubusercontent.com/10561050/71799146-72a39080-308f-11ea-9ece-31ba2707eac9.png">


### Detailed test instructions:

1. Go to Analytics->Settings.
2. Run an import from a specified date.
3. Make sure the correct date is shown when the import has completed (not “F j, 2019”).
