### PR TITLE
Add outline styling to focused textarea element

### DIFF
--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -99,6 +99,7 @@
 	}
 
 	input:focus,
+	textarea:focus,
 	select:focus,
 	button:focus {
 		color: $core-grey-dark-700;


### PR DESCRIPTION
Textarea and input elements look different in the form because outline styling is not
applied to text area element.

### Screenshots
**Before** 
![wc_admin_outline_before](https://user-images.githubusercontent.com/3139099/73532682-3f55e680-442e-11ea-8dd6-acc82e114cf5.gif)

**After**
![wc_admin_outline_after](https://user-images.githubusercontent.com/3139099/73532696-4977e500-442e-11ea-8194-0b7f936d89da.gif)


### Detailed test instructions:

- Create a form with input and text area elements.
- Focus each element and compare the outline.
