### PR TITLE
Use cron for unsnoozing admin notes

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -67,7 +67,7 @@ function wc_admin_update_0230_db_version() {
  * Remove the note unsnoozing scheduled action.
  */
 function wc_admin_update_0251_remove_unsnooze_action() {
-	wc_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, array(), WC_Admin_Notes::QUEUE_GROUP );
+	as_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, null, WC_Admin_Notes::QUEUE_GROUP );
 }
 
 /**

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -66,13 +66,13 @@ function wc_admin_update_0230_db_version() {
 /**
  * Remove the note unsnoozing scheduled action.
  */
-function wc_admin_update_0241_remove_unsnooze_action() {
+function wc_admin_update_0251_remove_unsnooze_action() {
 	wc_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, array(), WC_Admin_Notes::QUEUE_GROUP );
 }
 
 /**
  * Update DB Version.
  */
-function wc_admin_update_0241_db_version() {
-	Installer::update_db_version( '0.24.1' );
+function wc_admin_update_0251_db_version() {
+	Installer::update_db_version( '0.25.1' );
 }

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -8,6 +8,7 @@
  */
 
 use \Automattic\WooCommerce\Admin\Install as Installer;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 /**
  * Update order stats `status` index length.
@@ -60,4 +61,18 @@ function wc_admin_update_0230_rename_gross_total() {
  */
 function wc_admin_update_0230_db_version() {
 	Installer::update_db_version( '0.23.0' );
+}
+
+/**
+ * Remove the note unsnoozing scheduled action.
+ */
+function wc_admin_update_0241_remove_unsnooze_action() {
+	wc_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, array(), WC_Admin_Notes::QUEUE_GROUP );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_0241_db_version() {
+	Installer::update_db_version( '0.24.1' );
 }

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -148,7 +148,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.24.1' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.25.1' );
 	}
 
 	/**

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -148,7 +148,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.25.1' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '0.24.1' );
 	}
 
 	/**

--- a/src/Install.php
+++ b/src/Install.php
@@ -36,9 +36,9 @@ class Install {
 			'wc_admin_update_0230_rename_gross_total',
 			'wc_admin_update_0230_db_version',
 		),
-		'0.24.1' => array(
-			'wc_admin_update_0241_remove_unsnooze_action',
-			'wc_admin_update_0241_db_version',
+		'0.25.1' => array(
+			'wc_admin_update_0251_remove_unsnooze_action',
+			'wc_admin_update_0251_db_version',
 		),
 	);
 

--- a/src/Install.php
+++ b/src/Install.php
@@ -36,6 +36,10 @@ class Install {
 			'wc_admin_update_0230_rename_gross_total',
 			'wc_admin_update_0230_db_version',
 		),
+		'0.24.1' => array(
+			'wc_admin_update_0241_remove_unsnooze_action',
+			'wc_admin_update_0241_db_version',
+		),
 	);
 
 	/**

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -154,17 +154,8 @@ class WC_Admin_Notes {
 	 * Schedule unsnooze notes event.
 	 */
 	public static function schedule_unsnooze_notes() {
-
-		$snooze_checked_transient_key = sprintf( '%s_checked', self::UNSNOOZE_HOOK );
-
-		if ( 'yes' !== get_transient( $snooze_checked_transient_key ) ) {
-			$queue = WC()->queue();
-			$next  = $queue->get_next( self::UNSNOOZE_HOOK );
-
-			if ( ! $next ) {
-				$queue->schedule_recurring( time(), HOUR_IN_SECONDS, self::UNSNOOZE_HOOK, array(), self::QUEUE_GROUP );
-			}
-			set_transient( $snooze_checked_transient_key, 'yes', HOUR_IN_SECONDS );
+		if ( ! wp_next_scheduled( self::UNSNOOZE_HOOK ) ) {
+			wp_schedule_event( time() + 5, 'hourly', self::UNSNOOZE_HOOK );
 		}
 	}
 


### PR DESCRIPTION
Fixes #3360.

This PR seeks to replace the Action Scheduler based "unsnooze" functionality with a recurring WP-Cron job.

There has been a lot of confusion and backlash around the Action Scheduler implementation:

* https://github.com/woocommerce/woocommerce-admin/issues/1946
* https://github.com/woocommerce/woocommerce-admin/issues/2364
* https://github.com/woocommerce/woocommerce-admin/issues/3360
* https://github.com/woocommerce/woocommerce-admin/issues/3659

### Detailed test instructions:

- Use WP Crontrol to verify a `wc_admin_unsnooze_admin_notes` cron event exists
- Go to Tools > Scheduled Actions, verify no `wc_admin_unsnooze_admin_notes` events are pending

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: use cron instead of Action Scheduler for unsnoozing notes.