### PR TITLE
Onboarding: Fix gap on plugins step

### DIFF
--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -349,10 +349,9 @@
 	.woocommerce-profile-wizard__plugins-actions {
 		text-align: left;
 		margin-left: $gap-largest + $gap-smallest;
-		margin-top: $gap;
 
 		button.is-button {
-			margin: 0;
+			margin: $gap 0 0;
 			height: 40px;
 			min-width: auto;
 			display: initial;

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -350,7 +350,6 @@
 		text-align: left;
 		margin-left: $gap-largest + $gap-smallest;
 		margin-top: $gap;
-		min-height: 28px;
 
 		button.is-button {
 			margin: 0;


### PR DESCRIPTION
Fixes #3578 

Removes the margin on an empty wrapper when plugins are being installed/activated.

### Screenshots
#### Before
<img width="546" alt="Screen Shot 2020-01-16 at 4 25 45 PM" src="https://user-images.githubusercontent.com/10561050/72780863-e41c3b00-3c5a-11ea-8354-c8b61ad98585.png">

#### After
<img width="511" alt="Screen Shot 2020-01-21 at 2 32 21 PM" src="https://user-images.githubusercontent.com/10561050/72780849-db2b6980-3c5a-11ea-92b1-2addcd1f0979.png">



### Detailed test instructions:

1. Deactivate either Jetpack or WCS.
1. Visit the plugins step of the profiler `wp-admin/admin.php?page=wc-admin&step=plugins`
1. Note the lack of gap while installing.
1. Make sure no regressions in spacing occur after the plugin actions (buttons) appear.