### PR TITLE
'All that include' option removed when input field is empty

### DIFF
--- a/packages/components/src/select-control/list.js
+++ b/packages/components/src/select-control/list.js
@@ -151,6 +151,10 @@ class List extends Component {
 		const listboxClasses = classnames( 'woocommerce-select-control__listbox', {
 			'is-static': staticList,
 		} );
+		const hasValues = options ? options[ 0 ].value.id !== '' : false;
+		if ( ! hasValues ) {
+			return null;
+		}
 
 		return (
 			<div ref={ this.listbox } id={ listboxId } role="listbox" className={ listboxClasses }>

--- a/packages/components/src/select-control/list.js
+++ b/packages/components/src/select-control/list.js
@@ -151,8 +151,8 @@ class List extends Component {
 		const listboxClasses = classnames( 'woocommerce-select-control__listbox', {
 			'is-static': staticList,
 		} );
-		const hasValues = options ? options[ 0 ].value.id !== '' : false;
-		if ( ! hasValues ) {
+		const optionsHaveValues = options ? options[ 0 ].value.id !== '' : false;
+		if ( ! optionsHaveValues ) {
 			return null;
 		}
 

--- a/packages/components/src/select-control/test/index.js
+++ b/packages/components/src/select-control/test/index.js
@@ -176,4 +176,23 @@ describe( 'SelectControl', () => {
 			expect( selectControl.find( Button ).filter( '.' + optionClassname ).length ).toBe( 1 );
 		}, 0 );
 	} );
+
+	it( "doesn't show options with an empty search", () => {
+		const optionsEmptyValue = [
+			{ key: '1', label: 'lorem 1', value: { id: '' } },
+        ];
+		const optionControlClassname = 'woocommerce-select-control__listbox';
+		const selectControl = mount(
+			<SelectControl
+				options={ optionsEmptyValue }
+			/>
+		);
+
+		selectControl.instance().search( '' );
+		selectControl.update();
+
+		setTimeout( function() {
+			expect( selectControl.find( '.' + optionControlClassname ).length ).toBe( 0 );
+		}, 0 );
+	} );
 } );


### PR DESCRIPTION
Fixes #3682 

Added control to check that when the input field `Search by customer name` is empty, the `All that include` option is not appearing.

### Screenshots
![screenshot-one wordpress test-2020 02 11-18_44_36](https://user-images.githubusercontent.com/1314156/74282411-d78d7e80-4cfe-11ea-9d7d-2c1fbffe9155.png)

### Detailed test instructions:
1. Go to `Analytics` > `Customers` report.
2. Click on `Search by customer name` input field.
3. If the input is empty, nothing should be shown.

### Changelog Note:
Added new control in `/packages/components/src/select-control/list.js`.