### PR TITLE
Update historical data notice to actioned on import

### DIFF
--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -20,6 +20,28 @@ class WC_Admin_Notes_Historical_Data {
 	const NOTE_NAME = 'wc-admin-historical-data';
 
 	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_analytics_regenerate_init', array( $this, 'update_status_to_actioned' ) );
+	}
+
+	/**
+	 * Update status of note to actioned on data import trigger.
+	 */
+	public static function update_status_to_actioned() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note( $note_ids[0] );
+		$note->set_status( 'actioned' );
+		$note->save();
+	}
+
+	/**
 	 * Creates a note for regenerating historical data.
 	 */
 	public static function add_note() {

--- a/src/ReportsSync.php
+++ b/src/ReportsSync.php
@@ -85,6 +85,14 @@ class ReportsSync {
 			$scheduler::schedule_action( 'import_batch_init', array( $days, $skip_existing ) );
 		}
 
+		/**
+		 * Fires when report data regeneration begins.
+		 *
+		 * @param int|bool $days Number of days to import.
+		 * @param bool     $skip_existing Skip exisiting records.
+		 */
+		do_action( 'woocommerce_analytics_regenerate_init', $days, $skip_existing );
+
 		return __( 'Report table data is being rebuilt.  Please allow some time for data to fully populate.', 'woocommerce-admin' );
 	}
 


### PR DESCRIPTION
Fixes #3420

* Adds an action hook for imports.
* Updates historical data note status to `actioned` on server-side import
* Updates historical data note status to `actioned` on client-side import so the note disappears without page refresh.

### Screenshots
<img width="701" alt="Screen Shot 2020-01-08 at 1 32 59 PM" src="https://user-images.githubusercontent.com/10561050/71952961-9d225480-321b-11ea-971f-6298fb0f8f69.png">


### Detailed test instructions:

1.  Create a store with no orders to create the historical data note.
2.  Run the importer from Analytics->Settings.
3. Make sure the note has been removed before page refresh.
4. Optionally repeat this process, but triggering an import via a request to `/wc-analytics/reports/import` to make sure this also removes the note.