### PR TITLE
Add deactivation note for feature plugin

### DIFF
--- a/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
+++ b/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
@@ -12,9 +12,9 @@ namespace Automattic\WooCommerce\Admin\Notes;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Admin_Notes_Update_Version.
+ * WC_Admin_Notes_Deactivate_Plugin.
  */
-class WC_Admin_Notes_Update_Version {
+class WC_Admin_Notes_Deactivate_Plugin {
 	const NOTE_NAME = 'wc-admin-deactivate-plugin';
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Update_Version.php
+++ b/src/Notes/WC_Admin_Notes_Update_Version.php
@@ -18,6 +18,13 @@ class WC_Admin_Notes_Update_Version {
 	const NOTE_NAME = 'wc-admin-update-version';
 
 	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'deactivate_feature_plugin' ) );
+	}
+
+	/**
 	 * Creates the note to deactivate the older version.
 	 */
 	public static function add_note() {
@@ -38,7 +45,7 @@ class WC_Admin_Notes_Update_Version {
 		$note->add_action(
 			'deactivate-feature-plugin',
 			__( 'Deactivate', 'woocommerce-admin' ),
-			wc_admin_url(),
+			wc_admin_url( '&action=deactivate-feature-plugin' ),
 			'unactioned',
 			true
 		);
@@ -50,5 +57,26 @@ class WC_Admin_Notes_Update_Version {
 	 */
 	public static function delete_note() {
 		WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+
+	/**
+	 * Deactivate feature plugin.
+	 */
+	public function deactivate_feature_plugin() {
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if (
+			! isset( $_GET['page'] ) ||
+			'wc-admin' !== $_GET['page'] ||
+			! isset( $_GET['action'] ) ||
+			'deactivate-feature-plugin' !== $_GET['action'] ||
+			! defined( 'WC_ADMIN_PLUGIN_FILE' )
+		) {
+			return;
+		}
+		/* phpcs:enable */
+
+		$deactivate_url = admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( WC_ADMIN_PLUGIN_FILE ) . '&plugin_status=all&paged=1&_wpnonce=' . wp_create_nonce( 'deactivate-plugin_' . WC_ADMIN_PLUGIN_FILE ) );
+		wp_safe_redirect( $deactivate_url );
+		exit;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Update_Version.php
+++ b/src/Notes/WC_Admin_Notes_Update_Version.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_Update_Version.
  */
 class WC_Admin_Notes_Update_Version {
-	const NOTE_NAME = 'wc-admin-update-version';
+	const NOTE_NAME = 'wc-admin-deactivate-plugin';
 
 	/**
 	 * Attach hooks.

--- a/src/Notes/WC_Admin_Notes_Update_Version.php
+++ b/src/Notes/WC_Admin_Notes_Update_Version.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * WooCommerce Admin: Update version reminder note.
+ *
+ * Creates a note to nudge users to use the newer version when two are installed.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Update_Version.
+ */
+class WC_Admin_Notes_Update_Version {
+	const NOTE_NAME = 'wc-admin-update-version';
+
+	/**
+	 * Creates the note to deactivate the older version.
+	 */
+	public static function add_note() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_icon( 'warning' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'deactivate-feature-plugin',
+			__( 'Deactivate', 'woocommerce-admin' ),
+			wc_admin_url(),
+			'unactioned',
+			true
+		);
+		$note->save();
+	}
+
+	/**
+	 * Delete the note if the version is higher than the included.
+	 */
+	public static function delete_note() {
+		WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
+	}
+}

--- a/src/Package.php
+++ b/src/Package.php
@@ -5,7 +5,7 @@
  * @package Automattic/WooCommerce/WCAdmin
  */
 
-namespace Automattic\WooCommerce\Admin;
+namespace Automattic\WooCommerce\Admin\Compose;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Update_Version;
+
 /**
  * Main package class.
  */
@@ -39,6 +41,12 @@ class Package {
 
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
+			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
+				WC_Admin_Notes_Update_Version::add_note();
+			} else {
+				WC_Admin_Notes_Update_Version::delete_note();
+			}
+
 			return;
 		}
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin\Compose;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Update_Version;
+use Automattic\WooCommerce\Admin\FeaturePlugin;
 
 /**
  * Main package class.

--- a/src/Package.php
+++ b/src/Package.php
@@ -5,7 +5,11 @@
  * @package Automattic/WooCommerce/WCAdmin
  */
 
-namespace Automattic\WooCommerce\Admin\Compose;
+/**
+ * This namespace isn't compatible with the PSR-4
+ * which ensures that the copy in the standalone plugin will not be autoloaded.
+ */
+namespace Automattic\WooCommerce\Admin\Composer;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -41,10 +41,11 @@ class Package {
 
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
+			$update_version = new WC_Admin_Notes_Update_Version();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
-				WC_Admin_Notes_Update_Version::add_note();
+				$update_version::add_note();
 			} else {
-				WC_Admin_Notes_Update_Version::delete_note();
+				$update_version::delete_note();
 			}
 
 			return;

--- a/src/Package.php
+++ b/src/Package.php
@@ -13,7 +13,7 @@ namespace Automattic\WooCommerce\Admin\Composer;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Update_Version;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Deactivate_Plugin;
 use Automattic\WooCommerce\Admin\FeaturePlugin;
 
 /**
@@ -46,7 +46,7 @@ class Package {
 
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
-			$update_version = new WC_Admin_Notes_Update_Version();
+			$update_version = new WC_Admin_Notes_Deactivate_Plugin();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
 				$update_version::add_note();
 			} else {


### PR DESCRIPTION
Fixes #

Adds a note to deactivate older versions of wc admin when the included core version is greater than the feature plugin running.

Notes:
* We can't use a standard URL with a nonce since the notes action is stored in the DB and the nonce would expire.
* We probably need to add some permission checks on notes at some point to prevent notes from being visible to those without permissions.  Currently this will show a permission error after clicking the action if the user does not have permission to disable plugins.

### Screenshots
<img width="712" alt="Screen Shot 2020-02-09 at 1 12 37 PM" src="https://user-images.githubusercontent.com/10561050/74110040-df51f500-4b3d-11ea-81d3-a47e170682ca.png">


### Detailed test instructions:

1. Symlink or copy this branch to the WC 4.0 beta `woocommerce/packages/woocommerce-admin` directory.
1. Run an older version as a feature plugin (or force this by changing the version constant in `Package.php`).
1. Visit any WC page with store alerts.
1. Note the error.
1. Disable the plugin with the action.
1. Make sure the feature plugin is successfully disabled.