### PR TITLE
Match Woo Core JP Autoloader version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "composer/installers": "1.7.0",
     "php": ">=5.6|>=7.0",
-    "automattic/jetpack-autoloader": "1.3.7"
+    "automattic/jetpack-autoloader": "^1.2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ad688c0caf3f4ea1cc7868676f5dbb6",
+    "content-hash": "b30011fe188d26e4de74485ff03d9786",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.3.7",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "34484f300429699e71bc09baa7f459eb1da0fe14"
+                "reference": "3cb0ad8496d04a648435ebee7c2a652c80eaf550"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/34484f300429699e71bc09baa7f459eb1da0fe14",
-                "reference": "34484f300429699e71bc09baa7f459eb1da0fe14",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/3cb0ad8496d04a648435ebee7c2a652c80eaf550",
+                "reference": "3cb0ad8496d04a648435ebee7c2a652c80eaf550",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-12-09T22:37:41+00:00"
+            "time": "2020-01-22T17:49:03+00:00"
         },
         {
             "name": "composer/installers",
@@ -1716,16 +1716,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.3",
+            "version": "3.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
+                "reference": "dceec07328401de6211037abbb18bda423677e26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
+                "reference": "dceec07328401de6211037abbb18bda423677e26",
                 "shasum": ""
             },
             "require": {
@@ -1763,7 +1763,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-12-04T04:46:47+00:00"
+            "time": "2020-01-30T22:20:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
From @jeffstieler 's feedback in [the merge PR](https://github.com/woocommerce/woocommerce/pull/25011#discussion_r374973402), this branch updates the jetpack-autoloader version to match what exists in [Woo Core](https://github.com/woocommerce/woocommerce/blob/master/composer.json#L11), [Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/composer.json#L16), and the [REST API](https://github.com/woocommerce/woocommerce-rest-api/blob/master/composer.json#L10).