### PR TITLE
Onboarding: Only Show Retry Button on Plugin install failure

### DIFF
--- a/client/dashboard/profile-wizard/steps/plugins.js
+++ b/client/dashboard/profile-wizard/steps/plugins.js
@@ -158,11 +158,12 @@ class Plugins extends Component {
 							</Button>
 						) }
 
-						{ ! ( hasErrors && 'activate' === step ) && (
-							<Button isPrimary isBusy={ activateButtonBusy } onClick={ this.activatePlugins }>
-								{ __( 'Activate & continue', 'woocommerce-admin' ) }
-							</Button>
-						) }
+						{ ! hasErrors &&
+							'activate' === step && (
+								<Button isPrimary isBusy={ activateButtonBusy } onClick={ this.activatePlugins }>
+									{ __( 'Activate & continue', 'woocommerce-admin' ) }
+								</Button>
+							) }
 					</div>
 				</Card>
 			</Fragment>


### PR DESCRIPTION
Partially addresses #3518

Currently when Jetpack and/or WCS fail to install on the 2nd step of the OBW, both the Retry and Activate and Continue Buttons are shown:

__Before__
![71818533-919f2400-3089-11ea-8e52-0e8b1fbb8113](https://user-images.githubusercontent.com/22080/72106444-3c128380-32e4-11ea-9c32-131f53b4a13d.png)

This branch fixes that by only showing the Retry button:

__After__
<img width="702" alt="Dashboard ‹ AWordPressSite — WooCommerce 2020-01-09 13-19-48" src="https://user-images.githubusercontent.com/22080/72106484-4fbdea00-32e4-11ea-8d07-49d3fe59e074.png">

### Detailed test instructions:

You could "fake" the failed plugin install state by modifying the code to set `hasErrors` to `true` [here](https://github.com/woocommerce/woocommerce-admin/blob/master/client/dashboard/profile-wizard/steps/plugins.js#L219)

Alternatively you can use our test GoDaddy hosting account `Testing WC: GoDaddy -- Hosting Account` in the SS, use the site called `http://tv7.b70.myftpupload.com` which already has this branch installed ✨ - just delete Jetpack & WCS and restart the setup wizard by visiting

http://tv7.b70.myftpupload.com/wp-admin/admin.php?page=wc-setup

Typically one of the plugins will fail to install on the GoDaddy env the first time ( we are still unsure _why_ ), and this will allow you to verify that only the "Retry" button is shown.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
