### PR TITLE
Updating unread stock indicator on stock update

### DIFF
--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -88,7 +88,7 @@ export function getUnapprovedReviews( select ) {
 }
 
 export function getUnreadStock( select ) {
-	const { getItems, getItemsError, getItemsTotalCount, isGetItemsRequesting } = select( 'wc-api' );
+	const { getItems, getItemsError, getItemsTotalCount } = select( 'wc-api' );
 	const productsQuery = {
 		page: 1,
 		per_page: 1,
@@ -98,9 +98,8 @@ export function getUnreadStock( select ) {
 	getItems( 'products', productsQuery );
 	const lowInStockCount = getItemsTotalCount( 'products', productsQuery );
 	const isError = Boolean( getItemsError( 'products', productsQuery ) );
-	const isRequesting = isGetItemsRequesting( 'products', productsQuery );
 
-	if ( isError || isRequesting ) {
+	if ( isError ) {
 		return null;
 	}
 

--- a/client/wc-api/items/operations.js
+++ b/client/wc-api/items/operations.js
@@ -117,8 +117,19 @@ function updateLocally( resourceNames, data ) {
 		return updateableTypes.includes( getResourcePrefix( name ) );
 	} );
 
+	const lowStockResourceName = getResourceName( 'items-query-products', {
+		page: 1,
+		per_page: 1,
+		low_in_stock: true,
+		status: 'publish',
+	} );
+
 	return filteredNames.map( async resourceName => {
-		return { [ resourceName ]: { data: data[ resourceName ] } };
+		return {
+			[ resourceName ]: { data: data[ resourceName ] },
+			// Force low stock products to be re-fetched after updating an item.
+			[ lowStockResourceName ]: { lastReceived: null },
+		};
 	} );
 }
 


### PR DESCRIPTION
Fixes #3218 

Updates the unread indicator for the activity stock panel when updating the stock from the panel.

### Screenshots
<img width="543" alt="Screen Shot 2020-01-13 at 4 57 02 PM" src="https://user-images.githubusercontent.com/10561050/72243099-f3c9cd00-3625-11ea-98fd-4d9214c7de92.png">


### Detailed test instructions:

1. Make sure you have at least one low stock item.
2. Note the unread indicator for low stock in the activity panel.
3. Open the low stock panel and update all products to a stock quantity that is not considered low.
4. Wait for the update.. wait for it...
5. Make sure the unread indicator disappears.