### PR TITLE
[0.26.0] OBW: fix sideloading image test error

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -358,7 +358,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		if ( count( $images_to_sideload ) < $number_of_images ) {
 			for ( $i = count( $images_to_sideload ); $i < $number_of_images; $i++ ) {
 				// Fill up missing image slots with the first selected industry, or other.
-				$industry             = $first_industry ? $first_industry : 'other';
+				$industry             = isset( $first_industry ) ? $first_industry : 'other';
 				$images_to_sideload[] = empty( $available_images[ $industry ] ) ? $available_images['other'] : $available_images[ $industry ];
 			}
 		}


### PR DESCRIPTION
Tests were failing version/1.0 branch. I'm not sure how it sneaked in (maybe a new branch was made from version/1.0 before Travis updates?), but discovered in  https://github.com/woocommerce/woocommerce-admin/pull/3753.

![Screen Shot 2020-02-24 at 11 46 03 AM](https://user-images.githubusercontent.com/1922453/75121732-aef08600-56fb-11ea-8610-d93664aad8c7.png)

### Test

Review code and ensure tests pass.


