### PR TITLE
Onboarding: Don't exclude selected option from options list in countrystate dropdown

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -177,6 +177,7 @@ export function StoreAddress( props ) {
 				label={ __( 'Country / State', 'woocommerce-admin' ) }
 				required
 				options={ countryStateOptions }
+				excludeSelectedOptions={ false }
 				isSearchable
 				{ ...getInputProps( 'countryState' ) }
 				controlClassName={ getInputProps( 'countryState' ).className }


### PR DESCRIPTION
Fixes #3519 

Includes the already selected option in the country state dropdown to make subsequent interactions with this box feel more intuitive and drop-down like.

@peterfabian Let me know if you feel this matches expectations better and if this lines up enough with example 3 from [this link](https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html).

### Screenshots
<img width="506" alt="Screen Shot 2020-01-08 at 2 41 14 PM" src="https://user-images.githubusercontent.com/10561050/71956079-21c5a080-3225-11ea-938a-0c97891b7203.png">

### Detailed test instructions:

1. Enable the onboarding profiler (can be done via the WC Help tab if currently disabled).
2. Navigate to the "Store Details" step of the profiler.
3. Select an option in country/state dropdown.
4. Click on the dropdown box again.
5. Note that the list is shown with the selected item.