### PR TITLE
Onboarding: Use existing store country if address line 1 is set

### DIFF
--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -39,11 +39,10 @@ class StoreDetails extends Component {
 			showUsageModal: false,
 		};
 
+		// Check if a store address is set so that we don't default
+		// to WooCommerce's default country of the UK.
 		const countryState =
-			( profileItems.hasOwnProperty( 'setup_client' ) &&
-				null !== profileItems.setup_client &&
-				settings.woocommerce_default_country ) ||
-			'';
+			( settings.woocommerce_store_address && settings.woocommerce_default_country ) || '';
 
 		this.initialValues = {
 			addressLine1: settings.woocommerce_store_address || '',


### PR DESCRIPTION
Fixes #3447 

Previously, https://github.com/woocommerce/woocommerce-admin/pull/3252 checked to see if the profile information had been filled before so we don't show the default "UK" for the country/state dropdown.

This PR instead checks to see if an address has previously been filled out and uses the saved country if so.

### Screenshots
<img width="502" alt="Screen Shot 2020-01-21 at 2 44 33 PM" src="https://user-images.githubusercontent.com/10561050/72781756-08791700-3c5d-11ea-9841-d13f6568fb88.png">


### Detailed test instructions:

1. Add at least a country and address line 1 to your address fields.
1. Enable the profiler.
1. Delete `woocommerce_onboarding_profile` from `wp_options`.
1. Visit the store details step.  `wp-admin/admin.php?page=wc-admin&step=store-details`
1. Make sure your store's country is shown in the country/state dropdown.