### PR TITLE
Fix image sideloading for store industries.

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -341,10 +341,15 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! empty( $profile['industry'] ) ) {
 			foreach ( $profile['industry'] as $selected_industry ) {
-				if ( ! is_array( $selected_industry ) || empty( $selected_industry['slug'] ) ) {
+				if ( is_string( $selected_industry ) ) {
+					$industry_slug = $selected_industry;
+				} elseif ( is_array( $selected_industry ) && ! empty( $selected_industry['slug'] ) ) {
+					$industry_slug = $selected_industry['slug'];
+				} else {
 					continue;
 				}
-				$industry_slug        = $selected_industry['slug'];
+				// Capture the first industry for use in our minimum images logic.
+				$first_industry       = isset( $first_industry ) ? $first_industry : $industry_slug;
 				$images_to_sideload[] = ! empty( $available_images[ $industry_slug ] ) ? $available_images[ $industry_slug ] : $available_images['other'];
 			}
 		}
@@ -353,15 +358,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( count( $images_to_sideload ) < $number_of_images ) {
 			for ( $i = count( $images_to_sideload ); $i < $number_of_images; $i++ ) {
 				// Fill up missing image slots with the first selected industry, or other.
-				$industry = 'other';
-				if (
-					! empty( $profile['industry'] ) &&
-					! empty( $profile['industry'][0] ) &&
-					! empty( $profile['industry'][0]['slug'] )
-				) {
-					$industry = $profile['industry'][0]['slug'];
-				}
-
+				$industry             = $first_industry ? $first_industry : 'other';
 				$images_to_sideload[] = empty( $available_images[ $industry ] ) ? $available_images['other'] : $available_images[ $industry ];
 			}
 		}

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -352,7 +352,17 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		// Make sure we have at least {$number_of_images} images.
 		if ( count( $images_to_sideload ) < $number_of_images ) {
 			for ( $i = count( $images_to_sideload ); $i < $number_of_images; $i++ ) {
-				$images_to_sideload[] = ! empty( $profile['industry'] ) && ! empty( $available_images[ $profile['industry'][0] ] ) ? $available_images[ $profile['industry'][0] ] : $available_images['other'];
+				// Fill up missing image slots with the first selected industry, or other.
+				$industry = 'other';
+				if (
+					! empty( $profile['industry'] ) &&
+					! empty( $profile['industry'][0] ) &&
+					! empty( $profile['industry'][0]['slug'] )
+				) {
+					$industry = $profile['industry'][0]['slug'];
+				}
+
+				$images_to_sideload[] = empty( $available_images[ $industry ] ) ? $available_images['other'] : $available_images[ $industry ];
 			}
 		}
 

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -341,7 +341,11 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		if ( ! empty( $profile['industry'] ) ) {
 			foreach ( $profile['industry'] as $selected_industry ) {
-				$images_to_sideload[] = ! empty( $available_images[ $selected_industry ] ) ? $available_images[ $selected_industry ] : $available_images['other'];
+				if ( ! is_array( $selected_industry ) || empty( $selected_industry['slug'] ) ) {
+					continue;
+				}
+				$industry_slug        = $selected_industry['slug'];
+				$images_to_sideload[] = ! empty( $available_images[ $industry_slug ] ) ? $available_images[ $industry_slug ] : $available_images['other'];
 			}
 		}
 


### PR DESCRIPTION
Data format for industries changed in https://github.com/woocommerce/woocommerce-admin/pull/3730

Fixes a PHP warning encountered in `sideload_homepage_images()`: `PHP Warning: Illegal offset type in isset or empty in /srv/www/wordpress-default/public_html/wp-content/plugins/woocommerce-admin/src/API/OnboardingTasks.php on line 344`

### Detailed test instructions:

- Go through the profiler again, selecting one or more industries
- Ensure your store has less than 4 products (or modify this line: https://github.com/woocommerce/woocommerce-admin/blob/24734f861cd00e2a61d5292b5e3338b43a0da33c/src/API/OnboardingTasks.php#L253)
- Use the task list to create a homepage
- Verify no PHP warnings in error logs, homepage has all expected images
- Ensure your store has more than 4 products (or modify this line: https://github.com/woocommerce/woocommerce-admin/blob/24734f861cd00e2a61d5292b5e3338b43a0da33c/src/API/OnboardingTasks.php#L253)
- Use the task list to create a homepage
- Verify no PHP warnings in error logs, homepage has all expected images
