### PR TITLE
Onboarding: Mark payments task complete on updating payment gateways

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -67,7 +67,23 @@ class OnboardingTasks {
 		// Update payment cache on payment gateways update.
 		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'check_stripe_completion' ), 10, 2 );
 		add_action( 'update_option_woocommerce_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
+		add_action( 'add_option_wc_square_refresh_tokens', array( $this, 'check_square_completion' ), 10, 2 );
 	}
+
+	/**
+	 * Check if Square payment settings are complete.
+	 *
+	 * @param string $option Option name.
+	 * @param array  $value Current value.
+	 */
+	public static function check_square_completion( $option, $value ) {
+		if ( empty( $value ) ) {
+			return;
+		}
+
+		self::maybe_update_payments_cache();
+	}
+
 
 	/**
 	 * Check if Paypal payment settings are complete.

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -66,7 +66,9 @@ class OnboardingTasks {
 
 		// Update payment cache on payment gateways update.
 		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'check_stripe_completion' ), 10, 2 );
-		add_action( 'update_option_woocommerce_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
+		add_action( 'add_option_woocommerce_stripe_settings', array( $this, 'check_stripe_completion' ), 10, 2 );
+		add_action( 'update_option_woocommerce_ppec_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
+		add_action( 'add_option_woocommerce_ppec_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
 		add_action( 'add_option_wc_square_refresh_tokens', array( $this, 'check_square_completion' ), 10, 2 );
 	}
 
@@ -95,8 +97,10 @@ class OnboardingTasks {
 		if (
 			! isset( $value['enabled'] ) ||
 			'yes' !== $value['enabled'] ||
-			! isset( $value['email'] ) ||
-			empty( $value['email'] )
+			! isset( $value['api_username'] ) ||
+			empty( $value['api_username'] ) ||
+			! isset( $value['api_password'] ) ||
+			empty( $value['api_password'] )
 		) {
 			return;
 		}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -66,6 +66,26 @@ class OnboardingTasks {
 
 		// Update payment cache on payment gateways update.
 		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'check_stripe_completion' ), 10, 2 );
+		add_action( 'update_option_woocommerce_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
+	}
+
+	/**
+	 * Check if Paypal payment settings are complete.
+	 *
+	 * @param mixed $old_value Old value.
+	 * @param array $value Current value.
+	 */
+	public static function check_paypal_completion( $old_value, $value ) {
+		if (
+			! isset( $value['enabled'] ) ||
+			'yes' !== $value['enabled'] ||
+			! isset( $value['email'] ) ||
+			empty( $value['email'] )
+		) {
+			return;
+		}
+
+		self::maybe_update_payments_cache();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3568

Mark the payments task complete when filling out Paypal, Stripe, or Square information outside of the task list.

### Detailed test instructions:

1. Delete the `woocommerce_task_list_payments` option.
2. Under WooCommerce->Settings, manually enable/connect Paypal, Square, and Stripe.
3. Note the payments task list item is complete.
4. Delete the `woocommerce_task_list_payments` option and try again