### PR TITLE
Remove unnecessary use of lodash get

### DIFF
--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -9,7 +9,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
 import { recordEvent } from 'lib/tracks';
-import { get } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -32,8 +31,7 @@ import withSelect from 'wc-api/with-select';
 class StoreDetails extends Component {
 	constructor( props ) {
 		super( ...arguments );
-		const settings = get( props, 'settings', false );
-		const profileItems = get( props, 'profileItems', {} );
+		const { profileItems, settings } = props;
 
 		this.state = {
 			showUsageModal: false,


### PR DESCRIPTION
While reviewing #3595 I noticed that in `store-details.js`:
* `settings` was using `false` as the fallback value, even though it's expected to be an object.
* Both [`settings`](https://github.com/woocommerce/woocommerce-admin/blob/master/client/wc-api/settings/selectors.js#L26) and [`profileItems`](https://github.com/woocommerce/woocommerce-admin/blob/master/client/wc-api/onboarding/selectors.js#L34) already default to an empty object, so if I'm not missing anything, it should be safe to access them directly from props.

### Detailed test instructions:

Go through the _Onboarding_ and verify there are no JS errors.