### PR TITLE
Onboarding: Mark profiler complete on WC update

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -63,6 +63,7 @@ class Onboarding {
 		// Adds the ability to toggle the new onboarding experience on or off.
 		// @todo This option should be removed when merging the onboarding feature to core.
 		add_action( 'current_screen', array( $this, 'enable_onboarding' ) );
+		add_action( 'woocommerce_updated', array( $this, 'maybe_mark_complete' ) );
 
 		if ( ! Loader::is_onboarding_enabled() ) {
 			add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
@@ -929,5 +930,25 @@ class Onboarding {
 		}
 
 		wp_safe_redirect( wc_admin_url() );
+	}
+
+	/**
+	 * When updating WooCommerce, mark the profiler and task list complete.
+	 */
+	public static function maybe_mark_complete() {
+		// The install notice still exists so don't complete the profiler.
+		if ( ! class_exists( 'WC_Admin_Notices' ) || \WC_Admin_Notices::has_notice( 'install' ) ) {
+			return;
+		}
+
+		$onboarding_data = get_option( self::PROFILE_DATA_OPTION, array() );
+		// Don't make updates if the profiler is completed, but task list is potentially incomplete.
+		if ( isset( $onboarding_data['completed'] ) && $onboarding_data['completed'] ) {
+			return;
+		}
+
+		$onboarding_data['completed'] = true;
+		update_option( self::PROFILE_DATA_OPTION, $onboarding_data );
+		update_option( 'woocommerce_task_list_hidden', 'yes' );
 	}
 }

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -934,6 +934,9 @@ class Onboarding {
 
 	/**
 	 * When updating WooCommerce, mark the profiler and task list complete.
+	 *
+	 * @todo The `maybe_enable_setup_wizard()` method should be revamped on onboarding enable in core.
+	 * See https://github.com/woocommerce/woocommerce/blob/1ca791f8f2325fe2ee0947b9c47e6a4627366374/includes/class-wc-install.php#L341
 	 */
 	public static function maybe_mark_complete() {
 		// The install notice still exists so don't complete the profiler.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -57,7 +57,8 @@ class Loader {
 	 */
 	public function __construct() {
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
-		add_action( 'init', array( __CLASS__, 'load_features' ) );
+		// Load feature before WooCommerce update hooks.
+		add_action( 'init', array( __CLASS__, 'load_features' ), 4 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_scripts' ), 15 );


### PR DESCRIPTION
Fixes #3564

Marks the profiler complete after WC is updated from an older version if the `install` notice is still shown (used to determine if the old onboarding should be shown).

Note that we'll need a follow-up in WC core on when onboarding is enabled by default in core to modify the check for non-new installs (todo note in the code).

### Detailed test instructions:

1. On a new install (or one where the previous onboarding is still enabled), enable onboarding.
2. Force an upgrade by incrementing the version number found in `class-wooocommerce.php`.
3. Make sure the onboarding profiler is still shown.
4. Disable the new onboarding experience and complete the old one.
5. Enable the new onboarding experiencing manually via by setting the `wc_onboarding_opt_in` to `yes`.
6. Force another version update.
7. Make sure the new onboarding experience is not shown.
8. Enable the profiler again via the "Help" tab.
9. Fill out some data in the profiler and complete it.
10. Bump the WC core version again and make sure no data is lost in `woocommerce_onboarding_profile`.