### PR TITLE
fix SQL error in category sort

### DIFF
--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -133,7 +133,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( false !== strpos( $order_by_clause, '_terms' ) ) {
 			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_id";
 			if ( 'inner' === $from_arg ) {
-				$this->subquery->add_sql_clause( 'join', $join );
+				$this->subquery->add_sql_clause( 'left_join', $join );
 			} else {
 				$this->add_sql_clause( 'join', $join );
 			}

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -133,7 +133,10 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( false !== strpos( $order_by_clause, '_terms' ) ) {
 			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_id";
 			if ( 'inner' === $from_arg ) {
-				// This joins to one of the left joined tables.
+				// Even though this is an (inner) JOIN, we're adding it as a `left_join` to
+				// affect its order in the query statement. The SqlQuery::$sql_filters variable
+				// determines the order in which joins are concatenated.
+				// See: https://github.com/woocommerce/woocommerce-admin/blob/1f261998e7287b77bc13c3d4ee2e84b717da7957/src/API/Reports/SqlQuery.php#L46-L50.
 				$this->subquery->add_sql_clause( 'left_join', $join );
 			} else {
 				$this->add_sql_clause( 'join', $join );

--- a/src/API/Reports/Categories/DataStore.php
+++ b/src/API/Reports/Categories/DataStore.php
@@ -133,6 +133,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		if ( false !== strpos( $order_by_clause, '_terms' ) ) {
 			$join = "JOIN {$wpdb->terms} AS _terms ON {$id_cell} = _terms.term_id";
 			if ( 'inner' === $from_arg ) {
+				// This joins to one of the left joined tables.
 				$this->subquery->add_sql_clause( 'left_join', $join );
 			} else {
 				$this->add_sql_clause( 'join', $join );

--- a/tests/api/reports-categories.php
+++ b/tests/api/reports-categories.php
@@ -6,6 +6,8 @@
  * @since 3.5.0
  */
 
+use Automattic\WooCommerce\Admin\CategoryLookup;
+
 /**
  * Class WC_Tests_API_Reports_Categories
  */
@@ -145,6 +147,78 @@ class WC_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 1, $category_report['products_count'] );
 		$this->assertArrayHasKey( '_links', $category_report );
 		$this->assertArrayHasKey( 'category', $category_report['_links'] );
+	}
+
+	/**
+	 * Test getting reports with sorting.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_get_reports_categories_sort() {
+		WC_Helper_Reports::reset_stats_dbs();
+		wp_set_current_user( $this->user );
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_total( 100 ); // $25 x 4.
+		$order->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product 2' );
+		$product->set_regular_price( 100 );
+		$second_category_id = wp_create_category( 'Second Category' );
+		$product->set_category_ids( array( $second_category_id ) );
+		$product->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		$uncategorized_term = get_term_by( 'slug', 'uncategorized', 'product_cat' );
+		$params             = array(
+			'orderby'    => 'category',
+			'order'      => 'desc',
+			'categories' => $uncategorized_term->term_id . ',' . $second_category_id,
+		);
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( $params );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $reports ) );
+
+		$category_report = reset( $reports );
+
+		$this->assertEquals( $uncategorized_term->term_id, $category_report['category_id'] );
+
+		$category_report = next( $reports );
+
+		$this->assertEquals( $second_category_id, $category_report['category_id'] );
+
+		$params['order'] = 'asc';
+		$request         = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params( $params );
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$category_report = reset( $reports );
+
+		$this->assertEquals( $second_category_id, $category_report['category_id'] );
+
+		$category_report = next( $reports );
+
+		$this->assertEquals( $uncategorized_term->term_id, $category_report['category_id'] );
 	}
 
 	/**

--- a/tests/api/reports-categories.php
+++ b/tests/api/reports-categories.php
@@ -164,7 +164,8 @@ class WC_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$product->set_regular_price( 25 );
 		$product->save();
 
-		$order = WC_Helper_Order::create_order( 1, $product );
+		$customer = WC_Helper_Customer::create_customer( 'sortcustomer', 'wcadminuser2', 'sortcustomer@woo.local' );
+		$order    = WC_Helper_Order::create_order( $customer->get_id(), $product );
 		$order->set_status( 'completed' );
 		$order->set_total( 100 ); // $25 x 4.
 		$order->save();
@@ -180,7 +181,7 @@ class WC_Tests_API_Reports_Categories extends WC_REST_Unit_Test_Case {
 		$product->set_category_ids( array( $second_category_id ) );
 		$product->save();
 
-		$order = WC_Helper_Order::create_order( 1, $product );
+		$order = WC_Helper_Order::create_order( $customer->get_id(), $product );
 		$order->set_status( 'completed' );
 		$order->set_total( 400 ); // $100 x 4.
 		$order->save();


### PR DESCRIPTION
Fixes #3426

This PR fixes the order in which JOIN clauses were added to the category datastore queries when the query included a sort by category.

### Detailed test instructions:

- Open the category report
- Sort the table by category
- Verify table is loaded and sorted
- Check other sort columns, filters & comparison all work as expected

### Changelog Note:

Fix: SQL error in category table sort.
