### PR TITLE
Product titles include encoded entities

### DIFF
--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -5,6 +5,7 @@
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
 import { map } from 'lodash';
 
 /**
@@ -109,12 +110,13 @@ class ProductsReportTable extends Component {
 				category_ids,
 				low_stock_amount,
 				manage_stock,
-				name,
 				sku,
 				stock_status,
 				stock_quantity,
 				variations = [],
 			} = extended_info;
+			const name = decodeEntities( extended_info.name );
+
 			const ordersLink = getNewPath( persistedQuery, '/analytics/orders', {
 				filter: 'advanced',
 				product_includes: product_id,

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -4,6 +4,7 @@
  */
 import { __, _n, _x } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * WooCommerce dependencies
@@ -66,13 +67,14 @@ export default class StockReportTable extends Component {
 			const {
 				id,
 				manage_stock,
-				name,
 				parent_id,
 				sku,
 				stock_quantity,
 				stock_status,
 				low_stock_amount,
 			} = product;
+
+			const name = decodeEntities( product.name );
 
 			const productDetailLink = getNewPath( persistedQuery, '/analytics/products', {
 				filter: 'single_product',

--- a/packages/components/src/dropdown-button/index.js
+++ b/packages/components/src/dropdown-button/index.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -22,7 +23,7 @@ const DropdownButton = props => {
 	return (
 		<Button className={ buttonClasses } aria-expanded={ isOpen } { ...otherProps }>
 			<div className="woocommerce-dropdown-button__labels">
-				{ labels.map( ( label, i ) => <span key={ i }>{ label }</span> ) }
+				{ labels.map( ( label, i ) => <span key={ i }>{ decodeEntities( label ) }</span> ) }
 			</div>
 		</Button>
 	);

--- a/packages/components/src/search/autocompleters/utils.js
+++ b/packages/components/src/search/autocompleters/utils.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Parse a string suggestion, split apart by where the first matching query is.
@@ -19,9 +20,9 @@ export function computeSuggestionMatch( suggestion, query ) {
 	const indexOfMatch = suggestion.toLocaleLowerCase().indexOf( query.toLocaleLowerCase() );
 
 	return {
-		suggestionBeforeMatch: suggestion.substring( 0, indexOfMatch ),
-		suggestionMatch: suggestion.substring( indexOfMatch, indexOfMatch + query.length ),
-		suggestionAfterMatch: suggestion.substring( indexOfMatch + query.length ),
+		suggestionBeforeMatch: decodeEntities( suggestion.substring( 0, indexOfMatch ) ),
+		suggestionMatch: decodeEntities( suggestion.substring( indexOfMatch, indexOfMatch + query.length ) ),
+		suggestionAfterMatch: decodeEntities( suggestion.substring( indexOfMatch + query.length ) ),
 	};
 }
 

--- a/packages/components/src/search/test/index.js
+++ b/packages/components/src/search/test/index.js
@@ -36,8 +36,8 @@ describe( 'Search', () => {
 	} );
 
 	it( 'returns an object with decoded text', () => {
-		const decodedText = computeSuggestionMatch( 'A test &amp; a &#97;&#101;&#115;&#116;', 'test' );
-		const expected = '{"suggestionBeforeMatch":"A ","suggestionMatch":"test","suggestionAfterMatch":" & a aest"}';
+		const decodedText = computeSuggestionMatch( 'A test &amp; a &#116;&#101;&#115;&#116;', 'test' );
+		const expected = '{"suggestionBeforeMatch":"A ","suggestionMatch":"test","suggestionAfterMatch":" & a test"}';
 		expect( JSON.stringify( decodedText ) ).toBe( expected );
 	} );
 } );

--- a/packages/components/src/search/test/index.js
+++ b/packages/components/src/search/test/index.js
@@ -8,6 +8,7 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { Search } from '../index';
+import { computeSuggestionMatch } from '../autocompleters/utils';
 
 describe( 'Search', () => {
 	it( 'shows the free text search option', () => {
@@ -32,6 +33,12 @@ describe( 'Search', () => {
 		const options = search.instance().appendFreeTextSearch( [], '' );
 
 		expect( options.length ).toBe( 0 );
+	} );
+
+	it( 'returns an object with decoded text', () => {
+		const decodedText = computeSuggestionMatch( 'A test &amp; a &#97;&#101;&#115;&#116;', 'test' );
+		const expected = '{"suggestionBeforeMatch":"A ","suggestionMatch":"test","suggestionAfterMatch":" & a aest"}';
+		expect( JSON.stringify( decodedText ) ).toBe( expected );
 	} );
 } );
 

--- a/packages/components/src/tag/index.js
+++ b/packages/components/src/tag/index.js
@@ -6,6 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import { Button, Dashicon, IconButton, Popover } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 import PropTypes from 'prop-types';
 import { withState, withInstanceId } from '@wordpress/compose';
 
@@ -32,6 +33,7 @@ const Tag = ( {
 		// @todo Maybe this should be a loading indicator?
 		return null;
 	}
+	label = decodeEntities( label );
 	const classes = classnames( 'woocommerce-tag', className, {
 		'has-remove': !! remove,
 	} );

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -127,7 +127,7 @@ class Products extends \WC_REST_Products_Controller {
 		if ( $request->get_param( 'low_in_stock' ) && is_numeric( $object_data['low_stock_amount'] ) ) {
 			$data->data['low_stock_amount'] = $object_data['low_stock_amount'];
 		}
-		$data->data['name'] = strip_tags( $data->data['name'] );
+		$data->data['name'] = wp_strip_all_tags( $data->data['name'] );
 
 		return $data;
 	}

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -127,6 +127,7 @@ class Products extends \WC_REST_Products_Controller {
 		if ( $request->get_param( 'low_in_stock' ) && is_numeric( $object_data['low_stock_amount'] ) ) {
 			$data->data['low_stock_amount'] = $object_data['low_stock_amount'];
 		}
+		$data->data['name'] = strip_tags( $data->data['name'] );
 
 		return $data;
 	}

--- a/src/API/Reports/Products/Controller.php
+++ b/src/API/Reports/Products/Controller.php
@@ -70,8 +70,8 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$data = array();
 
 		foreach ( $products_data->data as $product_data ) {
-			$item   = $this->prepare_item_for_response( $product_data, $request );
-			if ( isset( $item->data['extended_info']['name'] ) ){
+			$item = $this->prepare_item_for_response( $product_data, $request );
+			if ( isset( $item->data['extended_info']['name'] ) ) {
 				$item->data['extended_info']['name'] = wp_strip_all_tags( $item->data['extended_info']['name'] );
 			}
 			$data[] = $this->prepare_response_for_collection( $item );

--- a/src/API/Reports/Products/Controller.php
+++ b/src/API/Reports/Products/Controller.php
@@ -70,9 +70,11 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$data = array();
 
 		foreach ( $products_data->data as $product_data ) {
-			$item                                = $this->prepare_item_for_response( $product_data, $request );
-			$item->data['extended_info']['name'] = wp_strip_all_tags( $item->data['extended_info']['name'] );
-			$data[]                              = $this->prepare_response_for_collection( $item );
+			$item   = $this->prepare_item_for_response( $product_data, $request );
+			if ( isset( $item->data['extended_info']['name'] ) ){
+				$item->data['extended_info']['name'] = wp_strip_all_tags( $item->data['extended_info']['name'] );
+			}
+			$data[] = $this->prepare_response_for_collection( $item );
 		}
 
 		$response = rest_ensure_response( $data );

--- a/src/API/Reports/Products/Controller.php
+++ b/src/API/Reports/Products/Controller.php
@@ -70,8 +70,9 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$data = array();
 
 		foreach ( $products_data->data as $product_data ) {
-			$item   = $this->prepare_item_for_response( $product_data, $request );
-			$data[] = $this->prepare_response_for_collection( $item );
+			$item                                = $this->prepare_item_for_response( $product_data, $request );
+			$item->data['extended_info']['name'] = wp_strip_all_tags( $item->data['extended_info']['name'] );
+			$data[]                              = $this->prepare_response_for_collection( $item );
 		}
 
 		$response = rest_ensure_response( $data );

--- a/src/API/Reports/Stock/Controller.php
+++ b/src/API/Reports/Stock/Controller.php
@@ -290,7 +290,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$data = array(
 			'id'               => $product->get_id(),
 			'parent_id'        => $product->get_parent_id(),
-			'name'             => $product->get_name(),
+			'name'             => strip_tags( $product->get_name() ),
 			'sku'              => $product->get_sku(),
 			'stock_status'     => $product->get_stock_status(),
 			'stock_quantity'   => (float) $product->get_stock_quantity(),

--- a/src/API/Reports/Stock/Controller.php
+++ b/src/API/Reports/Stock/Controller.php
@@ -290,7 +290,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 		$data = array(
 			'id'               => $product->get_id(),
 			'parent_id'        => $product->get_parent_id(),
-			'name'             => strip_tags( $product->get_name() ),
+			'name'             => wp_strip_all_tags( $product->get_name() ),
 			'sku'              => $product->get_sku(),
 			'stock_status'     => $product->get_stock_status(),
 			'stock_quantity'   => (float) $product->get_stock_quantity(),


### PR DESCRIPTION
Fixes #3747

- Added some frontend and backend changes to support HTML tags and encoded entities on product titles.

### Screenshots
![screenshot-1](https://user-images.githubusercontent.com/1314156/75188583-238ee900-572b-11ea-96be-9c843d81ebae.png)
![screenshot-3](https://user-images.githubusercontent.com/1314156/75188608-2e497e00-572b-11ea-898f-8b6423eeab2c.png)
![screenshot-4](https://user-images.githubusercontent.com/1314156/75188705-6355d080-572b-11ea-8d62-b19ff2c0f4dd.png)


### Detailed test instructions:
**Case 1**
- Go to: `WooCommerce` | `Analytics` | `Products` (URL -> `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts&type=instock`).
- Click on the dropdown `All Products` under the `Show:` label.
- Choose `Single Product`.
- Start typing a product's name (the product name for this test should be one that has an HTML tag and an encoded character).
- The product's name should be shown without tag and decoded.
- Choose the product.
- The product's name should be shown without tags and decoded in the dropdown.
- If we press again on the dropdown, a tag with the product's name without errors should be visible.
- Also, the product list should show the product's name correctly.

**Case 2**
- Go to: `WooCommerce` | `Analytics` | `Stock` (URL -> `http://one.wordpress.test/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fstock`).
- On the product's list, the product's name should be displayed correctly.

![Screen Capture on 2020-02-24 at 17-51-02](https://user-images.githubusercontent.com/1314156/75190098-5be3f680-572e-11ea-9bce-248e477c1504.gif)
