### PR TITLE
add deactivation hook to Package.php

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -53,6 +53,9 @@ class Package {
 				$update_version::delete_note();
 			}
 
+			// Register a deactivation hook for the feature plugin.
+			register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( __CLASS__, 'on_deactivation' ) );
+
 			return;
 		}
 
@@ -75,5 +78,13 @@ class Package {
 	 */
 	public static function get_path() {
 		return dirname( __DIR__ );
+	}
+
+	/**
+	 * Add deactivation hook for versions of the plugin that don't have the deactivation note.
+	 */
+	public static function on_deactivation() {
+		$update_version = new WC_Admin_Notes_Deactivate_Plugin();
+		$update_version::delete_note();
 	}
 }


### PR DESCRIPTION
Fixes #3769

This PR adds a deactivation hook to `Package.php` to remove the deactivation note when an older version of WC Admin is deactivated. Pre-0.26.0 versions of the plugin don't have the deactivation note functionality so they do not remove the note.

### Screenshots

### Detailed test instructions:

- Checkout https://github.com/woocommerce/woocommerce/pull/25701
- Copy `src/Package.php` to `woocommerce/packages/woocommerce-admin/src`
- Activate WCA 0.26.0
- No note should be displayed
- Activate WCA 0.25.0
- Deactivation note should be displayed
- Deactivate WCA
- No note should be displayed

### Changelog Note:

Fix: Remove deactivation notice when earlier versions of WCA are deactivated.