### PR TITLE
Onboarding: Allow Jetpack connection to be skipped in tax task

### DIFF
--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -38,17 +38,22 @@ class Connect extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting } = this.props;
+		const { hasErrors, isRequesting, onSkip, skipText } = this.props;
 
-		return hasErrors ? (
-			<Button isPrimary onClick={ () => location.reload() }>
-				{ __( 'Retry', 'woocommerce-admin' ) }
-			</Button>
-		) : (
+		return (
 			<Fragment>
-				<Button isBusy={ isRequesting } isPrimary onClick={ this.connectJetpack }>
-					{ __( 'Connect', 'woocommerce-admin' ) }
-				</Button>
+				{ hasErrors ? (
+					<Button isPrimary onClick={ () => location.reload() }>
+						{ __( 'Retry', 'woocommerce-admin' ) }
+					</Button>
+				) : (
+					<Button isBusy={ isRequesting } isPrimary onClick={ this.connectJetpack }>
+						{ __( 'Connect', 'woocommerce-admin' ) }
+					</Button>
+				) }
+				{ onSkip && (
+					<Button onClick={ onSkip }>{ skipText || __( 'No thanks', 'woocommerce-admin' ) }</Button>
+				) }
 			</Fragment>
 		);
 	}
@@ -76,9 +81,17 @@ Connect.propTypes = {
 	 */
 	jetpackConnectUrl: PropTypes.string,
 	/**
+	 * Called when the plugin connection is skipped.
+	 */
+	onSkip: PropTypes.func,
+	/**
 	 * Redirect URL to encode as a URL param for the connection path.
 	 */
 	redirectUrl: PropTypes.string,
+	/**
+	 * Text used for the skip connection button.
+	 */
+	skipText: PropTypes.string,
 };
 
 export default compose(

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -241,6 +241,12 @@ class Tax extends Component {
 						onConnect={ () => {
 							recordEvent( 'tasklist_tax_connect_store' );
 						} }
+						onSkip={ () => {
+							window.location.href = getAdminLink(
+								'admin.php?page=wc-settings&tab=tax&section=standard'
+							);
+						} }
+						skipText={ __( 'Set up tax rates manually', 'woocommerce-admin' ) }
 					/>
 				),
 				visible: ! isJetpackConnected && this.isTaxJarSupported(),

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -239,9 +239,10 @@ class Tax extends Component {
 					<Connect
 						{ ...this.props }
 						onConnect={ () => {
-							recordEvent( 'tasklist_tax_connect_store' );
+							recordEvent( 'tasklist_tax_connect_store', { connect: true } );
 						} }
 						onSkip={ () => {
+							queueRecordEvent( 'tasklist_tax_connect_store', { connect: false } );
 							window.location.href = getAdminLink(
 								'admin.php?page=wc-settings&tab=tax&section=standard'
 							);


### PR DESCRIPTION
Fixes #3567 

Adds a skip button for the connect step in the tax task and tracks event.

### Screenshots
<img width="720" alt="Screen Shot 2020-01-20 at 1 57 08 PM" src="https://user-images.githubusercontent.com/10561050/72702378-77873a80-3b8d-11ea-8791-b30d07163480.png">


### Detailed test instructions:

1. Make sure your store is in a TaxJar supported country.  (e.g., `US`).
2. Disconnect Jetpack.
3. Walk through the tax task to the "Connect" step.
4. Make sure the skip button is shown and works as expected.
5. Make sure using the skip or connect option record respective track events with the correct `connect` property.