### PR TITLE
Onboarding: Update profiler theme action buttons

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -193,7 +193,7 @@ class Theme extends Component {
 							</Button>
 						) }
 						{ demo_url && (
-							<Button isDefault onClick={ () => this.openDemo( theme ) }>
+							<Button isTertiary onClick={ () => this.openDemo( theme ) }>
 								{ __( 'Live demo', 'woocommerce-admin' ) }
 							</Button>
 						) }

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -177,7 +177,6 @@ class Theme extends Component {
 						{ slug === activeTheme ? (
 							<Button
 								isPrimary
-								isDefault={ ! Boolean( demo_url ) }
 								onClick={ () => this.onChoose( theme, 'card' ) }
 								isBusy={ chosen === slug }
 							>

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -145,6 +145,7 @@ class Theme extends Component {
 	renderTheme( theme ) {
 		const { demo_url, has_woocommerce_support, image, slug, title } = theme;
 		const { chosen } = this.state;
+		const { activeTheme = '' } = getSetting( 'onboarding', {} );
 
 		return (
 			<Card className="woocommerce-profile-wizard__theme" key={ theme.slug }>
@@ -173,17 +174,27 @@ class Theme extends Component {
 						{ this.getThemeStatus( theme ) }
 					</p>
 					<div className="woocommerce-profile-wizard__theme-actions">
-						<Button
-							isPrimary
-							isDefault={ ! Boolean( demo_url ) }
-							onClick={ () => this.onChoose( theme, 'card' ) }
-							isBusy={ chosen === slug }
-						>
-							{ __( 'Choose', 'woocommerce-admin' ) }
-						</Button>
+						{ slug === activeTheme ? (
+							<Button
+								isPrimary
+								isDefault={ ! Boolean( demo_url ) }
+								onClick={ () => this.onChoose( theme, 'card' ) }
+								isBusy={ chosen === slug }
+							>
+								{ __( 'Continue with my active theme', 'woocommerce-admin' ) }
+							</Button>
+						) : (
+							<Button
+								isDefault
+								onClick={ () => this.onChoose( theme, 'card' ) }
+								isBusy={ chosen === slug }
+							>
+								{ __( 'Choose', 'woocommerce-admin' ) }
+							</Button>
+						) }
 						{ demo_url && (
 							<Button isDefault onClick={ () => this.openDemo( theme ) }>
-								{ __( 'Live Demo', 'woocommerce-admin' ) }
+								{ __( 'Live demo', 'woocommerce-admin' ) }
 							</Button>
 						) }
 					</div>

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -102,14 +102,12 @@
 
 	.woocommerce-profile-wizard__theme-actions {
 		button.components-button {
-			margin-top: 13px;
+			margin: 13px auto 0 auto;
 			display: block;
-			float: left;
 			width: auto;
 			min-width: 106px;
 			height: 40px;
 			line-height: 1;
-			margin-right: $gap-smaller;
 			box-shadow: none;
 
 			&.is-default {

--- a/client/dashboard/profile-wizard/steps/theme/style.scss
+++ b/client/dashboard/profile-wizard/steps/theme/style.scss
@@ -113,10 +113,16 @@
 			&.is-default {
 				border-color: $studio-pink-50;
 				color: $studio-pink-50;
+				background: transparent;
 			}
 
 			&.is-primary {
 				color: $studio-white;
+			}
+
+			&.is-tertiary {
+				font-size: 14px;
+				font-weight: 500;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3450 

Updates the button text and styling for theme action buttons.

### Screenshots
<img width="418" alt="Screen Shot 2020-01-10 at 12 44 28 PM" src="https://user-images.githubusercontent.com/10561050/72126517-59f4ec80-33a7-11ea-9e26-5cacbc9bc21c.png">
<img width="413" alt="Screen Shot 2020-01-10 at 12 44 21 PM" src="https://user-images.githubusercontent.com/10561050/72126518-59f4ec80-33a7-11ea-8aba-274723ce6916.png">


### Detailed test instructions:

1. Enable the onboarding profiler.
2. Visit the theme step of the profiler.
3. Make sure the styles match the ones outlined in #3450 