### PR TITLE
Onboarding: Add missing space between manual tax info and link

### DIFF
--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -276,7 +276,7 @@ class Tax extends Component {
 								interpolateComponents( {
 									mixedString: __(
 										'By clicking "Configure" you\'re enabling tax rates and calculations.' +
-											'More info {{link}}here{{/link}}.',
+											' More info {{link}}here{{/link}}.',
 										'woocommerce-admin'
 									),
 									components: {

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -275,8 +275,9 @@ class Tax extends Component {
 							{ 'yes' !== generalSettings.woocommerce_calc_taxes &&
 								interpolateComponents( {
 									mixedString: __(
-										'By clicking "Configure" you\'re enabling tax rates and calculations.' +
-											' More info {{link}}here{{/link}}.',
+										/*eslint-disable max-len*/
+										'By clicking "Configure" you\'re enabling tax rates and calculations. More info {{link}}here{{/link}}.',
+										/*eslint-enable max-len*/
 										'woocommerce-admin'
 									),
 									components: {


### PR DESCRIPTION
Fixes #3604

Adds a space between the two sentences underneath the "Configure" button.

### Screenshots
<img width="594" alt="Screen Shot 2020-01-22 at 4 29 22 PM" src="https://user-images.githubusercontent.com/10561050/72877707-77756f00-3d34-11ea-9294-645345f49d08.png">


### Detailed test instructions:

1. Enable the task list and go to the tax task.
2. Force manual configuration by setting to a country outside of TaxJar supported countries.
3. Make sure the option `woocommerce_calc_taxes` is set to `no`.
4. Note the space between the sentences `By clicking "Configure" you're enabling tax rates and calculations. More info here.`