### PR TITLE
Remove free text Search option when no query exists

### DIFF
--- a/packages/components/src/search/index.js
+++ b/packages/components/src/search/index.js
@@ -29,7 +29,7 @@ import {
  * A search box which autocompletes results while typing, allowing for the user to select an existing object
  * (product, order, customer, etc). Currently only products are supported.
  */
-class Search extends Component {
+export class Search extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
@@ -113,6 +113,10 @@ class Search extends Component {
 	appendFreeTextSearch( options, query ) {
 		const autocompleter = this.getAutocompleter();
 		const { allowFreeTextSearch } = this.props;
+
+		if ( ! query || ! query.length ) {
+			return [];
+		}
 
 		if ( ! allowFreeTextSearch ) {
 			return options;

--- a/packages/components/src/search/test/index.js
+++ b/packages/components/src/search/test/index.js
@@ -10,6 +10,18 @@ import { shallow } from 'enzyme';
 import { Search } from '../index';
 
 describe( 'Search', () => {
+	it( 'shows the free text search option', () => {
+		const search = shallow(
+			<Search
+				type="products"
+				allowFreeTextSearch
+			/>
+		);
+		const options = search.instance().appendFreeTextSearch( [], 'Product Query' );
+
+		expect( options.length ).toBe( 1 );
+	} );
+
 	it( "doesn't show options with an empty search", () => {
 		const search = shallow(
 			<Search

--- a/packages/components/src/search/test/index.js
+++ b/packages/components/src/search/test/index.js
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { Search } from '../index';
+
+describe( 'Search', () => {
+	it( "doesn't show options with an empty search", () => {
+		const search = shallow(
+			<Search
+				type="products"
+				allowFreeTextSearch
+			/>
+		);
+		const options = search.instance().appendFreeTextSearch( [], '' );
+
+		expect( options.length ).toBe( 0 );
+	} );
+} );
+

--- a/packages/components/src/select-control/list.js
+++ b/packages/components/src/select-control/list.js
@@ -151,10 +151,6 @@ class List extends Component {
 		const listboxClasses = classnames( 'woocommerce-select-control__listbox', {
 			'is-static': staticList,
 		} );
-		const optionsHaveValues = options ? options[ 0 ].value.id !== '' : false;
-		if ( ! optionsHaveValues ) {
-			return null;
-		}
 
 		return (
 			<div ref={ this.listbox } id={ listboxId } role="listbox" className={ listboxClasses }>

--- a/packages/components/src/select-control/test/index.js
+++ b/packages/components/src/select-control/test/index.js
@@ -176,23 +176,4 @@ describe( 'SelectControl', () => {
 			expect( selectControl.find( Button ).filter( '.' + optionClassname ).length ).toBe( 1 );
 		}, 0 );
 	} );
-
-	it( "doesn't show options with an empty search", () => {
-		const optionsEmptyValue = [
-			{ key: '1', label: 'lorem 1', value: { id: '' } },
-        ];
-		const optionControlClassname = 'woocommerce-select-control__listbox';
-		const selectControl = mount(
-			<SelectControl
-				options={ optionsEmptyValue }
-			/>
-		);
-
-		selectControl.instance().search( '' );
-		selectControl.update();
-
-		setTimeout( function() {
-			expect( selectControl.find( '.' + optionControlClassname ).length ).toBe( 0 );
-		}, 0 );
-	} );
 } );


### PR DESCRIPTION
Fixes #3754 

Moves the logic for #3700 into the `Search` component.

### Screenshots
<img width="569" alt="Screen Shot 2020-02-21 at 10 32 41 AM" src="https://user-images.githubusercontent.com/10561050/75022190-eb22ad00-5495-11ea-83bf-e689b7db32e8.png">
<img width="530" alt="Screen Shot 2020-02-21 at 10 31 17 AM" src="https://user-images.githubusercontent.com/10561050/75022341-363cc000-5496-11ea-8514-2865f5face4f.png">


### Detailed test instructions:

1. Open the onboarding profiler store details step.
1. Focus the `SelectControl` (country/state dropdown) and make sure no errors occur.
1. Go to an analytics screen with a `Search` component and free text search option (e.g., Products or Customers).
1. Click on the `Search` component and make sure no options are shown.
1. Type a query and make sure you're given the "free text" search option (e.g. "All products with titles that include...").