### PR TITLE
Reports: Use new data store

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -5,9 +5,6 @@
 import { __, _x } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { applyFilters } from '@wordpress/hooks';
-import { getSetting } from '@woocommerce/wc-admin-settings';
-
-const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
 
 /**
  * Internal dependencies
@@ -55,289 +52,297 @@ export const filters = applyFilters( CUSTOMERS_REPORT_FILTERS_FILTER, [
 ] );
 
 /*eslint-disable max-len*/
-export const advancedFilters = applyFilters( CUSTOMERS_REPORT_ADVANCED_FILTERS_FILTER, {
-	title: _x(
-		'Customers Match {{select /}} Filters',
-		'A sentence describing filters for Customers. See screen shot for context: https://cloudup.com/cCsm3GeXJbE',
-		'woocommerce-admin'
-	),
-	filters: {
-		name: {
-			labels: {
-				add: __( 'Name', 'woocommerce-admin' ),
-				placeholder: __( 'Search', 'woocommerce-admin' ),
-				remove: __( 'Remove customer name filter', 'woocommerce-admin' ),
-				rule: __( 'Select a customer name filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Name{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select customer name', 'woocommerce-admin' ),
+export const getAdvancedFilters = countries => {
+	return applyFilters( CUSTOMERS_REPORT_ADVANCED_FILTERS_FILTER, {
+		title: _x(
+			'Customers Match {{select /}} Filters',
+			'A sentence describing filters for Customers. See screen shot for context: https://cloudup.com/cCsm3GeXJbE',
+			'woocommerce-admin'
+		),
+		filters: {
+			name: {
+				labels: {
+					add: __( 'Name', 'woocommerce-admin' ),
+					placeholder: __( 'Search', 'woocommerce-admin' ),
+					remove: __( 'Remove customer name filter', 'woocommerce-admin' ),
+					rule: __( 'Select a customer name filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+					title: __( '{{title}}Name{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select customer name', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to customer names including a given name(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Includes', 'customer names', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to customer names excluding a given name(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Excludes', 'customer names', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Search',
+					type: 'customers',
+					getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
+						id: customer.id,
+						label: customer.name,
+					} ) ),
+				},
 			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to customer names including a given name(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Includes', 'customer names', 'woocommerce-admin' ),
+			country: {
+				labels: {
+					add: __( 'Country', 'woocommerce-admin' ),
+					placeholder: __( 'Search', 'woocommerce-admin' ),
+					remove: __( 'Remove country filter', 'woocommerce-admin' ),
+					rule: __( 'Select a country filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+					title: __( '{{title}}Country{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select country', 'woocommerce-admin' ),
 				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to customer names excluding a given name(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Excludes', 'customer names', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Search',
-				type: 'customers',
-				getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
-					id: customer.id,
-					label: customer.name,
-				} ) ),
-			},
-		},
-		country: {
-			labels: {
-				add: __( 'Country', 'woocommerce-admin' ),
-				placeholder: __( 'Search', 'woocommerce-admin' ),
-				remove: __( 'Remove country filter', 'woocommerce-admin' ),
-				rule: __( 'Select a country filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Country{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select country', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to countries including a given country or countries. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Includes', 'countries', 'woocommerce-admin' ),
-				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to countries excluding a given country or countries. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Excludes', 'countries', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Search',
-				type: 'countries',
-				getLabels: async value => {
-					const allLabels = countries.map( country => ( {
-						key: country.code,
-						label: decodeEntities( country.name ),
-					} ) );
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to countries including a given country or countries. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Includes', 'countries', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to countries excluding a given country or countries. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Excludes', 'countries', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Search',
+					type: 'countries',
+					getLabels: async value => {
+						const allLabels = countries.map( country => ( {
+							key: country.code,
+							label: decodeEntities( country.name ),
+						} ) );
 
-					const labels = value.split( ',' );
-					return await allLabels.filter( label => {
-						return labels.includes( label.key );
-					} );
+						const labels = value.split( ',' );
+						return await allLabels.filter( label => {
+							return labels.includes( label.key );
+						} );
+					},
 				},
 			},
-		},
-		username: {
-			labels: {
-				add: __( 'Username', 'woocommerce-admin' ),
-				placeholder: __( 'Search customer username', 'woocommerce-admin' ),
-				remove: __( 'Remove customer username filter', 'woocommerce-admin' ),
-				rule: __( 'Select a customer username filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Username{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select customer username', 'woocommerce-admin' ),
+			username: {
+				labels: {
+					add: __( 'Username', 'woocommerce-admin' ),
+					placeholder: __( 'Search customer username', 'woocommerce-admin' ),
+					remove: __( 'Remove customer username filter', 'woocommerce-admin' ),
+					rule: __( 'Select a customer username filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a customer username filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+					title: __( '{{title}}Username{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select customer username', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to customer usernames including a given username(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Includes', 'customer usernames', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to customer usernames excluding a given username(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Excludes', 'customer usernames', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Search',
+					type: 'usernames',
+					getLabels: getCustomerLabels,
+				},
 			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to customer usernames including a given username(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Includes', 'customer usernames', 'woocommerce-admin' ),
+			email: {
+				labels: {
+					add: __( 'Email', 'woocommerce-admin' ),
+					placeholder: __( 'Search customer email', 'woocommerce-admin' ),
+					remove: __( 'Remove customer email filter', 'woocommerce-admin' ),
+					rule: __( 'Select a customer email filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a customer email filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+					title: __( '{{title}}Email{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select customer email', 'woocommerce-admin' ),
 				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to customer usernames excluding a given username(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Excludes', 'customer usernames', 'woocommerce-admin' ),
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to customer emails including a given email(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Includes', 'customer emails', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to customer emails excluding a given email(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Excludes', 'customer emails', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Search',
+					type: 'emails',
+					getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
+						id: customer.id,
+						label: customer.email,
+					} ) ),
 				},
-			],
-			input: {
-				component: 'Search',
-				type: 'usernames',
-				getLabels: getCustomerLabels,
 			},
-		},
-		email: {
-			labels: {
-				add: __( 'Email', 'woocommerce-admin' ),
-				placeholder: __( 'Search customer email', 'woocommerce-admin' ),
-				remove: __( 'Remove customer email filter', 'woocommerce-admin' ),
-				rule: __( 'Select a customer email filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a customer email filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Email{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select customer email', 'woocommerce-admin' ),
+			orders_count: {
+				labels: {
+					add: __( 'No. of Orders', 'woocommerce-admin' ),
+					remove: __( 'Remove order filter', 'woocommerce-admin' ),
+					rule: __( 'Select an order count filter match', 'woocommerce-admin' ),
+					title: __(
+						'{{title}}No. of Orders{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-admin'
+					),
+				},
+				rules: [
+					{
+						value: 'max',
+						/* translators: Sentence fragment, logical, "Less Than" refers to number of orders a customer has placed, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Less Than', 'number of orders', 'woocommerce-admin' ),
+					},
+					{
+						value: 'min',
+						/* translators: Sentence fragment, logical, "More Than" refers to number of orders a customer has placed, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'More Than', 'number of orders', 'woocommerce-admin' ),
+					},
+					{
+						value: 'between',
+						/* translators: Sentence fragment, logical, "Between" refers to number of orders a customer has placed, between two given integers. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Between', 'number of orders', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Number',
+				},
 			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to customer emails including a given email(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Includes', 'customer emails', 'woocommerce-admin' ),
+			total_spend: {
+				labels: {
+					add: __( 'Total Spend', 'woocommerce-admin' ),
+					remove: __( 'Remove total spend filter', 'woocommerce-admin' ),
+					rule: __( 'Select a total spend filter match', 'woocommerce-admin' ),
+					title: __(
+						'{{title}}Total Spend{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-admin'
+					),
 				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to customer emails excluding a given email(s). Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Excludes', 'customer emails', 'woocommerce-admin' ),
+				rules: [
+					{
+						value: 'max',
+						/* translators: Sentence fragment, logical, "Less Than" refers to total spending by a customer, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Less Than', 'total spend by customer', 'woocommerce-admin' ),
+					},
+					{
+						value: 'min',
+						/* translators: Sentence fragment, logical, "Less Than" refers to total spending by a customer, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'More Than', 'total spend by customer', 'woocommerce-admin' ),
+					},
+					{
+						value: 'between',
+						/* translators: Sentence fragment, logical, "Between" refers to total spending by a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Between', 'total spend by customer', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Currency',
 				},
-			],
-			input: {
-				component: 'Search',
-				type: 'emails',
-				getLabels: getRequestByIdString( NAMESPACE + '/customers', customer => ( {
-					id: customer.id,
-					label: customer.email,
-				} ) ),
 			},
-		},
-		orders_count: {
-			labels: {
-				add: __( 'No. of Orders', 'woocommerce-admin' ),
-				remove: __( 'Remove order filter', 'woocommerce-admin' ),
-				rule: __( 'Select an order count filter match', 'woocommerce-admin' ),
-				title: __(
-					'{{title}}No. of Orders{{/title}} {{rule /}} {{filter /}}',
-					'woocommerce-admin'
-				),
-			},
-			rules: [
-				{
-					value: 'max',
-					/* translators: Sentence fragment, logical, "Less Than" refers to number of orders a customer has placed, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Less Than', 'number of orders', 'woocommerce-admin' ),
+			avg_order_value: {
+				labels: {
+					add: __( 'AOV', 'woocommerce-admin' ),
+					remove: __( 'Remove average order value filter', 'woocommerce-admin' ),
+					rule: __( 'Select an average order value filter match', 'woocommerce-admin' ),
+					title: __( '{{title}}AOV{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
 				},
-				{
-					value: 'min',
-					/* translators: Sentence fragment, logical, "More Than" refers to number of orders a customer has placed, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'More Than', 'number of orders', 'woocommerce-admin' ),
-				},
-				{
-					value: 'between',
-					/* translators: Sentence fragment, logical, "Between" refers to number of orders a customer has placed, between two given integers. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Between', 'number of orders', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Number',
-			},
-		},
-		total_spend: {
-			labels: {
-				add: __( 'Total Spend', 'woocommerce-admin' ),
-				remove: __( 'Remove total spend filter', 'woocommerce-admin' ),
-				rule: __( 'Select a total spend filter match', 'woocommerce-admin' ),
-				title: __( '{{title}}Total Spend{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'max',
-					/* translators: Sentence fragment, logical, "Less Than" refers to total spending by a customer, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Less Than', 'total spend by customer', 'woocommerce-admin' ),
-				},
-				{
-					value: 'min',
-					/* translators: Sentence fragment, logical, "Less Than" refers to total spending by a customer, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'More Than', 'total spend by customer', 'woocommerce-admin' ),
-				},
-				{
-					value: 'between',
-					/* translators: Sentence fragment, logical, "Between" refers to total spending by a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Between', 'total spend by customer', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Currency',
-			},
-		},
-		avg_order_value: {
-			labels: {
-				add: __( 'AOV', 'woocommerce-admin' ),
-				remove: __( 'Remove average order value filter', 'woocommerce-admin' ),
-				rule: __( 'Select an average order value filter match', 'woocommerce-admin' ),
-				title: __( '{{title}}AOV{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'max',
-					/* translators: Sentence fragment, logical, "Less Than" refers to average order value of a customer, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Less Than', 'average order value of customer', 'woocommerce-admin' ),
-				},
-				{
-					value: 'min',
-					/* translators: Sentence fragment, logical, "Less Than" refers to average order value of a customer, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+				rules: [
+					{
+						value: 'max',
+						/* translators: Sentence fragment, logical, "Less Than" refers to average order value of a customer, more than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Less Than', 'average order value of customer', 'woocommerce-admin' ),
+					},
+					{
+						value: 'min',
+						/* translators: Sentence fragment, logical, "Less Than" refers to average order value of a customer, less than a given amount. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
 
-					label: _x( 'More Than', 'average order value of customer', 'woocommerce-admin' ),
+						label: _x( 'More Than', 'average order value of customer', 'woocommerce-admin' ),
+					},
+					{
+						value: 'between',
+						/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Between', 'average order value of customer', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Currency',
 				},
-				{
-					value: 'between',
-					/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Between', 'average order value of customer', 'woocommerce-admin' ),
+			},
+			registered: {
+				labels: {
+					add: __( 'Registered', 'woocommerce-admin' ),
+					remove: __( 'Remove registered filter', 'woocommerce-admin' ),
+					rule: __( 'Select a registered filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+					title: __( '{{title}}Registered{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select registered date', 'woocommerce-admin' ),
 				},
-			],
-			input: {
-				component: 'Currency',
+				rules: [
+					{
+						value: 'before',
+						/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Before', 'date', 'woocommerce-admin' ),
+					},
+					{
+						value: 'after',
+						/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'After', 'date', 'woocommerce-admin' ),
+					},
+					{
+						value: 'between',
+						/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Between', 'date', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Date',
+				},
+			},
+			last_active: {
+				labels: {
+					add: __( 'Last active', 'woocommerce-admin' ),
+					remove: __( 'Remove last active filter', 'woocommerce-admin' ),
+					rule: __( 'Select a last active filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
+					title: __(
+						'{{title}}Last active{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-admin'
+					),
+					filter: __( 'Select registered date', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'before',
+						/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Before', 'date', 'woocommerce-admin' ),
+					},
+					{
+						value: 'after',
+						/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'After', 'date', 'woocommerce-admin' ),
+					},
+					{
+						value: 'between',
+						/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
+						label: _x( 'Between', 'date', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Date',
+				},
 			},
 		},
-		registered: {
-			labels: {
-				add: __( 'Registered', 'woocommerce-admin' ),
-				remove: __( 'Remove registered filter', 'woocommerce-admin' ),
-				rule: __( 'Select a registered filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Registered{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select registered date', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'before',
-					/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Before', 'date', 'woocommerce-admin' ),
-				},
-				{
-					value: 'after',
-					/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'After', 'date', 'woocommerce-admin' ),
-				},
-				{
-					value: 'between',
-					/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Between', 'date', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Date',
-			},
-		},
-		last_active: {
-			labels: {
-				add: __( 'Last active', 'woocommerce-admin' ),
-				remove: __( 'Remove last active filter', 'woocommerce-admin' ),
-				rule: __( 'Select a last active filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Last active{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select registered date', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'before',
-					/* translators: Sentence fragment, logical, "Before" refers to customers registered before a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Before', 'date', 'woocommerce-admin' ),
-				},
-				{
-					value: 'after',
-					/* translators: Sentence fragment, logical, "after" refers to customers registered after a given date. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'After', 'date', 'woocommerce-admin' ),
-				},
-				{
-					value: 'between',
-					/* translators: Sentence fragment, logical, "Between" refers to average order value of a customer, between two given amounts. Screenshot for context: https://cloudup.com/cCsm3GeXJbE */
-					label: _x( 'Between', 'date', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Date',
-			},
-		},
-	},
-} );
+	} );
+};
 /*eslint-enable max-len*/

--- a/client/analytics/report/customers/index.js
+++ b/client/analytics/report/customers/index.js
@@ -2,46 +2,55 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { useSettings } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
-import { filters, advancedFilters } from './config';
+import { filters, getAdvancedFilters } from './config';
 import CustomersReportTable from './table';
 import ReportFilters from 'analytics/components/report-filters';
 
-export default class CustomersReport extends Component {
-	render() {
-		const { isRequesting, query, path } = this.props;
-		const tableQuery = {
-			orderby: 'date_last_active',
-			order: 'desc',
-			...query,
-		};
+const CustomersReport = ( { isRequesting, query, path } ) => {
+	const { dataEndpoints, getAdminLink } = useSettings( [ 'dataEndpoints', 'getAdminLink' ] );
+	const { countries = { countries: {} } } = dataEndpoints;
+	const advancedFilters = getAdvancedFilters( countries );
+	const tableQuery = {
+		orderby: 'date_last_active',
+		order: 'desc',
+		...query,
+	};
 
-		return (
-			<Fragment>
-				<ReportFilters
-					query={ query }
-					path={ path }
-					filters={ filters }
-					showDatePicker={ false }
-					advancedFilters={ advancedFilters }
-					report="customers"
-				/>
-				<CustomersReportTable
-					isRequesting={ isRequesting }
-					query={ tableQuery }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-				/>
-			</Fragment>
-		);
-	}
-}
+	return (
+		<Fragment>
+			<ReportFilters
+				query={ query }
+				path={ path }
+				filters={ filters }
+				showDatePicker={ false }
+				advancedFilters={ advancedFilters }
+				report="customers"
+			/>
+			<CustomersReportTable
+				getAdminLink={ getAdminLink }
+				countries={ countries }
+				isRequesting={ isRequesting }
+				query={ tableQuery }
+				filters={ filters }
+				advancedFilters={ advancedFilters }
+			/>
+		</Fragment>
+	);
+};
 
 CustomersReport.propTypes = {
 	query: PropTypes.object.isRequired,
 };
+
+export default CustomersReport;

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -13,9 +13,6 @@ import { defaultTableDateFormat } from 'lib/date';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { Date, Link } from '@woocommerce/components';
 import { formatValue } from 'lib/number-format';
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
-
-const { countries } = getSetting( 'dataEndpoints', { countries: {} } );
 
 /**
  * Internal dependencies
@@ -104,7 +101,7 @@ export default class CustomersReportTable extends Component {
 		];
 	}
 
-	getCountryName( code ) {
+	getCountryName( code, countries ) {
 		return typeof countries[ code ] !== 'undefined' ? countries[ code ] : null;
 	}
 
@@ -125,7 +122,8 @@ export default class CustomersReportTable extends Component {
 				state,
 				country,
 			} = customer;
-			const countryName = this.getCountryName( country );
+			const { countries, getAdminLink } = this.props;
+			const countryName = this.getCountryName( country, countries );
 
 			const customerNameLink = user_id ? (
 				<Link href={ getAdminLink( 'user-edit.php?user_id=' + user_id ) } type="wp-admin">

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -6,6 +6,7 @@ import { __, _n } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { map } from 'lodash';
 import moment from 'moment';
+import { withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -14,14 +15,14 @@ import { defaultTableDateFormat, getCurrentDates } from 'lib/date';
 import { Date, Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { formatValue } from 'lib/number-format';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
 import ReportTable from 'analytics/components/report-table';
 
-export default class CouponsReportTable extends Component {
+class CouponsReportTable extends Component {
 	constructor() {
 		super();
 
@@ -67,7 +68,7 @@ export default class CouponsReportTable extends Component {
 	}
 
 	getRowsContent( downloads ) {
-		const { query } = this.props;
+		const { query, getAdminLink } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( downloads, download => {
@@ -174,3 +175,11 @@ export default class CouponsReportTable extends Component {
 		);
 	}
 }
+
+export default withSelect( select => {
+	const { getSetting } = select( SETTINGS_STORE_NAME );
+
+	return {
+		getAdminLink: getSetting( 'getAdminLink' ),
+	};
+} )( CouponsReportTable );

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -8,13 +8,14 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { find } from 'lodash';
+import { withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
 import { useFilters } from '@woocommerce/components';
 import { getQuery, getSearchWords } from '@woocommerce/navigation';
-import { getSetting } from '@woocommerce/wc-admin-settings';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -31,12 +32,10 @@ import StockReport from './stock';
 import CustomersReport from './customers';
 import ReportError from 'analytics/components/report-error';
 import { searchItemsByString } from 'wc-api/items/utils';
-import withSelect from 'wc-api/with-select';
 
 export const REPORTS_FILTER = 'woocommerce_admin_reports_list';
-const manageStock = getSetting( 'manageStock', 'no' );
 
-export const getReports = () => {
+export const getReports = manageStock => {
 	const reports = [
 		{
 			report: 'revenue',
@@ -118,13 +117,13 @@ class Report extends Component {
 			return null;
 		}
 
-		const { params, isError } = this.props;
+		const { params, isError, manageStock } = this.props;
 
 		if ( isError ) {
 			return <ReportError isError />;
 		}
 
-		const report = find( getReports(), { report: params.report } );
+		const report = find( getReports( manageStock ), { report: params.report } );
 		if ( ! report ) {
 			return null;
 		}
@@ -140,11 +139,12 @@ Report.propTypes = {
 export default compose(
 	useFilters( REPORTS_FILTER ),
 	withSelect( ( select, props ) => {
+		const manageStock = select( SETTINGS_STORE_NAME ).getSetting( 'manageStock', 'no' );
 		const query = getQuery();
 		const { search } = query;
 
 		if ( ! search ) {
-			return {};
+			return { manageStock };
 		}
 
 		const { report } = props.params;
@@ -159,6 +159,7 @@ export default compose(
 			return {
 				isError,
 				isRequesting,
+				manageStock,
 			};
 		}
 
@@ -169,6 +170,7 @@ export default compose(
 				...props.query,
 				[ mappedReport ]: ids.join( ',' ),
 			},
+			manageStock,
 		};
 	} )
 )( Report );

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -4,7 +4,6 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
-import { ORDER_STATUSES } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -56,163 +55,171 @@ export const filters = applyFilters( ORDERS_REPORT_FILTERS_FILTER, [
 ] );
 
 /*eslint-disable max-len*/
-export const advancedFilters = applyFilters( ORDERS_REPORT_ADVANCED_FILTERS_FILTER, {
-	title: _x(
-		'Orders Match {{select /}} Filters',
-		'A sentence describing filters for Orders. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
-		'woocommerce-admin'
-	),
-	filters: {
-		status: {
-			labels: {
-				add: __( 'Order Status', 'woocommerce-admin' ),
-				remove: __( 'Remove order status filter', 'woocommerce-admin' ),
-				rule: __( 'Select an order status filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing an Order Status filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( '{{title}}Order Status{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select an order status', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'is',
-					/* translators: Sentence fragment, logical, "Is" refers to searching for orders matching a chosen order status. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Is', 'order status', 'woocommerce-admin' ),
+export const getAdvancedFilters = orderStatuses => {
+	return applyFilters( ORDERS_REPORT_ADVANCED_FILTERS_FILTER, {
+		title: _x(
+			'Orders Match {{select /}} Filters',
+			'A sentence describing filters for Orders. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ',
+			'woocommerce-admin'
+		),
+		filters: {
+			status: {
+				labels: {
+					add: __( 'Order Status', 'woocommerce-admin' ),
+					remove: __( 'Remove order status filter', 'woocommerce-admin' ),
+					rule: __( 'Select an order status filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing an Order Status filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+					title: __(
+						'{{title}}Order Status{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-admin'
+					),
+					filter: __( 'Select an order status', 'woocommerce-admin' ),
 				},
-				{
-					value: 'is_not',
-					/* translators: Sentence fragment, logical, "Is Not" refers to searching for orders that don\'t match a chosen order status. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Is Not', 'order status', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'SelectControl',
-				options: Object.keys( ORDER_STATUSES ).map( key => ( {
-					value: key,
-					label: ORDER_STATUSES[ key ],
-				} ) ),
-			},
-		},
-		product: {
-			labels: {
-				add: __( 'Products', 'woocommerce-admin' ),
-				placeholder: __( 'Search products', 'woocommerce-admin' ),
-				remove: __( 'Remove products filter', 'woocommerce-admin' ),
-				rule: __( 'Select a product filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( '{{title}}Product{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select products', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to orders including a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Includes', 'products', 'woocommerce-admin' ),
-				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Excludes', 'products', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Search',
-				type: 'products',
-				getLabels: getProductLabels,
-			},
-		},
-		coupon: {
-			labels: {
-				add: __( 'Coupon Codes', 'woocommerce-admin' ),
-				placeholder: __( 'Search coupons', 'woocommerce-admin' ),
-				remove: __( 'Remove coupon filter', 'woocommerce-admin' ),
-				rule: __( 'Select a coupon filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Coupon filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( '{{title}}Coupon Code{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select coupon codes', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to orders including a given coupon code(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Includes', 'coupon code', 'woocommerce-admin' ),
-				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given coupon code(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Excludes', 'coupon code', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Search',
-				type: 'coupons',
-				getLabels: getCouponLabels,
-			},
-		},
-		customer_type: {
-			labels: {
-				add: __( 'Customer Type', 'woocommerce-admin' ),
-				remove: __( 'Remove customer filter', 'woocommerce-admin' ),
-				rule: __( 'Select a customer filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a Customer filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( '{{title}}Customer is{{/title}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select a customer type', 'woocommerce-admin' ),
-			},
-			input: {
-				component: 'SelectControl',
-				options: [
-					{ value: 'new', label: __( 'New', 'woocommerce-admin' ) },
-					{ value: 'returning', label: __( 'Returning', 'woocommerce-admin' ) },
+				rules: [
+					{
+						value: 'is',
+						/* translators: Sentence fragment, logical, "Is" refers to searching for orders matching a chosen order status. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Is', 'order status', 'woocommerce-admin' ),
+					},
+					{
+						value: 'is_not',
+						/* translators: Sentence fragment, logical, "Is Not" refers to searching for orders that don\'t match a chosen order status. Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Is Not', 'order status', 'woocommerce-admin' ),
+					},
 				],
-				defaultOption: 'new',
+				input: {
+					component: 'SelectControl',
+					options: Object.keys( orderStatuses ).map( key => ( {
+						value: key,
+						label: orderStatuses[ key ],
+					} ) ),
+				},
 			},
-		},
-		refunds: {
-			labels: {
-				add: __( 'Refunds', 'woocommerce-admin' ),
-				remove: __( 'Remove refunds filter', 'woocommerce-admin' ),
-				rule: __( 'Select a refund filter match', 'woocommerce-admin' ),
-				title: __( '{{title}}Refunds{{/title}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select a refund type', 'woocommerce-admin' ),
-			},
-			input: {
-				component: 'SelectControl',
-				options: [
-					{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
-					{ value: 'partial', label: __( 'Partially refunded', 'woocommerce-admin' ) },
-					{ value: 'full', label: __( 'Fully refunded', 'woocommerce-admin' ) },
-					{ value: 'none', label: __( 'None', 'woocommerce-admin' ) },
+			product: {
+				labels: {
+					add: __( 'Products', 'woocommerce-admin' ),
+					placeholder: __( 'Search products', 'woocommerce-admin' ),
+					remove: __( 'Remove products filter', 'woocommerce-admin' ),
+					rule: __( 'Select a product filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+					title: __( '{{title}}Product{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select products', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Includes', 'products', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given product(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Excludes', 'products', 'woocommerce-admin' ),
+					},
 				],
-				defaultOption: 'all',
+				input: {
+					component: 'Search',
+					type: 'products',
+					getLabels: getProductLabels,
+				},
+			},
+			coupon: {
+				labels: {
+					add: __( 'Coupon Codes', 'woocommerce-admin' ),
+					placeholder: __( 'Search coupons', 'woocommerce-admin' ),
+					remove: __( 'Remove coupon filter', 'woocommerce-admin' ),
+					rule: __( 'Select a coupon filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Coupon filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+					title: __(
+						'{{title}}Coupon Code{{/title}} {{rule /}} {{filter /}}',
+						'woocommerce-admin'
+					),
+					filter: __( 'Select coupon codes', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given coupon code(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Includes', 'coupon code', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given coupon code(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Excludes', 'coupon code', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Search',
+					type: 'coupons',
+					getLabels: getCouponLabels,
+				},
+			},
+			customer_type: {
+				labels: {
+					add: __( 'Customer Type', 'woocommerce-admin' ),
+					remove: __( 'Remove customer filter', 'woocommerce-admin' ),
+					rule: __( 'Select a customer filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a Customer filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+					title: __( '{{title}}Customer is{{/title}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select a customer type', 'woocommerce-admin' ),
+				},
+				input: {
+					component: 'SelectControl',
+					options: [
+						{ value: 'new', label: __( 'New', 'woocommerce-admin' ) },
+						{ value: 'returning', label: __( 'Returning', 'woocommerce-admin' ) },
+					],
+					defaultOption: 'new',
+				},
+			},
+			refunds: {
+				labels: {
+					add: __( 'Refunds', 'woocommerce-admin' ),
+					remove: __( 'Remove refunds filter', 'woocommerce-admin' ),
+					rule: __( 'Select a refund filter match', 'woocommerce-admin' ),
+					title: __( '{{title}}Refunds{{/title}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select a refund type', 'woocommerce-admin' ),
+				},
+				input: {
+					component: 'SelectControl',
+					options: [
+						{ value: 'all', label: __( 'All', 'woocommerce-admin' ) },
+						{ value: 'partial', label: __( 'Partially refunded', 'woocommerce-admin' ) },
+						{ value: 'full', label: __( 'Fully refunded', 'woocommerce-admin' ) },
+						{ value: 'none', label: __( 'None', 'woocommerce-admin' ) },
+					],
+					defaultOption: 'all',
+				},
+			},
+			tax_rate: {
+				labels: {
+					add: __( 'Tax Rates', 'woocommerce-admin' ),
+					placeholder: __( 'Search tax rates', 'woocommerce-admin' ),
+					remove: __( 'Remove tax rate filter', 'woocommerce-admin' ),
+					rule: __( 'Select a tax rate filter match', 'woocommerce-admin' ),
+					/* translators: A sentence describing a tax rate filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
+					title: __( '{{title}}Tax Rate{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+					filter: __( 'Select tax rates', 'woocommerce-admin' ),
+				},
+				rules: [
+					{
+						value: 'includes',
+						/* translators: Sentence fragment, logical, "Includes" refers to orders including a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Includes', 'tax rate', 'woocommerce-admin' ),
+					},
+					{
+						value: 'excludes',
+						/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
+						label: _x( 'Excludes', 'tax rate', 'woocommerce-admin' ),
+					},
+				],
+				input: {
+					component: 'Search',
+					type: 'taxes',
+					getLabels: getTaxRateLabels,
+				},
 			},
 		},
-		tax_rate: {
-			labels: {
-				add: __( 'Tax Rates', 'woocommerce-admin' ),
-				placeholder: __( 'Search tax rates', 'woocommerce-admin' ),
-				remove: __( 'Remove tax rate filter', 'woocommerce-admin' ),
-				rule: __( 'Select a tax rate filter match', 'woocommerce-admin' ),
-				/* translators: A sentence describing a tax rate filter. See screen shot for context: https://cloudup.com/cSsUY9VeCVJ */
-				title: __( '{{title}}Tax Rate{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
-				filter: __( 'Select tax rates', 'woocommerce-admin' ),
-			},
-			rules: [
-				{
-					value: 'includes',
-					/* translators: Sentence fragment, logical, "Includes" refers to orders including a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Includes', 'tax rate', 'woocommerce-admin' ),
-				},
-				{
-					value: 'excludes',
-					/* translators: Sentence fragment, logical, "Excludes" refers to orders excluding a given tax rate(s). Screenshot for context: https://cloudup.com/cSsUY9VeCVJ */
-					label: _x( 'Excludes', 'tax rate', 'woocommerce-admin' ),
-				},
-			],
-			input: {
-				component: 'Search',
-				type: 'taxes',
-				getLabels: getTaxRateLabels,
-			},
-		},
-	},
-} );
+	} );
+};
 /*eslint-enable max-len*/

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -2,59 +2,65 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { useSettings } from '@woocommerce/data';
 
 /**
  * Internal dependencies
  */
-import { advancedFilters, charts, filters } from './config';
+import { getAdvancedFilters, charts, filters } from './config';
 import getSelectedChart from 'lib/get-selected-chart';
 import OrdersReportTable from './table';
 import ReportChart from 'analytics/components/report-chart';
 import ReportSummary from 'analytics/components/report-summary';
 import ReportFilters from 'analytics/components/report-filters';
 
-export default class OrdersReport extends Component {
-	render() {
-		const { path, query } = this.props;
-
-		return (
-			<Fragment>
-				<ReportFilters
-					query={ query }
-					path={ path }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-					report="orders"
-				/>
-				<ReportSummary
-					charts={ charts }
-					endpoint="orders"
-					query={ query }
-					selectedChart={ getSelectedChart( query.chart, charts ) }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-				/>
-				<ReportChart
-					endpoint="orders"
-					path={ path }
-					query={ query }
-					selectedChart={ getSelectedChart( query.chart, charts ) }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-				/>
-				<OrdersReportTable
-					query={ query }
-					filters={ filters }
-					advancedFilters={ advancedFilters }
-				/>
-			</Fragment>
-		);
-	}
-}
+const OrdersReport = ( { path, query } ) => {
+	const { orderStatuses = {} } = useSettings( [ 'orderStatuses' ] );
+	const advancedFilters = getAdvancedFilters( orderStatuses );
+	return (
+		<Fragment>
+			<ReportFilters
+				query={ query }
+				path={ path }
+				filters={ filters }
+				advancedFilters={ advancedFilters }
+				report="orders"
+			/>
+			<ReportSummary
+				charts={ charts }
+				endpoint="orders"
+				query={ query }
+				selectedChart={ getSelectedChart( query.chart, charts ) }
+				filters={ filters }
+				advancedFilters={ advancedFilters }
+			/>
+			<ReportChart
+				endpoint="orders"
+				path={ path }
+				query={ query }
+				selectedChart={ getSelectedChart( query.chart, charts ) }
+				filters={ filters }
+				advancedFilters={ advancedFilters }
+			/>
+			<OrdersReportTable
+				query={ query }
+				filters={ filters }
+				advancedFilters={ advancedFilters }
+				orderStatuses={ orderStatuses }
+			/>
+		</Fragment>
+	);
+};
 
 OrdersReport.propTypes = {
 	path: PropTypes.string.isRequired,
 	query: PropTypes.object.isRequired,
 };
+
+export default OrdersReport;

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -13,7 +13,6 @@ import { Date, Link, OrderStatus, ViewMoreList } from '@woocommerce/components';
 import { defaultTableDateFormat } from 'lib/date';
 import { formatCurrency, renderCurrency } from 'lib/currency-format';
 import { formatValue } from 'lib/number-format';
-import { getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -103,7 +102,7 @@ export default class OrdersReportTable extends Component {
 	}
 
 	getRowsContent( tableData ) {
-		const { query } = this.props;
+		const { query, orderStatuses } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 		return map( tableData, row => {
 			const {
@@ -165,7 +164,7 @@ export default class OrdersReportTable extends Component {
 						<OrderStatus
 							className="woocommerce-orders-table__status"
 							order={ { status } }
-							orderStatusMap={ getSetting( 'orderStatuses', {} ) }
+							orderStatusMap={ orderStatuses }
 						/>
 					),
 					value: status,

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -13,16 +13,12 @@ import { Link } from '@woocommerce/components';
 import { formatCurrency, getCurrencyFormatDecimal } from 'lib/currency-format';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { formatValue } from 'lib/number-format';
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
  */
 import ReportTable from 'analytics/components/report-table';
 import { isLowStock } from './utils';
-
-const manageStock = getSetting( 'manageStock', 'no' );
-const stockStatuses = getSetting( 'stockStatuses', {} );
 
 export default class VariationsReportTable extends Component {
 	constructor() {
@@ -33,6 +29,7 @@ export default class VariationsReportTable extends Component {
 	}
 
 	getHeadersContent() {
+		const { manageStock } = this.props;
 		return [
 			{
 				label: __( 'Product / Variation Title', 'woocommerce-admin' ),
@@ -85,7 +82,7 @@ export default class VariationsReportTable extends Component {
 	}
 
 	getRowsContent( data = [] ) {
-		const { query } = this.props;
+		const { query, getAdminLink, manageStock, stockStatuses } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( data, row => {

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -14,7 +14,6 @@ import { formatCurrency, getCurrencyFormatDecimal, renderCurrency } from 'lib/cu
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { Link, Tag } from '@woocommerce/components';
 import { formatValue } from 'lib/number-format';
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -25,9 +24,6 @@ import ReportTable from 'analytics/components/report-table';
 import withSelect from 'wc-api/with-select';
 import './style.scss';
 
-const manageStock = getSetting( 'manageStock', 'no' );
-const stockStatuses = getSetting( 'stockStatuses', {} );
-
 class ProductsReportTable extends Component {
 	constructor() {
 		super();
@@ -37,6 +33,7 @@ class ProductsReportTable extends Component {
 	}
 
 	getHeadersContent() {
+		const { manageStock } = this.props;
 		return [
 			{
 				label: __( 'Product Title', 'woocommerce-admin' ),
@@ -99,7 +96,7 @@ class ProductsReportTable extends Component {
 	}
 
 	getRowsContent( data = [] ) {
-		const { query } = this.props;
+		const { query, stockStatuses, manageStock, getAdminLink } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 
 		return map( data, row => {

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -4,6 +4,7 @@
  */
 import { __, _n, _x } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { withSelect } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
@@ -11,7 +12,7 @@ import { Component } from '@wordpress/element';
 import { Link } from '@woocommerce/components';
 import { getNewPath, getPersistedQuery } from '@woocommerce/navigation';
 import { formatValue } from 'lib/number-format';
-import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -19,9 +20,7 @@ import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import ReportTable from 'analytics/components/report-table';
 import { isLowStock } from './utils';
 
-const stockStatuses = getSetting( 'stockStatuses', {} );
-
-export default class StockReportTable extends Component {
+class StockReportTable extends Component {
 	constructor() {
 		super();
 
@@ -59,7 +58,7 @@ export default class StockReportTable extends Component {
 	}
 
 	getRowsContent( products ) {
-		const { query } = this.props;
+		const { query, stockStatuses, getAdminLink } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 
 		return products.map( product => {
@@ -167,3 +166,12 @@ export default class StockReportTable extends Component {
 		);
 	}
 }
+
+export default withSelect( select => {
+	const { getSetting } = select( SETTINGS_STORE_NAME );
+
+	return {
+		stockStatuses: getSetting( 'stockStatuses', {} ),
+		getAdminLink: getSetting( 'getAdminLink' ),
+	};
+} )( StockReportTable );

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,8 +299,21 @@
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "requires": {
+        "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@babel/parser": {
@@ -991,7 +1004,20 @@
       "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
       "requires": {
         "@jest/source-map": "^24.9.0",
+        "chalk": "^2.0.1",
         "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@jest/core": {
@@ -1005,6 +1031,7 @@
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
         "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
         "jest-changed-files": "^24.9.0",
@@ -1028,6 +1055,16 @@
         "strip-ansi": "^5.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -1068,6 +1105,7 @@
         "@jest/test-result": "^24.9.0",
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.2",
         "istanbul-lib-coverage": "^2.0.2",
@@ -1086,6 +1124,16 @@
         "string-length": "^2.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1139,6 +1187,7 @@
         "@babel/core": "^7.1.0",
         "@jest/types": "^24.9.0",
         "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.15",
@@ -1153,6 +1202,16 @@
         "write-file-atomic": "2.4.1"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3562,6 +3621,7 @@
         "@wordpress/npm-package-json-lint-config": "^2.1.0",
         "babel-jest": "^24.7.1",
         "babel-loader": "^8.0.5",
+        "chalk": "^2.4.1",
         "check-node-version": "^3.1.1",
         "cross-spawn": "^5.1.0",
         "eslint": "^5.16.0",
@@ -3768,6 +3828,16 @@
           "version": "5.7.3",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
           "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "chrome-trace-event": {
           "version": "0.1.3",
@@ -4389,12 +4459,23 @@
       "requires": {
         "browserslist": "^4.8.0",
         "caniuse-lite": "^1.0.30001012",
+        "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.23",
         "postcss-value-parser": "^4.0.2"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "postcss-value-parser": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
@@ -4532,7 +4613,20 @@
         "@types/babel__core": "^7.1.0",
         "babel-plugin-istanbul": "^5.1.0",
         "babel-preset-jest": "^24.9.0",
+        "chalk": "^2.4.2",
         "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "babel-loader": {
@@ -5435,12 +5529,25 @@
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.3.0.tgz",
       "integrity": "sha512-OAtp7prQf+8YYKn2UB/fK1Ppb9OT+apW56atoKYUvucYLPq69VozOY0B295okBwCKymk2cictrS3qsdcZwyfzw==",
       "requires": {
+        "chalk": "^2.3.0",
         "map-values": "^1.0.1",
         "minimist": "^1.2.0",
         "object-filter": "^1.0.2",
         "object.assign": "^4.0.4",
         "run-parallel": "^1.1.4",
         "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "check-types": {
@@ -8015,6 +8122,7 @@
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
@@ -8050,6 +8158,16 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -8758,10 +8876,21 @@
       "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.3.tgz",
       "integrity": "sha512-+IA+AUsQCf3uucawyTwMWcY+2M3FXq3BRvw3S+j5Jvydjk31f/+NPWpYZOJs+JUs2GvxH4Yfr6Wham0ZtRLlPA==",
       "requires": {
+        "chalk": "^2.0.1",
         "commander": "^2.11.0",
         "debug": "^2.6.8"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -11018,6 +11147,7 @@
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "requires": {
         "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
@@ -11031,6 +11161,16 @@
         "through": "^2.3.6"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -11582,6 +11722,16 @@
         "jest-cli": "^24.9.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "jest-cli": {
           "version": "24.9.0",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
@@ -11590,6 +11740,7 @@
             "@jest/core": "^24.9.0",
             "@jest/test-result": "^24.9.0",
             "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
             "exit": "^0.1.2",
             "import-local": "^2.0.0",
             "is-ci": "^2.0.0",
@@ -11622,6 +11773,7 @@
         "@jest/test-sequencer": "^24.9.0",
         "@jest/types": "^24.9.0",
         "babel-jest": "^24.9.0",
+        "chalk": "^2.0.1",
         "glob": "^7.1.1",
         "jest-environment-jsdom": "^24.9.0",
         "jest-environment-node": "^24.9.0",
@@ -11634,6 +11786,18 @@
         "micromatch": "^3.1.10",
         "pretty-format": "^24.9.0",
         "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-dev-server": {
@@ -11641,12 +11805,25 @@
       "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.3.0.tgz",
       "integrity": "sha512-bC9flKY2G1honQ/UI0gEhb0wFnDhpFr7xidC8Nk+evi7TgnNtfsGIzzF2dcIhF1G9BGF0n/M7CJrMAzwQhyTPA==",
       "requires": {
+        "chalk": "^2.4.2",
         "cwd": "^0.10.0",
         "find-process": "^1.4.2",
         "prompts": "^2.1.0",
         "spawnd": "^4.0.0",
         "tree-kill": "^1.2.1",
         "wait-on": "^3.3.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -11654,9 +11831,22 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
       "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
       "requires": {
+        "chalk": "^2.0.1",
         "diff-sequences": "^24.9.0",
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-docblock": {
@@ -11673,9 +11863,22 @@
       "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
       "requires": {
         "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
         "jest-get-type": "^24.9.0",
         "jest-util": "^24.9.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-environment-jsdom": {
@@ -11708,9 +11911,22 @@
       "resolved": "https://registry.npmjs.org/jest-environment-puppeteer/-/jest-environment-puppeteer-4.3.0.tgz",
       "integrity": "sha512-ZighMsU39bnacn2ylyHb88CB+ldgCfXGD3lS78k4PEo8A8xyt6+2mxmSR62FH3Y7K+W2gPDu5+QM3/LZuq42fQ==",
       "requires": {
+        "chalk": "^2.4.2",
         "cwd": "^0.10.0",
         "jest-dev-server": "^4.3.0",
         "merge-deep": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-get-type": {
@@ -11746,6 +11962,7 @@
         "@jest/environment": "^24.9.0",
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
         "co": "^4.6.0",
         "expect": "^24.9.0",
         "is-generator-fn": "^2.0.0",
@@ -11757,6 +11974,18 @@
         "jest-util": "^24.9.0",
         "pretty-format": "^24.9.0",
         "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-leak-detector": {
@@ -11773,9 +12002,22 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
       "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
       "requires": {
+        "chalk": "^2.0.1",
         "jest-diff": "^24.9.0",
         "jest-get-type": "^24.9.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-message-util": {
@@ -11787,9 +12029,22 @@
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
         "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
         "micromatch": "^3.1.10",
         "slash": "^2.0.0",
         "stack-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-mock": {
@@ -11826,8 +12081,21 @@
       "requires": {
         "@jest/types": "^24.9.0",
         "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
         "jest-pnp-resolver": "^1.2.1",
         "realpath-native": "^1.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-resolve-dependencies": {
@@ -11849,6 +12117,7 @@
         "@jest/environment": "^24.9.0",
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
+        "chalk": "^2.4.2",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
         "jest-config": "^24.9.0",
@@ -11863,6 +12132,18 @@
         "jest-worker": "^24.6.0",
         "source-map-support": "^0.5.6",
         "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-runtime": {
@@ -11876,6 +12157,7 @@
         "@jest/transform": "^24.9.0",
         "@jest/types": "^24.9.0",
         "@types/yargs": "^13.0.0",
+        "chalk": "^2.0.1",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.15",
@@ -11892,6 +12174,18 @@
         "slash": "^2.0.0",
         "strip-bom": "^3.0.0",
         "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-serializer": {
@@ -11906,6 +12200,7 @@
       "requires": {
         "@babel/types": "^7.0.0",
         "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
         "expect": "^24.9.0",
         "jest-diff": "^24.9.0",
         "jest-get-type": "^24.9.0",
@@ -11918,6 +12213,16 @@
         "semver": "^6.2.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -11936,6 +12241,7 @@
         "@jest/test-result": "^24.9.0",
         "@jest/types": "^24.9.0",
         "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
         "graceful-fs": "^4.1.15",
         "is-ci": "^2.0.0",
         "mkdirp": "^0.5.1",
@@ -11943,6 +12249,16 @@
         "source-map": "^0.6.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11957,9 +12273,22 @@
       "requires": {
         "@jest/types": "^24.9.0",
         "camelcase": "^5.3.1",
+        "chalk": "^2.0.1",
         "jest-get-type": "^24.9.0",
         "leven": "^3.1.0",
         "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-watcher": {
@@ -11971,8 +12300,21 @@
         "@jest/types": "^24.9.0",
         "@types/yargs": "^13.0.0",
         "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
         "jest-util": "^24.9.0",
         "string-length": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "jest-worker": {
@@ -12599,7 +12941,22 @@
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg=="
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "requires": {
+        "chalk": "^2.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
     },
     "long": {
       "version": "3.2.0",
@@ -13790,6 +14147,7 @@
       "integrity": "sha512-eWi1pZ/ZhPHAOMLC1+njBJj81yCu2Ek4VxhwpPHABvSVHS0dkaL6aKhSj/TX8Rtm/0rIg3edgMLt3kSRtWkFaA==",
       "requires": {
         "ajv": "^6.10.0",
+        "chalk": "^2.4.2",
         "glob": "^7.1.4",
         "ignore": "^5.1.2",
         "is-path-inside": "^2.1.0",
@@ -13803,6 +14161,16 @@
         "validator": "^10.11.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "ignore": {
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
@@ -14765,10 +15133,31 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
       "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
       "requires": {
+        "chalk": "^2.4.2",
         "source-map": "^0.6.1",
         "supports-color": "^6.1.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15300,9 +15689,22 @@
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
       "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
       "requires": {
+        "chalk": "^2.4.1",
         "lodash": "^4.17.11",
         "log-symbols": "^2.2.0",
         "postcss": "^7.0.7"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "postcss-resolve-nested-selector": {
@@ -18421,6 +18823,7 @@
       "requires": {
         "autoprefixer": "^9.0.0",
         "balanced-match": "^1.0.0",
+        "chalk": "^2.4.1",
         "cosmiconfig": "^5.0.0",
         "debug": "^4.0.0",
         "execall": "^1.0.0",
@@ -18467,6 +18870,16 @@
         "table": "^5.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "file-entry-cache": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
@@ -18589,7 +19002,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -19917,10 +20329,21 @@
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.7.tgz",
       "integrity": "sha512-pJ6cSBIa0w1sDg4y/wXN4bmvhM9OneOvwdFHo647L2NShBi/oXG4lRaLic5cO1HaYGbUhEvratPfl/WMlIC+tg==",
       "requires": {
+        "chalk": "^2.4.2",
         "commander": "^3.0.2",
         "debug": "^4.1.1"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "commander": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
@@ -20096,6 +20519,7 @@
         "acorn": "^6.0.7",
         "acorn-walk": "^6.1.1",
         "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
         "commander": "^2.18.0",
         "ejs": "^2.6.1",
         "express": "^4.16.3",
@@ -20107,6 +20531,16 @@
         "ws": "^6.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -20122,6 +20556,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
       "integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
       "requires": {
+        "chalk": "2.4.2",
         "cross-spawn": "6.0.5",
         "enhanced-resolve": "4.1.0",
         "findup-sync": "3.0.0",
@@ -20134,6 +20569,26 @@
         "yargs": "13.2.4"
       },
       "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
         "cross-spawn": {
           "version": "6.0.5",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/packages/data/src/settings/selectors.js
+++ b/packages/data/src/settings/selectors.js
@@ -30,7 +30,7 @@ export const getIsDirty = ( state, keys = [] ) => {
 export const getSettingsForKeys = ( state, keys ) => {
 	const allSettings = getSettings( state );
 	return keys.reduce( ( accumulator, key ) => {
-		accumulator[ key ] = allSettings[ key ] || null;
+		accumulator[ key ] = allSettings[ key ];
 		return accumulator;
 	}, {} );
 };

--- a/packages/data/src/settings/with-settings-hydration.js
+++ b/packages/data/src/settings/with-settings-hydration.js
@@ -10,6 +10,11 @@ import { useSelect } from '@wordpress/data';
  */
 import { STORE_NAME } from './constants';
 
+const getHelperFunctions = settings => {
+	const getAdminLink = path => ( settings.adminUrl || '' ) + path;
+	return { getAdminLink };
+};
+
 export const withSettingsHydration = settings => OriginalComponent => {
 	return props => {
 		const settingsRef = useRef( settings );
@@ -33,6 +38,7 @@ export const withSettingsHydration = settings => OriginalComponent => {
 			) {
 				startResolution( 'getSettings', [] );
 				updateSettings( settingsRef.current );
+				updateSettings( getHelperFunctions( settingsRef.current ) );
 				clearIsDirty();
 				finishResolution( 'getSettings', [] );
 			}


### PR DESCRIPTION
Depends on https://github.com/woocommerce/woocommerce-admin/pull/3560

Migrate the Reports pages away from using `@woocommerce/wc-admin-settings` as a source for settings in favour of the new settings data store found in packages.

When reviewing this PR, I'd suggest adding the `?w=1` parameter to avoid looking at whitespace changes.

### Detailed test instructions:

Make sure the Reports are functioning as they should.

You may notice stock statuses aren't rendering in the Stock Report. That fix is in https://github.com/woocommerce/woocommerce-admin/pull/3573