### PR TITLE
Onboarding: Add tracks to profiler reminder note actions

### DIFF
--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -25,6 +25,14 @@ class WC_Admin_Notes_Onboarding_Profiler {
 	public function __construct() {
 		add_action( 'admin_init', array( $this, 'add_reminder' ) );
 		add_action( 'update_option_wc_onboarding_profile', array( $this, 'update_status_on_complete' ), 10, 2 );
+		add_action( 'woocommerce_note_action_continue-profiler', array( $this, 'track_continue_profiler' ) );
+	}
+
+	/**
+	 * Track when a user continues the profiler via the note.
+	 */
+	public static function track_continue_profiler() {
+		wc_admin_record_tracks_event( 'onboarding_continue_profiler' );
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -26,6 +26,7 @@ class WC_Admin_Notes_Onboarding_Profiler {
 		add_action( 'admin_init', array( $this, 'add_reminder' ) );
 		add_action( 'update_option_wc_onboarding_profile', array( $this, 'update_status_on_complete' ), 10, 2 );
 		add_action( 'woocommerce_note_action_continue-profiler', array( $this, 'track_continue_profiler' ) );
+		add_action( 'woocommerce_note_action_skip-profiler', array( $this, 'track_skip_profiler' ) );
 	}
 
 	/**
@@ -33,6 +34,13 @@ class WC_Admin_Notes_Onboarding_Profiler {
 	 */
 	public static function track_continue_profiler() {
 		wc_admin_record_tracks_event( 'onboarding_continue_profiler' );
+	}
+
+	/**
+	 * Track when a user skips the profiler via the note.
+	 */
+	public static function track_skip_profiler() {
+		wc_admin_record_tracks_event( 'onboarding_skip_profiler' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3242 

Adds tracking to continue and skip buttons in profiler.

### Screenshots
<img width="907" alt="Screen Shot 2020-01-07 at 8 35 17 PM" src="https://user-images.githubusercontent.com/10561050/71949614-23846980-320f-11ea-8125-52db1e114633.png">

### Detailed test instructions:

1. Delete the note `wc-admin-onboarding-profiler-reminder` if it exists.
2. Enable the profiler and visit any non-dashboard WC page.
3. Click on the continue button in the note.
4. Check that the event was tracked.
5. Go back to the note and click on the skip button.
6. Check that the skip event was tracked.