### PR TITLE
Onboarding: Set minimum height on muriel text inputs

### DIFF
--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -30,6 +30,7 @@
 		line-height: 21px;
 		margin: 0;
 		padding: 0;
+		min-height: 30px;
 
 		&:focus {
 			box-shadow: none;


### PR DESCRIPTION
Fixes #3537

Explicitly set a minimum height on inputs to prevent styling breakage that occurs on smaller viewports.

### Screenshots
#### Before
<img width="441" alt="Screen Shot 2020-01-08 at 11 43 54 AM" src="https://user-images.githubusercontent.com/10561050/71951576-77468100-3216-11ea-92c7-6a3e65edb4f9.png">

#### After
<img width="497" alt="Screen Shot 2020-01-08 at 12 55 41 PM" src="https://user-images.githubusercontent.com/10561050/71951568-73b2fa00-3216-11ea-9f8d-300de3ec31f7.png">


### Detailed test instructions:

1. Enable the onboarding profiler and visit the profiler.
2. Narrow the viewport to <783px.
3. Make sure text input styling is not broken.
