### PR TITLE
Fix/select text alignment

### DIFF
--- a/client/stylesheets/shared/_global.scss
+++ b/client/stylesheets/shared/_global.scss
@@ -146,6 +146,7 @@
 
 	select.components-select-control__input {
 		max-width: 100%;
+		line-height: 1;
 	}
 }
 


### PR DESCRIPTION
Fixes #[3683](https://github.com/woocommerce/woocommerce-admin/issues/3683)

Added `line-height: 1` to fix alignment of select text.

### Screenshots
#### Before
![74069597-09e96400-49ff-11ea-8390-bd448039c26a](https://user-images.githubusercontent.com/13222067/74584708-39f0c280-5010-11ea-877d-93e2fc7bc22a.png)

#### After
<img width="443" alt="select-text-alignment-fix" src="https://user-images.githubusercontent.com/13222067/74584685-06159d00-5010-11ea-9cd6-30f7092f4b25.png">

### Detailed test instructions:
Go to Analytics > Settings and scroll down to the Import Historical Data section.

### Changelog Note:
Fix: Alignment of select text
