### PR TITLE
Decode breadcrumb correctly

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -130,7 +130,7 @@ class Header extends Component {
 						) : (
 							section
 						);
-						return <span key={ i }>{ sectionPiece }</span>;
+						return <span key={ i }>{ decodeEntities( sectionPiece ) }</span>;
 					} ) }
 				</h1>
 				{ window.wcAdminFeatures[ 'activity-panels' ] && <ActivityPanel /> }

--- a/client/header/test/index.js
+++ b/client/header/test/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Header from '../index.js';
+
+const encodedBreadcrumb = [
+	[ 'admin.php?page=wc-settings', 'Settings' ],
+	'Accounts &amp; Privacy',
+];
+
+describe( 'Header', () => {
+	test( 'should render decoded breadcrumb name', () => {
+		const header = shallow( <Header sections={ encodedBreadcrumb } isEmbedded={ true } />, {
+			disableLifecycleMethods: true,
+		} );
+		expect( header.text().includes( 'Accounts &amp; Privacy' ) ).toBe( false );
+		expect( header.text().includes( 'Accounts & Privacy' ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
Fixes #3627

This pull request solves a problem when viewing the `Accounts & Privacy` tab in `WooCommerce Settings`. The page title in the breadcrumbs included an `&amp;` instead of `&`.

### Fix
To fix this issue it was necessary to decode the page title before rendering.

### Screenshots
![73102003-c7c00e80-3ea5-11ea-82fa-a45d00f8c44e](https://user-images.githubusercontent.com/1314156/73505471-5a364580-43b1-11ea-99c4-76a6fb3d1b0b.png)

### Detailed test instructions:

- Visit wp-admin/admin.php?page=wc-settings&tab=account with wc-admin installed

### Changelog Note:
Now `decodeEntities` method is used to correct the breadcrumb.
