### PR TITLE
Ensure continue setup loads the onboarding profiler

### DIFF
--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -52,7 +52,7 @@ class WC_Admin_Notes_Onboarding_Profiler {
 		$note->add_action(
 			'continue-profiler',
 			__( 'Continue Store Setup', 'woocommerce-admin' ),
-			wc_admin_url(),
+			wc_admin_url( '&enable_onboarding=1' ),
 			'unactioned',
 			true
 		);


### PR DESCRIPTION
This PR updates the onboarding profiler reminder note to include the query string for enabling the profiler.

To reproduce the issue
- set the `woocommerce_setup_ab_wc_admin_onboarding` option to `b`
- delete the `woocommerce_onboarding_profile` & `woocommerce_onboarding_opt_in` options
- turn off `WP_DEBUG`
- Ensure the `wc-admin-onboarding-profiler-reminder` note is unactioned
- Visit Analytics -> Orders
- Click `Continue Store Setup`

### Detailed test instructions:

- Delete the `wc-admin-onboarding-profiler-reminder` note
- Enable the new profiler in WooCommerce -> Orders -> Help -< Setup Wizard
- Use the address bar to go back to WP dashboard
- Go to Analytics -> Orders
- Click `Continue Store Setup`

