### PR TITLE
Make package-based load inert when plugin is active.

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -31,6 +31,12 @@ class Package {
 		if ( ! $wordpress_minimum_met ) {
 			return;
 		}
+
+		// Avoid double initialization when the feature plugin is in use.
+		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
+			return;
+		}
+
 		FeaturePlugin::instance()->init();
 	}
 


### PR DESCRIPTION
Found while testing #3392.

This PR seeks to stop the `FeaturePlugin` class from being double initialized.

### Detailed test instructions:

- Copy `src/Package.php` to `packages/woocommerce-admin/src/Package.php` in your `woocommerce` directory (running https://github.com/woocommerce/woocommerce/pull/25011)
- Ensure that `woocommerce-admin` from this PR is active
- Verify that only one instance is hooked into the `wc_admin_process_orders_milestone ` cron event (use WP Crontrol)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->
