### PR TITLE
Dashboard: fix usermeta prefix

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -678,7 +678,7 @@ class Loader {
 
 		$current_user_data = array();
 		foreach ( self::get_user_data_fields() as $user_field ) {
-			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'wc_admin_' . $user_field, true ) );
+			$current_user_data[ $user_field ] = json_decode( get_user_meta( get_current_user_id(), 'woocommerce_admin_' . $user_field, true ) );
 		}
 		$settings['currentUserData']      = $current_user_data;
 		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );


### PR DESCRIPTION
Dashboard user preferences weren't getting loaded due to a wrong prefix for user meta. Most likely a leftover from the changes made in https://github.com/woocommerce/woocommerce-admin/pull/3546

Bug found in https://github.com/woocommerce/woocommerce-admin/pull/3581#pullrequestreview-344856667 by @timmyc. 

### Detailed test instructions:

1. Load the dashboard. If you have anything custom, such as section names or section order, it should load correctly. This isn't working on master. If you don't, proceed to step 2.
2. Change a column name, see the public api request return successfully.
3. Reload and confirm the new column name appears.


