### PR TITLE
Enable onboarding in production.

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -5,7 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"devdocs": false,
-		"onboarding": false,
+		"onboarding": true,
 		"store-alerts": true
 	}
 }


### PR DESCRIPTION
From conversations and debugging around Beta of 4.0, @joshuatf pointed out that we missed enabling onboarding in production.