### PR TITLE
cast tax amount to float

### DIFF
--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -425,7 +425,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$tax_data    = $order_item->get_taxes();
 			foreach ( $order_taxes as $tax_item ) {
 				$tax_item_id = $tax_item->get_rate_id();
-				$tax_amount += isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : 0;
+				$tax_amount += isset( $tax_data['total'][ $tax_item_id ] ) ? (float) $tax_data['total'][ $tax_item_id ] : 0;
 			}
 
 			$net_revenue = round( $order_item->get_total( 'edit' ), $decimals );


### PR DESCRIPTION
Fixes #3654

This PR casts the tax amount to a float to account for the possibility that it's set but contains an empty string.

### Detailed test instructions:

- Unit test coverage should be sufficient

### Changelog Note:

Fix: Warning in product data store when tax amount is non-numeric.