### PR TITLE
SelectControl: Add an option to show all options on refocus

### DIFF
--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -178,6 +178,7 @@ export function StoreAddress( props ) {
 				required
 				options={ countryStateOptions }
 				excludeSelectedOptions={ false }
+				showAllOnFocus
 				isSearchable
 				{ ...getInputProps( 'countryState' ) }
 				controlClassName={ getInputProps( 'countryState' ).className }

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -38,11 +38,13 @@ class Control extends Component {
 	}
 
 	onFocus( onSearch ) {
-		const { isSearchable, setExpanded } = this.props;
+		const { isSearchable, setExpanded, showAllOnFocus, updateFilteredOptions } = this.props;
 
 		return event => {
 			this.setState( { isActive: true } );
-			if ( isSearchable ) {
+			if ( isSearchable && showAllOnFocus ) {
+				updateFilteredOptions( '' );
+			} else if ( isSearchable ) {
 				onSearch( event.target.value );
 			} else {
 				setExpanded( true );
@@ -271,6 +273,10 @@ Control.propTypes = {
 			label: PropTypes.string,
 		} )
 	),
+	/**
+	 * Show all options on focusing, even if a query exists.
+	 */
+	showAllOnFocus: PropTypes.bool,
 };
 
 export default Control;

--- a/packages/components/src/select-control/control.js
+++ b/packages/components/src/select-control/control.js
@@ -43,6 +43,7 @@ class Control extends Component {
 		return event => {
 			this.setState( { isActive: true } );
 			if ( isSearchable && showAllOnFocus ) {
+				event.target.select();
 				updateFilteredOptions( '' );
 			} else if ( isSearchable ) {
 				onSearch( event.target.value );

--- a/packages/components/src/select-control/docs/example.js
+++ b/packages/components/src/select-control/docs/example.js
@@ -56,6 +56,7 @@ export default withState( {
 	simpleSelected: [],
 	simpleMultipleSelected: [],
 	singleSelected: [],
+	singleSelectedShowAll: [],
 	multipleSelected: [],
 	inlineSelected: [],
 } )(
@@ -63,6 +64,7 @@ export default withState( {
 		simpleSelected,
 		simpleMultipleSelected,
 		singleSelected,
+		singleSelectedShowAll,
 		multipleSelected,
 		inlineSelected,
 		setState,
@@ -92,6 +94,16 @@ export default withState( {
 				options={ options }
 				placeholder="Start typing to filter options..."
 				selected={ singleSelected }
+			/>
+			<br />
+			<SelectControl
+				label="Single value searchable with options on refocus"
+				isSearchable
+				onChange={ selected => setState( { singleSelectedShowAll: selected } ) }
+				options={ options }
+				placeholder="Start typing to filter options..."
+				selected={ singleSelectedShowAll }
+				showAllOnFocus
 			/>
 			<br />
 			<SelectControl

--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -42,7 +42,7 @@ export class SelectControl extends Component {
 		this.decrementSelectedIndex = this.decrementSelectedIndex.bind( this );
 		this.incrementSelectedIndex = this.incrementSelectedIndex.bind( this );
 		this.onAutofillChange = this.onAutofillChange.bind( this );
-		this.updateFilteredOptions = debounce( this.updateFilteredOptions, props.searchDebounceTime );
+		this.updateFilteredOptions = debounce( this.updateFilteredOptions.bind( this ), props.searchDebounceTime );
 		this.search = this.search.bind( this );
 		this.selectOption = this.selectOption.bind( this );
 		this.setExpanded = this.setExpanded.bind( this );
@@ -292,6 +292,7 @@ export class SelectControl extends Component {
 					onSearch={ this.search }
 					selected={ this.getSelected() }
 					setExpanded={ this.setExpanded }
+					updateFilteredOptions={ this.updateFilteredOptions }
 					decrementSelectedIndex={ this.decrementSelectedIndex }
 					incrementSelectedIndex={ this.incrementSelectedIndex }
 				/>
@@ -427,6 +428,10 @@ SelectControl.propTypes = {
 	 */
 	hideBeforeSearch: PropTypes.bool,
 	/**
+	 * Show all options on focusing, even if a query exists.
+	 */
+	showAllOnFocus: PropTypes.bool,
+	/**
 	 * Render results list positioned statically instead of absolutely.
 	 */
 	staticList: PropTypes.bool,
@@ -446,6 +451,7 @@ SelectControl.defaultProps = {
 	searchDebounceTime: 0,
 	searchInputType: 'search',
 	selected: [],
+	showAllOnFocus: false,
 	showClearButton: false,
 	hideBeforeSearch: false,
 	staticList: false,


### PR DESCRIPTION
Fixes #3335

Shows all options for a `SelectControl` dropdown on refocus instead of limiting to the existing query.

### Screenshots
<img width="492" alt="Screen Shot 2020-01-13 at 8 12 32 PM" src="https://user-images.githubusercontent.com/10561050/72255249-35b43c80-3641-11ea-9cbb-a1c979365d1c.png">


### Detailed test instructions:

1. Navigate to the devdocs ("Single value searchable with options on refocus" example) or store details step (country/state dropdown) of the onboarding profiler.
1. Select an option.
1. Click on the dropdown to refocus
1. Check that all options are shown and the query text is selected (highlighted for easy replacement).
1. Make sure other `SelectControl` components continue to work as expected.