### PR TITLE
Fix styling of search control in report table header and filters.

### DIFF
--- a/client/analytics/components/report-table/style.scss
+++ b/client/analytics/components/report-table/style.scss
@@ -66,7 +66,7 @@
 
 		&.has-search:not(.has-compare) {
 			.woocommerce-card__action {
-				grid-template-columns: auto;
+				grid-template-columns: 1fr auto;
 
 				.woocommerce-search {
 					align-self: center;
@@ -99,6 +99,10 @@
 
 		.woocommerce-search {
 			margin: 0 $gap;
+
+			.woocommerce-select-control__control {
+				height: 38px;
+			}
 		}
 
 		.woocommerce-compare-button {

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -156,6 +156,12 @@
 
 .woocommerce-filters-advanced__input {
 	width: 100%;
+
+	&.woocommerce-search.woocommerce-select-control {
+		.woocommerce-select-control__control {
+			height: 38px;
+		}
+	}
 }
 
 .woocommerce-filters-advanced__add-filter-dropdown {


### PR DESCRIPTION
Found some styling issues while starting to write documentation on the Customers Report.

This PR fixes the height of the `<Search>` component when used in advanced filters and the report table header. It also fixed the width/flex of the search component in the report table header.

~**NOTE: ** It's not clear to me why this regressed. I have not yet tried to find the root cause.~

Regressed in 686f2c678d6424f30e9fe9fa5d1c27c4523d6430.

### Screenshots

**Before**

![Screen Shot 2020-01-21 at 10 33 03 AM](https://user-images.githubusercontent.com/63922/72828449-defac400-3c39-11ea-93e4-4bef2166d78f.png)

**After**

![Screen Shot 2020-01-21 at 10 32 17 AM](https://user-images.githubusercontent.com/63922/72828464-e5893b80-3c39-11ea-9f0c-c2311556c4bd.png)

### Detailed test instructions:

- Open a report that uses `<Search>` in an advanced filter (like Customers)
- Add the advanced filer
- Verify the component height matches the rest of the row (and the icon is centered)
- Open a report that uses `<Search>` in the table header (like Customers)
- Verify the component height matches the rest of the row (and the icon is centered)
- Verify the component stretches as the window is resized (width) and the download button remains a constant width, right justified

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

