### PR TITLE
Don't modify the document title on existing WooCommerce pages.

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -32,6 +32,7 @@ class Header extends Component {
 		this.onWindowScroll = this.onWindowScroll.bind( this );
 		this.updateIsScrolled = this.updateIsScrolled.bind( this );
 		this.trackLinkClick = this.trackLinkClick.bind( this );
+		this.updateDocumentTitle = this.updateDocumentTitle.bind( this );
 	}
 
 	componentDidMount() {
@@ -64,9 +65,14 @@ class Header extends Component {
 		recordEvent( 'navbar_breadcrumb_click', { href, text: event.target.innerText } );
 	}
 
-	render() {
+	updateDocumentTitle() {
 		const { sections, isEmbedded } = this.props;
-		const { isScrolled } = this.state;
+
+		// Don't modify the document title on existing WooCommerce pages.
+		if ( isEmbedded ) {
+			return;
+		}
+
 		const _sections = Array.isArray( sections ) ? sections : [ sections ];
 
 		const documentTitle = _sections
@@ -83,6 +89,14 @@ class Header extends Component {
 				getSetting( 'siteTitle', '' )
 			)
 		);
+	}
+
+	render() {
+		const { sections, isEmbedded } = this.props;
+		const { isScrolled } = this.state;
+		const _sections = Array.isArray( sections ) ? sections : [ sections ];
+
+		this.updateDocumentTitle();
 
 		const className = classnames( 'woocommerce-layout__header', {
 			'is-scrolled': isScrolled,

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -585,10 +585,7 @@ class Loader {
 	public static function update_admin_title( $admin_title ) {
 		if (
 			! did_action( 'current_screen' ) ||
-			(
-				! self::is_admin_page() &&
-				! self::is_embed_page()
-			)
+			! self::is_admin_page()
 		) {
 			return $admin_title;
 		}


### PR DESCRIPTION
It was decided in p1579286695014200-slack-wc-admin that we shouldn't be modifying the page titles on existing WooCommerce pages.

This behavior has existed in WooCommerce Admin for a long time, but was called into question when it caused core WooCommerce E2E tests to fail. See: https://travis-ci.org/woocommerce/woocommerce/jobs/638547916#L517

This PR seeks to stop modifying "embed" page titles.

### Detailed test instructions:

- Go to Products > Add New
- Verify the page title is "Add new product" and not "Add New < Products < [Store Name] - WooCommerce"
- Go to Analytics > Orders
- Verify the page title is "Orders < Analytics < [Store Name] - WooCommerce"

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: don't modify page titles for existing WooCommerce pages.
