### PR TITLE
Onboarding: Center button to continue without installation

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -285,22 +285,24 @@ class BusinessDetails extends Component {
 				</div>
 
 				{ installExtensions && (
-					<Plugins
-						onComplete={ () => {
-							goToNextStep();
-						} }
-						onSkip={ () => {
-							goToNextStep();
-						} }
-						onError={ () => {
-							this.setState( {
-								extensionInstallError: true,
-								isInstallingExtensions: false,
-							} );
-						} }
-						autoInstall
-						pluginSlugs={ extensionsToInstall }
-					/>
+					<div className="woocommerce-profile-wizard__card-actions">
+						<Plugins
+							onComplete={ () => {
+								goToNextStep();
+							} }
+							onSkip={ () => {
+								goToNextStep();
+							} }
+							onError={ () => {
+								this.setState( {
+									extensionInstallError: true,
+									isInstallingExtensions: false,
+								} );
+							} }
+							autoInstall
+							pluginSlugs={ extensionsToInstall }
+						/>
+					</div>
 				) }
 			</Fragment>
 		);

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -180,6 +180,7 @@
 
 		&:last-child p {
 			border-bottom: 0;
+			margin-bottom: 0;
 		}
 	}
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -36,6 +36,14 @@
 		}
 	}
 
+	.woocommerce-profile-wizard__card-actions {
+		text-align: center;
+
+		.components-button {
+			margin-top: $gap-small;
+		}
+	}
+
 	.woocommerce-profile-wizard__container {
 		.woocommerce-profile-wizard__tos {
 			font-size: 12px;


### PR DESCRIPTION
Fixes #3570 

Centers an uncentered button.

### Screenshots

#### Before
<img width="521" alt="Screen Shot 2020-01-15 at 4 12 34 PM" src="https://user-images.githubusercontent.com/10561050/72699969-5fabb880-3b85-11ea-8da3-8d4f06539301.png">


#### After
<img width="484" alt="Screen Shot 2020-01-20 at 1 01 33 PM" src="https://user-images.githubusercontent.com/10561050/72699976-620e1280-3b85-11ea-9e9b-61cf5db278af.png">


### Detailed test instructions:

1. You can intentionally cause an install to fail by updating by replacing `$slug` with an empty string `''` in https://github.com/woocommerce/woocommerce-admin/blob/5d5f55e3b19fcceb928ee14fb05a1b7d7554a4a6/src/API/OnboardingPlugins.php#L195
1. Remove Mailchimp and/or Facebook plugins.
1. Visit the Business Details step.
1. Attempt to install these plugins on this step.
1. Note the button placement.