### PR TITLE
Add active version functions

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -80,7 +80,7 @@ class Package {
 	}
 
 	/**
-	 * Return the active version WC Admin.
+	 * Return the active version of WC Admin.
 	 *
 	 * @return string
 	 */

--- a/src/Package.php
+++ b/src/Package.php
@@ -29,6 +29,13 @@ class Package {
 	const VERSION = '0.26.0';
 
 	/**
+	 * Package active.
+	 *
+	 * @var string
+	 */
+	private static $package_active = false;
+
+	/**
 	 * Init the package.
 	 *
 	 * Only initialize for WP 5.3 or greater.
@@ -59,6 +66,7 @@ class Package {
 			return;
 		}
 
+		self::$package_active = true;
 		FeaturePlugin::instance()->init();
 	}
 
@@ -69,6 +77,24 @@ class Package {
 	 */
 	public static function get_version() {
 		return self::VERSION;
+	}
+
+	/**
+	 * Return the active version WC Admin.
+	 *
+	 * @return string
+	 */
+	public static function get_active_version() {
+		return self::$package_active ? self::VERSION : WC_ADMIN_VERSION_NUMBER;
+	}
+
+	/**
+	 * Return whether the package is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_package_active() {
+		return self::$package_active;
 	}
 
 	/**

--- a/src/Package.php
+++ b/src/Package.php
@@ -31,7 +31,7 @@ class Package {
 	/**
 	 * Package active.
 	 *
-	 * @var string
+	 * @var bool
 	 */
 	private static $package_active = false;
 


### PR DESCRIPTION
Fixes #3771

This PR adds 2 functions to `Package.php` for WC core to use to determine which version of WC Admin is active.

### Detailed test instructions:

- Checkout https://github.com/woocommerce/woocommerce/pull/25701
- Copy `src/Package.php` to `woocommerce/packages/woocommerce-admin/src`
- Visit the WooCommerce -> Status page
- With both plugins active the standalone plugin should be shown as active
- With WC Admin deactivated the packaged version should be shown as active
<img width="1138" alt="Screen Shot 2020-02-25 at 3 08 03 PM" src="https://user-images.githubusercontent.com/343847/75278647-a7ef7380-57e0-11ea-894b-18b951cea9ad.png">

