### PR TITLE
Update form example to better format the form return data

### DIFF
--- a/packages/components/src/form/docs/example.js
+++ b/packages/components/src/form/docs/example.js
@@ -77,8 +77,11 @@ export default () => (
 				</Button>
 				<br />
 				<br />
-				Values: { JSON.stringify( values ) }<br />
-				Errors: { JSON.stringify( errors ) }<br />
+				<h3>Return data:</h3>
+				<pre>
+					Values: { JSON.stringify( values ) }<br />
+					Errors: { JSON.stringify( errors ) }
+				</pre>
 			</div>
 		) }
 	</Form>


### PR DESCRIPTION
Fixes #3553

I was originally going to just remove the return data but it looks to be helpful so I just updated the formatting.

### Accessibility

- [x] I've tested using a screen reader

### Screenshots

![image](https://user-images.githubusercontent.com/224531/74300050-4ff54d80-4d9a-11ea-9d98-6c418edc23c8.png)

### Detailed test instructions:

1. Open `/wp-admin/admin.php?page=wc-admin&path=/devdocs&component=form`
2. Play with the form values
3. Watch the return data update 

### Changelog Note:

Tweak: Update form example to better format the form return data
