### PR TITLE
Only add onboarding settings on wc-admin pages when task list should …

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -165,7 +165,13 @@ class OnboardingTasks {
 	 * @return array
 	 */
 	public function component_settings( $settings ) {
-		$products = wp_count_posts( 'product' );
+		// Bail early if not on a wc-admin powered page, or task list shouldn't be shown.
+		if (
+			! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ||
+			! \Automattic\WooCommerce\Admin\Features\Onboarding::should_show_tasks()
+		) {
+			return $settings;
+		}
 
 		// @todo We may want to consider caching some of these and use to check against
 		// task completion along with cache busting for active tasks.


### PR DESCRIPTION
Fixes #3663 

This branch seeks to remove the expensive query for physical products that is happening on any Woo page where the new navigation bar is displayed. 

Just a bit of background on the query first. It appears the check for physical products is used to determine if the Shipping step in the checklist [should be displayed or not](https://github.com/woocommerce/woocommerce-admin/blob/master/client/dashboard/task-list/tasks.js#L110-L124). The boolean of `hasPhysicalProducts` is not used anywhere else besides the task list, as such I based my proposed fix here on that.

Changes Proposed:
In lieu of caching the query, which could be problematic in the context of the onboarding checklist ( granted we could clear the cache after each product save ) I have instead opted to return early from the logic if the request is not a wc-admin page ( i.e. Dashboard or Report ) and more importantly, if the task list should not be shown.

Therefore this query should only happen when a store is in "setup mode" / the setup checklist is being shown, and will only happen on wc-admin pages.

### Detailed test instructions:

- Open any non wc-admin woo page, like Orders, and verify that the query described in the original issue does not happen.
- Enable the setup checklist via the Help Menu in the orders listing page

![enable-task-list](https://user-images.githubusercontent.com/22080/74576950-eadc5c00-4f41-11ea-87cd-488b6c0b5c9d.png)

- Verify the checklist still operates as expected ( i.e. Shipping task shows if you have physical products setup )

![image](https://user-images.githubusercontent.com/22080/74576906-c41e2580-4f41-11ea-861f-391719d49b77.png)

### Changelog Note:

Performance: Remove slow physical products query from non setup checklist pages
