### PR TITLE
Onboarding: Fix toggle tracking events

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -62,11 +62,6 @@ class Onboarding {
 	public function __construct() {
 		$this->add_toggle_actions();
 
-		if ( ! Loader::is_onboarding_enabled() ) {
-			add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
-			return;
-		}
-
 		// Include WC Admin Onboarding classes.
 		if ( self::should_show_tasks() ) {
 			OnboardingTasks::get_instance();
@@ -89,6 +84,11 @@ class Onboarding {
 		// Track the onboarding toggle event earlier so they are captured before redirecting.
 		add_action( 'add_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
 		add_action( 'update_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
+
+		if ( ! Loader::is_onboarding_enabled() ) {
+			add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
+			return;
+		}
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -74,8 +74,6 @@ class Onboarding {
 
 		// Rest API hooks need to run before is_admin() checks.
 		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
-		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
-		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
 
 		// Add onboarding notes.
 		new WC_Admin_Notes_Onboarding_Profiler();
@@ -92,14 +90,6 @@ class Onboarding {
 		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
-		add_action( 'current_screen', array( $this, 'finish_paypal_connect' ) );
-		add_action( 'current_screen', array( $this, 'finish_square_connect' ) );
-		add_action( 'current_screen', array( $this, 'add_help_tab' ), 60 );
-		add_action( 'current_screen', array( $this, 'reset_profiler' ) );
-		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
-		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
-		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
-		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
 	}
@@ -114,6 +104,28 @@ class Onboarding {
 		// Track the onboarding toggle event earlier so they are captured before redirecting.
 		add_action( 'add_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
 		add_action( 'update_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
+	}
+
+	/**
+	 * Add onboarding actions.
+	 */
+	private function add_actions() {
+		// Rest API hooks need to run before is_admin() checks.
+		add_action( 'woocommerce_theme_installed', array( $this, 'delete_themes_transient' ) );
+		add_action( 'after_switch_theme', array( $this, 'delete_themes_transient' ) );
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		add_action( 'current_screen', array( $this, 'finish_paypal_connect' ) );
+		add_action( 'current_screen', array( $this, 'finish_square_connect' ) );
+		add_action( 'current_screen', array( $this, 'add_help_tab' ), 60 );
+		add_action( 'current_screen', array( $this, 'reset_profiler' ) );
+		add_action( 'current_screen', array( $this, 'reset_task_list' ) );
+		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
+		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
+		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -67,9 +67,14 @@ class Onboarding {
 			OnboardingTasks::get_instance();
 		}
 
+		if ( ! Loader::is_onboarding_enabled() ) {
+			return;
+		}
+
 		// Add onboarding notes.
 		new WC_Admin_Notes_Onboarding_Profiler();
 
+		// Add actions and filters.
 		$this->add_actions();
 		$this->add_filters();
 	}
@@ -87,7 +92,6 @@ class Onboarding {
 
 		if ( ! Loader::is_onboarding_enabled() ) {
 			add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
-			return;
 		}
 	}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -72,26 +72,11 @@ class Onboarding {
 			OnboardingTasks::get_instance();
 		}
 
-		// Rest API hooks need to run before is_admin() checks.
-		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
-
 		// Add onboarding notes.
 		new WC_Admin_Notes_Onboarding_Profiler();
 
-		if ( ! is_admin() ) {
-			return;
-		}
-
-		// Old settings injection.
-		// Run after Automattic\WooCommerce\Admin\Loader.
-		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
-		// New settings injection.
-		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
-		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
-		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
-		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
-		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
-		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
+		$this->add_actions();
+		$this->add_filters();
 	}
 
 	/**
@@ -126,6 +111,29 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'calypso_tests' ) );
 		add_action( 'current_screen', array( $this, 'redirect_wccom_install' ) );
 		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
+	}
+
+	/**
+	 * Add onboarding filters.
+	 */
+	private function add_filters() {
+		// Rest API hooks need to run before is_admin() checks.
+		add_filter( 'woocommerce_rest_prepare_themes', array( $this, 'add_uploaded_theme_data' ) );
+
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		// Old settings injection.
+		// Run after Automattic\WooCommerce\Admin\Loader.
+		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
+		// New settings injection.
+		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
+		add_filter( 'woocommerce_component_settings_preload_endpoints', array( $this, 'add_preload_endpoints' ) );
+		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
+		add_filter( 'woocommerce_admin_preload_settings', array( $this, 'preload_settings' ) );
+		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
+		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -60,13 +60,7 @@ class Onboarding {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
-		// Adds the ability to toggle the new onboarding experience on or off.
-		// @todo This option should be removed when merging the onboarding feature to core.
-		add_action( 'current_screen', array( $this, 'enable_onboarding' ) );
-		add_action( 'woocommerce_updated', array( $this, 'maybe_mark_complete' ) );
-		// Track the onboarding toggle event earlier so they are captured before redirecting.
-		add_action( 'add_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
-		add_action( 'update_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
+		$this->add_toggle_actions();
 
 		if ( ! Loader::is_onboarding_enabled() ) {
 			add_action( 'current_screen', array( $this, 'update_help_tab' ), 60 );
@@ -108,6 +102,18 @@ class Onboarding {
 		add_action( 'current_screen', array( $this, 'redirect_old_onboarding' ) );
 		add_filter( 'woocommerce_admin_is_loading', array( $this, 'is_loading' ) );
 		add_filter( 'woocommerce_show_admin_notice', array( $this, 'remove_install_notice' ), 10, 2 );
+	}
+
+	/**
+	 * Adds the ability to toggle the new onboarding experience on or off.
+	 */
+	private function add_toggle_actions() {
+		// @todo This toggle option should be removed when a/b testing is complete.
+		add_action( 'current_screen', array( $this, 'enable_onboarding' ) );
+		add_action( 'woocommerce_updated', array( $this, 'maybe_mark_complete' ) );
+		// Track the onboarding toggle event earlier so they are captured before redirecting.
+		add_action( 'add_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
+		add_action( 'update_option_' . self::OPT_IN_OPTION, array( $this, 'track_onboarding_toggle' ), 1, 2 );
 	}
 
 	/**

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -713,7 +713,7 @@ class Onboarding {
 		$enabled = 1 === absint( $_GET['enable_onboarding'] ); // phpcs:ignore CSRF ok.
 
 		wc_admin_record_tracks_event(
-			'wcadmin_onboarding_toggled',
+			'onboarding_toggled',
 			array(
 				'previous'  => ! $enabled,
 				'new_value' => $enabled,


### PR DESCRIPTION
Fixes #3643

Fixes a double `wcadmin_` prefix on the event and tracks on any update of the option in case this option is updated from some other code directly (e.g., `update_option( 'woocommerce_onboarding_opt_in', 'yes' );` is used directly in core).

### Detailed test instructions:

1. Try toggling onboarding on/off via the "Help" tab.
1. Make sure the `wcadmin_onboarding_toggle` event is fired with the correct value.
1. Try adding `update_option( 'woocommerce_onboarding_opt_in', 'yes' );` or `update_option( 'woocommerce_onboarding_opt_in', 'no' );` and making sure the event is fired. (Note this will only work when the option is updated and does not stay the same value.