### PR TITLE
fix strict standards in Scheduler classes

### DIFF
--- a/src/Schedulers/ImportInterface.php
+++ b/src/Schedulers/ImportInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Import related abstract functions.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+namespace Automattic\WooCommerce\Admin\Schedulers;
+
+interface ImportInterface {
+	/**
+	 * Get items based on query and return IDs along with total available.
+	 *
+	 * @param int      $limit Number of records to retrieve.
+	 * @param int      $page  Page number.
+	 * @param int|bool $days Number of days prior to current date to limit search results.
+	 * @param bool     $skip_existing Skip already imported items.
+	 */
+	public static function get_items( $limit, $page, $days, $skip_existing );
+
+	/**
+	 * Get total number of items already imported.
+	 *
+	 * @return null
+	 */
+	public static function get_total_imported();
+
+}

--- a/src/Schedulers/ImportScheduler.php
+++ b/src/Schedulers/ImportScheduler.php
@@ -15,7 +15,7 @@ use \Automattic\WooCommerce\Admin\Schedulers\SchedulerTraits;
 /**
  * ImportScheduler class.
  */
-abstract class ImportScheduler {
+abstract class ImportScheduler implements ImportInterface {
 	/**
 	 * Import stats option name.
 	 */
@@ -89,23 +89,6 @@ abstract class ImportScheduler {
 			'import'            => 'wc-admin_import_' . static::$name,
 		);
 	}
-
-	/**
-	 * Get items based on query and return IDs along with total available.
-	 *
-	 * @param int      $limit Number of records to retrieve.
-	 * @param int      $page  Page number.
-	 * @param int|bool $days Number of days prior to current date to limit search results.
-	 * @param bool     $skip_existing Skip already imported items.
-	 */
-	abstract public static function get_items( $limit, $page, $days, $skip_existing );
-
-	/**
-	 * Get total number of items already imported.
-	 *
-	 * @return null
-	 */
-	abstract public static function get_total_imported();
 
 	/**
 	 * Queue the imports into multiple batches.

--- a/src/Schedulers/SchedulerTraits.php
+++ b/src/Schedulers/SchedulerTraits.php
@@ -74,7 +74,9 @@ trait SchedulerTraits {
 	 *
 	 * @return array
 	 */
-	abstract public static function get_scheduler_actions();
+	public static function get_scheduler_actions() {
+		return array();
+	}
 
 	/**
 	 * Get all available scheduling actions.


### PR DESCRIPTION
This PR fixes some new coding standard warnings due to upgrading the sniffs.

```
PHP Strict Standards:  Static function Automattic\WooCommerce\Admin\Schedulers\ImportScheduler::get_items() should not be abstract in /tmp/wordpress/wp-content/plugins/woocommerce-admin/src/Schedulers/ImportScheduler.php on line 101
PHP Strict Standards:  Static function Automattic\WooCommerce\Admin\Schedulers\ImportScheduler::get_total_imported() should not be abstract in /tmp/wordpress/wp-content/plugins/woocommerce-admin/src/Schedulers/ImportScheduler.php on line 108
Strict Standards: Static function Automattic\WooCommerce\Admin\Schedulers\SchedulerTraits::get_scheduler_actions() should not be abstract in /tmp/wordpress/wp-content/plugins/woocommerce-admin/src/Schedulers/SchedulerTraits.php on line 77
```

### Detailed test instructions:

- Check all test runs on this PR to see that the warnings don't appear.
