### PR TITLE
Fix Search component token display in ReportTable

### DIFF
--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -317,8 +317,9 @@ class ReportTable extends Component {
 		const totals = get( primaryData, [ 'data', 'totals' ], {} );
 		const totalResults = items.totalResults;
 		const downloadable = 0 < totalResults;
-		const searchWords = getSearchWords( query );
-		const searchedLabels = searchWords.map( v => ( { id: v, label: v } ) );
+		// Search words are in the query string, not the table query.
+		const searchWords = getSearchWords( this.props.query );
+		const searchedLabels = searchWords.map( v => ( { key: v, label: v } ) );
 
 		/**
 		 * Filter report table.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Added `<ImageUpload />` component.
 - Style form components for WordPress 5.3.
 - Fix CompareFilter options format (key prop vs. id).
+- Fix styling of `<Search />` component "clear all" button.
 
 # 4.0.0
 

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -97,7 +97,7 @@
 
 	.woocommerce-select-control__clear {
 		position: absolute;
-		right: 0;
+		right: 10px;
 		top: calc(50% - 10px);
 
 		& > .dashicon {

--- a/packages/components/src/select-control/tags.js
+++ b/packages/components/src/select-control/tags.js
@@ -4,8 +4,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
-import classnames from 'classnames';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { findIndex } from 'lodash';
 import PropTypes from 'prop-types';
 
@@ -43,39 +42,37 @@ class Tags extends Component {
 			return null;
 		}
 
-		const classes = classnames( 'woocommerce-select-control__tags', {
-			'has-clear': showClearButton,
-		} );
-
 		return (
-			<div className={ classes }>
-				{ selected.map( ( item, i ) => {
-					if ( ! item.label ) {
-						return null;
-					}
-					const screenReaderLabel = sprintf(
-						__( '%1$s (%2$s of %3$s)', 'woocommerce-admin' ),
-						item.label,
-						i + 1,
-						selected.length
-					);
-					return (
-						<Tag
-							key={ item.key }
-							id={ item.key }
-							label={ item.label }
-							remove={ this.removeResult }
-							screenReaderLabel={ screenReaderLabel }
-						/>
-					);
-				} ) }
+			<Fragment>
+				<div className="woocommerce-select-control__tags">
+					{ selected.map( ( item, i ) => {
+						if ( ! item.label ) {
+							return null;
+						}
+						const screenReaderLabel = sprintf(
+							__( '%1$s (%2$s of %3$s)', 'woocommerce-admin' ),
+							item.label,
+							i + 1,
+							selected.length
+						);
+						return (
+							<Tag
+								key={ item.key }
+								id={ item.key }
+								label={ item.label }
+								remove={ this.removeResult }
+								screenReaderLabel={ screenReaderLabel }
+							/>
+						);
+					} ) }
+				</div>
 				{ showClearButton && (
 					<Button className="woocommerce-select-control__clear" isLink onClick={ this.removeAll }>
 						<Icon icon="dismiss" />
 						<span className="screen-reader-text">{ __( 'Clear all', 'woocommerce-admin' ) }</span>
 					</Button>
 				) }
-			</div>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
Fixes a regression from https://github.com/woocommerce/woocommerce-admin/pull/2900.

This PR seeks to fix the display of search terms/tokens in report tables. Additionally, it fixes the styling of the "clear all" button at the right of the input.

### Screenshots

**Before**

![Screen Shot 2020-01-22 at 5 47 24 PM](https://user-images.githubusercontent.com/63922/72947443-451d3f00-3d3f-11ea-8011-b24e737a26f3.png)


**After**

![Screen Shot 2020-01-22 at 5 44 16 PM](https://user-images.githubusercontent.com/63922/72947418-29b23400-3d3f-11ea-8454-8f49ceca8d5a.png)


### Detailed test instructions:

- Open any report with a `<Search>` at the top of the `<ReportTable>`, like Customers report
- Search for a term, select a result
- Verify that a removable token is displayed for the selection

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: report table search component.
