### PR TITLE
Fix/coding standards violations

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -90,7 +90,8 @@ class OrdersPanel extends Component {
 
 		const getCustomerString = ( order ) => {
 			const extendedInfo = order.extended_info || {};
-			const { first_name: firstName, last_name: lastName } = extendedInfo.customer || {};
+			const { first_name: firstName, last_name: lastName } =
+				extendedInfo.customer || {};
 
 			if ( ! firstName && ! lastName ) {
 				return '';
@@ -110,7 +111,11 @@ class OrdersPanel extends Component {
 		};
 
 		const orderCardTitle = ( order ) => {
-			const { extended_info: extendedInfo, order_id: orderId, orderNumber } = order;
+			const {
+				extended_info: extendedInfo,
+				order_id: orderId,
+				order_number: orderNumber,
+			} = order;
 			const { customer } = extendedInfo || {};
 			const customerUrl = customer.customer_id
 				? getNewPath( {}, '/analytics/customers', {

--- a/client/wc-api/items/utils.js
+++ b/client/wc-api/items/utils.js
@@ -20,7 +20,12 @@ import { appendTimestamp, getCurrentDates } from 'lib/date';
  */
 export function getLeaderboard( options ) {
 	const endpoint = 'leaderboards';
-	const { per_page: perPage, persisted_query: persistedQuery, query, select } = options;
+	const {
+		per_page: perPage,
+		persisted_query: persistedQuery,
+		query,
+		select,
+	} = options;
 	const { getItems, getItemsError, isGetItemsRequesting } = select(
 		'wc-api'
 	);
@@ -38,13 +43,17 @@ export function getLeaderboard( options ) {
 		persisted_query: JSON.stringify( persistedQuery ),
 	};
 
+	// Disable eslint rule requiring `getItems` to be defined below because the next two statements
+	// depend on `getItems` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const leaderboards = getItems( endpoint, leaderboardQuery );
+
 	if ( isGetItemsRequesting( endpoint, leaderboardQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getItemsError( endpoint, leaderboardQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const leaderboards = getItems( endpoint, leaderboardQuery );
 	const leaderboard = leaderboards.get( options.id );
 	return { ...response, rows: leaderboard.rows };
 }

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -246,13 +246,18 @@ export function getSummaryNumbers( options ) {
 	};
 
 	const primaryQuery = getRequestQuery( { ...options, dataType: 'primary' } );
+
+	// Disable eslint rule requiring `getReportStats` to be defined below because the next two statements
+	// depend on `getReportStats` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const primary = getReportStats( endpoint, primaryQuery );
+
 	if ( isReportStatsRequesting( endpoint, primaryQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getReportStatsError( endpoint, primaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const primary = getReportStats( endpoint, primaryQuery );
 	const primaryTotals =
 		( primary && primary.data && primary.data.totals ) || null;
 
@@ -260,13 +265,18 @@ export function getSummaryNumbers( options ) {
 		...options,
 		dataType: 'secondary',
 	} );
+
+	// Disable eslint rule requiring `getReportStats` to be defined below because the next two statements
+	// depend on `getReportStats` to have been called.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const secondary = getReportStats( endpoint, secondaryQuery );
+
 	if ( isReportStatsRequesting( endpoint, secondaryQuery ) ) {
 		return { ...response, isRequesting: true };
 	} else if ( getReportStatsError( endpoint, secondaryQuery ) ) {
 		return { ...response, isError: true };
 	}
 
-	const secondary = getReportStats( endpoint, secondaryQuery );
 	const secondaryTotals =
 		( secondary && secondary.data && secondary.data.totals ) || null;
 


### PR DESCRIPTION
Partially addresses https://github.com/woocommerce/woocommerce-admin/issues/3752

https://github.com/woocommerce/woocommerce-admin/pull/3674 let a few errors slip through the cracks in the large refactor to update the coding standards.

### Screenshots

### Detailed test instructions:

1. Ensure Dashboard Leaderboards load correctly
2. Orders Activity Panel - Make sure the title renders correcly, no "order #undefined".
3. Categories Report: Compare mode, make sure Summary Numbers render.

### Changelog Note:

Dev: Address coding standards refactor errors
