### PR TITLE
Onboarding: Add reminder to complete profiler

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -9,6 +9,7 @@
 namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\Loader;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Profiler;
 
 /**
  * Contains backend logic for the onboarding profile and checklist feature.
@@ -89,6 +90,14 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
+		add_filter( 'admin_init', array( $this, 'add_profiler_reminder_note' ) );
+	}
+
+	/**
+	 * Add reminder note to complete profiler.
+	 */
+	public static function add_profiler_reminder_note() {
+		WC_Admin_Notes_Onboarding_Profiler::add_reminder();
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -67,6 +67,9 @@ class Onboarding {
 		// Rest API hooks need to run before is_admin() checks.
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
 
+		// Add onboarding notes.
+		new WC_Admin_Notes_Onboarding_Profiler();
+
 		if ( ! is_admin() ) {
 			return;
 		}
@@ -90,14 +93,6 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
-		add_filter( 'admin_init', array( $this, 'add_profiler_reminder_note' ) );
-	}
-
-	/**
-	 * Add reminder note to complete profiler.
-	 */
-	public static function add_profiler_reminder_note() {
-		WC_Admin_Notes_Onboarding_Profiler::add_reminder();
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WooCommerce Admin: Profile reminder note.
+ *
+ * Adds a notes to complete or skip the profiler.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use \Automattic\WooCommerce\Admin\Features\Onboarding;
+
+/**
+ * WC_Admin_Notes_Onboarding_Profiler.
+ */
+class WC_Admin_Notes_Onboarding_Profiler {
+	const NOTE_NAME = 'wc-admin-onboarding-profiler-reminder';
+
+	/**
+	 * Creates a note to remind store owners to complete the profiler.
+	 */
+	public static function add_reminder() {
+		if ( ! Onboarding::should_show_profiler() ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Welcome to WooCommerce! Set up your store and start selling', 'woocommerce-admin' ) );
+		$note->set_content( __( "We're here to help you going through the most important steps to get your store up and running.", 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'continue',
+			__( 'Continue Store Setup', 'woocommerce-admin' ),
+			false,
+			'actioned',
+			true
+		);
+		$note->add_action(
+			'skip',
+			__( 'Skip Setup', 'woocommerce-admin' ),
+			false,
+			'actioned',
+			false
+		);
+
+		$note->save();
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -42,16 +42,16 @@ class WC_Admin_Notes_Onboarding_Profiler {
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
-			'continue',
+			'continue-profiler',
 			__( 'Continue Store Setup', 'woocommerce-admin' ),
-			false,
-			'actioned',
+			wc_admin_url(),
+			'unactioned',
 			true
 		);
 		$note->add_action(
-			'skip',
+			'skip-profiler',
 			__( 'Skip Setup', 'woocommerce-admin' ),
-			false,
+			wc_admin_url( '&reset_profiler=0' ),
 			'actioned',
 			false
 		);


### PR DESCRIPTION
Fixes #3242

Adds a notice to complete or skip the profiler.  @pmcpinto Just to double check, we wanted to give a secondary action to skip the profiler, right? (As opposed to just dismissing the notice).

This also adds a way to mark the note as `actioned` both in client-side and server-side since both are capable of marking the profiler complete.

~Tracking for note actions will be handled in a follow-up.~ Tracking is handled by default for all note actions.

### Screenshots
<img width="907" alt="Screen Shot 2020-01-07 at 8 35 17 PM" src="https://user-images.githubusercontent.com/10561050/71895965-6d2c7000-318d-11ea-80fe-e6e1957d754f.png">


### Detailed test instructions:

1. Enable the profiler.
2. Visit any non-dashboard WC pages and note the reminder to complete the profiler in the store alerts section.
3. Walk through the profiler, selecting a theme, and completing the profiler.
4. Note that the note is removed.
5. Delete the note (name - `wc-admin-onboarding-profiler-reminder`) in the `wc_admin_notes` table.
6. Re-enable the profiler and make sure the note is added again.
7. Click "Continue Store Setup" and make sure this brings you to the onboarding profiler.
8. Go back to the note and click "Skip Setup" and make sure this marks the notice `actioned` (hides it) and takes you to the task list.
9. Delete the note.
10. Enable the profiler via the Help tab and disable it again.
11. Make sure the note has been removed.