### PR TITLE
Onboarding - payments task: filter payment gateways if the user selects CBD

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -346,6 +346,10 @@
 		color: $studio-gray-60;
 		margin: 0;
 		margin-right: $gap-larger;
+
+		.text-style-strong {
+			font-weight: bold;
+		}
 	}
 
 	.woocommerce-task-payment__after {

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -4,7 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { filter } from 'lodash';
+import { filter, some } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -31,11 +31,15 @@ export function getPaymentMethods( {
 	countryCode,
 	options,
 	profileItems,
-	hasCbdIndustry,
 } ) {
 	const stripeCountries = getSetting( 'onboarding', {
 		stripeSupportedCountries: [],
 	} ).stripeSupportedCountries;
+
+	const hasCbdIndustry =
+		some( profileItems.industry, {
+			slug: 'cbd-other-hemp-derived-products',
+		} ) || false;
 
 	const methods = [
 		{

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -31,6 +31,7 @@ export function getPaymentMethods( {
 	countryCode,
 	options,
 	profileItems,
+	hasCbdIndustry,
 } ) {
 	const stripeCountries = getSetting( 'onboarding', {
 		stripeSupportedCountries: [],
@@ -53,7 +54,8 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
-			visible: stripeCountries.includes( countryCode ),
+			visible:
+				stripeCountries.includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
 			isConfigured:
@@ -77,7 +79,7 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
-			visible: true,
+			visible: ! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
 			container: <PayPal />,
 			isConfigured:
@@ -99,7 +101,9 @@ export function getPaymentMethods( {
 			before: (
 				<img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />
 			),
-			visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
+			visible:
+				[ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ) &&
+				! hasCbdIndustry,
 			plugins: [ 'klarna-checkout-for-woocommerce' ],
 			container: <Klarna plugin={ 'checkout' } />,
 			// @todo This should check actual Klarna connection information.
@@ -121,7 +125,9 @@ export function getPaymentMethods( {
 			before: (
 				<img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />
 			),
-			visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
+			visible:
+				[ 'DK', 'DE', 'AT' ].includes( countryCode ) &&
+				! hasCbdIndustry,
 			plugins: [ 'klarna-payments-for-woocommerce' ],
 			container: <Klarna plugin={ 'payments' } />,
 			// @todo This should check actual Klarna connection information.
@@ -136,18 +142,32 @@ export function getPaymentMethods( {
 		{
 			key: 'square',
 			title: __( 'Square', 'woocommerce-admin' ),
-			content: __(
-				'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). ' +
-					'Sell online and in store and track sales and inventory in one place.',
-				'woocommerce-admin'
+			content: (
+				<Fragment>
+					{ __(
+						'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). ' +
+							'Sell online and in store and track sales and inventory in one place.',
+						'woocommerce-admin'
+					) }
+					{ hasCbdIndustry && (
+						<span className="text-style-strong">
+							{ __(
+								' Selling CBD products is only supported by Square.',
+								'woocommerce-admin'
+							) }
+						</span>
+					) }
+				</Fragment>
 			),
 			before: (
 				<img src={ wcAssetUrl + 'images/square-black.png' } alt="" />
 			),
 			visible:
-				[ 'brick-mortar', 'brick-mortar-other' ].includes(
+				( hasCbdIndustry && [ 'US' ].includes( countryCode ) ) ||
+				( [ 'brick-mortar', 'brick-mortar-other' ].includes(
 					profileItems.selling_venues
-				) && [ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ),
+				) &&
+					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ) ),
 			plugins: [ 'woocommerce-square' ],
 			container: <Square />,
 			isConfigured:
@@ -182,7 +202,7 @@ export function getPaymentMethods( {
 					alt="PayFast logo"
 				/>
 			),
-			visible: [ 'ZA' ].includes( countryCode ),
+			visible: [ 'ZA' ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payfast-gateway' ],
 			container: <PayFast />,
 			isConfigured:
@@ -203,8 +223,10 @@ export function getPaymentMethods( {
 				'woocommerce-admin'
 			),
 			before: <CodIcon />,
-			visible: true,
-			isEnabled: options.woocommerce_cod_settings && options.woocommerce_cod_settings.enabled === 'yes',
+			visible: ! hasCbdIndustry,
+			isEnabled:
+				options.woocommerce_cod_settings &&
+				options.woocommerce_cod_settings.enabled === 'yes',
 			optionName: 'woocommerce_cod_settings',
 		},
 		{
@@ -215,10 +237,14 @@ export function getPaymentMethods( {
 				'woocommerce-admin'
 			),
 			before: <BacsIcon />,
-			visible: true,
+			visible: ! hasCbdIndustry,
 			container: <Bacs />,
-			isConfigured: options.woocommerce_bacs_accounts && options.woocommerce_bacs_accounts.length,
-			isEnabled: options.woocommerce_bacs_settings && options.woocommerce_bacs_settings.enabled === 'yes',
+			isConfigured:
+				options.woocommerce_bacs_accounts &&
+				options.woocommerce_bacs_accounts.length,
+			isEnabled:
+				options.woocommerce_bacs_settings &&
+				options.woocommerce_bacs_settings.enabled === 'yes',
 			optionName: 'woocommerce_bacs_settings',
 		},
 	];

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -492,7 +492,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		if ( 'US' === WC()->countries->get_base_country() ) {
 			$profile = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 			if ( ! empty( $profile['industry'] ) ) {
-				$has_cbd_industry = array_search( 'cbd-other-hemp-derived-products', array_column( $profile, 'industry' ) );
+				$has_cbd_industry = array_search( 'cbd-other-hemp-derived-products', array_column( $profile['industry'], 'slug' ) );
 			}
 		}
 

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -489,7 +489,18 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 			return new WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error connecting to Square.', 'woocommerce-admin' ), 500 );
 		}
 
-		$url = \WooCommerce\Square\Handlers\Connection::CONNECT_URL_PRODUCTION;
+		if ( 'US' === WC()->countries->get_base_country() ) {
+			$profile = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+			if ( ! empty( $profile['industry'] ) ) {
+				$has_cbd_industry = array_search( 'cbd-other-hemp-derived-products', array_column( $profile, 'industry' ) );
+			}
+		}
+
+		if ( $has_cbd_industry ) {
+			$url  = 'https://squareup.com/t/f_partnerships/d_referrals/p_woocommerce/c_general/o_none/l_us/dt_alldevice/pr_payments/?route=/solutions/cbd';
+		} else {
+			$url = \WooCommerce\Square\Handlers\Connection::CONNECT_URL_PRODUCTION;
+		}
 
 		$redirect_url = wp_nonce_url( wc_admin_url( '&task=payments&method=square&square-connect-finish=1' ), 'wc_square_connected' );
 		$args         = array(


### PR DESCRIPTION
Fixes #3657

- Added control for CBD payments gateways
- Added tooltip to CBD in the payment gateway. The tooltip will alert the user that only Square supports CBD.

### Screenshots
![screenshot-tooltip](https://user-images.githubusercontent.com/1314156/75053961-e7505400-54b0-11ea-8204-112acb9aa8e7.png)


### Detailed test instructions:
- On the 2nd step of the `Onboarding Wizard` (_Industry_) choose `CBD and other hemp-derived products`.
- The `countryCode` must be `US`
- Go to:
      `WooCommerce`|`Dashboard`|`Set up payments` (or use this URL `/wp-admin/admin.php?page=wc-admin&task=payments`)
- **Only** the `Square` payment method should be visible.
- Also, a tooltip should be visible, next to the `Continue` button, with the text:
      `Selling CBD products is only supported by Square.`

- After finishing the process the user should be redirected to: `https://squareup.com/t/f_partnerships/d_referrals/p_woocommerce/c_general/o_none/l_us/dt_alldevice/pr_payments/?route=/solutions/cbd`

_If the industry `CBD and other hemp-derived products` is not selected, the `Set up payments` should  have a normal behavior._


### An "easy" way to add this industry is:
- Checkout the branch `fix/3631` (this is the [PR](https://github.com/woocommerce/woocommerce-admin/pull/3730)) and select the industry `CBD and other hemp-derived products` on the onboarding's second step.
- After that go back to this branch (`fix/3657`) and continue with the testing.


### UPDATE:
- The tooltip was removed. Now the text: `Selling CBD products is only supported by Square` is added at the end of the `Square` description text, like the screenshot below.
![screenshot-square](https://user-images.githubusercontent.com/1314156/77069938-167eb600-69c8-11ea-9155-7dd3e0a4d0f7.png)