### PR TITLE
Fix/3631

### DIFF
--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -52,7 +52,7 @@ class Industry extends Component {
 
 		recordEvent( 'storeprofiler_store_industry_continue', {
 			store_industry: selectedIndustriesList,
-			industriesWithDetail,
+			industries_with_detail: industriesWithDetail,
 		} );
 		await updateProfileItems( { industry: this.state.selected } );
 

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -45,8 +45,15 @@ class Industry extends Component {
 		}
 
 		const { createNotice, goToNextStep, isError, updateProfileItems } = this.props;
+		const selectedIndustriesList = this.state.selected.map( industry => industry.slug );
+		const industriesWithDetail = filter( this.state.selected, value => {
+			return typeof value.detail !== 'undefined';
+		} );
 
-		recordEvent( 'storeprofiler_store_industry_continue', { store_industry: this.state.selected } );
+		recordEvent( 'storeprofiler_store_industry_continue', {
+			store_industry: selectedIndustriesList,
+			industriesWithDetail,
+		} );
 		await updateProfileItems( { industry: this.state.selected } );
 
 		if ( ! isError ) {

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -31,11 +31,11 @@ class Industry extends Component {
 		this.state = {
 			error: null,
 			selected: profileItems.industry || [],
-			textInputListContent: [],
+			textInputListContent: {},
 		};
 		this.onContinue = this.onContinue.bind( this );
-		this.onChange = this.onChange.bind( this );
-		this.onInputChange = this.onInputChange.bind( this );
+		this.onIndustryChange = this.onIndustryChange.bind( this );
+		this.onDetailChange = this.onDetailChange.bind( this );
 	}
 
 	async onContinue() {
@@ -66,7 +66,7 @@ class Industry extends Component {
 		this.setState( { error } );
 	}
 
-	onChange( slug ) {
+	onIndustryChange( slug ) {
 		this.setState(
 			state => {
 				const newSelected = state.selected;
@@ -91,13 +91,16 @@ class Industry extends Component {
 		);
 	}
 
-	onInputChange( value, slug ) {
+	onDetailChange( value, slug ) {
 		this.setState( state => {
 			const newSelected = state.selected;
+			const newTextInputListContent = state.textInputListContent;
 			const industryIndex = findIndex( newSelected, { slug: slug } );
 			newSelected[ industryIndex ].detail = value;
+			newTextInputListContent[ slug ] = value;
 			return {
 				selected: newSelected,
+				textInputListContent: newTextInputListContent,
 			};
 		} );
 	}
@@ -124,7 +127,7 @@ class Industry extends Component {
 									<CheckboxControl
 										key={ `checkbox-control-${ slug }` }
 										label={ industries[ slug ].label }
-										onChange={ () => this.onChange( slug ) }
+										onChange={ () => this.onIndustryChange( slug ) }
 										checked={ selectedIndustry || false }
 										className="woocommerce-profile-wizard__checkbox"
 									/>
@@ -134,7 +137,7 @@ class Industry extends Component {
 												key={ `text-control-${ selectedIndustry.slug }` }
 												label={ industries[ selectedIndustry.slug ].description_label }
 												value={ selectedIndustry.detail || textInputListContent[ slug ] || '' }
-												onChange={ value => this.onInputChange( value, selectedIndustry.slug ) }
+												onChange={ value => this.onDetailChange( value, selectedIndustry.slug ) }
 												className="woocommerce-profile-wizard__text"
 											/>
 										) }

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -240,16 +240,6 @@
 			padding: $gap-small $gap;
 			min-height: 56px;
 
-			&::after {
-				content: '';
-				position: absolute;
-				left: $gap-large * 2 + $gap;
-				width: calc(100% - #{$gap-large * 2 + $gap});
-				height: 1px;
-				background-color: $studio-gray-5;
-				bottom: 0;
-			}
-
 			.components-base-control {
 				position: relative;
 			}
@@ -291,6 +281,10 @@
 					display: none;
 				}
 			}
+		}
+
+		.woocommerce-profile-wizard__text {
+			margin: 0 16px 10px;
 		}
 
 		svg.dashicon.components-checkbox-control__checked {

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -241,6 +241,9 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
+				'items'             => array(
+					'type' => 'json',
+				),
 			),
 			'product_types'       => array(
 				'type'              => 'array',

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -240,12 +240,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 				'description'       => __( 'Industry.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
-				'sanitize_callback' => 'wp_parse_slug_list',
 				'validate_callback' => 'rest_validate_request_arg',
-				'items'             => array(
-					'enum' => array_keys( Onboarding::get_allowed_industries() ),
-					'type' => 'string',
-				),
 			),
 			'product_types'       => array(
 				'type'              => 'array',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -149,17 +149,50 @@ class Onboarding {
 	 * @return array
 	 */
 	public static function get_allowed_industries() {
+		/* With "use_description" we turn the description input on. With "description_label" we set the input label */
 		return apply_filters(
 			'woocommerce_admin_onboarding_industries',
 			array(
-				'fashion-apparel-accessories'		=> __( 'Fashion, apparel, and accessories', 'woocommerce-admin' ),
-				'health-beauty'             		=> __( 'Health and beauty', 'woocommerce-admin' ),
-				'art-music-photography'       		=> __( 'Art, music, and photography', 'woocommerce-admin' ),
-				'electronics-computers'       		=> __( 'Electronics and computers', 'woocommerce-admin' ),
-				'food-drink'                  		=> __( 'Food and drink', 'woocommerce-admin' ),
-				'home-furniture-garden'				=> __( 'Home, furniture, and garden', 'woocommerce-admin' ),
-				'cbd-other-hemp-derived-products'	=> __( 'CBD and other hemp-derived products', 'woocommerce-admin' ),
-				'other'                       		=> __( 'Other', 'woocommerce-admin' ),
+				'fashion-apparel-accessories'     => array(
+					'label'             => __( 'Fashion, apparel, and accessories', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'health-beauty'                   => array(
+					'label'             => __( 'Health and beauty', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'art-music-photography'           => array(
+					'label'             => __( 'Art, music, and photography', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'electronics-computers'           => array(
+					'label'             => __( 'Electronics and computers', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'food-drink'                      => array(
+					'label'             => __( 'Food and drink', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'home-furniture-garden'           => array(
+					'label'             => __( 'Home, furniture, and garden', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'cbd-other-hemp-derived-products' => array(
+					'label'             => __( 'CBD and other hemp-derived products', 'woocommerce-admin' ),
+					'use_description'   => false,
+					'description_label' => '',
+				),
+				'other'                           => array(
+					'label'             => __( 'Other', 'woocommerce-admin' ),
+					'use_description'   => true,
+					'description_label' => 'Description',
+				),
 			)
 		);
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -152,13 +152,14 @@ class Onboarding {
 		return apply_filters(
 			'woocommerce_admin_onboarding_industries',
 			array(
-				'fashion-apparel-accessories' => __( 'Fashion, apparel, and accessories', 'woocommerce-admin' ),
-				'health-beauty'               => __( 'Health and beauty', 'woocommerce-admin' ),
-				'art-music-photography'       => __( 'Art, music, and photography', 'woocommerce-admin' ),
-				'electronics-computers'       => __( 'Electronics and computers', 'woocommerce-admin' ),
-				'food-drink'                  => __( 'Food and drink', 'woocommerce-admin' ),
-				'home-furniture-garden'       => __( 'Home, furniture, and garden', 'woocommerce-admin' ),
-				'other'                       => __( 'Other', 'woocommerce-admin' ),
+				'fashion-apparel-accessories'		=> __( 'Fashion, apparel, and accessories', 'woocommerce-admin' ),
+				'health-beauty'             		=> __( 'Health and beauty', 'woocommerce-admin' ),
+				'art-music-photography'       		=> __( 'Art, music, and photography', 'woocommerce-admin' ),
+				'electronics-computers'       		=> __( 'Electronics and computers', 'woocommerce-admin' ),
+				'food-drink'                  		=> __( 'Food and drink', 'woocommerce-admin' ),
+				'home-furniture-garden'				=> __( 'Home, furniture, and garden', 'woocommerce-admin' ),
+				'cbd-other-hemp-derived-products'	=> __( 'CBD and other hemp-derived products', 'woocommerce-admin' ),
+				'other'                       		=> __( 'Other', 'woocommerce-admin' ),
 			)
 		);
 	}


### PR DESCRIPTION
Fixes #3631

This PR adds to the onboarding process:

- The option `CBD and other hemp-derived products` to the industries list
- When the user clicks on the `Other` checkbox, an input is displayed.

### Screenshots
![Screen Capture on 2020-02-18 at 14-02-20](https://user-images.githubusercontent.com/1314156/74759428-8c6ff000-5257-11ea-9bdd-3700e0497aac.gif)


### Detailed test instructions:
**Test 1**
1. Start the onboarding process
2. In the `Industry` step check whether the option `CBD and other hemp-derived products` is visible and works
3. Select the option: `CBD and other hemp-derived products`
4. Press the `Continue` button. It should save the information in the database
5. Go back to the `Industry` step, reload the page and verify that the option `CBD and other hemp-derived products` is still checked. That means the data was successfully saved.

**Test 2**
Steps 1 and 2 are the same

3. Select the option: `Other`
4. An empty input should appear under the `Other` checkbox.
5. Fill the input with a description.
6. Press the `Continue` button.
7. Go back to the `Industry` step, reload the page and verify that the option `Other` is still selected and the input has the inserted text.

**Test 3**
First 5 steps are the same

6. After filling the input, press the `Other` checkbox again.
7. The input should disappear. Press again the `Other` checkbox.
8. The inserted text before should now be visible again.

### Changelog Note:
- Now we can add a new description input (for the other industries listed) changing the value `use_description` to `true` in the `get_allowed_industries` method in the file `src/Features/Onboarding.php`.
The current options for each item now are: `label` (_string_), `use_description` (_boolean_), `description_label` (_string_).
- The frontend will show an input for each list option, depending on the list above.
- Some styles were changed in order to better see the added inputs.
