### PR TITLE
remove languages/woocommerce-admin.php from deploy

### DIFF
--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -100,7 +100,6 @@ git commit -m "Adding feature-config.php directory to release" --no-verify
 
 # Force add language files
 git add languages/woocommerce-admin.pot --force
-git add languages/woocommerce-admin.php --force
 git add .
 git commit -m "Adding translations to release" --no-verify
 
@@ -128,7 +127,6 @@ zip -r ${ZIP_FILE} \
 	images/ \
 	$build_files \
 	languages/woocommerce-admin.pot \
-	languages/woocommerce-admin.php \
 	readme.txt \
 	src/ \
 	vendor/


### PR DESCRIPTION
This PR removes `languages/woocommerce-admin.php` from the deploy script. #3433 changed the translation build process and `woocommerce-admin.php` is no longer generated.

### Detailed test instructions:

- Generate a build to verify this change doesn't break the script.
