### PR TITLE
Add Timeline component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 5.0.0 (Unreleased)
+- Added `<Timeline />` component.
 - Added `<ImageUpload />` component.
 - Style form components for WordPress 5.3.
 - Fix CompareFilter options format (key prop vs. id).

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -57,6 +57,7 @@ export { default as TableSummary } from './table/summary';
 export { default as Tag } from './tag';
 export { default as TextControl } from './text-control';
 export { default as TextControlWithAffixes } from './text-control-with-affixes';
+export { default as Timeline } from './timeline';
 export { default as useFilters } from './higher-order/use-filters';
 export { default as ViewMoreList } from './view-more-list';
 export { default as WebPreview } from './web-preview';

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -35,5 +35,6 @@
 @import 'tag/style.scss';
 @import 'text-control/style.scss';
 @import 'text-control-with-affixes/style.scss';
+@import 'timeline/style.scss';
 @import 'view-more-list/style.scss';
 @import 'web-preview/style.scss';

--- a/packages/components/src/timeline/README.md
+++ b/packages/components/src/timeline/README.md
@@ -9,11 +9,12 @@ It accepts `items` for the timeline content and will order the data for you.
 ```jsx
 import Timeline from './Timeline';
 import { orderByOptions, groupByOptions } from './Timeline';
+import GridIcon from 'gridicons';
 
 const items = [
   {
     datetime: new Date( 2019, 9, 28, 9, 0 )
-    gridicon: 'checkmark',
+    icon: <GridIcon icon={ 'checkmark' } />,
     headline: 'A payment of $90.00 was successfully charged',
     body: [
       'Fee: $2.91 ( 2.9% + $0.30 )',
@@ -22,13 +23,13 @@ const items = [
   },
   {
     datetime: new Date( 2019, 9, 28, 9, 32 ),
-    gridicon: 'plus',
+    icon: <GridIcon icon={ 'plus' } />,
     headline: '$94.16 was added to your October 29, 2019 deposit',
     body: [],
   },
   {
     datetime: new Date( 2019, 9, 27, 20, 9 ),
-    gridicon: 'checkmark',
+    icon: <GridIcon icon={ 'checkmark' } />,
     headline: 'A payment of $90.00 was successfully authorized',
     body: [],
   },
@@ -56,6 +57,6 @@ Name | Type | Default | Description
 A list of items with properties:
 
 - `datetime`: int - Unix timestamp
-- `gridicon`: String - The name of the gridicon associated with this item
+- `icon`: Element - The element used to represent the icon for this item
 - `headline`: String - The title text of this item
 - `body`: Array - Detail text associated with this item

--- a/packages/components/src/timeline/README.md
+++ b/packages/components/src/timeline/README.md
@@ -58,11 +58,11 @@ A list of items with properties:
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`datetime` | int | Required | Unix timestamp when this item happened
-`icon` | Element | Required | The element used to represent the icon for this item
-`headline` | String | Required | The title text of this item
-`body` | Array | `[]` | Elements that contain details pertaining to this item
-`hideTimestamp` | Bool | `false` | Allows the user to hide the timestamp associated with this item
+`datetime` | int | Required | Unix timestamp when this event happened
+`icon` | Element | Required | The element used to represent the icon for this event
+`headline` | Element | Required | The element used to represent the title of this event
+`body` | Array | `[]` | Elements that contain details pertaining to this event
+`hideTimestamp` | Bool | `false` | Allows the user to hide the timestamp associated with this event
 
 Icon color can be customized by adding 1 of 3 classes to the icon element: `is-success` (green), `is-warning` (yellow), and `is-error` (red)
   - If no class is provided the icon will be gray

--- a/packages/components/src/timeline/README.md
+++ b/packages/components/src/timeline/README.md
@@ -17,8 +17,8 @@ const items = [
     icon: <GridIcon icon={ 'checkmark' } />,
     headline: 'A payment of $90.00 was successfully charged',
     body: [
-      'Fee: $2.91 ( 2.9% + $0.30 )',
-      'Net deposit: $87.09',
+      <p key={ '1' }>{ 'Fee: $2.91 ( 2.9% + $0.30 )' }</p>,
+      <p key={ '2' }>{ 'Net deposit: $87.09' }</p>,
     ],
   },
   {
@@ -29,7 +29,7 @@ const items = [
   },
   {
     datetime: new Date( 2019, 9, 27, 20, 9 ),
-    icon: <GridIcon icon={ 'checkmark' } />,
+    icon: <GridIcon icon={ 'checkmark' } className={ 'is-success' } />,
     headline: 'A payment of $90.00 was successfully authorized',
     body: [],
   },
@@ -57,6 +57,8 @@ Name | Type | Default | Description
 A list of items with properties:
 
 - `datetime`: int - Unix timestamp
-- `icon`: Element - The element used to represent the icon for this item
+- `icon`: Element - The element used to represent the icon for this item.
+  - Icon color can be customized with 3 classes: `is-success` (green), `is-warning` (yellow), and `is-error` (red)
+  - If no class is provided the icon will be gray
 - `headline`: String - The title text of this item
-- `body`: Array - Detail text associated with this item
+- `body`: Array - Elements that contain details pertaining to this item

--- a/packages/components/src/timeline/README.md
+++ b/packages/components/src/timeline/README.md
@@ -1,0 +1,61 @@
+Timeline
+===
+
+This is a timeline for displaying data, such as events, in chronological order.
+It accepts `items` for the timeline content and will order the data for you.
+
+## Usage
+
+```jsx
+import Timeline from './Timeline';
+import { orderByOptions, groupByOptions } from './Timeline';
+
+const items = [
+  {
+    datetime: new Date( 2019, 9, 28, 9, 0 )
+    gridicon: 'checkmark',
+    headline: 'A payment of $90.00 was successfully charged',
+    body: [
+      'Fee: $2.91 ( 2.9% + $0.30 )',
+      'Net deposit: $87.09',
+    ],
+  },
+  {
+    datetime: new Date( 2019, 9, 28, 9, 32 ),
+    gridicon: 'plus',
+    headline: '$94.16 was added to your October 29, 2019 deposit',
+    body: [],
+  },
+  {
+    datetime: new Date( 2019, 9, 27, 20, 9 ),
+    gridicon: 'checkmark',
+    headline: 'A payment of $90.00 was successfully authorized',
+    body: [],
+  },
+]
+
+<Timeline
+  items={ items }
+  groupBy={ groupByOptions.DAY }
+  orderBy={ orderByOptions.ASC }
+/>
+```
+
+### Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`className` | String | `''` | Additional class names that can be applied for styling purposes
+`items` | Array | `[]` | An array of items to be displayed on the timeline
+`orderBy` | String | `'asc'` | How the items should be ordered, either `'asc'` or `'desc'`
+`groupBy` | String | `'day'` | How the items should be grouped, one of `'day'`, `'week'`, or `'month'`
+
+
+### `items` structure
+
+A list of items with properties:
+
+- `datetime`: int - Unix timestamp
+- `gridicon`: String - The name of the gridicon associated with this item
+- `headline`: String - The title text of this item
+- `body`: Array - Detail text associated with this item

--- a/packages/components/src/timeline/README.md
+++ b/packages/components/src/timeline/README.md
@@ -56,9 +56,13 @@ Name | Type | Default | Description
 
 A list of items with properties:
 
-- `datetime`: int - Unix timestamp
-- `icon`: Element - The element used to represent the icon for this item.
-  - Icon color can be customized with 3 classes: `is-success` (green), `is-warning` (yellow), and `is-error` (red)
+Name | Type | Default | Description
+--- | --- | --- | ---
+`datetime` | int | Required | Unix timestamp when this item happened
+`icon` | Element | Required | The element used to represent the icon for this item
+`headline` | String | Required | The title text of this item
+`body` | Array | `[]` | Elements that contain details pertaining to this item
+`hideTimestamp` | Bool | `false` | Allows the user to hide the timestamp associated with this item
+
+Icon color can be customized by adding 1 of 3 classes to the icon element: `is-success` (green), `is-warning` (yellow), and `is-error` (red)
   - If no class is provided the icon will be gray
-- `headline`: String - The title text of this item
-- `body`: Array - Elements that contain details pertaining to this item

--- a/packages/components/src/timeline/README.md
+++ b/packages/components/src/timeline/README.md
@@ -13,7 +13,7 @@ import GridIcon from 'gridicons';
 
 const items = [
   {
-    datetime: new Date( 2019, 9, 28, 9, 0 )
+    date: new Date( 2019, 9, 28, 9, 0 ),
     icon: <GridIcon icon={ 'checkmark' } />,
     headline: 'A payment of $90.00 was successfully charged',
     body: [
@@ -22,13 +22,13 @@ const items = [
     ],
   },
   {
-    datetime: new Date( 2019, 9, 28, 9, 32 ),
+    date: new Date( 2019, 9, 28, 9, 32 ),
     icon: <GridIcon icon={ 'plus' } />,
     headline: '$94.16 was added to your October 29, 2019 deposit',
     body: [],
   },
   {
-    datetime: new Date( 2019, 9, 27, 20, 9 ),
+    date: new Date( 2019, 9, 27, 20, 9 ),
     icon: <GridIcon icon={ 'checkmark' } className={ 'is-success' } />,
     headline: 'A payment of $90.00 was successfully authorized',
     body: [],
@@ -50,6 +50,8 @@ Name | Type | Default | Description
 `items` | Array | `[]` | An array of items to be displayed on the timeline
 `orderBy` | String | `'asc'` | How the items should be ordered, either `'asc'` or `'desc'`
 `groupBy` | String | `'day'` | How the items should be grouped, one of `'day'`, `'week'`, or `'month'`
+`dateFormat` | String | `'F j, Y'` | PHP date format string used to format dates, see php.net/date
+`clockFormat` | String | `'g:ia'` | PHP clock format string used to format times, see php.net/date
 
 
 ### `items` structure
@@ -58,7 +60,7 @@ A list of items with properties:
 
 Name | Type | Default | Description
 --- | --- | --- | ---
-`datetime` | int | Required | Unix timestamp when this event happened
+`date` | Date | Required | JavaScript Date object set to when this event happened
 `icon` | Element | Required | The element used to represent the icon for this event
 `headline` | Element | Required | The element used to represent the title of this event
 `body` | Array | `[]` | Elements that contain details pertaining to this event

--- a/packages/components/src/timeline/__mocks__/timeline-mock-data.js
+++ b/packages/components/src/timeline/__mocks__/timeline-mock-data.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import GridIcon from 'gridicons';
+
+export default [
+	{
+		datetime: new Date( 2020, 0, 20, 1, 30 ).getTime() / 1000,
+		body: [ <p key={ '1' }>{ 'p element in body' }</p>, 'string in body' ],
+		headline: <p>{ 'p tag in headline' }</p>,
+		icon: (
+			<GridIcon
+				className={ 'is-success' }
+				icon={ 'checkmark' }
+				size={ 16 }
+			/>
+		),
+		hideTimestamp: true,
+	},
+	{
+		datetime: new Date( 2020, 0, 20, 23, 45 ).getTime() / 1000,
+		body: [],
+		headline: <span>{ 'span in headline' }</span>,
+		icon: (
+			<GridIcon
+				className={ 'is-warning' }
+				icon={ 'refresh' }
+				size={ 16 }
+			/>
+		),
+	},
+	{
+		datetime: new Date( 2020, 0, 22, 15, 13 ).getTime() / 1000,
+		body: [ <span key={ '1' }>{ 'span in body' }</span> ],
+		headline: 'string in headline',
+		icon: (
+			<GridIcon className={ 'is-error' } icon={ 'cross' } size={ 16 } />
+		),
+	},
+	{
+		datetime: new Date( 2020, 0, 17, 1, 45 ).getTime() / 1000,
+		headline: 'undefined body and string headline',
+		icon: <GridIcon icon={ 'cross' } size={ 16 } />,
+	},
+];

--- a/packages/components/src/timeline/__mocks__/timeline-mock-data.js
+++ b/packages/components/src/timeline/__mocks__/timeline-mock-data.js
@@ -5,7 +5,7 @@ import GridIcon from 'gridicons';
 
 export default [
 	{
-		datetime: new Date( 2020, 0, 20, 1, 30 ).getTime() / 1000,
+		date: new Date( 2020, 0, 20, 1, 30 ),
 		body: [ <p key={ '1' }>{ 'p element in body' }</p>, 'string in body' ],
 		headline: <p>{ 'p tag in headline' }</p>,
 		icon: (
@@ -18,7 +18,7 @@ export default [
 		hideTimestamp: true,
 	},
 	{
-		datetime: new Date( 2020, 0, 20, 23, 45 ).getTime() / 1000,
+		date: new Date( 2020, 0, 20, 23, 45 ),
 		body: [],
 		headline: <span>{ 'span in headline' }</span>,
 		icon: (
@@ -30,7 +30,7 @@ export default [
 		),
 	},
 	{
-		datetime: new Date( 2020, 0, 22, 15, 13 ).getTime() / 1000,
+		date: new Date( 2020, 0, 22, 15, 13 ),
 		body: [ <span key={ '1' }>{ 'span in body' }</span> ],
 		headline: 'string in headline',
 		icon: (
@@ -38,7 +38,7 @@ export default [
 		),
 	},
 	{
-		datetime: new Date( 2020, 0, 17, 1, 45 ).getTime() / 1000,
+		date: new Date( 2020, 0, 17, 1, 45 ),
 		headline: 'undefined body and string headline',
 		icon: <GridIcon icon={ 'cross' } size={ 16 } />,
 	},

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 const Timeline = ( { className, items } ) => {
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
 
-	if ( items.length === 0 ) {
+	if ( ! items || items.length === 0 ) {
 		return (
 			<div className={ timelineClassName }>
 				<p className="timeline_no_events">

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -65,11 +65,16 @@ Timeline.propTypes = {
 			/**
 			 * Headline displayed for the list item.
 			 */
-			headline: PropTypes.element.isRequired,
+			headline: PropTypes.oneOfType( [
+				PropTypes.element,
+				PropTypes.string,
+			] ).isRequired,
 			/**
 			 * Body displayed for the list item.
 			 */
-			body: PropTypes.arrayOf( PropTypes.element ),
+			body: PropTypes.arrayOf(
+				PropTypes.oneOfType( [ PropTypes.element, PropTypes.string ] )
+			),
 			/**
 			 * Allows users to toggle the timestamp on or off.
 			 */

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -6,30 +6,10 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 
-const daysToTimelineItems = ( day, dayNum ) => {
-	const dayToTimelineItem = ( item, itemIndex ) => {
-		const itemTimeString = moment( item.datetime ).format( 'h:mma' );
-		const itemKey = dayNum + '-' + itemIndex;
-		return (
-			<li key={ itemKey }>
-				{ item.headline } <span>{ itemTimeString }</span>
-				{ item.body.map( function( line, bodyLineIndex ) {
-					const bodyLineKey =
-						dayNum + '-' + itemIndex + '-' + bodyLineIndex;
-					return <p key={ bodyLineKey }>{ line }</p>;
-				} ) }
-			</li>
-		);
-	};
-
-	const dayString = moment( dayNum.toString() ).format( 'MMMM D, YYYY' );
-	return (
-		<li key={ dayNum }>
-			{ dayString }
-			<ul>{ day.map( dayToTimelineItem ) }</ul>
-		</li>
-	);
-};
+/**
+ * Internal dependencies
+ */
+import TimelineGroup from './timeline-group';
 
 const Timeline = ( { className, items } ) => {
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
@@ -45,14 +25,14 @@ const Timeline = ( { className, items } ) => {
 	}
 
 	// Sort all the items reverse chronologically
-	items.sort( function( a, b ) {
+	items.sort( ( a, b ) => {
 		return a.datetime - b.datetime;
 	} );
 
 	// Group the items into local day collections
 	const days = [];
 
-	items.forEach( function( item ) {
+	items.forEach( ( item ) => {
 		const itemLocalDatetime = moment.unix( item.datetime );
 		const dayNum = parseInt( itemLocalDatetime.format( 'YYYYMMDD' ), 10 );
 		if ( ! ( dayNum in days ) ) {
@@ -61,9 +41,13 @@ const Timeline = ( { className, items } ) => {
 		days[ dayNum ].push( item );
 	} );
 
+	const timelineGroups = days.map( ( day, dayIndex ) => (
+		<TimelineGroup key={ dayIndex } items={ day } groupKey={ dayIndex } />
+	) );
+
 	return (
 		<div className={ timelineClassName }>
-			<ul>{ days.map( daysToTimelineItems ) }</ul>
+			<ul>{ timelineGroups }</ul>
 		</div>
 	);
 };

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -1,7 +1,105 @@
-const Timeline = () => {
+/** @format */
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
+
+const Timeline = ( { className, items } ) => {
+	const timelineClassName = classnames( 'woocommerce-timeline', className );
+
+	// Sort all the items reverse chronologically
+	items.sort( function( a, b ) {
+		return a.datetime - b.datetime;
+	} );
+
+	// Group the items into local day collections
+	const days = [];
+
+	items.forEach( function( item ) {
+		const itemLocalDatetime = moment.unix( item.datetime );
+		const dayNum = parseInt( itemLocalDatetime.format( 'YYYYMMDD' ), 10 );
+		if ( ! ( dayNum in days ) ) {
+			days[ dayNum ] = [];
+		}
+		days[ dayNum ].push( item );
+	} );
+
+	if ( 0 === items.count ) {
+		return (
+			<div className={ timelineClassName }>
+				<p class="timeline_no_events">
+					{ __( 'No events to display' ) }
+				</p>
+			</div>
+		);
+	}
+
 	return (
-		<div>Hello world.</div>
+		<div className={ timelineClassName }>
+			<ul>
+				{ days.map( function( day, dayNum ) {
+					const dayString = moment( dayNum ).format( 'MMMM D, YYYY' );
+					return (
+						<li key={ dayNum }>
+							{ dayString }
+							<ul>
+								{ day.map( function( item ) {
+									const timeString = moment( item.datetime ).format( 'h:mma' );
+									return (
+										<li>
+											{ item.headline } <span>{ timeString }</span>
+											{ item.body.map( function( line ) {
+												return (
+													<p>
+														{ line }
+													</p>
+												);
+											} ) }
+										</li>
+									);
+								} ) }
+							</ul>
+						</li>
+					);
+				} ) }
+			</ul>
+		</div>
 	);
+};
+
+Timeline.propTypes = {
+	/**
+	 * Additional CSS classes.
+	 */
+	className: PropTypes.string,
+	/**
+	 * An array of list items.
+	 */
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			/**
+			 * Timestamp (in seconds) for the timeline item.
+			 */
+			datetime: PropTypes.number.isRequired,
+			/**
+			 * GridIcon for the Timeline item.
+			 */
+			gridicon: PropTypes.string.isRequired,
+			/**
+			 * Headline displayed for the list item.
+			 */
+			headline: PropTypes.string.isRequired,
+			/**
+			 * Body displayed for the list item.
+			 */
+			body: PropTypes.arrayOf(
+				PropTypes.string
+			),
+		} )
+	).isRequired,
 };
 
 export default Timeline;

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -1,0 +1,7 @@
+const Timeline = () => {
+	return (
+		<div>Hello world.</div>
+	);
+};
+
+export default Timeline;

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -9,7 +9,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Card from '../card';
 import TimelineGroup from './timeline-group';
 
 export const groupByOptions = {
@@ -31,11 +30,11 @@ const Timeline = ( props ) => {
 	// Early return in case no data was passed to the component.
 	if ( ! items || items.length === 0 ) {
 		return (
-			<Card title={ 'Timeline' } className={ timelineClassName }>
-				<p className="timeline_no_events">
+			<div className={ timelineClassName }>
+				<p className={ 'timeline_no_events' }>
 					{ __( 'No data to display', 'woocommerce-admin' ) }
 				</p>
-			</Card>
+			</div>
 		);
 	}
 
@@ -77,9 +76,9 @@ const Timeline = ( props ) => {
 		.map( ( g ) => <TimelineGroup key={ g.id.toString() } group={ g } /> );
 
 	return (
-		<Card title={ 'Timeline' } className={ timelineClassName }>
+		<div className={ timelineClassName }>
 			<ul>{ timelineGroups }</ul>
-		</Card>
+		</div>
 	);
 };
 

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -29,20 +29,21 @@ const Timeline = ( { className, items } ) => {
 		return a.datetime - b.datetime;
 	} );
 
-	// Group the items into local day collections
-	const days = [];
+	// Group items by days.
+	// TODO: Maybe the items passed into the Timeline component
+	// should already be grouped and sorted?
+	const groups = items.reduce( ( acc, curr ) => {
+		const itemLocalDatetime = moment.unix( curr.datetime );
+		const formattedDate = itemLocalDatetime.format( 'YYYYMMDD' );
 
-	items.forEach( ( item ) => {
-		const itemLocalDatetime = moment.unix( item.datetime );
-		const dayNum = parseInt( itemLocalDatetime.format( 'YYYYMMDD' ), 10 );
-		if ( ! ( dayNum in days ) ) {
-			days[ dayNum ] = [];
-		}
-		days[ dayNum ].push( item );
-	} );
+		return {
+			...acc,
+			[ formattedDate ]: [ ...( acc[ formattedDate ] || [] ), curr ],
+		};
+	}, {} );
 
-	const timelineGroups = days.map( ( day, dayIndex ) => (
-		<TimelineGroup key={ dayIndex } items={ day } groupKey={ dayIndex } />
+	const timelineGroups = Object.keys( groups ).map( ( key ) => (
+		<TimelineGroup key={ key } items={ groups[ key ] } groupKey={ key } />
 	) );
 
 	return (

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 
@@ -10,21 +9,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import TimelineGroup from './timeline-group';
-
-export const groupByOptions = {
-	DAY: 'day',
-	WEEK: 'week',
-	MONTH: 'month',
-};
-
-export const orderByOptions = {
-	ASC: 'asc',
-	DESC: 'desc',
-};
+import { sortByDateUsing, groupItemsUsing } from './util';
 
 const Timeline = ( props ) => {
 	const { className, items, groupBy, orderBy } = props;
-
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
 
 	// Early return in case no data was passed to the component.
@@ -38,48 +26,20 @@ const Timeline = ( props ) => {
 		);
 	}
 
-	// Reducer used for grouping items.
-	const itemsToGroups = ( groups, item ) => {
-		const timeToMoment = ( ts ) => moment.unix( ts );
-		const haveSameMoment = ( g, i ) =>
-			timeToMoment( g.id ).isSame( timeToMoment( i.datetime ), groupBy );
-
-		const groupIndex = groups.findIndex( ( g ) =>
-			haveSameMoment( g, item )
-		);
-		if ( groupIndex < 0 ) {
-			return [
-				...groups,
-				{
-					id: item.datetime,
-					title: timeToMoment( item.datetime ).format(
-						'MMMM D, YYYY'
-					),
-					items: [ item ],
-				},
-			];
-		}
-
-		groups[ groupIndex ].items.push( item );
-		return groups;
-	};
-
-	const sortAscending = ( groupA, groupB ) => groupA.id - groupB.id;
-	const sortDescending = ( groupA, groupB ) => groupB.id - groupA.id;
-	const sortMethod =
-		orderByOptions.ASC === orderBy ? sortAscending : sortDescending;
-
-	// Group items together, sort, and map to Timeline groups.
-	const timelineGroups = items
-		.reduce( itemsToGroups, [] )
-		.sort( sortMethod )
-		.map( ( group ) => (
-			<TimelineGroup key={ group.id.toString() } group={ group } />
-		) );
-
 	return (
 		<div className={ timelineClassName }>
-			<ul>{ timelineGroups }</ul>
+			<ul>
+				{ items
+					.reduce( groupItemsUsing( groupBy ), [] )
+					.sort( sortByDateUsing( orderBy ) )
+					.map( ( group ) => (
+						<TimelineGroup
+							key={ group.datetime.toString() }
+							group={ group }
+							orderBy={ orderBy }
+						/>
+					) ) }
+			</ul>
 		</div>
 	);
 };
@@ -133,4 +93,5 @@ Timeline.defaultProps = {
 	orderBy: 'desc',
 };
 
+export { orderByOptions, groupByOptions } from './util';
 export default Timeline;

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -97,9 +97,9 @@ Timeline.propTypes = {
 			 */
 			datetime: PropTypes.number.isRequired,
 			/**
-			 * GridIcon for the Timeline item.
+			 * Icon for the Timeline item.
 			 */
-			gridicon: PropTypes.string.isRequired,
+			icon: PropTypes.element.isRequired,
 			/**
 			 * Headline displayed for the list item.
 			 */

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -73,7 +73,9 @@ const Timeline = ( props ) => {
 	const timelineGroups = items
 		.reduce( itemsToGroups, [] )
 		.sort( sortMethod )
-		.map( ( g ) => <TimelineGroup key={ g.id.toString() } group={ g } /> );
+		.map( ( group ) => (
+			<TimelineGroup key={ group.id.toString() } group={ group } />
+		) );
 
 	return (
 		<div className={ timelineClassName }>

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import Card from '../card';
 import TimelineGroup from './timeline-group';
 
 const Timeline = ( props ) => {
@@ -48,9 +49,9 @@ const Timeline = ( props ) => {
 	) );
 
 	return (
-		<div className={ timelineClassName }>
+		<Card title={ 'Timeline' } className={ timelineClassName }>
 			<ul>{ timelineGroups }</ul>
-		</div>
+		</Card>
 	);
 };
 

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -125,7 +125,7 @@ Timeline.defaultProps = {
 	className: '',
 	items: [],
 	groupBy: 'day',
-	orderBy: 'asc',
+	orderBy: 'desc',
 };
 
 export default Timeline;

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -84,4 +84,9 @@ Timeline.propTypes = {
 	).isRequired,
 };
 
+Timeline.defaultProps = {
+	className: '',
+	items: [],
+};
+
 export default Timeline;

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -6,6 +6,31 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 
+const daysToTimelineItems = ( day, dayNum ) => {
+	const dayToTimelineItem = ( item, itemIndex ) => {
+		const itemTimeString = moment( item.datetime ).format( 'h:mma' );
+		const itemKey = dayNum + '-' + itemIndex;
+		return (
+			<li key={ itemKey }>
+				{ item.headline } <span>{ itemTimeString }</span>
+				{ item.body.map( function( line, bodyLineIndex ) {
+					const bodyLineKey =
+						dayNum + '-' + itemIndex + '-' + bodyLineIndex;
+					return <p key={ bodyLineKey }>{ line }</p>;
+				} ) }
+			</li>
+		);
+	};
+
+	const dayString = moment( dayNum.toString() ).format( 'MMMM D, YYYY' );
+	return (
+		<li key={ dayNum }>
+			{ dayString }
+			<ul>{ day.map( dayToTimelineItem ) }</ul>
+		</li>
+	);
+};
+
 const Timeline = ( { className, items } ) => {
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
 
@@ -38,46 +63,7 @@ const Timeline = ( { className, items } ) => {
 
 	return (
 		<div className={ timelineClassName }>
-			<ul>
-				{ days.map( function( day, dayNum ) {
-					const dayString = moment( dayNum ).format( 'MMMM D, YYYY' );
-					return (
-						<li key={ dayNum }>
-							{ dayString }
-							<ul>
-								{ day.map( function( item, itemIndex ) {
-									const itemTimeString = moment(
-										item.datetime
-									).format( 'h:mma' );
-									const itemKey = dayNum + '-' + itemIndex;
-									return (
-										<li key={ itemKey }>
-											{ item.headline }{ ' ' }
-											<span>{ itemTimeString }</span>
-											{ item.body.map( function(
-												line,
-												bodyLineIndex
-											) {
-												const bodyLineKey =
-													dayNum +
-													'-' +
-													itemIndex +
-													'-' +
-													bodyLineIndex;
-												return (
-													<p key={ bodyLineKey }>
-														{ line }
-													</p>
-												);
-											} ) }
-										</li>
-									);
-								} ) }
-							</ul>
-						</li>
-					);
-				} ) }
-			</ul>
+			<ul>{ days.map( daysToTimelineItems ) }</ul>
 		</div>
 	);
 };

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -13,7 +13,7 @@ const Timeline = ( { className, items } ) => {
 		return (
 			<div className={ timelineClassName }>
 				<p className="timeline_no_events">
-					{ __( 'No events to display' ) }
+					{ __( 'No events to display', 'woocommerce-admin' ) }
 				</p>
 			</div>
 		);

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -9,6 +9,16 @@ import { __ } from '@wordpress/i18n';
 const Timeline = ( { className, items } ) => {
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
 
+	if ( items.length === 0 ) {
+		return (
+			<div className={ timelineClassName }>
+				<p className="timeline_no_events">
+					{ __( 'No events to display' ) }
+				</p>
+			</div>
+		);
+	}
+
 	// Sort all the items reverse chronologically
 	items.sort( function( a, b ) {
 		return a.datetime - b.datetime;
@@ -26,16 +36,6 @@ const Timeline = ( { className, items } ) => {
 		days[ dayNum ].push( item );
 	} );
 
-	if ( 0 === items.length ) {
-		return (
-			<div className={ timelineClassName }>
-				<p className="timeline_no_events">
-					{ __( 'No events to display' ) }
-				</p>
-			</div>
-		);
-	}
-
 	return (
 		<div className={ timelineClassName }>
 			<ul>
@@ -46,13 +46,24 @@ const Timeline = ( { className, items } ) => {
 							{ dayString }
 							<ul>
 								{ day.map( function( item, itemIndex ) {
-									const itemTimeString = moment( item.datetime ).format( 'h:mma' );
+									const itemTimeString = moment(
+										item.datetime
+									).format( 'h:mma' );
 									const itemKey = dayNum + '-' + itemIndex;
 									return (
-										<li key={ itemKey } >
-											{ item.headline } <span>{ itemTimeString }</span>
-											{ item.body.map( function( line, bodyLineIndex ) {
-												const bodyLineKey = dayNum + '-' + itemIndex + '-' + bodyLineIndex;
+										<li key={ itemKey }>
+											{ item.headline }{ ' ' }
+											<span>{ itemTimeString }</span>
+											{ item.body.map( function(
+												line,
+												bodyLineIndex
+											) {
+												const bodyLineKey =
+													dayNum +
+													'-' +
+													itemIndex +
+													'-' +
+													bodyLineIndex;
 												return (
 													<p key={ bodyLineKey }>
 														{ line }
@@ -96,9 +107,7 @@ Timeline.propTypes = {
 			/**
 			 * Body displayed for the list item.
 			 */
-			body: PropTypes.arrayOf(
-				PropTypes.string
-			),
+			body: PropTypes.arrayOf( PropTypes.string ),
 		} )
 	).isRequired,
 };

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -108,6 +108,10 @@ Timeline.propTypes = {
 			 * Body displayed for the list item.
 			 */
 			body: PropTypes.arrayOf( PropTypes.element ),
+			/**
+			 * Allows users to toggle the timestamp on or off.
+			 */
+			hideTimestamp: PropTypes.bool,
 		} )
 	).isRequired,
 	/**

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -27,10 +26,10 @@ const Timeline = ( { className, items } ) => {
 		days[ dayNum ].push( item );
 	} );
 
-	if ( 0 === items.count ) {
+	if ( 0 === items.length ) {
 		return (
 			<div className={ timelineClassName }>
-				<p class="timeline_no_events">
+				<p className="timeline_no_events">
 					{ __( 'No events to display' ) }
 				</p>
 			</div>
@@ -46,14 +45,16 @@ const Timeline = ( { className, items } ) => {
 						<li key={ dayNum }>
 							{ dayString }
 							<ul>
-								{ day.map( function( item ) {
-									const timeString = moment( item.datetime ).format( 'h:mma' );
+								{ day.map( function( item, itemIndex ) {
+									const itemTimeString = moment( item.datetime ).format( 'h:mma' );
+									const itemKey = dayNum + '-' + itemIndex;
 									return (
-										<li>
-											{ item.headline } <span>{ timeString }</span>
-											{ item.body.map( function( line ) {
+										<li key={ itemKey } >
+											{ item.headline } <span>{ itemTimeString }</span>
+											{ item.body.map( function( line, bodyLineIndex ) {
+												const bodyLineKey = dayNum + '-' + itemIndex + '-' + bodyLineIndex;
 												return (
-													<p>
+													<p key={ bodyLineKey }>
 														{ line }
 													</p>
 												);

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -103,7 +103,7 @@ Timeline.propTypes = {
 			/**
 			 * Headline displayed for the list item.
 			 */
-			headline: PropTypes.string.isRequired,
+			headline: PropTypes.element.isRequired,
 			/**
 			 * Body displayed for the list item.
 			 */

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -11,7 +11,8 @@ import { __ } from '@wordpress/i18n';
  */
 import TimelineGroup from './timeline-group';
 
-const Timeline = ( { className, items } ) => {
+const Timeline = ( props ) => {
+	const { className, items } = props;
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
 
 	if ( ! items || items.length === 0 ) {

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -107,7 +107,7 @@ Timeline.propTypes = {
 			/**
 			 * Body displayed for the list item.
 			 */
-			body: PropTypes.arrayOf( PropTypes.string ),
+			body: PropTypes.arrayOf( PropTypes.element ),
 		} )
 	).isRequired,
 	/**

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -34,7 +34,7 @@ const Timeline = ( props ) => {
 					.sort( sortByDateUsing( orderBy ) )
 					.map( ( group ) => (
 						<TimelineGroup
-							key={ group.datetime.toString() }
+							key={ group.date.getTime().toString() }
 							group={ group }
 							orderBy={ orderBy }
 						/>
@@ -55,9 +55,9 @@ Timeline.propTypes = {
 	items: PropTypes.arrayOf(
 		PropTypes.shape( {
 			/**
-			 * Timestamp (in seconds) for the timeline item.
+			 * Date for the timeline item.
 			 */
-			datetime: PropTypes.number.isRequired,
+			date: PropTypes.instanceOf( Date ).isRequired,
 			/**
 			 * Icon for the Timeline item.
 			 */

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -4,6 +4,7 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
+import { format } from '@wordpress/date';
 
 /**
  * Internal dependencies
@@ -12,7 +13,14 @@ import TimelineGroup from './timeline-group';
 import { sortByDateUsing, groupItemsUsing } from './util';
 
 const Timeline = ( props ) => {
-	const { className, items, groupBy, orderBy } = props;
+	const {
+		className,
+		items,
+		groupBy,
+		orderBy,
+		dateFormat,
+		clockFormat,
+	} = props;
 	const timelineClassName = classnames( 'woocommerce-timeline', className );
 
 	// Early return in case no data was passed to the component.
@@ -26,17 +34,26 @@ const Timeline = ( props ) => {
 		);
 	}
 
+	const addGroupTitles = ( group ) => {
+		return {
+			...group,
+			title: format( dateFormat, group.date ),
+		};
+	};
+
 	return (
 		<div className={ timelineClassName }>
 			<ul>
 				{ items
 					.reduce( groupItemsUsing( groupBy ), [] )
+					.map( addGroupTitles )
 					.sort( sortByDateUsing( orderBy ) )
 					.map( ( group ) => (
 						<TimelineGroup
 							key={ group.date.getTime().toString() }
 							group={ group }
 							orderBy={ orderBy }
+							clockFormat={ clockFormat }
 						/>
 					) ) }
 			</ul>
@@ -89,6 +106,14 @@ Timeline.propTypes = {
 	 * Defines how groups should be ordered.
 	 */
 	orderBy: PropTypes.oneOf( [ 'asc', 'desc' ] ),
+	/**
+	 * The PHP date format string used to format dates, see php.net/date.
+	 */
+	dateFormat: PropTypes.string,
+	/**
+	 * The PHP clock format string used to format times, see php.net/date.
+	 */
+	clockFormat: PropTypes.string,
 };
 
 Timeline.defaultProps = {
@@ -96,6 +121,8 @@ Timeline.defaultProps = {
 	items: [],
 	groupBy: 'day',
 	orderBy: 'desc',
+	dateFormat: 'F j, Y',
+	clockFormat: 'g:ia',
 };
 
 export { orderByOptions, groupByOptions } from './util';

--- a/packages/components/src/timeline/index.js
+++ b/packages/components/src/timeline/index.js
@@ -121,8 +121,10 @@ Timeline.defaultProps = {
 	items: [],
 	groupBy: 'day',
 	orderBy: 'desc',
-	dateFormat: 'F j, Y',
-	clockFormat: 'g:ia',
+	/* translators: PHP date format string used to display dates, see php.net/date. */
+	dateFormat: __( 'F j, Y', 'woocommerce-admin' ),
+	/* translators: PHP clock format string used to display times, see php.net/date. */
+	clockFormat: __( 'g:ia', 'woocommerce-admin' ),
 };
 
 export { orderByOptions, groupByOptions } from './util';

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -37,7 +37,9 @@ export const Filled = () => (
 						{ text( 'event 1, second event', 'bar happened' ) }
 					</p>,
 				],
-				headline: text( 'event 1, headline', '2 events in body' ),
+				headline: (
+					<p>{ text( 'event 1, headline', '2 events in body' ) }</p>
+				),
 				icon: (
 					<GridIcon
 						className={ 'is-success' }
@@ -52,7 +54,7 @@ export const Filled = () => (
 					new Date( 2020, 0, 20, 23, 45 )
 				),
 				body: [],
-				headline: text( 'event 2, headline', 'empty body' ),
+				headline: <p>{ text( 'event 2, headline', 'empty body' ) }</p>,
 				icon: (
 					<GridIcon
 						className={ 'is-warning' }
@@ -72,7 +74,9 @@ export const Filled = () => (
 						{ text( 'event 3, second event', 'baz happened' ) }
 					</p>,
 				],
-				headline: text( 'event 3, headline', '1 event in body' ),
+				headline: (
+					<p>{ text( 'event 3, headline', '1 event in body' ) }</p>
+				),
 				icon: (
 					<GridIcon
 						className={ 'is-error' }

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -85,6 +85,21 @@ export const Filled = () => (
 					/>
 				),
 			},
+			{
+				datetime: itemDate(
+					'event 4 date',
+					new Date( 2020, 0, 17, 1, 45 )
+				),
+				headline: (
+					<p>{ text( 'event 4, headline', 'undefined body' ) }</p>
+				),
+				icon: (
+					<GridIcon
+						icon={ text( 'event 4 gridicon', 'cross' ) }
+						size={ 16 }
+					/>
+				),
+			},
 		] }
 	/>
 );

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { date, text } from '@storybook/addon-knobs';
+import GridIcon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -33,9 +34,14 @@ export const Filled = () => (
 					text( 'event 1, second event', 'bar happened' ),
 				],
 				headline: text( 'event 1, headline', '2 events in body' ),
-				gridicon: text(
-					'event 1 gridicon',
-					text( 'event 1 gridicon', 'checkmark' )
+				icon: (
+					<GridIcon
+						icon={ text(
+							'event 1 gridicon',
+							text( 'event 1 gridicon', 'checkmark' )
+						) }
+						size={ 16 }
+					/>
 				),
 			},
 			{
@@ -45,9 +51,14 @@ export const Filled = () => (
 				),
 				body: [],
 				headline: text( 'event 2, headline', 'empty body' ),
-				gridicon: text(
-					'event 2 gridicon',
-					text( 'event 2 gridicon', 'checkmark' )
+				icon: (
+					<GridIcon
+						icon={ text(
+							'event 2 gridicon',
+							text( 'event 2 gridicon', 'checkmark' )
+						) }
+						size={ 16 }
+					/>
 				),
 			},
 			{
@@ -57,9 +68,14 @@ export const Filled = () => (
 				),
 				body: [ text( 'event 3, second event', 'baz happened' ) ],
 				headline: text( 'event 3, headline', '1 event in body' ),
-				gridicon: text(
-					'event 3 gridicon',
-					text( 'event 3 gridicion', 'checkmark' )
+				icon: (
+					<GridIcon
+						icon={ text(
+							'event 3 gridicon',
+							text( 'event 3 gridicion', 'checkmark' )
+						) }
+						size={ 16 }
+					/>
 				),
 			},
 		] }

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -24,22 +24,43 @@ export const Filled = () => (
 	<Timeline
 		items={ [
 			{
-				datetime: itemDate( 'event 1 date', new Date( 'Jan 20 2020' ) ),
+				datetime: itemDate(
+					'event 1 date',
+					new Date( 2020, 0, 20, 1, 30 )
+				),
 				body: [
 					text( 'event 1, first event', 'foo happened' ),
 					text( 'event 1, second event', 'bar happened' ),
 				],
-				headline: text( 'event 1, headline', 'headline' ),
-				gridicon: text( 'event 1 gridicon', 'plus' ),
+				headline: text( 'event 1, headline', '2 events in body' ),
+				gridicon: text(
+					'event 1 gridicon',
+					text( 'event 1 gridicon', 'checkmark' )
+				),
 			},
 			{
-				datetime: itemDate( 'event 2 date', new Date( 'Jan 22 2020' ) ),
-				body: [
-					text( 'event 2, first event', 'foo happened' ),
-					text( 'event 2, second event', 'bar happened' ),
-				],
-				headline: text( 'event 2, headline', 'headline' ),
-				gridicon: text( 'event 2 gridicon', 'plus' ),
+				datetime: itemDate(
+					'event 2 date',
+					new Date( 2020, 0, 20, 23, 45 )
+				),
+				body: [],
+				headline: text( 'event 2, headline', 'empty body' ),
+				gridicon: text(
+					'event 2 gridicon',
+					text( 'event 2 gridicon', 'checkmark' )
+				),
+			},
+			{
+				datetime: itemDate(
+					'event 3 date',
+					new Date( 2020, 0, 22, 15, 13 )
+				),
+				body: [ text( 'event 3, second event', 'baz happened' ) ],
+				headline: text( 'event 3, headline', '1 event in body' ),
+				gridicon: text(
+					'event 3 gridicon',
+					text( 'event 3 gridicion', 'checkmark' )
+				),
 			},
 		] }
 	/>

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -32,14 +32,12 @@ export const Filled = () => (
 				),
 				body: [
 					<p key={ '1' }>
-						{ text( 'event 1, first event', 'foo happened' ) }
+						{ text( 'event 1, first event', 'p element in body' ) }
 					</p>,
-					<p key={ '2' }>
-						{ text( 'event 1, second event', 'bar happened' ) }
-					</p>,
+					text( 'event 1, second event', 'string in body' ),
 				],
 				headline: (
-					<p>{ text( 'event 1, headline', '2 events in body' ) }</p>
+					<p>{ text( 'event 1, headline', 'p tag in headline' ) }</p>
 				),
 				icon: (
 					<GridIcon
@@ -56,7 +54,11 @@ export const Filled = () => (
 					new Date( 2020, 0, 20, 23, 45 )
 				),
 				body: [],
-				headline: <p>{ text( 'event 2, headline', 'empty body' ) }</p>,
+				headline: (
+					<span>
+						{ text( 'event 2, headline', 'span in headline' ) }
+					</span>
+				),
 				icon: (
 					<GridIcon
 						className={ 'is-warning' }
@@ -71,13 +73,11 @@ export const Filled = () => (
 					new Date( 2020, 0, 22, 15, 13 )
 				),
 				body: [
-					<p key={ '1' }>
-						{ text( 'event 3, second event', 'baz happened' ) }
-					</p>,
+					<span key={ '1' }>
+						{ text( 'event 3, second event', 'span in body' ) }
+					</span>,
 				],
-				headline: (
-					<p>{ text( 'event 3, headline', '1 event in body' ) }</p>
-				),
+				headline: text( 'event 3, headline', 'string in headline' ),
 				icon: (
 					<GridIcon
 						className={ 'is-error' }
@@ -91,8 +91,9 @@ export const Filled = () => (
 					'event 4 date',
 					new Date( 2020, 0, 17, 1, 45 )
 				),
-				headline: (
-					<p>{ text( 'event 4, headline', 'undefined body' ) }</p>
+				headline: text(
+					'event 4, headline',
+					'undefined body and string headline'
 				),
 				icon: (
 					<GridIcon

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -7,7 +7,7 @@ import GridIcon from 'gridicons';
 /**
  * Internal dependencies
  */
-import Timeline from '../';
+import Timeline, { orderByOptions } from '../';
 
 export default {
 	title: 'WooCommerce Admin/components/Timeline',
@@ -23,6 +23,7 @@ const itemDate = ( label, value ) => {
 
 export const Filled = () => (
 	<Timeline
+		orderBy={ orderByOptions.DESC }
 		items={ [
 			{
 				datetime: itemDate(
@@ -47,6 +48,7 @@ export const Filled = () => (
 						size={ 16 }
 					/>
 				),
+				hideTimestamp: true,
 			},
 			{
 				datetime: itemDate(
@@ -62,7 +64,6 @@ export const Filled = () => (
 						size={ 16 }
 					/>
 				),
-				hideTimestamp: true,
 			},
 			{
 				datetime: itemDate(

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -60,6 +60,7 @@ export const Filled = () => (
 						size={ 16 }
 					/>
 				),
+				hideTimestamp: true,
 			},
 			{
 				datetime: itemDate(

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { date, text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import Timeline from '../';
+
+export default {
+	title: 'WooCommerce Admin/components/Timeline',
+	component: Timeline,
+};
+
+export const Empty = () => <Timeline />;
+
+const itemDate = ( label, value ) => {
+	const d = date( label, value );
+	return parseInt( d, 10 ) / 1000;
+};
+
+export const Filled = () => (
+	<Timeline
+		items={ [
+			{
+				datetime: itemDate( 'event 1 date', new Date( 'Jan 20 2020' ) ),
+				body: [
+					text( 'event 1, first event', 'foo happened' ),
+					text( 'event 1, second event', 'bar happened' ),
+				],
+				headline: text( 'event 1, headline', 'headline' ),
+				gridicon: text( 'event 1 gridicon', 'plus' ),
+			},
+			{
+				datetime: itemDate( 'event 2 date', new Date( 'Jan 22 2020' ) ),
+				body: [
+					text( 'event 2, first event', 'foo happened' ),
+					text( 'event 2, second event', 'bar happened' ),
+				],
+				headline: text( 'event 2, headline', 'headline' ),
+				gridicon: text( 'event 2 gridicon', 'plus' ),
+			},
+		] }
+	/>
+);

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -30,8 +30,12 @@ export const Filled = () => (
 					new Date( 2020, 0, 20, 1, 30 )
 				),
 				body: [
-					text( 'event 1, first event', 'foo happened' ),
-					text( 'event 1, second event', 'bar happened' ),
+					<p key={ '1' }>
+						{ text( 'event 1, first event', 'foo happened' ) }
+					</p>,
+					<p key={ '2' }>
+						{ text( 'event 1, second event', 'bar happened' ) }
+					</p>,
 				],
 				headline: text( 'event 1, headline', '2 events in body' ),
 				icon: (
@@ -62,7 +66,11 @@ export const Filled = () => (
 					'event 3 date',
 					new Date( 2020, 0, 22, 15, 13 )
 				),
-				body: [ text( 'event 3, second event', 'baz happened' ) ],
+				body: [
+					<p key={ '1' }>
+						{ text( 'event 3, second event', 'baz happened' ) }
+					</p>,
+				],
 				headline: text( 'event 3, headline', '1 event in body' ),
 				icon: (
 					<GridIcon

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -36,10 +36,8 @@ export const Filled = () => (
 				headline: text( 'event 1, headline', '2 events in body' ),
 				icon: (
 					<GridIcon
-						icon={ text(
-							'event 1 gridicon',
-							text( 'event 1 gridicon', 'checkmark' )
-						) }
+						className={ 'is-success' }
+						icon={ text( 'event 1 gridicon', 'checkmark' ) }
 						size={ 16 }
 					/>
 				),
@@ -53,10 +51,8 @@ export const Filled = () => (
 				headline: text( 'event 2, headline', 'empty body' ),
 				icon: (
 					<GridIcon
-						icon={ text(
-							'event 2 gridicon',
-							text( 'event 2 gridicon', 'checkmark' )
-						) }
+						className={ 'is-warning' }
+						icon={ text( 'event 2 gridicon', 'refresh' ) }
 						size={ 16 }
 					/>
 				),
@@ -70,10 +66,8 @@ export const Filled = () => (
 				headline: text( 'event 3, headline', '1 event in body' ),
 				icon: (
 					<GridIcon
-						icon={ text(
-							'event 3 gridicon',
-							text( 'event 3 gridicion', 'checkmark' )
-						) }
+						className={ 'is-error' }
+						icon={ text( 'event 3 gridicon', 'cross' ) }
 						size={ 16 }
 					/>
 				),

--- a/packages/components/src/timeline/stories/index.js
+++ b/packages/components/src/timeline/stories/index.js
@@ -18,7 +18,7 @@ export const Empty = () => <Timeline />;
 
 const itemDate = ( label, value ) => {
 	const d = date( label, value );
-	return parseInt( d, 10 ) / 1000;
+	return new Date( d );
 };
 
 export const Filled = () => (
@@ -26,7 +26,7 @@ export const Filled = () => (
 		orderBy={ orderByOptions.DESC }
 		items={ [
 			{
-				datetime: itemDate(
+				date: itemDate(
 					'event 1 date',
 					new Date( 2020, 0, 20, 1, 30 )
 				),
@@ -49,7 +49,7 @@ export const Filled = () => (
 				hideTimestamp: true,
 			},
 			{
-				datetime: itemDate(
+				date: itemDate(
 					'event 2 date',
 					new Date( 2020, 0, 20, 23, 45 )
 				),
@@ -68,7 +68,7 @@ export const Filled = () => (
 				),
 			},
 			{
-				datetime: itemDate(
+				date: itemDate(
 					'event 3 date',
 					new Date( 2020, 0, 22, 15, 13 )
 				),
@@ -87,7 +87,7 @@ export const Filled = () => (
 				),
 			},
 			{
-				datetime: itemDate(
+				date: itemDate(
 					'event 4 date',
 					new Date( 2020, 0, 17, 1, 45 )
 				),

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -1,41 +1,47 @@
 
 .woocommerce-timeline {
 	ul {
-		list-style-type: none;
+		margin: 0;
 		padding-left: 0;
+		list-style-type: none;
 	}
 
 	.woocommerce-timeline-group {
 		.woocommerce-timeline-group__title {
-			text-transform: uppercase;
-			font-weight: 600;
-			font-size: 12px;
 			color: $studio-gray-90;
+			font-size: 12px;
+			font-weight: 600;
+			text-transform: uppercase;
+
+			margin: 0;
 		}
 
 		hr {
 			float: right;
 			width: calc(100% - #{ $gap-largest });
+
+			margin-bottom: $gap;
+
 			// Color is according to design, we should probably find a suitable color variable.
 			border: 0.5px solid #e3dfe2;
-			margin: $gap-largest 0;
 		}
 	}
 
 	.woocommerce-timeline-item {
 		.woocommerce-timeline-item__title {
 			display: flex;
+			align-items: center;
 			flex-direction: row;
 			justify-content: space-between;
-			align-items: center;
-			font-size: 16px;
+
 			color: $studio-gray-80;
+			font-size: 16px;
 		}
 
 		.woocommerce-timeline-item__headline {
 			display: flex;
-			flex-direction: row;
 			align-items: center;
+			flex-direction: row;
 
 			span {
 				padding: $gap;
@@ -43,18 +49,22 @@
 
 			svg {
 				fill: $studio-white;
+				padding: $gap-smallest;
 				background: $studio-gray-10;
 				border-radius: 9999px;
-				padding: $gap-smallest;
 			}
 		}
 
 		.woocommerce-timeline-item__body {
-			border-left: 1px solid $studio-gray-10;
-			padding: $gap $gap-larger;
-			margin-left: calc(#{ $gap-small } + 1px);
+			display: flex;
+			flex-direction: column;
+
 			color: $studio-gray-60;
 			font-size: 14px;
+
+			margin: 0 calc(#{ $gap-small } + 1px);
+			padding: $gap-smaller $gap-larger;
+			border-left: 1px solid $studio-gray-10;
 		}
 	}
 }

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -56,8 +56,9 @@
 			flex-direction: row;
 			margin: $gap-smaller 0;
 
-			span {
+			* {
 				padding: 0 $gap;
+				margin: 0;
 			}
 
 			svg {

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -69,6 +69,18 @@
 				// We hard code the size to maintain consistent styling and spacing.
 				width: 16px;
 				height: 16px;
+
+				&.is-success {
+					background: $valid-green;
+				}
+
+				&.is-warning {
+					background: $notice-yellow;
+				}
+
+				&.is-error {
+					background: $error-red;
+				}
 			}
 		}
 

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -45,14 +45,14 @@
 				fill: $studio-white;
 				background: $studio-gray-10;
 				border-radius: 9999px;
-				padding: $gap-smaller;
+				padding: $gap-smallest;
 			}
 		}
 
 		.woocommerce-timeline-item__body {
 			border-left: 1px solid $studio-gray-10;
 			padding: $gap $gap-larger;
-			margin-left: $gap;
+			margin-left: calc(#{ $gap-small } + 1px);
 			color: $studio-gray-60;
 			font-size: 14px;
 		}

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -99,6 +99,11 @@
 			margin: 0 $gap-small;
 			padding: $gap-smaller $gap-larger;
 			border-left: 1px solid $studio-gray-10;
+
+			// Make sure child elements fit tightly together.
+			* {
+				margin: 0;
+			}
 		}
 	}
 }

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -4,6 +4,10 @@
 		margin: 0;
 		padding-left: 0;
 		list-style-type: none;
+
+		li {
+			margin-bottom: 0;
+		}
 	}
 
 	.woocommerce-timeline-group {
@@ -40,8 +44,10 @@
 			flex-direction: row;
 			justify-content: space-between;
 
-			color: $studio-gray-80;
-			font-size: 16px;
+			p {
+				color: $studio-gray-80;
+				font-size: 16px;
+			}
 		}
 
 		.woocommerce-timeline-item__headline {
@@ -56,11 +62,13 @@
 
 			svg {
 				fill: $studio-white;
-				min-width: 16px;
-				min-height: 16px;
 				padding: $gap-smallest;
 				background: $studio-gray-10;
 				border-radius: 9999px;
+				box-sizing: content-box;
+				// We hard code the size to maintain consistent styling and spacing.
+				width: 16px;
+				height: 16px;
 			}
 		}
 

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -5,33 +5,33 @@
 		padding-left: 0;
 	}
 
-	hr {
-		float: right;
-		width: calc(100% - 56px);
-		margin-left: 0;
-		margin-right: 0;
-		// Color is according to design, we should probably find a suitable color variable.
-		border: 0.5px solid #e3dfe2;
-	}
-
 	.woocommerce-timeline-group {
-		padding: $gap;
-
 		.woocommerce-timeline-group__title {
 			text-transform: uppercase;
 			font-weight: 600;
+			font-size: 12px;
+			color: $studio-gray-90;
+		}
+
+		hr {
+			float: right;
+			width: calc(100% - #{ $gap-largest });
+			// Color is according to design, we should probably find a suitable color variable.
+			border: 0.5px solid #e3dfe2;
+			margin: $gap-largest 0;
 		}
 	}
 
 	.woocommerce-timeline-item {
-		padding-bottom: $gap;
-
 		.woocommerce-timeline-item__title {
 			display: flex;
 			flex-direction: row;
 			justify-content: space-between;
 			align-items: center;
+			font-size: 16px;
+			color: $studio-gray-80;
 		}
+
 		.woocommerce-timeline-item__headline {
 			display: flex;
 			flex-direction: row;
@@ -48,10 +48,13 @@
 				padding: $gap-smaller;
 			}
 		}
+
 		.woocommerce-timeline-item__body {
 			border-left: 1px solid $studio-gray-10;
-			padding: $gap 0 $gap 2*$gap;
+			padding: $gap $gap-larger;
 			margin-left: $gap;
+			color: $studio-gray-60;
+			font-size: 14px;
 		}
 	}
 }

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -1,0 +1,62 @@
+
+.woocommerce-timeline {
+	ul {
+		list-style-type: none;
+		padding-left: 0;
+	}
+
+	hr {
+		float: right;
+		width: calc(100% - 56px);
+		margin-left: 0;
+		margin-right: 0;
+		// Color is according to design, we should probably find a suitable color variable.
+		border: 0.5px solid #e3dfe2;
+	}
+
+	.woocommerce-timeline-group {
+		padding: $gap;
+
+		.woocommerce-timeline-group__title {
+			text-transform: uppercase;
+			font-weight: 600;
+		}
+	}
+
+	.woocommerce-timeline-item {
+		padding-bottom: $gap;
+
+		.woocommerce-timeline-item__title {
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			align-items: center;
+		}
+		.woocommerce-timeline-item__headline {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+
+			span {
+				padding: $gap;
+			}
+
+			svg {
+				fill: $studio-white;
+				background: $studio-gray-10;
+				border-radius: 9999px;
+				padding: $gap-smaller;
+			}
+		}
+		.woocommerce-timeline-item__body {
+			border-left: 1px solid $studio-gray-10;
+			padding: $gap 0 $gap 2*$gap;
+			margin-left: $gap;
+		}
+	}
+}
+
+// Hide last <hr /> element.
+.woocommerce-timeline ul :last-child.woocommerce-timeline-group hr:last-child {
+	display: none;
+}

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -28,6 +28,12 @@
 	}
 
 	.woocommerce-timeline-item {
+		.woocommerce-timeline-item__top-border {
+			min-height: 16px;
+			border-left: 1px solid $studio-gray-10;
+			margin: 0 $gap-small;
+		}
+
 		.woocommerce-timeline-item__title {
 			display: flex;
 			align-items: center;

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -18,6 +18,11 @@
 			text-transform: uppercase;
 
 			margin: 0 0 $gap 0;
+
+			// Overrides the default `display: block` for p elements in the title.
+			// This is done to prevent soft line breaks from appearing in shorter
+			// titles.
+			display: inline-block;
 		}
 
 		hr {

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -57,8 +57,10 @@
 			margin: $gap-smaller 0;
 
 			* {
-				padding: 0 $gap;
 				margin: 0;
+			}
+			& > * {
+				padding: 0 $gap;
 			}
 
 			svg {

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -43,9 +43,9 @@
 			align-items: center;
 			flex-direction: row;
 			justify-content: space-between;
+			color: $studio-gray-80;
 
-			p {
-				color: $studio-gray-80;
+			* {
 				font-size: 16px;
 			}
 		}
@@ -97,7 +97,6 @@
 			flex-direction: column;
 
 			color: $studio-gray-60;
-			font-size: 14px;
 
 			margin: 0 $gap-small;
 			padding: $gap-smaller $gap-larger;
@@ -106,6 +105,7 @@
 			// Make sure child elements fit tightly together.
 			* {
 				margin: 0;
+				font-size: 14px;
 			}
 		}
 	}

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -42,7 +42,7 @@
 			display: flex;
 			align-items: center;
 			flex-direction: row;
-			margin: $gap-small 0; 
+			margin: $gap-smaller 0;
 
 			span {
 				padding: 0 $gap;
@@ -50,9 +50,8 @@
 
 			svg {
 				fill: $studio-white;
-				width: 16px;
 				min-width: 16px;
-				height: 16px;
+				min-height: 16px;
 				padding: $gap-smallest;
 				background: $studio-gray-10;
 				border-radius: 9999px;
@@ -72,7 +71,7 @@
 			font-size: 14px;
 
 			margin: 0 $gap-small;
-			padding: $gap-smallest $gap-larger;
+			padding: $gap-smaller $gap-larger;
 			border-left: 1px solid $studio-gray-10;
 		}
 	}

--- a/packages/components/src/timeline/style.scss
+++ b/packages/components/src/timeline/style.scss
@@ -13,7 +13,7 @@
 			font-weight: 600;
 			text-transform: uppercase;
 
-			margin: 0;
+			margin: 0 0 $gap 0;
 		}
 
 		hr {
@@ -42,17 +42,26 @@
 			display: flex;
 			align-items: center;
 			flex-direction: row;
+			margin: $gap-small 0; 
 
 			span {
-				padding: $gap;
+				padding: 0 $gap;
 			}
 
 			svg {
 				fill: $studio-white;
+				width: 16px;
+				min-width: 16px;
+				height: 16px;
 				padding: $gap-smallest;
 				background: $studio-gray-10;
 				border-radius: 9999px;
 			}
+		}
+
+		.woocommerce-timeline-item__timestamp {
+			font-size: 14px;
+			line-height: 16px;
 		}
 
 		.woocommerce-timeline-item__body {
@@ -62,8 +71,8 @@
 			color: $studio-gray-60;
 			font-size: 14px;
 
-			margin: 0 calc(#{ $gap-small } + 1px);
-			padding: $gap-smaller $gap-larger;
+			margin: 0 $gap-small;
+			padding: $gap-smallest $gap-larger;
 			border-left: 1px solid $studio-gray-10;
 		}
 	}

--- a/packages/components/src/timeline/test/__snapshots__/index.js.snap
+++ b/packages/components/src/timeline/test/__snapshots__/index.js.snap
@@ -1,0 +1,231 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Timeline Empty snapshot 1`] = `
+<div
+  className="woocommerce-timeline"
+>
+  <p
+    className="timeline_no_events"
+  >
+    No data to display
+  </p>
+</div>
+`;
+
+exports[`Timeline With data snapshot 1`] = `
+<div
+  className="woocommerce-timeline"
+>
+  <ul>
+    <li
+      className="woocommerce-timeline-group"
+    >
+      <p
+        className="woocommerce-timeline-group__title"
+      >
+        January 22, 2020
+      </p>
+      <ul>
+        <li
+          className="woocommerce-timeline-item"
+        >
+          <div
+            className="woocommerce-timeline-item__top-border"
+          />
+          <div
+            className="woocommerce-timeline-item__title"
+          >
+            <div
+              className="woocommerce-timeline-item__headline"
+            >
+              <svg
+                className="gridicon gridicons-cross is-error"
+                height={16}
+                viewBox="0 0 24 24"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"
+                  />
+                </g>
+              </svg>
+              <span>
+                string in headline
+              </span>
+            </div>
+            <span
+              className="woocommerce-timeline-item__timestamp"
+            >
+              3:13pm
+            </span>
+          </div>
+          <div
+            className="woocommerce-timeline-item__body"
+          >
+            <span>
+              <span>
+                span in body
+              </span>
+            </span>
+          </div>
+        </li>
+      </ul>
+      <hr />
+    </li>
+    <li
+      className="woocommerce-timeline-group"
+    >
+      <p
+        className="woocommerce-timeline-group__title"
+      >
+        January 20, 2020
+      </p>
+      <ul>
+        <li
+          className="woocommerce-timeline-item"
+        >
+          <div
+            className="woocommerce-timeline-item__top-border"
+          />
+          <div
+            className="woocommerce-timeline-item__title"
+          >
+            <div
+              className="woocommerce-timeline-item__headline"
+            >
+              <svg
+                className="gridicon gridicons-refresh is-warning"
+                height={16}
+                viewBox="0 0 24 24"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M17.91 14c-.478 2.833-2.943 5-5.91 5-3.308 0-6-2.692-6-6s2.692-6 6-6h2.172l-2.086 2.086L13.5 10.5 18 6l-4.5-4.5-1.414 1.414L14.172 5H12c-4.418 0-8 3.582-8 8s3.582 8 8 8c4.08 0 7.438-3.055 7.93-7h-2.02z"
+                  />
+                </g>
+              </svg>
+              <span>
+                <span>
+                  span in headline
+                </span>
+              </span>
+            </div>
+            <span
+              className="woocommerce-timeline-item__timestamp"
+            >
+              11:45pm
+            </span>
+          </div>
+          <div
+            className="woocommerce-timeline-item__body"
+          />
+        </li>
+        <li
+          className="woocommerce-timeline-item"
+        >
+          <div
+            className="woocommerce-timeline-item__top-border"
+          />
+          <div
+            className="woocommerce-timeline-item__title"
+          >
+            <div
+              className="woocommerce-timeline-item__headline"
+            >
+              <svg
+                className="gridicon gridicons-checkmark is-success"
+                height={16}
+                viewBox="0 0 24 24"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"
+                  />
+                </g>
+              </svg>
+              <span>
+                <p>
+                  p tag in headline
+                </p>
+              </span>
+            </div>
+            <span
+              className="woocommerce-timeline-item__timestamp"
+            />
+          </div>
+          <div
+            className="woocommerce-timeline-item__body"
+          >
+            <span>
+              <p>
+                p element in body
+              </p>
+            </span>
+            <span>
+              string in body
+            </span>
+          </div>
+        </li>
+      </ul>
+      <hr />
+    </li>
+    <li
+      className="woocommerce-timeline-group"
+    >
+      <p
+        className="woocommerce-timeline-group__title"
+      >
+        January 17, 2020
+      </p>
+      <ul>
+        <li
+          className="woocommerce-timeline-item"
+        >
+          <div
+            className="woocommerce-timeline-item__top-border"
+          />
+          <div
+            className="woocommerce-timeline-item__title"
+          >
+            <div
+              className="woocommerce-timeline-item__headline"
+            >
+              <svg
+                className="gridicon gridicons-cross"
+                height={16}
+                viewBox="0 0 24 24"
+                width={16}
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <g>
+                  <path
+                    d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z"
+                  />
+                </g>
+              </svg>
+              <span>
+                undefined body and string headline
+              </span>
+            </div>
+            <span
+              className="woocommerce-timeline-item__timestamp"
+            >
+              1:45am
+            </span>
+          </div>
+          <div
+            className="woocommerce-timeline-item__body"
+          />
+        </li>
+      </ul>
+      <hr />
+    </li>
+  </ul>
+</div>
+`;

--- a/packages/components/src/timeline/test/index.js
+++ b/packages/components/src/timeline/test/index.js
@@ -10,6 +10,7 @@ import renderer from 'react-test-renderer';
  */
 import Timeline from '..';
 import mockData from '../__mocks__/timeline-mock-data';
+import { sortByDateUsing } from '../util.js';
 
 describe( 'Timeline', () => {
 	test( 'Renders empty correctly', () => {
@@ -100,7 +101,39 @@ describe( 'Timeline', () => {
 	} );
 
 	describe( 'Timeline utilities', () => {
-		test.todo( 'Sorts correctly' );
+		test( 'Sorts correctly', () => {
+			const data = [
+				{ id: 0, datetime: new Date( 2020, 0, 22 ) },
+				{ id: 1, datetime: new Date( 2020, 0, 21 ) },
+				{ id: 2, datetime: new Date( 2020, 0, 23 ) },
+			];
+			const expectedAsc = [
+				{ id: 1, datetime: new Date( 2020, 0, 21 ) },
+				{ id: 0, datetime: new Date( 2020, 0, 22 ) },
+				{ id: 2, datetime: new Date( 2020, 0, 23 ) },
+			];
+			const expectedDesc = [
+				{ id: 2, datetime: new Date( 2020, 0, 23 ) },
+				{ id: 0, datetime: new Date( 2020, 0, 22 ) },
+				{ id: 1, datetime: new Date( 2020, 0, 21 ) },
+			];
+
+			expect( data.sort( sortByDateUsing( 'asc' ) ) ).toStrictEqual(
+				expectedAsc
+			);
+			expect( data.sort( sortByDateUsing( 'desc' ) ) ).toStrictEqual(
+				expectedDesc
+			);
+		} );
+
+		test( "Empty item list doesn't break sort", () => {
+			expect( [].sort( sortByDateUsing( 'asc' ) ) ).toStrictEqual( [] );
+		} );
+
+		test( "Single item doesn't change on sort", () => {
+			const items = [ { datetime: new Date( 2020, 0, 1 ) } ];
+			expect( items.sort( sortByDateUsing( 'asc' ) ) ).toBe( items );
+		} );
 
 		test.todo( 'Groups correctly' );
 	} );

--- a/packages/components/src/timeline/test/index.js
+++ b/packages/components/src/timeline/test/index.js
@@ -1,0 +1,107 @@
+/* eslint-disable jest/no-mocks-import */
+/**
+ * External dependencies
+ */
+import { shallow, mount } from 'enzyme';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import Timeline from '..';
+import mockData from '../__mocks__/timeline-mock-data';
+
+describe( 'Timeline', () => {
+	test( 'Renders empty correctly', () => {
+		const timeline = shallow( <Timeline /> );
+		expect( timeline.find( '.timeline_no_events' ).length ).toBe( 1 );
+		expect(
+			timeline
+				.find( '.timeline_no_events' )
+				.first()
+				.contains( 'No data to display' )
+		).toBe( true );
+	} );
+
+	test( 'Renders data correctly', () => {
+		const timeline = mount( <Timeline items={ mockData } /> );
+
+		// Ensure correct divs are loaded.
+		expect( timeline.find( '.timeline_no_events' ).length ).toBe( 0 );
+		expect( timeline.find( '.woocommerce-timeline' ).length ).toBe( 1 );
+
+		// Ensure groups have the correct number of items.
+		expect( timeline.find( '.woocommerce-timeline-group' ).length ).toBe(
+			3
+		);
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-group ul' )
+				.at( 0 )
+				.children().length
+		).toBe( 1 );
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-group ul' )
+				.at( 1 )
+				.children().length
+		).toBe( 2 );
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-group ul' )
+				.at( 2 )
+				.children().length
+		).toBe( 1 );
+
+		// Ensure dates are correctly rendered.
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-group__title' )
+				.first()
+				.text()
+		).toBe( 'January 22, 2020' );
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-group__title' )
+				.last()
+				.text()
+		).toBe( 'January 17, 2020' );
+
+		// Ensure the correct number of items is rendered.
+		expect( timeline.find( '.woocommerce-timeline-item' ).length ).toBe(
+			4
+		);
+
+		// Ensure hidden timestamps are actually hidden and vice versa.
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-item__timestamp' )
+				.at( 2 )
+				.text()
+		).toBe( '' );
+		expect(
+			timeline
+				.find( '.woocommerce-timeline-item__timestamp' )
+				.at( 1 )
+				.text()
+		).not.toBe( '' );
+	} );
+
+	test( 'Empty snapshot', () => {
+		const tree = renderer.create( <Timeline /> ).toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'With data snapshot', () => {
+		const tree = renderer
+			.create( <Timeline items={ mockData } /> )
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	describe( 'Timeline utilities', () => {
+		test.todo( 'Sorts correctly' );
+
+		test.todo( 'Groups correctly' );
+	} );
+} );

--- a/packages/components/src/timeline/test/index.js
+++ b/packages/components/src/timeline/test/index.js
@@ -10,7 +10,7 @@ import renderer from 'react-test-renderer';
  */
 import Timeline from '..';
 import mockData from '../__mocks__/timeline-mock-data';
-import { sortByDateUsing } from '../util.js';
+import { groupItemsUsing, sortByDateUsing } from '../util.js';
 
 describe( 'Timeline', () => {
 	test( 'Renders empty correctly', () => {
@@ -102,20 +102,24 @@ describe( 'Timeline', () => {
 
 	describe( 'Timeline utilities', () => {
 		test( 'Sorts correctly', () => {
+			const jan21 = new Date( 2020, 0, 21 ).getTime() / 1000;
+			const jan22 = new Date( 2020, 0, 22 ).getTime() / 1000;
+			const jan23 = new Date( 2020, 0, 23 ).getTime() / 1000;
+
 			const data = [
-				{ id: 0, datetime: new Date( 2020, 0, 22 ) },
-				{ id: 1, datetime: new Date( 2020, 0, 21 ) },
-				{ id: 2, datetime: new Date( 2020, 0, 23 ) },
+				{ id: 0, datetime: jan22 },
+				{ id: 1, datetime: jan21 },
+				{ id: 2, datetime: jan23 },
 			];
 			const expectedAsc = [
-				{ id: 1, datetime: new Date( 2020, 0, 21 ) },
-				{ id: 0, datetime: new Date( 2020, 0, 22 ) },
-				{ id: 2, datetime: new Date( 2020, 0, 23 ) },
+				{ id: 1, datetime: jan21 },
+				{ id: 0, datetime: jan22 },
+				{ id: 2, datetime: jan23 },
 			];
 			const expectedDesc = [
-				{ id: 2, datetime: new Date( 2020, 0, 23 ) },
-				{ id: 0, datetime: new Date( 2020, 0, 22 ) },
-				{ id: 1, datetime: new Date( 2020, 0, 21 ) },
+				{ id: 2, datetime: jan23 },
+				{ id: 0, datetime: jan22 },
+				{ id: 1, datetime: jan21 },
 			];
 
 			expect( data.sort( sortByDateUsing( 'asc' ) ) ).toStrictEqual(
@@ -131,10 +135,60 @@ describe( 'Timeline', () => {
 		} );
 
 		test( "Single item doesn't change on sort", () => {
-			const items = [ { datetime: new Date( 2020, 0, 1 ) } ];
+			const items = [
+				{ datetime: new Date( 2020, 0, 1 ).getTime() / 1000 },
+			];
 			expect( items.sort( sortByDateUsing( 'asc' ) ) ).toBe( items );
 		} );
 
-		test.todo( 'Groups correctly' );
+		test( 'Groups correctly', () => {
+			const jan22 = new Date( 2020, 0, 22 ).getTime() / 1000;
+			const jan23 = new Date( 2020, 0, 23 ).getTime() / 1000;
+			const items = [
+				{ id: 0, datetime: jan22 },
+				{ id: 1, datetime: jan23 },
+				{ id: 2, datetime: jan22 },
+			];
+			const expected = [
+				{
+					datetime: jan22,
+					title: 'January 22, 2020',
+					items: [
+						{ id: 0, datetime: jan22 },
+						{ id: 2, datetime: jan22 },
+					],
+				},
+				{
+					datetime: jan23,
+					title: 'January 23, 2020',
+					items: [ { id: 1, datetime: jan23 } ],
+				},
+			];
+
+			expect(
+				items.reduce( groupItemsUsing( 'days' ), [] )
+			).toStrictEqual( expected );
+		} );
+
+		test( "Empty item list doesn't break grouping", () => {
+			expect( [].reduce( groupItemsUsing( 'days' ), [] ) ).toStrictEqual(
+				[]
+			);
+		} );
+
+		test( 'Single item grouped correctly', () => {
+			const jan22 = new Date( 2020, 0, 22 ).getTime() / 1000;
+			const items = [ { id: 0, datetime: jan22 } ];
+			const expected = [
+				{
+					datetime: jan22,
+					title: 'January 22, 2020',
+					items: [ { id: 0, datetime: jan22 } ],
+				},
+			];
+			expect(
+				items.reduce( groupItemsUsing( 'days' ), [] )
+			).toStrictEqual( expected );
+		} );
 	} );
 } );

--- a/packages/components/src/timeline/test/index.js
+++ b/packages/components/src/timeline/test/index.js
@@ -150,7 +150,6 @@ describe( 'Timeline', () => {
 			const expected = [
 				{
 					date: jan22,
-					title: 'January 22, 2020',
 					items: [
 						{ id: 0, date: jan22 },
 						{ id: 2, date: jan22 },
@@ -158,7 +157,6 @@ describe( 'Timeline', () => {
 				},
 				{
 					date: jan23,
-					title: 'January 23, 2020',
 					items: [ { id: 1, date: jan23 } ],
 				},
 			];
@@ -180,7 +178,6 @@ describe( 'Timeline', () => {
 			const expected = [
 				{
 					date: jan22,
-					title: 'January 22, 2020',
 					items: [ { id: 0, date: jan22 } ],
 				},
 			];

--- a/packages/components/src/timeline/test/index.js
+++ b/packages/components/src/timeline/test/index.js
@@ -102,24 +102,24 @@ describe( 'Timeline', () => {
 
 	describe( 'Timeline utilities', () => {
 		test( 'Sorts correctly', () => {
-			const jan21 = new Date( 2020, 0, 21 ).getTime() / 1000;
-			const jan22 = new Date( 2020, 0, 22 ).getTime() / 1000;
-			const jan23 = new Date( 2020, 0, 23 ).getTime() / 1000;
+			const jan21 = new Date( 2020, 0, 21 );
+			const jan22 = new Date( 2020, 0, 22 );
+			const jan23 = new Date( 2020, 0, 23 );
 
 			const data = [
-				{ id: 0, datetime: jan22 },
-				{ id: 1, datetime: jan21 },
-				{ id: 2, datetime: jan23 },
+				{ id: 0, date: jan22 },
+				{ id: 1, date: jan21 },
+				{ id: 2, date: jan23 },
 			];
 			const expectedAsc = [
-				{ id: 1, datetime: jan21 },
-				{ id: 0, datetime: jan22 },
-				{ id: 2, datetime: jan23 },
+				{ id: 1, date: jan21 },
+				{ id: 0, date: jan22 },
+				{ id: 2, date: jan23 },
 			];
 			const expectedDesc = [
-				{ id: 2, datetime: jan23 },
-				{ id: 0, datetime: jan22 },
-				{ id: 1, datetime: jan21 },
+				{ id: 2, date: jan23 },
+				{ id: 0, date: jan22 },
+				{ id: 1, date: jan21 },
 			];
 
 			expect( data.sort( sortByDateUsing( 'asc' ) ) ).toStrictEqual(
@@ -135,33 +135,31 @@ describe( 'Timeline', () => {
 		} );
 
 		test( "Single item doesn't change on sort", () => {
-			const items = [
-				{ datetime: new Date( 2020, 0, 1 ).getTime() / 1000 },
-			];
+			const items = [ { date: new Date( 2020, 0, 1 ) } ];
 			expect( items.sort( sortByDateUsing( 'asc' ) ) ).toBe( items );
 		} );
 
 		test( 'Groups correctly', () => {
-			const jan22 = new Date( 2020, 0, 22 ).getTime() / 1000;
-			const jan23 = new Date( 2020, 0, 23 ).getTime() / 1000;
+			const jan22 = new Date( 2020, 0, 22 );
+			const jan23 = new Date( 2020, 0, 23 );
 			const items = [
-				{ id: 0, datetime: jan22 },
-				{ id: 1, datetime: jan23 },
-				{ id: 2, datetime: jan22 },
+				{ id: 0, date: jan22 },
+				{ id: 1, date: jan23 },
+				{ id: 2, date: jan22 },
 			];
 			const expected = [
 				{
-					datetime: jan22,
+					date: jan22,
 					title: 'January 22, 2020',
 					items: [
-						{ id: 0, datetime: jan22 },
-						{ id: 2, datetime: jan22 },
+						{ id: 0, date: jan22 },
+						{ id: 2, date: jan22 },
 					],
 				},
 				{
-					datetime: jan23,
+					date: jan23,
 					title: 'January 23, 2020',
-					items: [ { id: 1, datetime: jan23 } ],
+					items: [ { id: 1, date: jan23 } ],
 				},
 			];
 
@@ -177,13 +175,13 @@ describe( 'Timeline', () => {
 		} );
 
 		test( 'Single item grouped correctly', () => {
-			const jan22 = new Date( 2020, 0, 22 ).getTime() / 1000;
-			const items = [ { id: 0, datetime: jan22 } ];
+			const jan22 = new Date( 2020, 0, 22 );
+			const items = [ { id: 0, date: jan22 } ];
 			const expected = [
 				{
-					datetime: jan22,
+					date: jan22,
 					title: 'January 22, 2020',
-					items: [ { id: 0, datetime: jan22 } ],
+					items: [ { id: 0, date: jan22 } ],
 				},
 			];
 			expect(

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -61,7 +61,7 @@ TimelineGroup.propTypes = {
 				/**
 				 * Headline displayed for the list item.
 				 */
-				headline: PropTypes.string.isRequired,
+				headline: PropTypes.element.isRequired,
 				/**
 				 * Body displayed for the list item.
 				 */

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -65,7 +65,7 @@ TimelineGroup.propTypes = {
 				/**
 				 * Body displayed for the list item.
 				 */
-				body: PropTypes.arrayOf( PropTypes.string ),
+				body: PropTypes.arrayOf( PropTypes.element ),
 			} )
 		).isRequired,
 	} ).isRequired,

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -27,8 +27,11 @@ const TimelineGroup = ( props ) => {
 
 	return (
 		<li className={ groupClassName }>
-			{ dayString }
+			<p className={ 'woocommerce-timeline-group__title' }>
+				{ dayString }
+			</p>
 			<ul>{ timelineItems }</ul>
+			<hr />
 		</li>
 	);
 };

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -3,6 +3,7 @@
  */
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -10,7 +11,11 @@ import PropTypes from 'prop-types';
 import TimelineItem from './timeline-item';
 
 const TimelineGroup = ( props ) => {
-	const { items, groupKey } = props;
+	const { items, groupKey, className } = props;
+	const groupClassName = classnames(
+		'woocommerce-timeline-group',
+		className
+	);
 
 	const timelineItems = items.map( ( item, itemIndex ) => {
 		const itemKey = groupKey + '-' + itemIndex;
@@ -21,7 +26,7 @@ const TimelineGroup = ( props ) => {
 	const dayString = moment( groupKey ).format( 'MMMM D, YYYY' );
 
 	return (
-		<li>
+		<li className={ groupClassName }>
 			{ dayString }
 			<ul>{ timelineItems }</ul>
 		</li>

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -11,24 +10,21 @@ import classnames from 'classnames';
 import TimelineItem from './timeline-item';
 
 const TimelineGroup = ( props ) => {
-	const { items, groupKey, className } = props;
+	const { group, className } = props;
 	const groupClassName = classnames(
 		'woocommerce-timeline-group',
 		className
 	);
 
-	const timelineItems = items.map( ( item, itemIndex ) => {
-		const itemKey = groupKey + '-' + itemIndex;
-		return (
-			<TimelineItem key={ itemKey } item={ item } itemKey={ itemKey } />
-		);
+	const timelineItems = group.items.map( ( item, itemIndex ) => {
+		const itemKey = group.title + '-' + itemIndex;
+		return <TimelineItem key={ itemKey } item={ item } />;
 	} );
-	const dayString = moment( groupKey ).format( 'MMMM D, YYYY' );
 
 	return (
 		<li className={ groupClassName }>
 			<p className={ 'woocommerce-timeline-group__title' }>
-				{ dayString }
+				{ group.title }
 			</p>
 			<ul>{ timelineItems }</ul>
 			<hr />
@@ -42,35 +38,45 @@ TimelineGroup.propTypes = {
 	 */
 	className: PropTypes.string,
 	/**
-	 * An array of list items.
+	 * The group to render.
 	 */
-	items: PropTypes.arrayOf(
-		PropTypes.shape( {
-			/**
-			 * Timestamp (in seconds) for the timeline item.
-			 */
-			datetime: PropTypes.number.isRequired,
-			/**
-			 * GridIcon for the Timeline item.
-			 */
-			gridicon: PropTypes.string.isRequired,
-			/**
-			 * Headline displayed for the list item.
-			 */
-			headline: PropTypes.string.isRequired,
-			/**
-			 * Body displayed for the list item.
-			 */
-			body: PropTypes.arrayOf( PropTypes.string ),
-		} )
-	).isRequired,
-	groupKey: PropTypes.string.isRequired,
+	group: PropTypes.shape( {
+		/**
+		 * The group title.
+		 */
+		title: PropTypes.string,
+		/**
+		 * An array of list items.
+		 */
+		items: PropTypes.arrayOf(
+			PropTypes.shape( {
+				/**
+				 * Timestamp (in seconds) for the timeline item.
+				 */
+				datetime: PropTypes.number.isRequired,
+				/**
+				 * GridIcon for the Timeline item.
+				 */
+				gridicon: PropTypes.string.isRequired,
+				/**
+				 * Headline displayed for the list item.
+				 */
+				headline: PropTypes.string.isRequired,
+				/**
+				 * Body displayed for the list item.
+				 */
+				body: PropTypes.arrayOf( PropTypes.string ),
+			} )
+		).isRequired,
+	} ).isRequired,
 };
 
 TimelineGroup.defaultProps = {
 	className: '',
-	items: [],
-	groupKey: '00000000',
+	group: {
+		title: '',
+		items: [],
+	},
 };
 
 export default TimelineGroup;

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -11,16 +11,14 @@ import TimelineItem from './timeline-item';
 
 const TimelineGroup = ( props ) => {
 	const { items, groupKey } = props;
-	const dayString = moment( groupKey.toString() ).format( 'MMMM D, YYYY' );
 
-	const dayToTimelineItem = ( item, itemIndex ) => {
+	const timelineItems = items.map( ( item, itemIndex ) => {
 		const itemKey = groupKey + '-' + itemIndex;
 		return (
 			<TimelineItem key={ itemKey } item={ item } itemKey={ itemKey } />
 		);
-	};
-
-	const timelineItems = items.map( dayToTimelineItem );
+	} );
+	const dayString = moment( groupKey ).format( 'MMMM D, YYYY' );
 
 	return (
 		<li>
@@ -58,7 +56,7 @@ TimelineGroup.propTypes = {
 			body: PropTypes.arrayOf( PropTypes.string ),
 		} )
 	).isRequired,
-	groupKey: PropTypes.number.isRequired,
+	groupKey: PropTypes.string.isRequired,
 };
 
 export default TimelineGroup;

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -8,25 +8,29 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import TimelineItem from './timeline-item';
+import { sortByDateUsing } from './util';
 
 const TimelineGroup = ( props ) => {
-	const { group, className } = props;
+	const { group, className, orderBy } = props;
 	const groupClassName = classnames(
 		'woocommerce-timeline-group',
 		className
 	);
-
-	const timelineItems = group.items.map( ( item, itemIndex ) => {
+	const itemsToTimlineItem = ( item, itemIndex ) => {
 		const itemKey = group.title + '-' + itemIndex;
 		return <TimelineItem key={ itemKey } item={ item } />;
-	} );
+	};
 
 	return (
 		<li className={ groupClassName }>
 			<p className={ 'woocommerce-timeline-group__title' }>
 				{ group.title }
 			</p>
-			<ul>{ timelineItems }</ul>
+			<ul>
+				{ group.items
+					.sort( sortByDateUsing( orderBy ) )
+					.map( itemsToTimlineItem ) }
+			</ul>
 			<hr />
 		</li>
 	);
@@ -73,6 +77,10 @@ TimelineGroup.propTypes = {
 			} )
 		).isRequired,
 	} ).isRequired,
+	/**
+	 * Defines how items should be ordered.
+	 */
+	orderBy: PropTypes.oneOf( [ 'asc', 'desc' ] ),
 };
 
 TimelineGroup.defaultProps = {
@@ -81,6 +89,7 @@ TimelineGroup.defaultProps = {
 		title: '',
 		items: [],
 	},
+	orderBy: 'desc',
 };
 
 export default TimelineGroup;

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -55,9 +55,9 @@ TimelineGroup.propTypes = {
 				 */
 				datetime: PropTypes.number.isRequired,
 				/**
-				 * GridIcon for the Timeline item.
+				 * Icon for the Timeline item.
 				 */
-				gridicon: PropTypes.string.isRequired,
+				icon: PropTypes.element.isRequired,
 				/**
 				 * Headline displayed for the list item.
 				 */

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -64,4 +64,10 @@ TimelineGroup.propTypes = {
 	groupKey: PropTypes.string.isRequired,
 };
 
+TimelineGroup.defaultProps = {
+	className: '',
+	items: [],
+	groupKey: '00000000',
+};
+
 export default TimelineGroup;

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -65,11 +65,19 @@ TimelineGroup.propTypes = {
 				/**
 				 * Headline displayed for the list item.
 				 */
-				headline: PropTypes.element.isRequired,
+				headline: PropTypes.oneOfType( [
+					PropTypes.element,
+					PropTypes.string,
+				] ).isRequired,
 				/**
 				 * Body displayed for the list item.
 				 */
-				body: PropTypes.arrayOf( PropTypes.element ),
+				body: PropTypes.arrayOf(
+					PropTypes.oneOfType( [
+						PropTypes.element,
+						PropTypes.string,
+					] )
+				),
 				/**
 				 * Allows users to toggle the timestamp on or off.
 				 */

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TimelineItem from './timeline-item';
+
+const TimelineGroup = ( props ) => {
+	const { items, groupKey } = props;
+	const dayString = moment( groupKey.toString() ).format( 'MMMM D, YYYY' );
+
+	const dayToTimelineItem = ( item, itemIndex ) => {
+		const itemKey = groupKey + '-' + itemIndex;
+		return (
+			<TimelineItem key={ itemKey } item={ item } itemKey={ itemKey } />
+		);
+	};
+
+	const timelineItems = items.map( dayToTimelineItem );
+
+	return (
+		<li>
+			{ dayString }
+			<ul>{ timelineItems }</ul>
+		</li>
+	);
+};
+
+TimelineGroup.propTypes = {
+	/**
+	 * Additional CSS classes.
+	 */
+	className: PropTypes.string,
+	/**
+	 * An array of list items.
+	 */
+	items: PropTypes.arrayOf(
+		PropTypes.shape( {
+			/**
+			 * Timestamp (in seconds) for the timeline item.
+			 */
+			datetime: PropTypes.number.isRequired,
+			/**
+			 * GridIcon for the Timeline item.
+			 */
+			gridicon: PropTypes.string.isRequired,
+			/**
+			 * Headline displayed for the list item.
+			 */
+			headline: PropTypes.string.isRequired,
+			/**
+			 * Body displayed for the list item.
+			 */
+			body: PropTypes.arrayOf( PropTypes.string ),
+		} )
+	).isRequired,
+	groupKey: PropTypes.number.isRequired,
+};
+
+export default TimelineGroup;

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -66,6 +66,10 @@ TimelineGroup.propTypes = {
 				 * Body displayed for the list item.
 				 */
 				body: PropTypes.arrayOf( PropTypes.element ),
+				/**
+				 * Allows users to toggle the timestamp on or off.
+				 */
+				hideTimestamp: PropTypes.bool,
 			} )
 		).isRequired,
 	} ).isRequired,

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -11,14 +11,20 @@ import TimelineItem from './timeline-item';
 import { sortByDateUsing } from './util';
 
 const TimelineGroup = ( props ) => {
-	const { group, className, orderBy } = props;
+	const { group, className, orderBy, clockFormat } = props;
 	const groupClassName = classnames(
 		'woocommerce-timeline-group',
 		className
 	);
 	const itemsToTimlineItem = ( item, itemIndex ) => {
 		const itemKey = group.title + '-' + itemIndex;
-		return <TimelineItem key={ itemKey } item={ item } />;
+		return (
+			<TimelineItem
+				key={ itemKey }
+				item={ item }
+				clockFormat={ clockFormat }
+			/>
+		);
 	};
 
 	return (
@@ -89,6 +95,10 @@ TimelineGroup.propTypes = {
 	 * Defines how items should be ordered.
 	 */
 	orderBy: PropTypes.oneOf( [ 'asc', 'desc' ] ),
+	/**
+	 * The PHP clock format string used to format times, see php.net/date.
+	 */
+	clockFormat: PropTypes.string,
 };
 
 TimelineGroup.defaultProps = {

--- a/packages/components/src/timeline/timeline-group.js
+++ b/packages/components/src/timeline/timeline-group.js
@@ -55,9 +55,9 @@ TimelineGroup.propTypes = {
 		items: PropTypes.arrayOf(
 			PropTypes.shape( {
 				/**
-				 * Timestamp (in seconds) for the timeline item.
+				 * Date for the timeline item.
 				 */
-				datetime: PropTypes.number.isRequired,
+				date: PropTypes.instanceOf( Date ).isRequired,
 				/**
 				 * Icon for the Timeline item.
 				 */

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -16,7 +16,7 @@ const TimelineItem = ( props ) => {
 		const bodyLineKey = itemKey + '-' + bodyLineIndex;
 		return <p key={ bodyLineKey }>{ line }</p>;
 	} );
-	const itemTimeString = moment( item.datetime ).format( 'h:mma' );
+	const itemTimeString = moment.unix( item.datetime ).format( 'h:mma' );
 
 	return (
 		<li className={ itemClassName }>

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+const TimelineItem = ( props ) => {
+	const { item, itemKey } = props;
+
+	const itemTimeString = moment( item.datetime ).format( 'h:mma' );
+	const itemBody = item.body.map( ( line, bodyLineIndex ) => {
+		const bodyLineKey = itemKey + '-' + bodyLineIndex;
+		return <p key={ bodyLineKey }>{ line }</p>;
+	} );
+
+	return (
+		<li>
+			{ item.headline } <span>{ itemTimeString }</span>
+			{ itemBody }
+		</li>
+	);
+};
+
+TimelineItem.propTypes = {
+	/**
+	 * Additional CSS classes.
+	 */
+	className: PropTypes.string,
+	/**
+	 * An array of list items.
+	 */
+	item: PropTypes.shape( {
+		/**
+		 * Timestamp (in seconds) for the timeline item.
+		 */
+		datetime: PropTypes.number.isRequired,
+		/**
+		 * GridIcon for the Timeline item.
+		 */
+		gridicon: PropTypes.string.isRequired,
+		/**
+		 * Headline displayed for the list item.
+		 */
+		headline: PropTypes.string.isRequired,
+		/**
+		 * Body displayed for the list item.
+		 */
+		body: PropTypes.arrayOf( PropTypes.string ),
+	} ).isRequired,
+	/**
+	 * The index of this item in the items array.
+	 */
+	itemKey: PropTypes.string.isRequired,
+};
+
+export default TimelineItem;

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 
 const TimelineItem = ( props ) => {
-	const { item, itemKey } = props;
+	const { item, itemKey, className } = props;
+	const itemClassName = classnames( 'woocommerce-timeline-item', className );
 
 	const itemBody = item.body.map( ( line, bodyLineIndex ) => {
 		const bodyLineKey = itemKey + '-' + bodyLineIndex;
@@ -14,7 +16,7 @@ const TimelineItem = ( props ) => {
 	const itemTimeString = moment( item.datetime ).format( 'h:mma' );
 
 	return (
-		<li>
+		<li className={ itemClassName }>
 			{ item.headline } <span>{ itemTimeString }</span>
 			{ itemBody }
 		</li>

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -24,7 +24,7 @@ const TimelineItem = ( props ) => {
 				</span>
 			</div>
 			<div className={ 'woocommerce-timeline-item__body' }>
-				{ item.body }
+				{ item.body || [] }
 			</div>
 		</li>
 	);

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -7,11 +7,11 @@ import PropTypes from 'prop-types';
 const TimelineItem = ( props ) => {
 	const { item, itemKey } = props;
 
-	const itemTimeString = moment( item.datetime ).format( 'h:mma' );
 	const itemBody = item.body.map( ( line, bodyLineIndex ) => {
 		const bodyLineKey = itemKey + '-' + bodyLineIndex;
 		return <p key={ bodyLineKey }>{ line }</p>;
 	} );
+	const itemTimeString = moment( item.datetime ).format( 'h:mma' );
 
 	return (
 		<li>

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -55,4 +55,10 @@ TimelineItem.propTypes = {
 	itemKey: PropTypes.string.isRequired,
 };
 
+TimelineItem.defaultProps = {
+	className: '',
+	item: {},
+	itemKey: '00000000-0',
+};
+
 export default TimelineItem;

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -9,11 +9,11 @@ import GridIcon from 'gridicons';
 const GRIDICON_SIZE = 18;
 
 const TimelineItem = ( props ) => {
-	const { item, itemKey, className } = props;
+	const { item, className } = props;
 	const itemClassName = classnames( 'woocommerce-timeline-item', className );
 
 	const itemBody = item.body.map( ( line, bodyLineIndex ) => {
-		const bodyLineKey = itemKey + '-' + bodyLineIndex;
+		const bodyLineKey = item.datetime + '-' + bodyLineIndex;
 		return <p key={ bodyLineKey }>{ line }</p>;
 	} );
 	const itemTimeString = moment.unix( item.datetime ).format( 'h:mma' );
@@ -60,16 +60,11 @@ TimelineItem.propTypes = {
 		 */
 		body: PropTypes.arrayOf( PropTypes.string ),
 	} ).isRequired,
-	/**
-	 * The index of this item in the items array.
-	 */
-	itemKey: PropTypes.string.isRequired,
 };
 
 TimelineItem.defaultProps = {
 	className: '',
 	item: {},
-	itemKey: '00000000-0',
 };
 
 export default TimelineItem;

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -17,14 +17,18 @@ const TimelineItem = ( props ) => {
 			<div className={ 'woocommerce-timeline-item__title' }>
 				<div className={ 'woocommerce-timeline-item__headline' }>
 					{ item.icon }
-					{ item.headline }
+					<span>{ item.headline }</span>
 				</div>
 				<span className={ 'woocommerce-timeline-item__timestamp' }>
 					{ item.hideTimestamp || false ? null : itemTimeString }
 				</span>
 			</div>
 			<div className={ 'woocommerce-timeline-item__body' }>
-				{ item.body || [] }
+				{ ( item.body || [] ).map( ( bodyItem, index ) => (
+					<span key={ `timeline-item-body-${ index }` }>
+						{ bodyItem }
+					</span>
+				) ) }
 			</div>
 		</li>
 	);
@@ -50,11 +54,14 @@ TimelineItem.propTypes = {
 		/**
 		 * Headline displayed for the list item.
 		 */
-		headline: PropTypes.element.isRequired,
+		headline: PropTypes.oneOfType( [ PropTypes.element, PropTypes.string ] )
+			.isRequired,
 		/**
 		 * Body displayed for the list item.
 		 */
-		body: PropTypes.arrayOf( PropTypes.element ),
+		body: PropTypes.arrayOf(
+			PropTypes.oneOfType( [ PropTypes.element, PropTypes.string ] )
+		),
 		/**
 		 * Allows users to toggle the timestamp on or off.
 		 */

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -4,9 +4,6 @@
 import classnames from 'classnames';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import GridIcon from 'gridicons';
-
-const GRIDICON_SIZE = 18;
 
 const TimelineItem = ( props ) => {
 	const { item, className } = props;
@@ -23,7 +20,7 @@ const TimelineItem = ( props ) => {
 			<div className={ 'woocommerce-timeline-item__top-border' }></div>
 			<div className={ 'woocommerce-timeline-item__title' }>
 				<p className={ 'woocommerce-timeline-item__headline' }>
-					<GridIcon icon={ item.gridicon } size={ GRIDICON_SIZE } />
+					{ item.icon }
 					<span>{ item.headline }</span>
 				</p>
 				<span className={ 'woocommerce-timeline-item__timestamp' }>
@@ -49,9 +46,9 @@ TimelineItem.propTypes = {
 		 */
 		datetime: PropTypes.number.isRequired,
 		/**
-		 * GridIcon for the Timeline item.
+		 * Icon for the Timeline item.
 		 */
-		gridicon: PropTypes.string.isRequired,
+		icon: PropTypes.element.isRequired,
 		/**
 		 * Headline displayed for the list item.
 		 */

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -15,10 +15,10 @@ const TimelineItem = ( props ) => {
 		<li className={ itemClassName }>
 			<div className={ 'woocommerce-timeline-item__top-border' }></div>
 			<div className={ 'woocommerce-timeline-item__title' }>
-				<p className={ 'woocommerce-timeline-item__headline' }>
+				<div className={ 'woocommerce-timeline-item__headline' }>
 					{ item.icon }
-					<span>{ item.headline }</span>
-				</p>
+					{ item.headline }
+				</div>
 				<span className={ 'woocommerce-timeline-item__timestamp' }>
 					{ item.hideTimestamp || false ? null : itemTimeString }
 				</span>
@@ -50,7 +50,7 @@ TimelineItem.propTypes = {
 		/**
 		 * Headline displayed for the list item.
 		 */
-		headline: PropTypes.string.isRequired,
+		headline: PropTypes.element.isRequired,
 		/**
 		 * Body displayed for the list item.
 		 */

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -7,12 +7,8 @@ import PropTypes from 'prop-types';
 
 const TimelineItem = ( props ) => {
 	const { item, className } = props;
-	const itemClassName = classnames( 'woocommerce-timeline-item', className );
 
-	const itemBody = item.body.map( ( line, bodyLineIndex ) => {
-		const bodyLineKey = item.datetime + '-' + bodyLineIndex;
-		return <span key={ bodyLineKey }>{ line }</span>;
-	} );
+	const itemClassName = classnames( 'woocommerce-timeline-item', className );
 	const itemTimeString = moment.unix( item.datetime ).format( 'h:mma' );
 
 	return (
@@ -27,7 +23,9 @@ const TimelineItem = ( props ) => {
 					{ itemTimeString }
 				</span>
 			</div>
-			<p className={ 'woocommerce-timeline-item__body' }>{ itemBody }</p>
+			<div className={ 'woocommerce-timeline-item__body' }>
+				{ item.body }
+			</div>
 		</li>
 	);
 };
@@ -56,7 +54,7 @@ TimelineItem.propTypes = {
 		/**
 		 * Body displayed for the list item.
 		 */
-		body: PropTypes.arrayOf( PropTypes.string ),
+		body: PropTypes.arrayOf( PropTypes.element ),
 	} ).isRequired,
 };
 

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -14,7 +14,7 @@ const TimelineItem = ( props ) => {
 
 	const itemBody = item.body.map( ( line, bodyLineIndex ) => {
 		const bodyLineKey = item.datetime + '-' + bodyLineIndex;
-		return <p key={ bodyLineKey }>{ line }</p>;
+		return <span key={ bodyLineKey }>{ line }</span>;
 	} );
 	const itemTimeString = moment.unix( item.datetime ).format( 'h:mma' );
 
@@ -27,9 +27,7 @@ const TimelineItem = ( props ) => {
 				</p>
 				<span>{ itemTimeString }</span>
 			</div>
-			<div className={ 'woocommerce-timeline-item__body' }>
-				{ itemBody }
-			</div>
+			<p className={ 'woocommerce-timeline-item__body' }>{ itemBody }</p>
 		</li>
 	);
 };

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -25,7 +25,7 @@ const TimelineItem = ( props ) => {
 					<GridIcon icon={ item.gridicon } size={ GRIDICON_SIZE } />
 					<span>{ item.headline }</span>
 				</p>
-				<span>{ itemTimeString }</span>
+				<span className={ 'woocommerce-timeline-item__timestamp' }>{ itemTimeString }</span>
 			</div>
 			<p className={ 'woocommerce-timeline-item__body' }>{ itemBody }</p>
 		</li>

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import GridIcon from 'gridicons';
 
-const GRIDICON_SIZE = 16;
+const GRIDICON_SIZE = 18;
 
 const TimelineItem = ( props ) => {
 	const { item, className } = props;

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -6,7 +6,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import GridIcon from 'gridicons';
 
-const GRIDICON_SIZE = 18;
+const GRIDICON_SIZE = 16;
 
 const TimelineItem = ( props ) => {
 	const { item, className } = props;
@@ -20,12 +20,15 @@ const TimelineItem = ( props ) => {
 
 	return (
 		<li className={ itemClassName }>
+			<div className={ 'woocommerce-timeline-item__top-border' }></div>
 			<div className={ 'woocommerce-timeline-item__title' }>
 				<p className={ 'woocommerce-timeline-item__headline' }>
 					<GridIcon icon={ item.gridicon } size={ GRIDICON_SIZE } />
 					<span>{ item.headline }</span>
 				</p>
-				<span className={ 'woocommerce-timeline-item__timestamp' }>{ itemTimeString }</span>
+				<span className={ 'woocommerce-timeline-item__timestamp' }>
+					{ itemTimeString }
+				</span>
 			</div>
 			<p className={ 'woocommerce-timeline-item__body' }>{ itemBody }</p>
 		</li>

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -20,7 +20,7 @@ const TimelineItem = ( props ) => {
 					<span>{ item.headline }</span>
 				</p>
 				<span className={ 'woocommerce-timeline-item__timestamp' }>
-					{ itemTimeString }
+					{ item.hideTimestamp || false ? null : itemTimeString }
 				</span>
 			</div>
 			<div className={ 'woocommerce-timeline-item__body' }>
@@ -55,6 +55,10 @@ TimelineItem.propTypes = {
 		 * Body displayed for the list item.
 		 */
 		body: PropTypes.arrayOf( PropTypes.element ),
+		/**
+		 * Allows users to toggle the timestamp on or off.
+		 */
+		hideTimestamp: PropTypes.bool,
 	} ).isRequired,
 };
 

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -4,6 +4,9 @@
 import classnames from 'classnames';
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import GridIcon from 'gridicons';
+
+const GRIDICON_SIZE = 18;
 
 const TimelineItem = ( props ) => {
 	const { item, itemKey, className } = props;
@@ -17,8 +20,16 @@ const TimelineItem = ( props ) => {
 
 	return (
 		<li className={ itemClassName }>
-			{ item.headline } <span>{ itemTimeString }</span>
-			{ itemBody }
+			<div className={ 'woocommerce-timeline-item__title' }>
+				<p className={ 'woocommerce-timeline-item__headline' }>
+					<GridIcon icon={ item.gridicon } size={ GRIDICON_SIZE } />
+					<span>{ item.headline }</span>
+				</p>
+				<span>{ itemTimeString }</span>
+			</div>
+			<div className={ 'woocommerce-timeline-item__body' }>
+				{ itemBody }
+			</div>
 		</li>
 	);
 };

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import moment from 'moment';
+import { format } from '@wordpress/date';
 import PropTypes from 'prop-types';
 
 const TimelineItem = ( props ) => {
-	const { item, className } = props;
+	const { item, className, clockFormat } = props;
 
 	const itemClassName = classnames( 'woocommerce-timeline-item', className );
-	const itemTimeString = moment( item.date ).format( 'h:mma' );
+	const itemTimeString = format( clockFormat, item.date );
 
 	return (
 		<li className={ itemClassName }>
@@ -66,6 +66,10 @@ TimelineItem.propTypes = {
 		 * Allows users to toggle the timestamp on or off.
 		 */
 		hideTimestamp: PropTypes.bool,
+		/**
+		 * The PHP clock format string used to format times, see php.net/date.
+		 */
+		clockFormat: PropTypes.string,
 	} ).isRequired,
 };
 

--- a/packages/components/src/timeline/timeline-item.js
+++ b/packages/components/src/timeline/timeline-item.js
@@ -9,7 +9,7 @@ const TimelineItem = ( props ) => {
 	const { item, className } = props;
 
 	const itemClassName = classnames( 'woocommerce-timeline-item', className );
-	const itemTimeString = moment.unix( item.datetime ).format( 'h:mma' );
+	const itemTimeString = moment( item.date ).format( 'h:mma' );
 
 	return (
 		<li className={ itemClassName }>
@@ -44,9 +44,9 @@ TimelineItem.propTypes = {
 	 */
 	item: PropTypes.shape( {
 		/**
-		 * Timestamp (in seconds) for the timeline item.
+		 * Date for the timeline item.
 		 */
-		datetime: PropTypes.number.isRequired,
+		date: PropTypes.instanceOf( Date ).isRequired,
 		/**
 		 * Icon for the Timeline item.
 		 */

--- a/packages/components/src/timeline/util.js
+++ b/packages/components/src/timeline/util.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+const orderByOptions = {
+	ASC: 'asc',
+	DESC: 'desc',
+};
+
+const groupByOptions = {
+	DAY: 'day',
+	WEEK: 'week',
+	MONTH: 'month',
+};
+
+const sortAscending = ( groupA, groupB ) => groupA.datetime - groupB.datetime;
+const sortDescending = ( groupA, groupB ) => groupB.datetime - groupA.datetime;
+
+const sortByDateUsing = ( orderBy ) => {
+	switch ( orderBy ) {
+		case orderByOptions.ASC:
+			return sortAscending;
+		case orderByOptions.DESC:
+		default:
+			return sortDescending;
+	}
+};
+
+const groupItemsUsing = ( groupBy ) => ( groups, newItem ) => {
+	// Helper functions defined to make the logic a bit more readable.
+	const timeToMoment = ( ts ) => moment.unix( ts );
+	const hasSameMoment = ( group, item ) => {
+		return timeToMoment( group.datetime ).isSame(
+			timeToMoment( item.datetime ),
+			groupBy
+		);
+	};
+	const groupIndexExists = ( index ) => index >= 0;
+	const groupForItem = groups.findIndex( ( group ) =>
+		hasSameMoment( group, newItem )
+	);
+
+	if ( ! groupIndexExists( groupForItem ) ) {
+		// Create new group for newItem.
+		return [
+			...groups,
+			{
+				datetime: newItem.datetime,
+				title: timeToMoment( newItem.datetime ).format(
+					'MMMM D, YYYY'
+				),
+				items: [ newItem ],
+			},
+		];
+	}
+
+	groups[ groupForItem ].items.push( newItem );
+	return groups;
+};
+
+export { groupByOptions, groupItemsUsing, orderByOptions, sortByDateUsing };

--- a/packages/components/src/timeline/util.js
+++ b/packages/components/src/timeline/util.js
@@ -45,7 +45,6 @@ const groupItemsUsing = ( groupBy ) => ( groups, newItem ) => {
 			...groups,
 			{
 				date: newItem.date,
-				title: moment( newItem.date ).format( 'MMMM D, YYYY' ),
 				items: [ newItem ],
 			},
 		];

--- a/packages/components/src/timeline/util.js
+++ b/packages/components/src/timeline/util.js
@@ -14,8 +14,10 @@ const groupByOptions = {
 	MONTH: 'month',
 };
 
-const sortAscending = ( groupA, groupB ) => groupA.datetime - groupB.datetime;
-const sortDescending = ( groupA, groupB ) => groupB.datetime - groupA.datetime;
+const sortAscending = ( groupA, groupB ) =>
+	groupA.date.getTime() - groupB.date.getTime();
+const sortDescending = ( groupA, groupB ) =>
+	groupB.date.getTime() - groupA.date.getTime();
 
 const sortByDateUsing = ( orderBy ) => {
 	switch ( orderBy ) {
@@ -29,12 +31,8 @@ const sortByDateUsing = ( orderBy ) => {
 
 const groupItemsUsing = ( groupBy ) => ( groups, newItem ) => {
 	// Helper functions defined to make the logic a bit more readable.
-	const timeToMoment = ( ts ) => moment.unix( ts );
 	const hasSameMoment = ( group, item ) => {
-		return timeToMoment( group.datetime ).isSame(
-			timeToMoment( item.datetime ),
-			groupBy
-		);
+		return moment( group.date ).isSame( moment( item.date ), groupBy );
 	};
 	const groupIndexExists = ( index ) => index >= 0;
 	const groupForItem = groups.findIndex( ( group ) =>
@@ -46,10 +44,8 @@ const groupItemsUsing = ( groupBy ) => ( groups, newItem ) => {
 		return [
 			...groups,
 			{
-				datetime: newItem.datetime,
-				title: timeToMoment( newItem.datetime ).format(
-					'MMMM D, YYYY'
-				),
+				date: newItem.date,
+				title: moment( newItem.date ).format( 'MMMM D, YYYY' ),
 				items: [ newItem ],
 			},
 		];


### PR DESCRIPTION
This adds a Timeline component that will be used in another WooCommerce project. The usage instructions can be found in the README that's been added in the `timeline` source folder.

![image](https://user-images.githubusercontent.com/13835680/80659232-efcd9800-8aba-11ea-92ca-880f1cf8fa83.png)


### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

Make sure unit tests succeed:
- `npm test packages/components/src/timeline`

Do a round of manual testing using Storybook
- `npm run storybook`
- Make sure both the `Empty` and `Filled` stories work as expected.
- Mess around with the knobs and make sure component behaves as expected.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
