### PR TITLE
Onboarding: Fix shipping rates overlapping currency prefix

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -193,15 +193,29 @@
 			margin-bottom: 0;
 		}
 
+		.components-base-control__label {
+			display: block;
+			position: relative;
+			top: -8px;
+			width: 100%;
+			font-size: 12px;
+		}
+
 		.text-control-with-affixes__prefix,
 		.text-control-with-affixes__suffix {
-			display: none;
 			font-size: 16px;
 			line-height: 24px;
 			color: $studio-gray-50;
 			border: 0;
 			padding: 0;
 			align-items: center;
+			display: flex;
+			top: -12px;
+		}
+
+		.components-text-control__input {
+			position: relative;
+			top: -12px;
 		}
 
 		.text-control-with-affixes__prefix {
@@ -210,14 +224,6 @@
 
 		.text-control-with-affixes__suffix {
 			margin-left: $gap-smallest;
-		}
-
-		&.with-value {
-			.text-control-with-affixes__prefix,
-			.text-control-with-affixes__suffix {
-				display: flex;
-				top: -12px;
-			}
 		}
 	}
 }

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -189,39 +189,35 @@
 	}
 
 	.woocommerce-shipping-rate__control-wrapper {
-		position: relative;
-
-		.muriel-input-text input {
-			left: $gap;
-			max-width: 90%;
-		}
-
 		.components-base-control {
 			margin-bottom: 0;
 		}
 
-		.woocommerce-shipping-rate__control-prefix,
-		.woocommerce-shipping-rate__control-suffix {
+		.text-control-with-affixes__prefix,
+		.text-control-with-affixes__suffix {
 			display: none;
-			position: absolute;
-			left: $gap;
-			top: 25px;
-			z-index: 1;
 			font-size: 16px;
 			line-height: 24px;
 			color: $studio-gray-50;
+			border: 0;
+			padding: 0;
+			align-items: center;
 		}
 
-		&.has-value {
-			.woocommerce-shipping-rate__control-prefix,
-			.woocommerce-shipping-rate__control-suffix {
-				display: block;
+		.text-control-with-affixes__prefix {
+			margin-right: $gap-smallest;
+		}
+
+		.text-control-with-affixes__suffix {
+			margin-left: $gap-smallest;
+		}
+
+		&.with-value {
+			.text-control-with-affixes__prefix,
+			.text-control-with-affixes__suffix {
+				display: flex;
+				top: -12px;
 			}
-		}
-
-		.woocommerce-shipping-rate__control-suffix {
-			left: auto;
-			right: $gap;
 		}
 	}
 }

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -122,6 +122,15 @@ class ShippingRates extends Component {
 		) : null;
 	}
 
+	getFormattedRate( value ) {
+		const currencyString = getCurrencyFormatString( value );
+		if ( ! value.length || ! currencyString.length ) {
+			return getCurrencyFormatString( 0 );
+		}
+
+		return getCurrencyFormatString( value );
+	}
+
 	getInitialValues() {
 		const values = {};
 
@@ -131,7 +140,7 @@ class ShippingRates extends Component {
 					? zone.methods.filter( method => 'flat_rate' === method.method_id )
 					: [];
 			const rate = flatRateMethods.length
-				? flatRateMethods[ 0 ].settings.cost.value
+				? this.getFormattedRate( flatRateMethods[ 0 ].settings.cost.value )
 				: getCurrencyFormatString( 0 );
 			values[ `${ zone.id }_rate` ] = rate;
 
@@ -204,7 +213,7 @@ class ShippingRates extends Component {
 														setTouched( `${ zone.id }_rate` );
 														setValue(
 															`${ zone.id }_rate`,
-															getCurrencyFormatString( values[ `${ zone.id }_rate` ] )
+															this.getFormattedRate( values[ `${ zone.id }_rate` ] )
 														);
 													} }
 													prefix={ this.renderInputPrefix() }

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -4,7 +4,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { Button, FormToggle } from '@wordpress/components';
 import PropTypes from 'prop-types';
@@ -12,7 +11,7 @@ import PropTypes from 'prop-types';
 /**
  * WooCommerce dependencies
  */
-import { Flag, Form, TextControl } from '@woocommerce/components';
+import { Flag, Form, TextControlWithAffixes } from '@woocommerce/components';
 import { CURRENCY, getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 
 /**
@@ -106,7 +105,7 @@ class ShippingRates extends Component {
 
 	renderInputPrefix() {
 		if ( 0 === symbolPosition.indexOf( 'right' ) ) {
-			return;
+			return null;
 		}
 		return <span className="woocommerce-shipping-rate__control-prefix">{ symbol }</span>;
 	}
@@ -197,26 +196,21 @@ class ShippingRates extends Component {
 												) }
 											</div>
 											{ ( ! zone.toggleEnabled || values[ `${ zone.id }_enabled` ] ) && (
-												<div
-													className={ classnames( 'woocommerce-shipping-rate__control-wrapper', {
-														'has-value': values[ `${ zone.id }_rate` ],
-													} ) }
-												>
-													{ this.renderInputPrefix() }
-													<TextControl
-														label={ __( 'Shipping cost', 'woocommerce-admin' ) }
-														required
-														{ ...getInputProps( `${ zone.id }_rate` ) }
-														onBlur={ () => {
-															setTouched( `${ zone.id }_rate` );
-															setValue(
-																`${ zone.id }_rate`,
-																getCurrencyFormatString( values[ `${ zone.id }_rate` ] )
-															);
-														} }
-													/>
-													{ this.renderInputSuffix( values[ `${ zone.id }_rate` ] ) }
-												</div>
+												<TextControlWithAffixes
+													label={ __( 'Shipping cost', 'woocommerce-admin' ) }
+													required
+													{ ...getInputProps( `${ zone.id }_rate` ) }
+													onBlur={ () => {
+														setTouched( `${ zone.id }_rate` );
+														setValue(
+															`${ zone.id }_rate`,
+															getCurrencyFormatString( values[ `${ zone.id }_rate` ] )
+														);
+													} }
+													prefix={ this.renderInputPrefix() }
+													suffix={ this.renderInputSuffix( values[ `${ zone.id }_rate` ] ) }
+													className="muriel-input-text woocommerce-shipping-rate__control-wrapper"
+												/>
 											) }
 										</div>
 									</div>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Added `<ImageUpload />` component.
 - Style form components for WordPress 5.3.
 - Fix CompareFilter options format (key prop vs. id).
+- Add state classes to `<TextControlWithAffixes />` component.
 
 # 4.0.0
 


### PR DESCRIPTION
Fixes #3606 

* Adds several state classes to `TextControlWithAffixes`
* Replaces the `TextControl` component in rates with `TextControlWithAffixes`
* Always formats shipping rates and always shows labels.

This forces users to always enter an amount for a shipping amount or set to 0 for free shipping.  I feel this is less ambiguous, but open for feedback. /cc @jameskoster @pmcpinto 

### Screenshots

#### Before
<img width="679" alt="Screen Shot 2020-01-24 at 4 57 56 PM" src="https://user-images.githubusercontent.com/10561050/73056969-3d8aa100-3ecb-11ea-82b1-9dc7dda279a3.png">

#### After
<img width="672" alt="Screen Shot 2020-01-24 at 4 57 04 PM" src="https://user-images.githubusercontent.com/10561050/73056970-3e233780-3ecb-11ea-87eb-924f08be4e14.png">

### Detailed test instructions:

1. Try this PR with multiple currencies, preferably some with multiple characters like the Brazilian reais.
1. Enable the task list and visit the shipping step.
1. Make sure the currency value and currency symbol don't overlap and are always spaced appropriately.
1. Make sure a properly formatted value is always used for a shipping rate.