### PR TITLE
Fix mobile table header styling

### DIFF
--- a/client/analytics/components/report-table/style.scss
+++ b/client/analytics/components/report-table/style.scss
@@ -22,6 +22,10 @@
 		flex-grow: 1;
 	}
 
+	.woocommerce-card__header {
+		position: relative;
+	}
+
 	&.has-compare,
 	&.has-search {
 		.woocommerce-card__action {
@@ -34,14 +38,16 @@
 
 		@include breakpoint( '<960px' ) {
 			.woocommerce-card__action {
-				grid-area: 1 / 1 / 3 / 4;
 				grid-gap: $gap-small;
-				grid-template-columns: auto 1fr 24px;
+				grid-template-columns: auto 1fr;
+				grid-row-start: 2;
+				grid-row-end: 2;
+				grid-column-start: 1;
+				grid-column-end: 4;
 				margin: 0;
 
 				.woocommerce-table__compare {
 					display: flex;
-					grid-area: 2 / 1 / 3 / 2;
 				}
 
 				.woocommerce-search {
@@ -53,13 +59,14 @@
 					grid-area: 1 / 2 / 2 / 3;
 					justify-self: end;
 					margin: -6px 0;
+					position: absolute;
 				}
 			}
 		}
 
 		&.has-search:not(.has-compare) {
 			.woocommerce-card__action {
-				grid-template-columns: 1fr auto;
+				grid-template-columns: auto;
 
 				.woocommerce-search {
 					align-self: center;
@@ -76,8 +83,7 @@
 
 			@include breakpoint( '<960px' ) {
 				.woocommerce-card__action {
-					grid-area: 1 / 1 / 3 / 4;
-					grid-template-columns: auto 1fr 24px;
+					grid-template-columns: auto;
 
 					.woocommerce-search {
 						grid-area: 2 / 1 / 3 / 4;

--- a/packages/components/src/search/style.scss
+++ b/packages/components/src/search/style.scss
@@ -1,6 +1,8 @@
 /** @format */
 
 .woocommerce-search.woocommerce-select-control {
+	position: relative;
+
 	i.material-icons-outlined {
 		position: absolute;
 		top: 9px;
@@ -33,6 +35,7 @@
 	.components-base-control .woocommerce-select-control__control-input {
 		margin: 0;
 		font-size: 13px;
+		min-height: auto;
 
 		&[type='number']::-webkit-outer-spin-button,
 		&[type='number']::-webkit-inner-spin-button {
@@ -44,10 +47,10 @@
 	.components-base-control .components-base-control__label {
 		font-size: 13px;
 		color: #72777c;
-		position: static;
-		transform: none;
 		margin: 0;
-		width: 100%;
+		width: calc(100% - 36px);
+		top: 50%;
+		left: 36px;
 	}
 
 	.is-active.components-base-control .components-base-control__label,


### PR DESCRIPTION
Fixes #2517

* Fixes order and styling for table header actions on smaller viewports (<960px)
* Fixes the search control label width and styling on smaller viewports

### Screenshots
#### Before
<img width="433" alt="Screen Shot 2020-01-10 at 11 57 19 AM" src="https://user-images.githubusercontent.com/10561050/72124683-9c66fb00-33a0-11ea-8ba4-7e88e581bed6.png">


#### After
<img width="537" alt="Screen Shot 2020-01-10 at 11 54 56 AM" src="https://user-images.githubusercontent.com/10561050/72124691-9ffa8200-33a0-11ea-8350-17afd6161a74.png">

### Detailed test instructions:

1. Narrow your viewport to <960px.
2. Visit various reports with comparisons (check ones that have the "Compare" button and those that just have search.
3. Make sure styles match those expected.
4. Make sure the other search controls styling don't have any regressions.