### PR TITLE
Added event props to identify stores with WCS and Jetpack installed

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -4,7 +4,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { get, intersection } from 'lodash';
+import { get } from 'lodash';
 import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
 import { Snackbar, Icon, Button, Modal } from '@wordpress/components';
@@ -77,15 +77,12 @@ class TaskDashboard extends Component {
 
 	getPluginsInformation() {
 		const { isJetpackConnected } = this.props;
-		const plugins = [ 'jetpack', 'woocommerce-services' ];
 		const { activePlugins, installedPlugins } = getSetting( 'onboarding', {} );
-		const matchedInstalledPlugins = intersection( installedPlugins, plugins );
-		const matchedActivePlugins = intersection( activePlugins, plugins );
 		return {
-			wcs_installed: matchedInstalledPlugins.includes( 'woocommerce-services' ),
-			wcs_active: matchedActivePlugins.includes( 'woocommerce-services' ),
-			jetpack_installed: matchedInstalledPlugins.includes( 'jetpack' ),
-			jetpack_active: matchedActivePlugins.includes( 'jetpack' ),
+			wcs_installed: installedPlugins.includes( 'woocommerce-services' ),
+			wcs_active: activePlugins.includes( 'woocommerce-services' ),
+			jetpack_installed: installedPlugins.includes( 'jetpack' ),
+			jetpack_active: activePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
 		};
 	}

--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -79,13 +79,13 @@ class TaskDashboard extends Component {
 		const { isJetpackConnected } = this.props;
 		const plugins = [ 'jetpack', 'woocommerce-services' ];
 		const { activePlugins, installedPlugins } = getSetting( 'onboarding', {} );
-		const installedPluginsStore = intersection( installedPlugins, plugins );
-		const activePluginsStore = intersection( activePlugins, plugins );
+		const matchedInstalledPlugins = intersection( installedPlugins, plugins );
+		const matchedActivePlugins = intersection( activePlugins, plugins );
 		return {
-			wcs_installed: installedPluginsStore.includes( 'woocommerce-services' ),
-			wcs_active: activePluginsStore.includes( 'woocommerce-services' ),
-			jetpack_installed: installedPluginsStore.includes( 'jetpack' ),
-			jetpack_active: activePluginsStore.includes( 'jetpack' ),
+			wcs_installed: matchedInstalledPlugins.includes( 'woocommerce-services' ),
+			wcs_active: matchedActivePlugins.includes( 'woocommerce-services' ),
+			jetpack_installed: matchedInstalledPlugins.includes( 'jetpack' ),
+			jetpack_active: matchedActivePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
 		};
 	}

--- a/src/Features/ActivityPanels.php
+++ b/src/Features/ActivityPanels.php
@@ -102,7 +102,7 @@ class ActivityPanels {
 	 *
 	 * @return boolean
 	 */
-	public function clear_low_out_of_stock_count_transient() {
+	public static function clear_low_out_of_stock_count_transient() {
 		delete_transient( self::LOW_STOCK_TRANSIENT_NAME );
 		return true;
 	}


### PR DESCRIPTION
Fixes #3728 

Added the following event props to `task_view` for tracking:
- `WCS` is installed
- `WCS` is active
- `Jetpack` is installed
- `Jetpack` is active
- `Jetpack` is connected

### Detailed test instructions:
- Go to the `Onboarding tasks list` and got to any `task`. 
- Check if the event props `wcs_installed`, `wcs_active`, `jetpack_installed`, `jetpack_active` and `jetpack_connected` are being tracked.

### Changelog Note:
- This may be soon replaced by global event props, but this is a good temporary solution until that lands.
