### PR TITLE
Coding Standards: Fix getReportItems function call order

### DIFF
--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -451,12 +451,16 @@ export function getReportTableData( options ) {
 		},
 	};
 
+	// Disable eslint rule requiring `items` to be defined below because the next two if statements
+	// depend on `getReportItems` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const items = getReportItems( endpoint, tableQuery );
+
 	if ( isReportItemsRequesting( endpoint, tableQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getReportItemsError( endpoint, tableQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const items = getReportItems( endpoint, tableQuery );
 	return { ...response, items };
 }


### PR DESCRIPTION
New eslint rules require a variable to be assigned just before its use. This was causing issues with logic around selectors that required a function call to happen before determining if a request was in flight or resulted in an error. 

This PR re-establishes the correct order and includes an eslint disable comment.

### Test Instructions

1. Load a variety of reports and ensure the table displays data instead of endless loading state.