### PR TITLE
Fix WP Coding Standards PR Regressions

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -110,7 +110,11 @@ class OrdersPanel extends Component {
 		};
 
 		const orderCardTitle = ( order ) => {
-			const { extended_info: extendedInfo, order_id: orderId, orderNumber } = order;
+			const {
+				extended_info: extendedInfo,
+				order_id: orderId,
+				order_number: orderNumber,
+			} = order;
 			const { customer } = extendedInfo || {};
 			const customerUrl = customer.customer_id
 				? getNewPath( {}, '/analytics/customers', {

--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -38,13 +38,17 @@ export function getLeaderboard( options ) {
 		persisted_query: JSON.stringify( persistedQuery ),
 	};
 
+	// Disable eslint rule requiring `leaderboards` to be defined below because
+	// the next two if statements depend on `getItems` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const leaderboards = getItems( endpoint, leaderboardQuery );
+
 	if ( isGetItemsRequesting( endpoint, leaderboardQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getItemsError( endpoint, leaderboardQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const leaderboards = getItems( endpoint, leaderboardQuery );
 	const leaderboard = leaderboards.get( options.id );
 	return { ...response, rows: leaderboard.rows };
 }

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -246,13 +246,18 @@ export function getSummaryNumbers( options ) {
 	};
 
 	const primaryQuery = getRequestQuery( { ...options, dataType: 'primary' } );
+
+	// Disable eslint rule requiring `primary` to be defined below because
+	// the next two if statements depend on `getReportStats` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const primary = getReportStats( endpoint, primaryQuery );
+	
 	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getReportStatsError( endpoint, primaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const primary = getReportStats( endpoint, primaryQuery );
 	const primaryTotals =
 		( primary && primary.data && primary.data.totals ) || null;
 
@@ -260,13 +265,18 @@ export function getSummaryNumbers( options ) {
 		...options,
 		dataType: 'secondary',
 	} );
+
+	// Disable eslint rule requiring `primary` to be defined below because
+	// the next two if statements depend on `getReportStats` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const secondary = getReportStats( endpoint, secondaryQuery );
+
 	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getReportStatsError( endpoint, secondaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const secondary = getReportStats( endpoint, secondaryQuery );
 	const secondaryTotals =
 		( secondary && secondary.data && secondary.data.totals ) || null;
 


### PR DESCRIPTION
Fixes #3752.

This PR fixes errant changes from the WP Coding Standards PR. They mostly consist of missing variables or function call order changes (due to eslint rules).

### Detailed test instructions:

- Verify that leaderboards load on the dashboard
- Verify that order numbers are displayed properly in the activity panel
- Verify that summary numbers load on the categories report in comparison mode
