### PR TITLE
Add PayFast payment gateway option for sites in South Africa

### DIFF
--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -330,6 +330,12 @@ class Payments extends Component {
 							'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.',
 							'woocommerce-admin'
 						) }
+						<p>
+							{ __(
+								'Selecting this extension will configure your store to use South African rands as the selected currency.',
+								'woocommerce-admin'
+							) }
+						</p>
 					</Fragment>
 				),
 				before: (

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -477,13 +477,8 @@ class Payments extends Component {
 				),
 				content: (
 					<PayFast
-						manualConfig={ manualConfig }
 						markConfigured={ this.markConfigured }
 						setRequestPending={ this.setMethodRequestPending }
-						createAccount={ values.create_payfast && ! manualConfig }
-						returnUrl={ getAdminLink(
-							'admin.php?page=wc-admin&task=payments&payfast-connect=1'
-						) }
 					/>
 				),
 				visible: showIndividualConfigs && methods.includes( 'payfast' )

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -36,6 +36,7 @@ import Stripe from './stripe';
 import Square from './square';
 import PayPal from './paypal';
 import Klarna from './klarna';
+import PayFast from './payfast';
 
 class Payments extends Component {
 	constructor() {
@@ -130,6 +131,7 @@ class Payments extends Component {
 			square: false,
 			create_stripe: this.isStripeEnabled(),
 			stripe_email: ( this.isStripeEnabled() && stripeEmail ) || '',
+			payfast: false,
 		};
 		return values;
 	}
@@ -229,7 +231,26 @@ class Payments extends Component {
 	getMethodOptions() {
 		const { getInputProps } = this.formData;
 		const { countryCode, profileItems } = this.props;
+
 		const methods = [
+			{
+				key: 'payfast',
+				title: __(
+					'PayFast',
+					'woocommerce-admin'
+				),
+				content: (
+					<Fragment>
+						{ __(
+							'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.',
+							'woocommerce-admin'
+						) }
+					</Fragment>
+				),
+				before: <img src={ wcAssetUrl + 'images/payfast.png' } alt="PayFast logo" />,
+				after: <FormToggle { ...getInputProps( 'payfast' ) } />,
+				visible: [ 'ZA' ].includes( countryCode ),
+			},
 			{
 				key: 'stripe',
 				title: __(
@@ -340,6 +361,7 @@ class Payments extends Component {
 			'klarna-checkout': values.klarna_checkout,
 			'klarna-payments': values.klarna_payments,
 			square: values.square,
+			payfast: values.payfast,
 		};
 		return keys( pickBy( methods ) );
 	}
@@ -352,6 +374,7 @@ class Payments extends Component {
 			'klarna-checkout-for-woocommerce': values.klarna_checkout,
 			'klarna-payments-for-woocommerce': values.klarna_payments,
 			'woocommerce-square': values.square,
+			'woocommerce-payfast-gateway': values.payfast,
 		};
 		return keys( pickBy( pluginSlugs ) );
 	}
@@ -380,7 +403,8 @@ class Payments extends Component {
 			values.paypal ||
 			values.klarna_checkout ||
 			values.klarna_payments ||
-			values.square;
+			values.square ||
+			values.payfast;
 
 		const { showIndividualConfigs } = this.state;
 		const { activePlugins, countryCode, isJetpackConnected } = this.props;
@@ -443,6 +467,26 @@ class Payments extends Component {
 				),
 				content: <Fragment />,
 				visible: ! showIndividualConfigs,
+			},
+			{
+				key: 'payfast',
+				label: __( 'Enable PayFast', 'woocommerce-admin' ),
+				description: __(
+					'Connect your store to your PayFast account',
+					'woocommerce-admin'
+				),
+				content: (
+					<PayFast
+						manualConfig={ manualConfig }
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+						createAccount={ values.create_payfast && ! manualConfig }
+						returnUrl={ getAdminLink(
+							'admin.php?page=wc-admin&task=payments&payfast-connect=1'
+						) }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'payfast' )
 			},
 			{
 				key: 'stripe',

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -234,24 +234,6 @@ class Payments extends Component {
 
 		const methods = [
 			{
-				key: 'payfast',
-				title: __(
-					'PayFast',
-					'woocommerce-admin'
-				),
-				content: (
-					<Fragment>
-						{ __(
-							'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.',
-							'woocommerce-admin'
-						) }
-					</Fragment>
-				),
-				before: <img src={ wcAssetUrl + 'images/payfast.png' } alt="PayFast logo" />,
-				after: <FormToggle { ...getInputProps( 'payfast' ) } />,
-				visible: [ 'ZA' ].includes( countryCode ),
-			},
-			{
 				key: 'stripe',
 				title: __(
 					'Credit cards - powered by Stripe',
@@ -338,6 +320,26 @@ class Payments extends Component {
 						profileItems.selling_venues
 					) &&
 					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ),
+			},
+			{
+				key: 'payfast',
+				title: __( 'PayFast', 'woocommerce-admin' ),
+				content: (
+					<Fragment>
+						{ __(
+							'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.',
+							'woocommerce-admin'
+						) }
+					</Fragment>
+				),
+				before: (
+					<img
+						src={ wcAssetUrl + 'images/payfast.png' }
+						alt="PayFast logo"
+					/>
+				),
+				after: <FormToggle { ...getInputProps( 'payfast' ) } />,
+				visible: [ 'ZA' ].includes( countryCode ),
 			},
 		];
 
@@ -469,21 +471,6 @@ class Payments extends Component {
 				visible: ! showIndividualConfigs,
 			},
 			{
-				key: 'payfast',
-				label: __( 'Enable PayFast', 'woocommerce-admin' ),
-				description: __(
-					'Connect your store to your PayFast account',
-					'woocommerce-admin'
-				),
-				content: (
-					<PayFast
-						markConfigured={ this.markConfigured }
-						setRequestPending={ this.setMethodRequestPending }
-					/>
-				),
-				visible: showIndividualConfigs && methods.includes( 'payfast' )
-			},
-			{
 				key: 'stripe',
 				label: __( 'Enable Stripe', 'woocommerce-admin' ),
 				description: __(
@@ -564,6 +551,21 @@ class Payments extends Component {
 				visible:
 					showIndividualConfigs &&
 					methods.includes( 'klarna-payments' ),
+			},
+			{
+				key: 'payfast',
+				label: __( 'Enable PayFast', 'woocommerce-admin' ),
+				description: __(
+					'Connect your store to your PayFast account',
+					'woocommerce-admin'
+				),
+				content: (
+					<PayFast
+						markConfigured={ this.markConfigured }
+						setRequestPending={ this.setMethodRequestPending }
+					/>
+				),
+				visible: showIndividualConfigs && methods.includes( 'payfast' ),
 			},
 		];
 

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -11,8 +11,7 @@ import { withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { ADMIN_URL } from '@woocommerce/wc-admin-settings';
-import { Form, Link, TextControl } from  '@woocommerce/components';
+import { Form, Link, TextControl } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -21,157 +20,169 @@ import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
 
 class PayFast extends Component {
-  constructor( props ) {
-    super( props );
-  }
+	getInitialConfigValues = () => {
+		return {
+			merchant_id: '',
+			merchant_key: '',
+			pass_phrase: '',
+		};
+	};
 
-  getInitialConfigValues = () => {
-    return {
-      merchant_id: '',
-      merchant_key: '',
-      pass_phrase: '',
-    };
-  };
+	validate = ( values ) => {
+		const errors = {};
 
-  validate = ( values ) => {
-    const errors = {};
+		if ( ! values.merchant_id ) {
+			errors.merchant_id = __(
+				'Please enter your merchant ID',
+				'woocommerce-admin'
+			);
+		}
 
-    if ( ! values.merchant_id ) {
-      errors.merchant_id = __( 'Please enter your merchant ID', 'woocommerce-admin' );
-    }
+		if ( ! values.merchant_key ) {
+			errors.merchant_key = __(
+				'Please enter your merchant key',
+				'woocommerce-admin'
+			);
+		}
 
-    if ( ! values.merchant_key ) {
-      errors.merchant_key = __( 'Please enter your merchant key', 'woocommerce-admin' );
-    }
+		if ( ! values.pass_phrase ) {
+			errors.pass_phrase = __(
+				'Please enter your passphrase',
+				'woocommerce-admin'
+			);
+		}
 
-    if ( ! values.pass_phrase ) {
-      errors.pass_phrase = __( 'Please enter your passphrase', 'woocommerce-admin' );
-    }
+		return errors;
+	};
 
-    return errors;
-  };
+	updateSettings = async ( values ) => {
+		const {
+			createNotice,
+			isSettingsError,
+			updateOptions,
+			markConfigured,
+			setRequestPending,
+		} = this.props;
 
-  updateSettings = async ( values ) => {
-    const {
-      createNotice,
-      isSettingsError,
-      updateOptions,
-      markConfigured,
-      setRequestPending,
-    } = this.props;
+		setRequestPending( true );
 
-    setRequestPending( true );
+		await updateOptions( {
+			woocommerce_payfast_settings: {
+				...this.props.options.woocommerce_payfast_settings,
+				merchant_id: values.merchant_id,
+				merchant_key: values.merchant_key,
+				pass_phrase: values.pass_phrase,
+				enabled: 'yes',
+			},
+		} );
 
-    await updateOptions( {
-      woocommerce_payfast_settings: {
-        ...this.props.options.woocommerce_payfast_settings,
-        merchant_id: values.merchant_id,
-        merchant_key: values.merchant_key,
-        pass_phrase: values.pass_phrase,
-        enabled: 'yes',
-      }
-    } );
+		if ( ! isSettingsError ) {
+			recordEvent( 'tasklist_payment_connect_method', {
+				payment_method: 'payfast',
+			} );
+			setRequestPending( false );
+			markConfigured( 'payfast' );
+			createNotice(
+				'success',
+				__( 'PayFast connected successfully', 'woocommerce-admin' )
+			);
+		} else {
+			setRequestPending( false );
+			createNotice(
+				'error',
+				__(
+					'There was a problem saving your payment setings',
+					'woocommerce-admin'
+				)
+			);
+		}
+	};
 
-    if ( !isSettingsError ) {
-      recordEvent( 'tasklist_payment_connect_method', {
-        payment_method: 'payfast'
-      } );
-      setRequestPending( false );
-      markConfigured( 'payfast' );
-      createNotice(
-        'success',
-        __( 'PayFast connected successfully', 'woocommerce-admin' )
-      );
-    } else {
-      setRequestPending( false );
-      createNotice(
-        'error',
-        __( 'There was a problem saving your payment setings', 'woocommerce-admin' )
-      );
-    }
-  };
+	render() {
+		const helpText = interpolateComponents( {
+			mixedString: __(
+				'Your API details can be obtained from your {{link}}PayFast account{{/link}}',
+				'woocommerce-admin'
+			),
+			components: {
+				link: (
+					<Link
+						href="https://www.payfast.co.za/"
+						target="_blank"
+						type="external"
+					/>
+				),
+			},
+		} );
 
-  render() {
-    const helpText = interpolateComponents( {
-      mixedString: __(
-        'Your API details can be obtained from your {{link}}PayFast account{{/link}}',
-        'woocommerce-admin'
-      ),
-      components: {
-        link: <Link 
-          href="https://www.payfast.co.za/"
-          target="_blank"
-          type="external"
-        />,
-      },
-    } );
-
-    return (
-      <Form
-        initialValues={ this.getInitialConfigValues() }
-        onSubmitCallback={ this.updateSettings }
-        validate={ this.validate }
-      >
-        { ( { getInputProps, handleSubmit } ) => {
-          return (
-            <Fragment>
-              <TextControl 
-                label={ __(
-                  'Merchant ID',
-                  'woocommerce-admin'
-                ) }
-                required
-                { ...getInputProps( 'merchant_id' ) }
-              />
-              <TextControl 
-                label={ __(
-                  'Merchant Key',
-                  'woocommerce-admin'
-                ) }
-                required
-                { ...getInputProps( 'merchant_key' ) }
-              />
-              <TextControl 
-                label={ __(
-                  'Passphrase',
-                  'woocommerce-admin'
-                ) }
-                required
-                { ...getInputProps( 'pass_phrase' ) }
-              />
-              <Button onClick={ handleSubmit } isPrimary>
-                { __( 'Proceed', 'woocommerce-admin' ) }
-              </Button>
-              <Button onClick={ () => {
-                this.props.markConfigured( 'payfast' )
-              } }>
-                { __( 'Skip', 'woocommerce-admin' ) }
-              </Button>
-              <p>{ helpText }</p>
-            </Fragment>
-          );
-        } }
-      </Form>
-    );
-  }
+		return (
+			<Form
+				initialValues={ this.getInitialConfigValues() }
+				onSubmitCallback={ this.updateSettings }
+				validate={ this.validate }
+			>
+				{ ( { getInputProps, handleSubmit } ) => {
+					return (
+						<Fragment>
+							<TextControl
+								label={ __(
+									'Merchant ID',
+									'woocommerce-admin'
+								) }
+								required
+								{ ...getInputProps( 'merchant_id' ) }
+							/>
+							<TextControl
+								label={ __(
+									'Merchant Key',
+									'woocommerce-admin'
+								) }
+								required
+								{ ...getInputProps( 'merchant_key' ) }
+							/>
+							<TextControl
+								label={ __(
+									'Passphrase',
+									'woocommerce-admin'
+								) }
+								required
+								{ ...getInputProps( 'pass_phrase' ) }
+							/>
+							<Button onClick={ handleSubmit } isPrimary>
+								{ __( 'Proceed', 'woocommerce-admin' ) }
+							</Button>
+							<Button
+								onClick={ () => {
+									this.props.markConfigured( 'payfast' );
+								} }
+							>
+								{ __( 'Skip', 'woocommerce-admin' ) }
+							</Button>
+							<p>{ helpText }</p>
+						</Fragment>
+					);
+				} }
+			</Form>
+		);
+	}
 }
 
 export default compose(
-  withSelect( ( select ) => {
-    const { getOptions } = select( 'wc-api' );
-    const options = getOptions( [ 'woocommerce_payfast_settings' ] );
+	withSelect( ( select ) => {
+		const { getOptions } = select( 'wc-api' );
+		const options = getOptions( [ 'woocommerce_payfast_settings' ] );
 
-    return {
-      options
-    };
-  } ),
-  withDispatch( ( dispatch ) => {
-    const { createNotice } = dispatch( 'core/notices' );
-    const { updateOptions } = dispatch( 'wc-api' );
-    
+		return {
+			options,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { updateOptions } = dispatch( 'wc-api' );
+
 		return {
 			createNotice,
 			updateOptions,
 		};
-  } )
+	} )
 )( PayFast );

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -5,58 +5,173 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
-import { Link } from '@woocommerce/components';
 import { ADMIN_URL } from '@woocommerce/wc-admin-settings';
+import { Form, Link, TextControl } from  '@woocommerce/components';
 
 /**
  * Internal dependencies
  */
 import { recordEvent } from 'lib/tracks';
+import withSelect from 'wc-api/with-select';
 
-export default class PayFast extends Component {
+class PayFast extends Component {
   constructor( props ) {
     super( props );
   }
 
-  continue = () => {
-    recordEvent( 'tasklist_payment_connect_method', {
-      payment_method: 'payfast'
-    } )
-  }
+  getInitialConfigValues = () => {
+    return {
+      merchant_id: '',
+      merchant_key: '',
+      pass_phrase: '',
+    };
+  };
+
+  validate = ( values ) => {
+    const errors = {};
+
+    if ( ! values.merchant_id ) {
+      errors.merchant_id = __( 'Please enter your merchant ID', 'woocommerce-admin' );
+    }
+
+    if ( ! values.merchant_key ) {
+      errors.merchant_key = __( 'Please enter your merchant key', 'woocommerce-admin' );
+    }
+
+    if ( ! values.pass_phrase ) {
+      errors.pass_phrase = __( 'Please enter your passphrase', 'woocommerce-admin' );
+    }
+
+    return errors;
+  };
+
+  updateSettings = async ( values ) => {
+    const {
+      createNotice,
+      isSettingsError,
+      updateOptions,
+      markConfigured,
+      setRequestPending,
+    } = this.props;
+
+    setRequestPending( true );
+
+    await updateOptions( {
+      woocommerce_payfast_settings: {
+        ...this.props.options.woocommerce_payfast_settings,
+        merchant_id: values.merchant_id,
+        merchant_key: values.merchant_key,
+        pass_phrase: values.pass_phrase,
+        enabled: 'yes',
+      }
+    } );
+
+    if ( !isSettingsError ) {
+      recordEvent( 'tasklist_payment_connect_method', {
+        payment_method: 'payfast'
+      } );
+      setRequestPending( false );
+      markConfigured( 'payfast' );
+      createNotice(
+        'success',
+        __( 'PayFast connected successfully', 'woocommerce-admin' )
+      );
+    } else {
+      setRequestPending( false );
+      createNotice(
+        'error',
+        __( 'There was a problem saving your payment setings', 'woocommerce-admin' )
+      );
+    }
+  };
 
   render() {
-    const link = <Link
-      href={ `${ ADMIN_URL }/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast` }
-      target="_blank"
-      type="external"
-    />;
-    const helpLink = <Link
-      href="https://docs.woocommerce.com/document/payfast-payment-gateway/"
-      target="_blank"
-      type="external"
-    />;
-    const configureText = interpolateComponents( {
+    const helpText = interpolateComponents( {
       mixedString: __(
-        'PayFast can be configured under your {{link}}store settings{{/link}}. Figure out {{helpLink}}what you need{{/helpLink}}.',
+        'Your API details can be obtained from your {{link}}PayFast account{{/link}}',
         'woocommerce-admin'
       ),
       components: {
-        link,
-        helpLink,
+        link: <Link 
+          href="https://www.payfast.co.za/"
+          target="_blank"
+          type="external"
+        />,
       },
     } );
 
     return (
-      <Fragment>
-        <p>{ configureText }</p>
-        <Button isPrimary isDefault onClick={ this.continue }>
-					{ __( 'Continue', 'woocommerce-admin' ) }
-				</Button>
-      </Fragment>
+      <Form
+        initialValues={ this.getInitialConfigValues() }
+        onSubmitCallback={ this.updateSettings }
+        validate={ this.validate }
+      >
+        { ( { getInputProps, handleSubmit } ) => {
+          return (
+            <Fragment>
+              <TextControl 
+                label={ __(
+                  'Merchant ID',
+                  'woocommerce-admin'
+                ) }
+                required
+                { ...getInputProps( 'merchant_id' ) }
+              />
+              <TextControl 
+                label={ __(
+                  'Merchant Key',
+                  'woocommerce-admin'
+                ) }
+                required
+                { ...getInputProps( 'merchant_key' ) }
+              />
+              <TextControl 
+                label={ __(
+                  'Passphrase',
+                  'woocommerce-admin'
+                ) }
+                required
+                { ...getInputProps( 'pass_phrase' ) }
+              />
+              <Button onClick={ handleSubmit } isPrimary>
+                { __( 'Proceed', 'woocommerce-admin' ) }
+              </Button>
+              <Button onClick={ () => {
+                this.props.markConfigured( 'payfast' )
+              } }>
+                { __( 'Skip', 'woocommerce-admin' ) }
+              </Button>
+              <p>{ helpText }</p>
+            </Fragment>
+          );
+        } }
+      </Form>
     );
   }
 }
+
+export default compose(
+  withSelect( ( select ) => {
+    const { getOptions } = select( 'wc-api' );
+    const options = getOptions( [ 'woocommerce_payfast_settings' ] );
+
+    return {
+      options
+    };
+  } ),
+  withDispatch( ( dispatch ) => {
+    const { createNotice } = dispatch( 'core/notices' );
+    const { updateOptions } = dispatch( 'wc-api' );
+    
+		return {
+			createNotice,
+			updateOptions,
+		};
+  } )
+)( PayFast );

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -17,7 +17,6 @@ import { Form, Link, TextControl } from '@woocommerce/components';
  * Internal dependencies
  */
 import { recordEvent } from 'lib/tracks';
-import withSelect from 'wc-api/with-select';
 
 class PayFast extends Component {
 	getInitialConfigValues = () => {
@@ -72,7 +71,6 @@ class PayFast extends Component {
 
 		await updateOptions( {
 			woocommerce_payfast_settings: {
-				...this.props.options.woocommerce_payfast_settings,
 				merchant_id: values.merchant_id,
 				merchant_key: values.merchant_key,
 				pass_phrase: values.pass_phrase,
@@ -172,17 +170,6 @@ class PayFast extends Component {
 }
 
 export default compose(
-	withSelect( ( select ) => {
-		const { getOptions } = select( 'wc-api' );
-		const options = getOptions( [
-			'woocommerce_payfast_settings',
-			'woocommerce_currency',
-		] );
-
-		return {
-			options,
-		};
-	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
 		const { updateOptions } = dispatch( 'wc-api' );

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -66,6 +66,10 @@ class PayFast extends Component {
 
 		setRequestPending( true );
 
+		// Because the PayFast extension only works with the South African Rand
+		// currency, force the store to use it
+		await updateOptions( { woocommerce_currency: 'ZAR' } );
+
 		await updateOptions( {
 			woocommerce_payfast_settings: {
 				...this.props.options.woocommerce_payfast_settings,
@@ -170,7 +174,10 @@ class PayFast extends Component {
 export default compose(
 	withSelect( ( select ) => {
 		const { getOptions } = select( 'wc-api' );
-		const options = getOptions( [ 'woocommerce_payfast_settings' ] );
+		const options = getOptions( [
+			'woocommerce_payfast_settings',
+			'woocommerce_currency',
+		] );
 
 		return {
 			options,

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -66,10 +66,9 @@ class PayFast extends Component {
 		setRequestPending( true );
 
 		// Because the PayFast extension only works with the South African Rand
-		// currency, force the store to use it
-		await updateOptions( { woocommerce_currency: 'ZAR' } );
-
+		// currency, force the store to use it while setting the PayFast settings
 		await updateOptions( {
+			woocommerce_currency: 'ZAR',
 			woocommerce_payfast_settings: {
 				merchant_id: values.merchant_id,
 				merchant_key: values.merchant_key,

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * WooCommerce dependencies
+ */
+import { Link } from '@woocommerce/components';
+import { ADMIN_URL } from '@woocommerce/wc-admin-settings';
+
+/**
+ * Internal dependencies
+ */
+import { recordEvent } from 'lib/tracks';
+
+export default class PayFast extends Component {
+  constructor( props ) {
+    super( props );
+  }
+
+  continue = () => {
+    recordEvent( 'tasklist_payment_connect_method', {
+      payment_method: 'payfast'
+    } )
+  }
+
+  render() {
+    const link = <Link
+      href={ `${ ADMIN_URL }/admin.php?page=wc-settings&tab=checkout&section=wc_gateway_payfast` }
+      target="_blank"
+      type="external"
+    />;
+    const helpLink = <Link
+      href="https://docs.woocommerce.com/document/payfast-payment-gateway/"
+      target="_blank"
+      type="external"
+    />;
+    const configureText = interpolateComponents( {
+      mixedString: __(
+        'PayFast can be configured under your {{link}}store settings{{/link}}. Figure out {{helpLink}}what you need{{/helpLink}}.',
+        'woocommerce-admin'
+      ),
+      components: {
+        link,
+        helpLink,
+      },
+    } );
+
+    return (
+      <Fragment>
+        <p>{ configureText }</p>
+        <Button isPrimary isDefault onClick={ this.continue }>
+					{ __( 'Continue', 'woocommerce-admin' ) }
+				</Button>
+      </Fragment>
+    );
+  }
+}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -521,6 +521,7 @@ class Onboarding {
 				'klarna-payments-for-woocommerce'     => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
 				'woocommerce-square'                  => 'woocommerce-square/woocommerce-square.php',
 				'woocommerce-shipstation-integration' => 'woocommerce-shipstation-integration/woocommerce-shipstation.php',
+				'woocommerce-payfast-gateway'         => 'woocommerce-payfast-gateway/woocommerce-payfast-gateway.php',
 			)
 		);
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -521,7 +521,7 @@ class Onboarding {
 				'klarna-payments-for-woocommerce'     => 'klarna-payments-for-woocommerce/klarna-payments-for-woocommerce.php',
 				'woocommerce-square'                  => 'woocommerce-square/woocommerce-square.php',
 				'woocommerce-shipstation-integration' => 'woocommerce-shipstation-integration/woocommerce-shipstation.php',
-				'woocommerce-payfast-gateway'         => 'woocommerce-payfast-gateway/woocommerce-payfast-gateway.php',
+				'woocommerce-payfast-gateway'         => 'woocommerce-payfast-gateway/gateway-payfast.php',
 			)
 		);
 	}


### PR DESCRIPTION
Fixes #3596

This adds the PayFast payment gateway option for sites in South Africa only.

### Screenshots

![image](https://user-images.githubusercontent.com/224531/74808295-4178da00-5336-11ea-8786-b49f13030cb0.png)

### Detailed test instructions:

1. Set the store address country/state to somewhere in South Africa
2. Go to WooCommerce -> Coupons -> Help -> Setup wizard -> and enable the task list
3. Go to WooCommerce -> Dashboard -> Set up payments
3. CHECK: PayFast payment gateway should be present in the list of available payment gateway options
4. Select PayFast payment gateway
5. Continue through the payments set up task
6. CHECK: PayFast payment gateway should be installed
7. Set the merchant ID, merchant key, and the passphrase for PayFast
8. WooCommerce -> Settings -> Payments -> Manage PayFast
9. CHECK: Confirm that the merchant ID, merchant key, and the passphrase are set correctly

### Changelog Note:

Dev: Add PayFast payment gateway option for sites in South Africa
