### PR TITLE
Try: Moving Customers to main Woo Menu

### DIFF
--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -118,13 +118,15 @@ class Report extends Component {
 			return null;
 		}
 
-		const { params, isError } = this.props;
+		const { params, path, isError } = this.props;
 
 		if ( isError ) {
 			return <ReportError isError />;
 		}
 
-		const report = find( getReports(), { report: params.report } );
+		const reportParam = params.report || path.replace( /^\/+/, '' );
+
+		const report = find( getReports(), { report: reportParam } );
 		if ( ! report ) {
 			return null;
 		}

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -67,6 +67,12 @@ export const getPages = () => {
 		} );
 		pages.push( {
 			container: AnalyticsReport,
+			path: '/customers',
+			breadcrumbs: [ __( 'Customers', 'woocommerce-admin' ) ],
+			wpOpenMenu: 'toplevel_page_woocommerce',
+		} );
+		pages.push( {
+			container: AnalyticsReport,
 			path: '/analytics/:report',
 			breadcrumbs: ( { match } ) => {
 				const report = find( getReports(), { report: match.params.report } );

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -134,8 +134,8 @@ class Analytics {
 			array(
 				'id'     => 'woocommerce-analytics-customers',
 				'title'  => __( 'Customers', 'woocommerce-admin' ),
-				'parent' => 'woocommerce-analytics',
-				'path'   => '/analytics/customers',
+				'parent' => 'woocommerce',
+				'path'   => '/customers',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-settings',


### PR DESCRIPTION
Background: p6q8Tx-1qj-p2

This try branch moves the Customers report from the Analytics menu, to a sub menu item under WooCommerce.

### Screenshots

<img width="1290" alt="customers" src="https://user-images.githubusercontent.com/22080/73225444-8dfb3c00-4121-11ea-85ce-1e1b706917f2.png">

### Detailed test instructions:

- Verify Customers appears under the WooCommerce menu, and clicking on it loads the report and highlights the sidebar menu item
- Verify other analytic reports ( i.e. Revenue ) still work as expected.

### Changelog Note:

Enhancement: Move Customers report to WooCommerce Menu
