### PR TITLE
Update PHP 5.6 in Travis test matrix to WC 3.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
   - name: "PHP 5.6 unit tests"
     php: 5.6
-    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
+    env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress WC_VERSION=3.8.1
   allow_failures:
     php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_RANDOM=1

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -170,7 +170,11 @@ install_deps() {
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
 
 	# Install WooCommerce (latest non-hyphenated (beta, RC) tag)
-	LATEST_WC_TAG="$(git ls-remote --tags https://github.com/woocommerce/woocommerce.git | awk '{print $2}' | sed 's/^refs\/tags\///' | grep -E '^[0-9]\.[0-9]\.[0-9]$' | sort -V | tail -n 1)"
+	if [[ "$WC_VERSION" == "" ]]; then
+		LATEST_WC_TAG="$(git ls-remote --tags https://github.com/woocommerce/woocommerce.git | awk '{print $2}' | sed 's/^refs\/tags\///' | grep -E '^[0-9]\.[0-9]\.[0-9]$' | sort -V | tail -n 1)"
+	else
+		LATEST_WC_TAG="$WC_VERSION"
+	fi
 	cd "wp-content/plugins/"
 	# As zip file does not include tests, we have to get it from git repo.
 	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git


### PR DESCRIPTION
Unit tests are failing the PHP 5.6 test suite because WooCommerce 3.9.0 requires PHP 7.0. This PR pins the PHP 5.6 run from the test matrix to WooCommerce 3.8.1.

Ref: https://github.com/woocommerce/woocommerce/blob/master/readme.txt#L6