### PR TITLE
Added link to "go shopping" button

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -185,6 +185,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return string Block content.
 	 */
 	private static function get_homepage_cover_block( $image ) {
+		$shop_url = site_url( '/?post_type=product' );
 		if ( ! empty( $image['url'] ) && ! empty( $image['id'] ) ) {
 			return '<!-- wp:cover {"url":"' . esc_url( $image['url'] ) . '","id":' . intval( $image['id'] ) . '} -->
 			<div class="wp-block-cover has-background-dim" style="background-image:url(' . esc_url( $image['url'] ) . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce-admin' ) . '","fontSize":"large"} -->
@@ -196,7 +197,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			<!-- /wp:paragraph -->
 
 			<!-- wp:button {"align":"center"} -->
-			<div class="wp-block-button aligncenter"><a class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
+			<div class="wp-block-button aligncenter"><a href="' . $shop_url . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
 			<!-- /wp:button --></div></div>
 			<!-- /wp:cover -->';
 		}
@@ -211,7 +212,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		<!-- /wp:paragraph -->
 
 		<!-- wp:button {"align":"center"} -->
-		<div class="wp-block-button aligncenter"><a class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
+		<div class="wp-block-button aligncenter"><a href="' . $shop_url . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
 		<!-- /wp:button --></div></div>
 		<!-- /wp:cover -->';
 	}

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -185,7 +185,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return string Block content.
 	 */
 	private static function get_homepage_cover_block( $image ) {
-		$shop_url = site_url( '/?post_type=product' );
+		$shop_url = get_permalink( woocommerce_get_page_id( 'shop' ) );
 		if ( ! empty( $image['url'] ) && ! empty( $image['id'] ) ) {
 			return '<!-- wp:cover {"url":"' . esc_url( $image['url'] ) . '","id":' . intval( $image['id'] ) . '} -->
 			<div class="wp-block-cover has-background-dim" style="background-image:url(' . esc_url( $image['url'] ) . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce-admin' ) . '","fontSize":"large"} -->

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -197,7 +197,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			<!-- /wp:paragraph -->
 
 			<!-- wp:button {"align":"center"} -->
-			<div class="wp-block-button aligncenter"><a href="' . $shop_url . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
+			<div class="wp-block-button aligncenter"><a href="' . esc_url( $shop_url ) . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
 			<!-- /wp:button --></div></div>
 			<!-- /wp:cover -->';
 		}
@@ -212,7 +212,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		<!-- /wp:paragraph -->
 
 		<!-- wp:button {"align":"center"} -->
-		<div class="wp-block-button aligncenter"><a href="' . $shop_url . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
+		<div class="wp-block-button aligncenter"><a href="' . esc_url( $shop_url ) . '" class="wp-block-button__link">' . __( 'Go shopping', 'woocommerce-admin' ) . '</a></div>
 		<!-- /wp:button --></div></div>
 		<!-- /wp:cover -->';
 	}

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -185,7 +185,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return string Block content.
 	 */
 	private static function get_homepage_cover_block( $image ) {
-		$shop_url = get_permalink( woocommerce_get_page_id( 'shop' ) );
+		$shop_url = get_permalink( wc_get_page_id( 'shop' ) );
 		if ( ! empty( $image['url'] ) && ! empty( $image['id'] ) ) {
 			return '<!-- wp:cover {"url":"' . esc_url( $image['url'] ) . '","id":' . intval( $image['id'] ) . '} -->
 			<div class="wp-block-cover has-background-dim" style="background-image:url(' . esc_url( $image['url'] ) . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"' . __( 'Write title…', 'woocommerce-admin' ) . '","fontSize":"large"} -->


### PR DESCRIPTION
Fixes #3625

Added a link to the shop page in the "go shopping" button

### Screenshots
![screenshot-shop-page-link2](https://user-images.githubusercontent.com/1314156/74363592-a027dc00-4da9-11ea-936b-efa548d4df36.png)


### Detailed test instructions:
1. Create a store with the new onboarding
2. Visit the Customize Appearance task in the task list
3. Click to proceed with the install of sample products
4. Click to create a homepage
5. Visit the homepage page editor
6. Preview the homepage and click in the `go shopping` button
7. The shop link page will be visible
