### PR TITLE
Onboarding: Mark payments task complete when payment configured

### DIFF
--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -159,15 +159,16 @@ class Payments extends Component {
 	markConfigured( method ) {
 		const { options, methods, configured } = this.props;
 		configured.push( method );
+		const stepsLeft = difference( methods, configured );
+
 		this.props.updateOptions( {
 			[ 'woocommerce_task_list_payments' ]: {
 				...options.woocommerce_task_list_payments,
 				configured,
-				completed: 1,
+				completed: 0 === stepsLeft.length ? 1 : 0,
 			},
 		} );
 
-		const stepsLeft = difference( methods, configured );
 		if ( 0 === stepsLeft.length ) {
 			this.completeTask();
 		}

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -92,13 +92,7 @@ class Payments extends Component {
 	}
 
 	completeTask() {
-		const { createNotice, updateOptions } = this.props;
-
-		updateOptions( {
-			[ 'woocommerce_task_list_payments' ]: {
-				completed: 1,
-			},
-		} );
+		const { createNotice } = this.props;
 
 		createNotice(
 			'success',
@@ -169,6 +163,7 @@ class Payments extends Component {
 			[ 'woocommerce_task_list_payments' ]: {
 				...options.woocommerce_task_list_payments,
 				configured,
+				completed: 1,
 			},
 		} );
 

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -83,7 +83,7 @@ class OnboardingTasks {
 			return;
 		}
 
-		self::maybe_update_payments_cache();
+		self::mark_payment_method_configured( 'square' );
 	}
 
 
@@ -105,7 +105,7 @@ class OnboardingTasks {
 			return;
 		}
 
-		self::maybe_update_payments_cache();
+		self::mark_payment_method_configured( 'paypal' );
 	}
 
 	/**
@@ -126,19 +126,28 @@ class OnboardingTasks {
 			return;
 		}
 
-		self::maybe_update_payments_cache();
+		self::mark_payment_method_configured( 'stripe' );
 	}
 
 	/**
 	 * Update the payments cache to complete if not already.
+	 *
+	 * @param string $payment_method Payment method slug.
 	 */
-	public static function maybe_update_payments_cache() {
-		$task_list_payments = get_option( 'woocommerce_task_list_payments', array() );
-		if ( isset( $task_list_payments['completed'] ) && $task_list_payments['completed'] ) {
-			return;
+	public static function mark_payment_method_configured( $payment_method ) {
+		$task_list_payments         = get_option( 'woocommerce_task_list_payments', array() );
+		$payment_methods            = isset( $task_list_payments['methods'] ) ? $task_list_payments['methods'] : array();
+		$configured_payment_methods = isset( $task_list_payments['configured'] ) ? $task_list_payments['configured'] : array();
+
+		if ( ! in_array( $payment_method, $configured_payment_methods, true ) ) {
+			$configured_payment_methods[]     = $payment_method;
+			$task_list_payments['configured'] = $configured_payment_methods;
 		}
 
-		$task_list_payments['completed'] = 1;
+		if ( 0 === count( array_diff( $payment_methods, $configured_payment_methods ) ) ) {
+			$task_list_payments['completed'] = 1;
+		}
+
 		update_option( 'woocommerce_task_list_payments', $task_list_payments );
 	}
 


### PR DESCRIPTION
Fixes #3566

Marks the payment task complete after manually setting up payment keys.

**Note:** This marks the task complete even if the user clicks "Skip" on the final step.  This is happening on master as well if you try to re-enter the payments after skipping, but we could update this to not mark complete until configured.  Note sure if there has been previous discussion around this.  Thoughts? /cc @pmcpinto 

### Screenshots
<img width="945" alt="Screen Shot 2020-01-16 at 5 10 25 PM" src="https://user-images.githubusercontent.com/10561050/72510032-a6e33200-3883-11ea-9a51-a9d91dd9f114.png">

### Detailed test instructions:

1. Delete the option `woocommerce_task_list_payments` if it exists in `wp_options`.
1. Connect Jetpack and install/active WCS.
1. Walk through each payment option, using the automatic "Connect" option on the last step.
1. Make sure the task is marked complete and delete `woocommerce_task_list_payments` again.
1. Disable WCS.
1. Walk through and use the manual configuration for each payment method.
1. Make sure the payments task is marked complete upon task completion.
1. Note that "Skip" will also mark the task complete (see note above).