### PR TITLE
Re-add stockStatuses to wcSettings

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -632,6 +632,7 @@ class Loader {
 			global $wp_locale;
 			// inject data not available via older versions of wc_blocks/woo.
 			$settings['orderStatuses'] = self::get_order_statuses( wc_get_order_statuses() );
+			$settings['stockStatuses'] = self::get_order_statuses( wc_get_product_stock_status_options() );
 			$settings['currency']      = self::get_currency_settings();
 			$settings['locale']        = [
 				'siteLocale'    => isset( $settings['siteLocale'] )


### PR DESCRIPTION
Stock Statuses were missing from `wcSettings`

This pr adds `stockStatuses` to the settings object.

### Before

![Screen Shot 2020-01-16 at 10 27 19 AM](https://user-images.githubusercontent.com/1922453/72473246-26a0da80-384b-11ea-82e8-a45f98d8de3b.png)

### After

![Screen Shot 2020-01-16 at 10 27 37 AM](https://user-images.githubusercontent.com/1922453/72473261-2c96bb80-384b-11ea-82f2-cbc8dfbf58eb.png)

### Detailed test instructions:

1. Ensure stock statuses are displayed on the Stock Report