### PR TITLE
Onboarding: Add tracks events when profiler steps are completed

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -23,6 +23,7 @@ import Plugins from './steps/plugins';
 import ProductTypes from './steps/product-types';
 import ProfileWizardHeader from './header';
 import { QUERY_DEFAULTS } from 'wc-api/constants';
+import { recordEvent } from 'lib/tracks';
 import Start from './steps/start';
 import StoreDetails from './steps/store-details';
 import Theme from './steps/theme';
@@ -141,7 +142,14 @@ class ProfileWizard extends Component {
 
 	async goToNextStep() {
 		const currentStep = this.getCurrentStep();
-		const currentStepIndex = this.getSteps().findIndex( s => s.key === currentStep.key );
+		const currentStepIndex = this.getSteps().findIndex(
+			( s ) => s.key === currentStep.key
+		);
+
+		recordEvent( 'storeprofiler_step_complete', {
+			step: currentStep.key,
+		} );
+
 		const nextStep = this.getSteps()[ currentStepIndex + 1 ];
 
 		if ( 'undefined' === typeof nextStep ) {

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -176,6 +176,7 @@ class ProfileWizard extends Component {
 	completeProfiler() {
 		const { notes, updateNote, updateProfileItems } = this.props;
 		updateProfileItems( { completed: true } );
+		recordEvent( 'storeprofiler_complete' );
 
 		const profilerNote = notes.find(
 			note => 'wc-admin-onboarding-profiler-reminder' === note.name


### PR DESCRIPTION
Fixes #3644 

Records an event `storeprofiler_step_complete` and `storeprofiler_complete` when a step is complete and the profiler is entirely completed.

### Screenshots
<img width="505" alt="Screen Shot 2020-02-17 at 11 50 22 AM" src="https://user-images.githubusercontent.com/10561050/74647287-b358f400-517b-11ea-82ce-edfb481f88f2.png">


### Detailed test instructions:

1. Enable the profiler.
1. Enter `localStorage.setItem( 'debug', 'wc-admin:*' );` into your console. Leave your console open.
1. Walk through the steps, checking that the `storeprofiler_step_complete` is tracked along with the step as an event param.
1. Complete the profiler with and without items that need purchase.  Note that `storeprofiler_complete` is tracked in both cases.