### PR TITLE
Onboarding: Update homepage publish message

### DIFF
--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -76,7 +76,7 @@ const onboardingHomepageNotice = () => {
 
 		dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
 		dispatch( 'core/notices' ).createSuccessNotice(
-			__( 'Your homepage was published.', 'woocommerce-admin' ),
+			__( "🏠 Nice work creating your store's homepage!", 'woocommerce-admin' ),
 			{
 				id: 'WOOCOMMERCE_ONBOARDING_HOME_PAGE_NOTICE',
 				type: notificationType,


### PR DESCRIPTION
Fixes #3569 

Updates the homepage published message to match the tone of messages in #3319 

### Screenshots
<img width="577" alt="Screen Shot 2020-01-16 at 5 30 31 PM" src="https://user-images.githubusercontent.com/10561050/72511450-296cf100-3886-11ea-894a-99d8c2baf208.png">

### Detailed test instructions:

1. Delete any homepages created through the task list.
1. Visit the task list appearance task.
1. Create a homepage.
1. Click "Publish"
1. Note the updated notice copy.