### PR TITLE
Onboarding: Hide other elements in wpcontent while in full screen mode

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -30,6 +30,7 @@
 .woocommerce-admin-is-loading {
 	#adminmenumain,
 	#wpfooter,
+	#wpcontent,
 	#wpadminbar,
 	#wpbody-content,
 	.woocommerce-layout__header,
@@ -50,11 +51,16 @@
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
 		'Helvetica Neue', sans-serif;
 
+	#wpwrap {
+		top: 0;
+	}
+
 	#wpbody-content {
 		min-height: 100vh;
 	}
 
 	/* Hide wp-admin and WooCommerce elements when the dashboard body class is present */
+	#wpcontent > *,
 	#adminmenumain,
 	.woocommerce-layout__header,
 	.update-nag,
@@ -68,5 +74,9 @@
 
 	#wpcontent {
 		margin-left: 0;
+
+		> #wpbody {
+			display: block;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3600

Fixes other elements, such as Jetpack's calypsoify, from showing on screen during onboarding.

### Screenshots
#### Before
<img width="1120" alt="Screen Shot 2020-01-23 at 6 04 15 PM" src="https://user-images.githubusercontent.com/10561050/72974982-f8069f00-3e0a-11ea-8c09-5786cdf979e2.png">

#### After
<img width="1116" alt="Screen Shot 2020-01-23 at 6 02 17 PM" src="https://user-images.githubusercontent.com/10561050/72974983-f8069f00-3e0a-11ea-8677-04569e8444f3.png">


### Detailed test instructions:

1. Disable wc calypso bridge if active.
1. Connect Jetpack.
1. Enable Jetpack's calypsoify by hitting the URL `wp-admin/admin.php?page=wc-admin&step=store-details&calypsoify=1` (You may have to hit it a couple times to enable).
1. Note that the Calypso side menu is not shown and that the menu sits flush against the top of the screen.