### PR TITLE
Fix for onboarding in 25.0

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -175,9 +175,10 @@ class Loader {
 		}
 
 		$onboarding_opt_in        = 'yes' === get_option( Onboarding::OPT_IN_OPTION, 'no' );
+		$legacy_onboarding_opt_in = 'yes' === get_option( 'wc_onboarding_opt_in', 'no' );
 		$onboarding_filter_opt_in = defined( 'WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED' ) && true === WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED;
 
-		if ( self::is_dev() || $onboarding_filter_opt_in || $onboarding_opt_in ) {
+		if ( self::is_dev() || $onboarding_filter_opt_in || $onboarding_opt_in || $legacy_onboarding_opt_in ) {
 			return true;
 		}
 


### PR DESCRIPTION
This branch seeks to fix the issue with the v0.25.0 release that is causing the new onboarding wizard to not be shown.

## Testing Instructions 

First verify the bug
- Spin up an ephemeral atomic site or :jurassicninja: site ( my last test pass i did both )
- Install and activate Woo Core
- Force my way into the a/b group that gets the new OBW via update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'b' )
- Manually upload and activate https://github.com/woocommerce/woocommerce-admin/releases/tag/v0.25.0-plugin
- Then either click on the notice to use the OBW or go to /wp-admin?page=wc-setup 
- You will then be prompted with the screen asking if you want to use the new onboarding experience, click "Yes Please"
- Note getting redirected to the wc-admin analytics dashboard, no onboarding is shown

Now reset the flow by `delete_option( 'wc_onboarding_opt_in' )`

Then repeat the test step, starting at:

- Apply the changeset in this branch ( I used the plugin editor 😲 in wp-admin )
- visit `/wp-admin?page=wc-setup`
- Click Yes Please
- Note you will now see the Onboarding Profiler