### PR TITLE
Onboarding: Allow any uploaded theme to be activated

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -236,9 +236,11 @@ class Theme extends Component {
 
 	getThemes( activeTab = 'all' ) {
 		const { uploadedThemes } = this.state;
-		const { themes = [] } = getSetting( 'onboarding', {} );
-		themes.concat( uploadedThemes );
-		const allThemes = [ ...themes, ...uploadedThemes ];
+		const { activeTheme = '', themes = [] } = getSetting( 'onboarding', {} );
+		const allThemes = [
+			...themes.filter( theme => theme.has_woocommerce_support || theme.slug === activeTheme ),
+			...uploadedThemes,
+		];
 
 		switch ( activeTab ) {
 			case 'paid':

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -236,12 +236,7 @@ class Onboarding {
 			$active_theme     = get_option( 'stylesheet' );
 
 			foreach ( $installed_themes as $slug => $theme ) {
-				$theme_data = self::get_theme_data( $theme );
-
-				if ( ! $theme_data['has_woocommerce_support'] && $active_theme !== $slug ) {
-					continue;
-				}
-
+				$theme_data       = self::get_theme_data( $theme );
 				$installed_themes = wp_get_themes();
 				$themes[ $slug ]  = $theme_data;
 			}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -77,6 +77,7 @@ class Onboarding {
 		// Rest API hooks need to run before is_admin() checks.
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
 		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
+		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 
 		// Add onboarding notes.
 		new WC_Admin_Notes_Onboarding_Profiler();
@@ -93,7 +94,6 @@ class Onboarding {
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
-		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'finish_paypal_connect' ) );
 		add_action( 'current_screen', array( $this, 'finish_square_connect' ) );
 		add_action( 'current_screen', array( $this, 'add_help_tab' ), 60 );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -76,6 +76,7 @@ class Onboarding {
 
 		// Rest API hooks need to run before is_admin() checks.
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
+		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 
 		// Add onboarding notes.
 		new WC_Admin_Notes_Onboarding_Profiler();
@@ -92,7 +93,6 @@ class Onboarding {
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
-		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
 		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 		add_action( 'current_screen', array( $this, 'finish_paypal_connect' ) );
 		add_action( 'current_screen', array( $this, 'finish_square_connect' ) );


### PR DESCRIPTION
Fixes #3601 

Allows any uploaded theme, regardless of WC support, to be activated and flushes the themes transient when this occurs.

### Screenshots
<img width="468" alt="Screen Shot 2020-01-23 at 5 24 40 PM" src="https://user-images.githubusercontent.com/10561050/72971817-54ff5680-3e05-11ea-82ee-5e1d775e7f06.png">
<img width="570" alt="Screen Shot 2020-01-23 at 5 24 31 PM" src="https://user-images.githubusercontent.com/10561050/72971820-54ff5680-3e05-11ea-8814-22833babe5f8.png">


### Detailed test instructions:

1. Enable the profiler and visit the theme step.
1. Upload a theme not already installed that does not have WC support.
1. Select "Choose" on this theme.
1. Note the success message and make sure the theme has been successfully installed and activated.