### PR TITLE
Avoid redundant/unnecessary cleanup.

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -96,6 +96,12 @@ class FeaturePlugin {
 	 * @return void
 	 */
 	public function on_deactivation() {
+		// Don't clean up if the WooCommerce Admin package is in core.
+		// NOTE: Any future divergence from the core package will need to be accounted for here.
+		if ( defined( 'WC_ADMIN_PACKAGE_EXISTS' ) && WC_ADMIN_PACKAGE_EXISTS ) {
+			return;
+		}
+
 		// Check if we are deactivating due to dependencies not being satisfied.
 		// If WooCommerce is disabled we can't include files that depend upon it.
 		if ( ! $this->has_satisfied_dependencies() ) {

--- a/src/Install.php
+++ b/src/Install.php
@@ -379,6 +379,7 @@ class Install {
 		if ( ! wp_next_scheduled( 'wc_admin_daily' ) ) {
 			wp_schedule_event( time(), 'daily', 'wc_admin_daily' );
 		}
+		// @todo This is potentially redundant when the core package exists.
 		wp_schedule_single_event( time() + 10, 'generate_category_lookup_table' );
 	}
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -32,6 +32,11 @@ class Package {
 			return;
 		}
 
+		// Indicate to the feature plugin that the core package exists.
+		if ( ! defined( 'WC_ADMIN_PACKAGE_EXISTS' ) ) {
+			define( 'WC_ADMIN_PACKAGE_EXISTS', true );
+		}
+
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 			return;


### PR DESCRIPTION
Found while testing #3392.

The feature plugin doesn't need to clean up when the core package exists.

This PR adds a constant `WC_ADMIN_PACKAGE_EXISTS` when WooCommerce Admin exists within core WooCommerce.

When the constant is present, the plugin won't "clean up" on deactivation because that would disrupt the version loaded from core.

**NOTE:** This PR **does not** provide a mechanism to handle divergence between the feature plugin and the core package. Any changes to DB schema, event scheduling, etc, will need to be considered and potentially handled in the future. (Should plugin users decide to deactivate)

### Detailed test instructions:

- Copy `src/Package.php` to `packages/woocommerce-admin/src/Package.php` in your `woocommerce` directory (running https://github.com/woocommerce/woocommerce/pull/25011)
- Activate `woocommerce-admin` from this PR is active
- Deactivate `woocommerce-admin`
- Verify that the `wc_admin_daily` cron event still exists (use WP Crontrol)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
