### PR TITLE
Ignore vendor directory for stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,7 @@
 {
 	"extends": "stylelint-config-wordpress",
 	"ignoreFiles": [
-        "./css/main.scss"
+        "./vendor/**/*.scss"
     ],
 	"rules": {
 		"at-rule-empty-line-before": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,8 @@
 {
 	"extends": "stylelint-config-wordpress",
+	"ignoreFiles": [
+        "./css/main.scss"
+    ],
 	"rules": {
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,


### PR DESCRIPTION
Fixes an exception being thrown by `npm run lint` - which I found while testing #3562. The proposed fix here is to not run the stylelint against the `vendor` directory

### Detailed test instructions:

- On `master`, run `npm run lint`, note the error thrown
- Check out this branch and run again, no error 🥇 

### Changelog Note:

Dev: Skip `vendor` directory when running stylelint
