### PR TITLE
Onboarding: Hide plugin install step when already installed

### DIFF
--- a/client/wc-api/onboarding/operations.js
+++ b/client/wc-api/onboarding/operations.js
@@ -6,11 +6,13 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
+import { uniq } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getResourceIdentifier, getResourceName } from '../utils';
+import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 import { JETPACK_NAMESPACE, WC_ADMIN_NAMESPACE } from '../constants';
 import { pluginNames } from './constants';
 
@@ -166,6 +168,11 @@ function activatePlugins( resourceNames, data, fetch ) {
 
 function activatePluginToResource( response, items ) {
 	const resourceName = 'plugin-activate';
+	const { activePlugins = [] } = getSetting( 'onboarding', {} );
+	setSetting( 'onboarding', {
+		...getSetting( 'onboarding', {} ),
+		activePlugins: uniq( [ ...activePlugins, ...items ] ),
+	} );
 
 	const resources = {
 		[ resourceName ]: { data: items },
@@ -258,6 +265,12 @@ function installPlugins( resourceNames, data, fetch ) {
 				},
 			} )
 				.then( response => {
+					const { installedPlugins = [] } = getSetting( 'onboarding', {} );
+					setSetting( 'onboarding', {
+						...getSetting( 'onboarding', {} ),
+						installedPlugins: uniq( [ ...installedPlugins, ...plugins ] ),
+					} );
+
 					return {
 						[ resourceName ]: { data: plugins },
 						[ getResourceName( resourceName, plugin ) ]: { data: response },


### PR DESCRIPTION
Fixes #3565 

* Hides the shipping label plugin step when the plugin is already installed.
* Updates the global settings with installed plugins & activations to most current data.

### Screenshots
<img width="713" alt="Screen Shot 2020-01-16 at 4 24 45 PM" src="https://user-images.githubusercontent.com/10561050/72506841-ae9fd800-387d-11ea-81ae-f7c6fbf20dee.png">


### Detailed test instructions:

1. Delete a required plugin for the shipping label step (`woocommerce-shipstation-integration` for GB, CA, & AU or `woocommerce-services` for US).
2. Visit the shipping task.
3. Make sure the plugins step is shown.
4. Complete the steps.
5. Without refreshing, make sure returning to the dashboard and back to this step does not show the `Enable shipping label printing` step again.
6. Make sure other instances of the `Plugin` component continue working as expected.