### PR TITLE
Onboarding: Create homepage without redirect

### DIFF
--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -20,9 +20,9 @@ import { getSetting, setSetting } from '@woocommerce/wc-admin-settings';
 /**
  * Internal dependencies
  */
+import { queueRecordEvent, recordEvent } from 'lib/tracks';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
-import { recordEvent } from 'lib/tracks';
 
 class Appearance extends Component {
 	constructor( props ) {
@@ -177,6 +177,10 @@ class Appearance extends Component {
 										'woocommerce-admin'
 									),
 									onClick: () => {
+										queueRecordEvent(
+											'tasklist_appearance_customize_homepage',
+											{}
+										);
 										window.location = `${ response.edit_post_link }&wc_onboarding_active_task=homepage`;
 									},
 								},

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -264,7 +264,11 @@ class Appearance extends Component {
 				),
 				content: (
 					<Fragment>
-						<Button isPrimary onClick={ this.createHomepage }>
+						<Button
+							isPrimary
+							isBusy={ isPending }
+							onClick={ this.createHomepage }
+						>
 							{ __( 'Create homepage', 'woocommerce-admin' ) }
 						</Button>
 						<Button

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -163,14 +163,29 @@ class Appearance extends Component {
 
 		recordEvent( 'tasklist_appearance_create_homepage', { create_homepage: true } );
 
-		apiFetch( { path: '/wc-admin/onboarding/tasks/create_homepage', method: 'POST' } )
-			.then( response => {
-				createNotice( response.status, response.message );
+		apiFetch( {
+			path: '/wc-admin/onboarding/tasks/create_homepage',
+			method: 'POST',
+		} )
+			.then( ( response ) => {
+				createNotice( response.status, response.message, {
+					actions: response.edit_post_link
+						? [
+								{
+									label: __(
+										'Customize',
+										'woocommerce-admin'
+									),
+									onClick: () => {
+										window.location = `${ response.edit_post_link }&wc_onboarding_active_task=homepage`;
+									},
+								},
+						  ]
+						: null,
+				} );
 
 				this.setState( { isPending: false } );
-				if ( response.edit_post_link ) {
-					window.location = `${ response.edit_post_link }&wc_onboarding_active_task=homepage`;
-				}
+				this.completeStep();
 			} )
 			.catch( error => {
 				createNotice( 'error', error.message );

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -23,9 +23,13 @@ import { queueRecordEvent } from 'lib/tracks';
  * @return {Promise} Promise for overlay existence.
  */
 const saveStarted = () => {
-	if ( document.querySelector( '.editor-post-publish-button' ) === null ) {
-		const promise = new Promise( resolve => {
-			requestAnimationFrame( resolve );
+	if (
+		! document
+			.querySelector( '.editor-post-publish-button' )
+			.classList.contains( 'is-busy' )
+	) {
+		const promise = new Promise( ( resolve ) => {
+			window.requestAnimationFrame( resolve );
 		} );
 		return promise.then( () => saveStarted() );
 	}
@@ -39,9 +43,13 @@ const saveStarted = () => {
  * @return {Promise} Promise for overlay existence.
  */
 const saveCompleted = () => {
-	if ( null === document.querySelector( '.post-publish-panel__postpublish' ) ) {
-		const promise = new Promise( resolve => {
-			requestAnimationFrame( resolve );
+	if (
+		document
+			.querySelector( '.editor-post-publish-button' )
+			.classList.contains( 'is-busy' )
+	) {
+		const promise = new Promise( ( resolve ) => {
+			window.requestAnimationFrame( resolve );
 		} );
 		return promise.then( () => saveCompleted() );
 	}
@@ -95,15 +103,13 @@ const onboardingHomepageNotice = () => {
 };
 
 domReady( () => {
-	const publishButton = document.querySelector( '.editor-post-publish-panel__toggle' );
+	const publishButton = document.querySelector(
+		'.editor-post-publish-button'
+	);
 	if ( publishButton ) {
-		publishButton.addEventListener( 'click', function() {
-			saveStarted().then( () => {
-				const confirmButton = document.querySelector( '.editor-post-publish-button' );
-				if ( confirmButton ) {
-					confirmButton.addEventListener( 'click', onboardingHomepageNotice );
-				}
-			} );
-		} );
+		publishButton.addEventListener(
+			'click',
+			saveStarted().then( () => onboardingHomepageNotice() )
+		);
 	}
 } );

--- a/client/wp-admin-scripts/onboarding-homepage-notice/index.js
+++ b/client/wp-admin-scripts/onboarding-homepage-notice/index.js
@@ -4,7 +4,6 @@
  */
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import domReady from '@wordpress/dom-ready';
 
 /**
@@ -69,18 +68,8 @@ const onboardingHomepageNotice = () => {
 	saveButton.classList.add( 'is-clicked' );
 
 	saveCompleted().then( () => {
-		const postId = document.querySelector( '#post_ID' ).value;
 		const notificationType =
 			null !== document.querySelector( '.components-snackbar__content' ) ? 'snackbar' : 'default';
-
-		apiFetch( {
-			path: '/wc-admin/options',
-			method: 'POST',
-			data: {
-				show_on_front: 'page',
-				page_on_front: postId,
-			},
-		} );
 
 		dispatch( 'core/notices' ).removeNotice( 'SAVE_POST_NOTICE_ID' );
 		dispatch( 'core/notices' ).createSuccessNotice(

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -401,7 +401,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			array(
 				'post_title'   => __( 'Homepage', 'woocommerce-admin' ),
 				'post_type'    => 'page',
-				'post_status'  => 'draft',
+				'post_status'  => 'publish',
 				'post_content' => '', // Template content is updated below, so images can be attached to the post.
 			)
 		);

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -420,7 +420,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 			return array(
 				'status'         => 'success',
-				'message'        => __( 'Homepage created successfully.', 'woocommerce-admin' ),
+				'message'        => __( 'Homepage created.', 'woocommerce-admin' ),
 				'post_id'        => $post_id,
 				'edit_post_link' => htmlspecialchars_decode( get_edit_post_link( $post_id ) ),
 			);

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -416,6 +416,8 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 				)
 			);
 
+			update_option( 'show_on_front', 'page' );
+			update_option( 'page_on_front', $post_id );
 			update_option( 'woocommerce_onboarding_homepage_post_id', $post_id );
 
 			return array(


### PR DESCRIPTION
Fixes #3708 

* Creates a published homepage on click in the task list.
* Adds a link to edit the homepage in the notice.
* Updates the homepage notice to continue working on post update.

### Screenshots
<img width="319" alt="Screen Shot 2020-02-17 at 7 56 33 PM" src="https://user-images.githubusercontent.com/10561050/74680093-f046da00-51bf-11ea-96f5-14ea8db54a79.png">
<img width="495" alt="Screen Shot 2020-02-17 at 7 54 46 PM" src="https://user-images.githubusercontent.com/10561050/74680096-f0df7080-51bf-11ea-8761-6b8455224c59.png">


### Detailed test instructions:

1. Delete any homepages created by the onboarding task list.
1. Enable the onboarding task list and visit the Customize Appearance task.
1. Click "Create homepage"
1. Make sure a success notice is shown with the link to edit the hompeage and you are not redirected.
1. Click "Customize" in the notice to edit the homepage.
1. Make an edit and click "Update."
1. Check that the homepage notice and action link to return to the task list is shown.