### PR TITLE
Onboarding: Update payments task flow

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, cloneElement, Fragment } from '@wordpress/element';
 import { get } from 'lodash';
 import { compose } from '@wordpress/compose';
 import classNames from 'classnames';
@@ -257,7 +257,7 @@ class TaskDashboard extends Component {
 	}
 
 	render() {
-		const { inline } = this.props;
+		const { inline, query } = this.props;
 		const { isCartModalOpen, isWelcomeModalOpen } = this.state;
 		const currentTask = this.getCurrentTask();
 		const listTasks = this.getTasks().map( ( task ) => {
@@ -285,7 +285,9 @@ class TaskDashboard extends Component {
 			<Fragment>
 				<div className="woocommerce-task-dashboard__container">
 					{ currentTask ? (
-						currentTask.container
+						cloneElement( currentTask.container, {
+							query,
+						} )
 					) : (
 						<Fragment>
 							<Card

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -317,6 +317,10 @@
 
 	.woocommerce-task-payment__after {
 		margin-left: $gap-larger;
+
+		.components-button.is-button {
+			margin: 0;
+		}
 	}
 
 	@include breakpoint( '<600px' ) {

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -351,6 +351,21 @@
 	}
 }
 
+.woocommerce-task-dashboard__container .woocommerce-task-payments .woocommerce-task-payments__actions {
+	text-align: center;
+
+	button.components-button.is-primary {
+		margin: 0;
+	}
+
+	button.components-button.is-link {
+		margin: 0;
+		height: auto;
+		color: $studio-gray-60;
+		font-weight: normal;
+	}
+}
+
 .woocommerce-task-appearance {
 	.woocommerce-image-upload {
 		margin-bottom: $gap-smallest;

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -291,6 +291,28 @@
 		padding: $gap-large $gap-larger;
 		align-items: center;
 		position: relative;
+		overflow: hidden;
+	}
+
+	.woocommerce-task-payment__recommended-ribbon {
+		position: absolute;
+		transform: rotate(-45deg) translate(-50%, -50%);
+		background: $studio-gray-80;
+		color: $studio-white;
+		font-size: 11px;
+		line-height: 20px;
+		position: absolute;
+		top: 0;
+		left: 0;
+		line-height: 1;
+		padding: 7px $gap-largest;
+		transform-origin: top left;
+		margin-top: 36px;
+		margin-left: 36px;
+
+		span {
+			max-width: 70px;
+		}
 	}
 
 	.woocommerce-task-payment__before {
@@ -326,6 +348,10 @@
 	@include breakpoint( '<600px' ) {
 		.woocommerce-card__body {
 			flex-direction: column;
+		}
+
+		.woocommerce-task-payment__recommended-ribbon {
+			display: none;
 		}
 
 		.woocommerce-task-payment__before {

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -285,97 +285,64 @@
 	}
 }
 
-.woocommerce-task-payments {
-	.woocommerce-list__item .woocommerce-list__item-after {
-		align-self: start;
-		margin-left: $gap;
-		margin-top: $gap-large;
+.woocommerce-task-payment {
+	.woocommerce-card__body {
+		display: flex;
+		padding: $gap-large $gap-larger;
+		align-items: center;
+		position: relative;
 	}
 
-	.woocommerce-list__item .woocommerce-list__item-before {
-		max-width: 96px;
-		background: $studio-gray-0;
-		padding: $gap-small;
-		align-self: start;
-		margin-top: $gap;
+	.woocommerce-task-payment__before {
+		margin-right: $gap-larger;
 
 		img {
-			max-width: 72px;
+			max-width: 100px;
 		}
 	}
 
-	.woocommerce-list__item-title {
-		border-top: 1px solid $studio-gray-5;
-		padding-top: $gap;
+	.woocommerce-task-payment__title {
+		font-size: 16px;
+		font-weight: 400;
+		color: $studio-gray-80;
+		margin-top: 0;
+		margin-bottom: $gap-smaller;
 	}
 
-	.woocommerce-task-payments__woocommerce-services-options {
-		border-top: 1px solid $studio-gray-5;
-		margin-top: $gap;
+	.woocommerce-task-payment__content {
+		font-size: 14px;
+		color: $studio-gray-60;
+		margin: 0;
+	}
+
+	.woocommerce-task-payment__after {
 		margin-left: $gap-larger;
-		padding-top: $gap;
-
-		svg.dashicon.components-checkbox-control__checked {
-			display: block;
-			left: -38px;
-			top: -1px;
-		}
-
-		.components-checkbox-control__input {
-			margin-left: -$gap-larger;
-		}
-
-		.components-checkbox-control__label {
-			font-size: 16px;
-			line-height: 22px;
-			padding-left: 0;
-			margin-left: -$gap-large;
-			color: #1a1a1a;
-		}
-
-		.muriel-component {
-			margin-left: $gap-smallest;
-		}
 	}
 
 	@include breakpoint( '<600px' ) {
-		.woocommerce-list__item > .woocommerce-list__item-inner {
+		.woocommerce-card__body {
 			flex-direction: column;
 		}
 
-		.woocommerce-list__item-title {
-			border-top: 0;
-		}
-
-		.woocommerce-list__item .woocommerce-list__item-before {
-			margin-top: 0;
+		.woocommerce-task-payment__before {
 			order: 1;
+			margin-right: auto;
+			margin-bottom: $gap-large;
 		}
 
-		.woocommerce-task-payments__woocommerce-services-options {
-			margin-top: $gap-smaller;
-			border-top: 0;
+		.woocommerce-task-payment__after {
+			position: absolute;
+			right: $gap-larger;
+			top: $gap-large;
+
+			.components-form-toggle {
+				margin-top: $gap-smallest;
+			}
 		}
 
-		.woocommerce-task-payments__woocommerce-services-options .muriel-component {
-			margin-left: -$gap-larger;
-		}
-
-		.woocommerce-list__item .woocommerce-list__item-after {
-			margin-left: 0;
-			order: 2;
-			align-self: flex-end;
-			margin-top: -$gap-larger;
-		}
-
-		.woocommerce-list__item .woocommerce-list__item-text {
+		.woocommerce-task-payment__text {
 			order: 3;
 			margin-top: $gap;
-		}
-
-		.woocommerce-task-payments__woocommerce-services-options .components-checkbox-control__label {
-			margin-left: -$gap-larger;
-			margin-top: -$gap-smaller;
 		}
 	}
 }

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -356,9 +356,20 @@ class Payments extends Component {
 									<Button
 										isPrimary={ key === 'stripe' }
 										isDefault={ key !== 'stripe' }
-										onClick={ () =>
-											updateQueryString( { method: key } )
-										}
+										onClick={ () => {
+											recordEvent(
+												'tasklist_payment_setup',
+												{
+													options: this.getMethodOptions().map(
+														( option ) => option.key
+													),
+													selected: key,
+												}
+											);
+											updateQueryString( {
+												method: key,
+											} );
+										} }
 									>
 										{ __( 'Set up', 'woocommerce-admin' ) }
 									</Button>

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -98,6 +98,9 @@ class Payments extends Component {
 
 	markConfigured( method ) {
 		const { options, configured, updateOptions } = this.props;
+
+		getHistory().push( getNewPath( { task: 'payments' }, '/', {} ) );
+
 		if ( configured.includes( method ) ) {
 			return;
 		}
@@ -113,8 +116,6 @@ class Payments extends Component {
 				configured,
 			},
 		} );
-
-		getHistory().push( getNewPath( { task: 'payments' }, '/', {} ) );
 	}
 
 	getMethodOptions() {

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment, cloneElement, Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { get, filter, difference } from 'lodash';
+import { get, filter } from 'lodash';
 import { Button, FormToggle } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
@@ -66,21 +66,18 @@ class Payments extends Component {
 	}
 
 	markConfigured( method ) {
-		const { options, methods, configured } = this.props;
-		configured.push( method );
-		const stepsLeft = difference( methods, configured );
+		const { options, configured } = this.props;
+		if ( configured.includes( method ) ) {
+			return;
+		}
 
+		configured.push( method );
 		this.props.updateOptions( {
 			woocommerce_task_list_payments: {
 				...options.woocommerce_task_list_payments,
 				configured,
-				completed: stepsLeft.length === 0 ? 1 : 0,
 			},
 		} );
-
-		if ( stepsLeft.length === 0 ) {
-			this.completeTask();
-		}
 	}
 
 	getMethodOptions() {
@@ -355,26 +352,10 @@ export default compose(
 			options.woocommerce_default_country
 		);
 
-		const methods = get(
-			options,
-			[ 'woocommerce_task_list_payments', 'methods' ],
-			[]
-		);
-		const installed = get(
-			options,
-			[ 'woocommerce_task_list_payments', 'installed' ],
-			false
-		);
 		const configured = get(
 			options,
 			[ 'woocommerce_task_list_payments', 'configured' ],
 			[]
-		);
-
-		const completed = get(
-			options,
-			[ 'woocommerce_task_list_payments', 'completed' ],
-			false
 		);
 
 		return {
@@ -382,10 +363,7 @@ export default compose(
 			profileItems: getProfileItems(),
 			activePlugins: getActivePlugins(),
 			options,
-			methods,
-			installed,
 			configured,
-			completed,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -78,6 +78,8 @@ class Payments extends Component {
 				configured,
 			},
 		} );
+
+		getHistory().push( getNewPath( { task: 'payments' }, '/', {} ) );
 	}
 
 	getMethodOptions() {

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -12,7 +12,11 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Card, H, List, TextControl } from '@woocommerce/components';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
+import {
+	getHistory,
+	getNewPath,
+	updateQueryString,
+} from '@woocommerce/navigation';
 import {
 	WC_ASSET_URL as wcAssetUrl,
 	getAdminLink,
@@ -207,7 +211,6 @@ class Payments extends Component {
 					</Fragment>
 				),
 				before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
-				after: <FormToggle />,
 				visible: this.isStripeEnabled(),
 			},
 			{
@@ -222,7 +225,6 @@ class Payments extends Component {
 					</Fragment>
 				),
 				before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
-				after: <FormToggle />,
 				visible: true,
 			},
 			{
@@ -238,7 +240,6 @@ class Payments extends Component {
 						alt=""
 					/>
 				),
-				after: <FormToggle />,
 				visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
 			},
 			{
@@ -254,7 +255,6 @@ class Payments extends Component {
 						alt=""
 					/>
 				),
-				after: <FormToggle />,
 				visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
 			},
 			{
@@ -271,7 +271,6 @@ class Payments extends Component {
 						alt=""
 					/>
 				),
-				after: <FormToggle />,
 				visible:
 					[ 'brick-mortar', 'brick-mortar-other' ].includes(
 						profileItems.selling_venues
@@ -301,7 +300,6 @@ class Payments extends Component {
 						alt="PayFast logo"
 					/>
 				),
-				after: <FormToggle />,
 				visible: [ 'ZA' ].includes( countryCode ),
 			},
 		];
@@ -542,8 +540,8 @@ class Payments extends Component {
 			<div className="woocommerce-task-payments">
 				{ methods.map( ( method ) => {
 					const {
-						after,
 						before,
+						container,
 						content,
 						key,
 						title,
@@ -571,7 +569,17 @@ class Payments extends Component {
 								</p>
 							</div>
 							<div className="woocommerce-task-payment__after">
-								{ after }
+								{ container ? (
+									<Button
+										isPrimary={ key === 'stripe' }
+										isDefault={ key !== 'stripe' }
+										onClick={ () =>
+											updateQueryString( { method: key } )
+										}
+									/>
+								) : (
+									<FormToggle />
+								) }
 							</div>
 						</Card>
 					);

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -40,11 +40,24 @@ class Payments extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.completeTask = this.completeTask.bind( this );
 		this.markConfigured = this.markConfigured.bind( this );
+		this.skipTask = this.skipTask.bind( this );
 	}
 
 	completeTask() {
-		const { createNotice } = this.props;
+		const { configured, createNotice, options, updateOptions } = this.props;
+
+		updateOptions( {
+			woocommerce_task_list_payments: {
+				...options.woocommerce_task_list_payments,
+				completed: 1,
+			},
+		} );
+
+		recordEvent( 'tasklist_payment_done', {
+			configured,
+		} );
 
 		createNotice(
 			'success',
@@ -53,6 +66,23 @@ class Payments extends Component {
 				'woocommerce-admin'
 			)
 		);
+
+		getHistory().push( getNewPath( {}, '/', {} ) );
+	}
+
+	skipTask() {
+		const { options, updateOptions } = this.props;
+
+		updateOptions( {
+			woocommerce_task_list_payments: {
+				...options.woocommerce_task_list_payments,
+				completed: 1,
+			},
+		} );
+
+		recordEvent( 'tasklist_payment_skip_task', {
+			options: this.getMethodOptions().map( ( method ) => method.key ),
+		} );
 
 		getHistory().push( getNewPath( {}, '/', {} ) );
 	}
@@ -274,7 +304,7 @@ class Payments extends Component {
 
 	render() {
 		const currentMethod = this.getCurrentMethod();
-		const { query } = this.props;
+		const { configured, query } = this.props;
 
 		if ( currentMethod ) {
 			return (
@@ -339,6 +369,20 @@ class Payments extends Component {
 						</Card>
 					);
 				} ) }
+				<div className="woocommerce-task-payments__actions">
+					{ configured.length === 0 ? (
+						<Button isLink onClick={ this.skipTask }>
+							{ __(
+								'My store doesn’t take payments',
+								'woocommerce-admin'
+							) }
+						</Button>
+					) : (
+						<Button isPrimary onClick={ this.completeTask }>
+							{ __( 'Done', 'woocommerce-admin' ) }
+						</Button>
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -66,13 +66,17 @@ class Payments extends Component {
 	}
 
 	markConfigured( method ) {
-		const { options, configured } = this.props;
+		const { options, configured, updateOptions } = this.props;
 		if ( configured.includes( method ) ) {
 			return;
 		}
 
+		recordEvent( 'tasklist_payment_connect_method', {
+			payment_method: method,
+		} );
+
 		configured.push( method );
-		this.props.updateOptions( {
+		updateOptions( {
 			woocommerce_task_list_payments: {
 				...options.woocommerce_task_list_payments,
 				configured,

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -40,6 +40,7 @@ class Payments extends Component {
 	constructor() {
 		super( ...arguments );
 
+		this.recommendedMethod = 'stripe';
 		this.completeTask = this.completeTask.bind( this );
 		this.markConfigured = this.markConfigured.bind( this );
 		this.skipTask = this.skipTask.bind( this );
@@ -341,6 +342,17 @@ class Payments extends Component {
 							className="woocommerce-task-payment is-narrow"
 						>
 							<div className="woocommerce-task-payment__before">
+								{ key === this.recommendedMethod &&
+									! configured.includes( key ) && (
+										<div className="woocommerce-task-payment__recommended-ribbon">
+											<span>
+												{ __(
+													'Recommended',
+													'woocommerce-admin'
+												) }
+											</span>
+										</div>
+									) }
 								{ before }
 							</div>
 							<div className="woocommerce-task-payment__text">
@@ -354,8 +366,12 @@ class Payments extends Component {
 							<div className="woocommerce-task-payment__after">
 								{ container ? (
 									<Button
-										isPrimary={ key === 'stripe' }
-										isDefault={ key !== 'stripe' }
+										isPrimary={
+											key === this.recommendedMethod
+										}
+										isDefault={
+											key !== this.recommendedMethod
+										}
 										onClick={ () => {
 											recordEvent(
 												'tasklist_payment_setup',

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment, cloneElement, Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { get, filter, keys, pickBy, difference } from 'lodash';
+import { get, filter, difference } from 'lodash';
 import { Button, FormToggle } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
@@ -120,6 +120,8 @@ class Payments extends Component {
 				),
 				before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
 				visible: true,
+				plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
+				container: <PayPal markConfigured={ this.markConfigured } />,
 			},
 			{
 				key: 'klarna_checkout',
@@ -135,6 +137,13 @@ class Payments extends Component {
 					/>
 				),
 				visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
+				plugins: [ 'klarna-checkout-for-woocommerce' ],
+				container: (
+					<Klarna
+						markConfigured={ this.markConfigured }
+						plugin={ 'checkout' }
+					/>
+				),
 			},
 			{
 				key: 'klarna_payments',
@@ -150,6 +159,13 @@ class Payments extends Component {
 					/>
 				),
 				visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
+				plugins: [ 'klarna-payments-for-woocommerce' ],
+				container: (
+					<Klarna
+						markConfigured={ this.markConfigured }
+						plugin={ 'payments' }
+					/>
+				),
 			},
 			{
 				key: 'square',
@@ -170,6 +186,8 @@ class Payments extends Component {
 						profileItems.selling_venues
 					) &&
 					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ),
+				plugins: [ 'woocommerce-square' ],
+				container: <Square markConfigured={ this.markConfigured } />,
 			},
 			{
 				key: 'payfast',
@@ -195,79 +213,12 @@ class Payments extends Component {
 					/>
 				),
 				visible: [ 'ZA' ].includes( countryCode ),
+				plugins: [ 'woocommerce-payfast-gateway' ],
+				container: <PayFast markConfigured={ this.markConfigured } />,
 			},
 		];
 
 		return filter( methods, ( method ) => method.visible );
-	}
-
-	getPluginsToInstall() {
-		const { values } = this.formData;
-		const pluginSlugs = {
-			'woocommerce-gateway-stripe': values.stripe,
-			'woocommerce-gateway-paypal-express-checkout': values.paypal,
-			'klarna-checkout-for-woocommerce': values.klarna_checkout,
-			'klarna-payments-for-woocommerce': values.klarna_payments,
-			'woocommerce-square': values.square,
-			'woocommerce-payfast-gateway': values.payfast,
-		};
-		return keys( pickBy( pluginSlugs ) );
-	}
-
-	getSteps() {
-		const steps = [
-			{
-				key: 'paypal',
-				label: __( 'Enable PayPal Checkout', 'woocommerce-admin' ),
-				description: __(
-					'Connect your store to your PayPal account',
-					'woocommerce-admin'
-				),
-				content: <PayPal markConfigured={ this.markConfigured } />,
-			},
-			{
-				key: 'square',
-				label: __( 'Enable Square', 'woocommerce-admin' ),
-				description: __(
-					'Connect your store to your Square account',
-					'woocommerce-admin'
-				),
-				content: <Square markConfigured={ this.markConfigured } />,
-			},
-			{
-				key: 'klarna-checkout',
-				label: __( 'Klarna', 'woocommerce-admin' ),
-				description: '',
-				content: (
-					<Klarna
-						markConfigured={ this.markConfigured }
-						plugin={ 'checkout' }
-					/>
-				),
-			},
-			{
-				key: 'klarna-payments',
-				label: __( 'Klarna', 'woocommerce-admin' ),
-				description: '',
-				content: (
-					<Klarna
-						markConfigured={ this.markConfigured }
-						plugin={ 'payments' }
-					/>
-				),
-			},
-			{
-				key: 'payfast',
-				label: __( 'Enable PayFast', 'woocommerce-admin' ),
-				description: __(
-					'Connect your store to your PayFast account',
-					'woocommerce-admin'
-				),
-				content: <PayFast markConfigured={ this.markConfigured } />,
-			},
-		];
-
-		return filter( steps, ( step ) => step.visible );
 	}
 
 	getCurrentMethod() {

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -90,7 +90,10 @@ class Klarna extends Component {
 					installStep,
 					{
 						key: 'connect',
-						label: __( 'Connect your Klarna account' ),
+						label: __(
+							'Connect your Klarna account',
+							'woocommerce-admin'
+						),
 						content: this.renderConnectStep(),
 					},
 				] }

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -10,7 +10,7 @@ import interpolateComponents from 'interpolate-components';
  * WooCommerce dependencies
  */
 import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
-import { Link } from '@woocommerce/components';
+import { Link, Stepper } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -24,23 +24,22 @@ class Klarna extends Component {
 	}
 
 	continue() {
+		const { markConfigured, plugin } = this.props;
+
 		const slug =
-			this.props.plugin === 'checkout'
-				? 'klarna-checkout'
-				: 'klarna-payments';
+			plugin === 'checkout' ? 'klarna-checkout' : 'klarna-payments';
 		recordEvent( 'tasklist_payment_connect_method', {
 			payment_method: slug,
 		} );
-		this.props.markConfigured( slug );
+		markConfigured( slug );
 	}
 
-	render() {
+	renderConnectStep() {
+		const { plugin } = this.props;
+
 		const slug =
-			this.props.plugin === 'checkout'
-				? 'klarna-checkout'
-				: 'klarna-payments';
-		const section =
-			this.props.plugin === 'checkout' ? 'kco' : 'klarna_payments';
+			plugin === 'checkout' ? 'klarna-checkout' : 'klarna-payments';
+		const section = plugin === 'checkout' ? 'kco' : 'klarna_payments';
 
 		const link = (
 			<Link
@@ -83,6 +82,26 @@ class Klarna extends Component {
 					{ __( 'Continue', 'woocommerce-admin' ) }
 				</Button>
 			</Fragment>
+		);
+	}
+
+	render() {
+		const { installStep } = this.props;
+
+		return (
+			<Stepper
+				isVertical
+				isPending={ ! installStep.isComplete }
+				currentStep={ installStep.isComplete ? 'connect' : 'install' }
+				steps={ [
+					installStep,
+					{
+						key: 'connect',
+						label: __( 'Connect your Klarna account' ),
+						content: this.renderConnectStep(),
+					},
+				] }
+			/>
 		);
 	}
 }

--- a/client/dashboard/task-list/tasks/payments/klarna.js
+++ b/client/dashboard/task-list/tasks/payments/klarna.js
@@ -12,11 +12,6 @@ import interpolateComponents from 'interpolate-components';
 import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
 import { Link, Stepper } from '@woocommerce/components';
 
-/**
- * Internal dependencies
- */
-import { recordEvent } from 'lib/tracks';
-
 class Klarna extends Component {
 	constructor( props ) {
 		super( props );
@@ -28,9 +23,7 @@ class Klarna extends Component {
 
 		const slug =
 			plugin === 'checkout' ? 'klarna-checkout' : 'klarna-payments';
-		recordEvent( 'tasklist_payment_connect_method', {
-			payment_method: slug,
-		} );
+
 		markConfigured( slug );
 	}
 

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -12,7 +12,6 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
-import { getHistory, getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -156,20 +155,7 @@ class PayFast extends Component {
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
 							</Button>
-							<Button
-								isBusy={ isOptionsRequesting }
-								onClick={ () => {
-									getHistory().push(
-										getNewPath(
-											{ task: 'payments' },
-											'/',
-											{}
-										)
-									);
-								} }
-							>
-								{ __( 'Skip', 'woocommerce-admin' ) }
-							</Button>
+
 							<p>{ helpText }</p>
 						</Fragment>
 					);

--- a/client/dashboard/task-list/tasks/payments/payfast.js
+++ b/client/dashboard/task-list/tasks/payments/payfast.js
@@ -17,7 +17,6 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { recordEvent } from 'lib/tracks';
 import withSelect from 'wc-api/with-select';
 
 class PayFast extends Component {
@@ -66,9 +65,6 @@ class PayFast extends Component {
 
 		if ( prevProps.isOptionsRequesting && ! isOptionsRequesting ) {
 			if ( ! hasOptionsError ) {
-				recordEvent( 'tasklist_payment_connect_method', {
-					payment_method: 'payfast',
-				} );
 				markConfigured( 'payfast' );
 				createNotice(
 					'success',

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -42,9 +42,9 @@ class PayPal extends Component {
 					'success',
 					__( 'PayPal connected successfully.', 'woocommerce-admin' )
 				);
+				markConfigured( 'paypal' );
 				return;
 			}
-			markConfigured( 'paypal' );
 
 			/* eslint-disable react/no-did-mount-set-state */
 			this.setState( {

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -13,7 +13,7 @@ import { withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
-import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
+import { getQuery } from '@woocommerce/navigation';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
@@ -205,20 +205,6 @@ class PayPal extends Component {
 								disabled={ isOptionsRequesting }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
-							</Button>
-
-							<Button
-								onClick={ () => {
-									getHistory().push(
-										getNewPath(
-											{ task: 'payments' },
-											'/',
-											{}
-										)
-									);
-								} }
-							>
-								{ __( 'Skip', 'woocommerce-admin' ) }
 							</Button>
 
 							<p>{ help }</p>

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -2,36 +2,37 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { withDispatch } from '@wordpress/data';
+import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import interpolateComponents from 'interpolate-components';
+import { withDispatch } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
-import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
-import { getQuery } from '@woocommerce/navigation';
-import { Form, Link, TextControl } from '@woocommerce/components';
-import withSelect from 'wc-api/with-select';
+import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
+import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
 import { recordEvent } from 'lib/tracks';
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
+import withSelect from 'wc-api/with-select';
 
 class PayPal extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.state = {
+			autoConnectFailed: false,
 			connectURL: '',
-			showManualConfiguration: props.manualConfig,
+			isPending: false,
 		};
 
 		this.updateSettings = this.updateSettings.bind( this );
 	}
 
 	componentDidMount() {
-		const { showManualConfiguration } = this.state;
+		const { autoConnectFailed } = this.state;
 
 		const query = getQuery();
 		// Handle redirect back from PayPal
@@ -40,72 +41,48 @@ class PayPal extends Component {
 				recordEvent( 'tasklist_payment_connect_method', {
 					payment_method: 'paypal',
 				} );
-				this.props.markConfigured( 'paypal' );
 				this.props.createNotice(
 					'success',
 					__( 'PayPal connected successfully.', 'woocommerce-admin' )
 				);
 				return;
 			}
+			this.props.markConfigured( 'paypal' );
 
 			/* eslint-disable react/no-did-mount-set-state */
 			this.setState( {
-				showManualConfiguration: true,
+				autoConnectFailed: true,
 			} );
 			/* eslint-enable react/no-did-mount-set-state */
 			return;
 		}
 
-		if ( ! showManualConfiguration ) {
+		if ( ! autoConnectFailed ) {
 			this.fetchOAuthConnectURL();
-		}
-	}
-
-	componentDidUpdate( prevProps, prevState ) {
-		if (
-			prevState.showManualConfiguration === true &&
-			this.state.showManualConfiguration === false
-		) {
-			this.fetchOAuthConnectURL();
-		}
-
-		if (
-			prevProps.optionsIsRequesting === false &&
-			this.props.optionsIsRequesting === true
-		) {
-			this.props.setRequestPending( true );
-		}
-
-		if (
-			prevProps.optionsIsRequesting === true &&
-			this.props.optionsIsRequesting === false
-		) {
-			this.props.setRequestPending( false );
 		}
 	}
 
 	async fetchOAuthConnectURL() {
-		this.props.setRequestPending( true );
+		this.setState( { isPending: true } );
 		try {
 			const result = await apiFetch( {
 				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-paypal',
 				method: 'POST',
 			} );
 			if ( ! result || ! result.connectUrl ) {
-				this.props.setRequestPending( false );
 				this.setState( {
-					showManualConfiguration: true,
+					autoConnectFailed: true,
 				} );
 				return;
 			}
-			this.props.setRequestPending( false );
 			this.setState( {
 				connectURL: result.connectUrl,
+				isPending: false,
 			} );
 		} catch ( error ) {
-			this.props.setRequestPending( false );
 			this.setState( {
-				showManualConfiguration: true,
+				autoConnectFailed: true,
+				isPending: false,
 			} );
 		}
 	}
@@ -127,7 +104,6 @@ class PayPal extends Component {
 			markConfigured,
 		} = this.props;
 
-		this.props.setRequestPending( true );
 		await updateOptions( {
 			woocommerce_ppec_paypal_settings: {
 				...this.props.options.woocommerce_ppec_paypal_settings,
@@ -141,14 +117,12 @@ class PayPal extends Component {
 			recordEvent( 'tasklist_payment_connect_method', {
 				payment_method: 'paypal',
 			} );
-			this.props.setRequestPending( false );
-			markConfigured( 'paypal' );
 			this.props.createNotice(
 				'success',
 				__( 'PayPal connected successfully.', 'woocommerce-admin' )
 			);
+			markConfigured( 'paypal' );
 		} else {
-			this.props.setRequestPending( false );
 			createNotice(
 				'error',
 				__(
@@ -186,7 +160,7 @@ class PayPal extends Component {
 	}
 
 	renderManualConfig() {
-		const { optionsIsRequesting } = this.props;
+		const { isOptionsRequesting } = this.props;
 		const link = (
 			<Link
 				href="https://docs.woocommerce.com/document/paypal-express-checkout/#section-8"
@@ -233,14 +207,20 @@ class PayPal extends Component {
 							<Button
 								onClick={ handleSubmit }
 								isPrimary
-								disabled={ optionsIsRequesting }
+								disabled={ isOptionsRequesting }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
 							</Button>
 
 							<Button
 								onClick={ () => {
-									this.props.markConfigured( 'paypal' );
+									getHistory().push(
+										getNewPath(
+											{ task: 'payments' },
+											'/',
+											{}
+										)
+									);
 								} }
 							>
 								{ __( 'Skip', 'woocommerce-admin' ) }
@@ -254,18 +234,50 @@ class PayPal extends Component {
 		);
 	}
 
+	getConnectStep() {
+		const { autoConnectFailed, connectURL, isPending } = this.state;
+		const connectStep = {
+			key: 'connect',
+			label: __( 'Connect your PayPal account', 'woocommerce-admin' ),
+		};
+
+		if ( isPending ) {
+			return connectStep;
+		}
+
+		if ( ! autoConnectFailed && connectURL ) {
+			return {
+				...connectStep,
+				description: __(
+					'A Paypal account is required to process payments. You will be redirected to the Paypal website to create the connection.',
+					'woocommerce-admin'
+				),
+				content: this.renderConnectButton(),
+			};
+		}
+
+		return {
+			...connectStep,
+			description: __(
+				'Connect your store to your PayPal account. Don’t have a PayPal account? Create one.',
+				'woocommerce-admin'
+			),
+			content: this.renderManualConfig(),
+		};
+	}
+
 	render() {
-		const { connectURL, showManualConfiguration } = this.state;
+		const { installStep } = this.props;
+		const { isPending } = this.state;
 
-		if ( connectURL && ! showManualConfiguration ) {
-			return this.renderConnectButton();
-		}
-
-		if ( showManualConfiguration ) {
-			return this.renderManualConfig();
-		}
-
-		return null;
+		return (
+			<Stepper
+				isVertical
+				isPending={ ! installStep.isComplete || isPending }
+				currentStep={ installStep.isComplete ? 'connect' : 'install' }
+				steps={ [ installStep, this.getConnectStep() ] }
+			/>
+		);
 	}
 }
 
@@ -277,13 +289,13 @@ export default compose(
 	withSelect( ( select ) => {
 		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
 		const options = getOptions( [ 'woocommerce_ppec_paypal_settings' ] );
-		const optionsIsRequesting = Boolean(
+		const isOptionsRequesting = Boolean(
 			isGetOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
 		);
 
 		return {
 			options,
-			optionsIsRequesting,
+			isOptionsRequesting,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -14,7 +14,6 @@ import { withDispatch } from '@wordpress/data';
  */
 import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
 import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
-import { recordEvent } from 'lib/tracks';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
@@ -33,21 +32,19 @@ class PayPal extends Component {
 
 	componentDidMount() {
 		const { autoConnectFailed } = this.state;
+		const { createNotice, markConfigured } = this.props;
 
 		const query = getQuery();
 		// Handle redirect back from PayPal
 		if ( query[ 'paypal-connect' ] ) {
 			if ( query[ 'paypal-connect' ] === '1' ) {
-				recordEvent( 'tasklist_payment_connect_method', {
-					payment_method: 'paypal',
-				} );
-				this.props.createNotice(
+				createNotice(
 					'success',
 					__( 'PayPal connected successfully.', 'woocommerce-admin' )
 				);
 				return;
 			}
-			this.props.markConfigured( 'paypal' );
+			markConfigured( 'paypal' );
 
 			/* eslint-disable react/no-did-mount-set-state */
 			this.setState( {
@@ -100,13 +97,14 @@ class PayPal extends Component {
 		const {
 			createNotice,
 			isSettingsError,
+			options,
 			updateOptions,
 			markConfigured,
 		} = this.props;
 
 		await updateOptions( {
 			woocommerce_ppec_paypal_settings: {
-				...this.props.options.woocommerce_ppec_paypal_settings,
+				...options.woocommerce_ppec_paypal_settings,
 				api_username: values.api_username,
 				api_password: values.api_password,
 				enabled: 'yes',
@@ -114,10 +112,7 @@ class PayPal extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
-			recordEvent( 'tasklist_payment_connect_method', {
-				payment_method: 'paypal',
-			} );
-			this.props.createNotice(
+			createNotice(
 				'success',
 				__( 'PayPal connected successfully.', 'woocommerce-admin' )
 			);

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -5,23 +5,25 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
-import { getQuery } from '@woocommerce/navigation';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
 /**
  * WooCommerce dependencies
  */
+import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
+import { Stepper } from '@woocommerce/components';
 
 class Square extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.state = {
-			showSkipButton: false,
+			connectionFailed: false,
+			isPending: false,
 		};
 
 		this.connect = this.connect.bind( this );
@@ -35,34 +37,18 @@ class Square extends Component {
 				recordEvent( 'tasklist_payment_connect_method', {
 					payment_method: 'square',
 				} );
-				this.props.markConfigured( 'square' );
 				this.props.createNotice(
 					'success',
 					__( 'Square connected successfully.', 'woocommerce-admin' )
 				);
+				this.props.markConfigured( 'square' );
 			}
-		}
-	}
-
-	componentDidUpdate( prevProps ) {
-		if (
-			prevProps.optionsIsRequesting === false &&
-			this.props.optionsIsRequesting === true
-		) {
-			this.props.setRequestPending( true );
-		}
-
-		if (
-			prevProps.optionsIsRequesting === true &&
-			this.props.optionsIsRequesting === false
-		) {
-			this.props.setRequestPending( false );
 		}
 	}
 
 	async connect() {
 		const { updateOptions } = this.props;
-		this.props.setRequestPending( true );
+		this.setState( { isPending: true } );
 
 		updateOptions( {
 			woocommerce_stripe_settings: {
@@ -83,39 +69,57 @@ class Square extends Component {
 			} );
 
 			if ( ! result || ! result.connectUrl ) {
-				this.props.setRequestPending( false );
-				this.setState( { showSkipButton: true } );
+				this.setState( { connectionFailed: true, isPending: false } );
 				this.props.createNotice( 'error', errorMessage );
 				return;
 			}
 
-			this.props.setRequestPending( false );
+			this.setState( { isPending: true } );
 			window.location = result.connectUrl;
 		} catch ( error ) {
-			this.props.setRequestPending( false );
-			this.setState( { showSkipButton: true } );
+			this.setState( { connectionFailed: true, isPending: false } );
 			this.props.createNotice( 'error', errorMessage );
 		}
 	}
 
 	render() {
-		const { showSkipButton } = this.state;
+		const { installStep } = this.props;
+		const { connectionFailed, isPending } = this.state;
 
 		return (
-			<Fragment>
-				<Button isPrimary isDefault onClick={ this.connect }>
-					{ __( 'Connect', 'woocommerce-admin' ) }
-				</Button>
-				{ showSkipButton && (
-					<Button
-						onClick={ () => {
-							this.props.markConfigured( 'square' );
-						} }
-					>
-						{ __( 'Skip', 'woocommerce-admin' ) }
-					</Button>
-				) }
-			</Fragment>
+			<Stepper
+				isVertical
+				isPending={ ! installStep.isComplete || isPending }
+				currentStep={ installStep.isComplete ? 'connect' : 'install' }
+				steps={ [
+					installStep,
+					{
+						key: 'connect',
+						label: __( 'Connect your Square account', 'woocommerce-admin' ),
+						description: __( 'A Square account is required to process payments. You will be redirected to the Square website to create the connection.', 'woocommerce-admin' ),
+						content: <Fragment>
+							<Button isPrimary isDefault isBusy={ isPending } onClick={ this.connect }>
+								{ __( 'Connect', 'woocommerce-admin' ) }
+							</Button>
+							{ connectionFailed && (
+							<Button
+								onClick={ () => {
+									getHistory().push(
+										getNewPath(
+											{ task: 'payments' },
+											'/',
+											{}
+										)
+									);
+								} }
+							>
+								{ __( 'Skip', 'woocommerce-admin' ) }
+							</Button>
+						) }
+						</Fragment>
+					}
+				] }
+			/>
 		);
 	}
 }

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -11,7 +11,7 @@ import { compose } from '@wordpress/compose';
 /**
  * WooCommerce dependencies
  */
-import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
+import { getQuery } from '@woocommerce/navigation';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { Stepper } from '@woocommerce/components';
@@ -21,7 +21,6 @@ class Square extends Component {
 		super( props );
 
 		this.state = {
-			connectionFailed: false,
 			isPending: false,
 		};
 
@@ -66,7 +65,7 @@ class Square extends Component {
 			} );
 
 			if ( ! result || ! result.connectUrl ) {
-				this.setState( { connectionFailed: true, isPending: false } );
+				this.setState( { isPending: false } );
 				createNotice( 'error', errorMessage );
 				return;
 			}
@@ -74,14 +73,14 @@ class Square extends Component {
 			this.setState( { isPending: true } );
 			window.location = result.connectUrl;
 		} catch ( error ) {
-			this.setState( { connectionFailed: true, isPending: false } );
+			this.setState( { isPending: false } );
 			createNotice( 'error', errorMessage );
 		}
 	}
 
 	render() {
 		const { installStep } = this.props;
-		const { connectionFailed, isPending } = this.state;
+		const { isPending } = this.state;
 
 		return (
 			<Stepper
@@ -110,21 +109,6 @@ class Square extends Component {
 								>
 									{ __( 'Connect', 'woocommerce-admin' ) }
 								</Button>
-								{ connectionFailed && (
-									<Button
-										onClick={ () => {
-											getHistory().push(
-												getNewPath(
-													{ task: 'payments' },
-													'/',
-													{}
-												)
-											);
-										} }
-									>
-										{ __( 'Skip', 'woocommerce-admin' ) }
-									</Button>
-								) }
 							</Fragment>
 						),
 					},

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -15,7 +15,7 @@ import { get } from 'lodash';
  */
 import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
-import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
+import { getQuery } from '@woocommerce/navigation';
 import { WCS_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
@@ -359,21 +359,6 @@ class Stripe extends Component {
 								onClick={ handleSubmit }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
-							</Button>
-
-							<Button
-								isBusy={ isOptionsRequesting }
-								onClick={ () => {
-									getHistory().push(
-										getNewPath(
-											{ task: 'payments' },
-											'/',
-											{}
-										)
-									);
-								} }
-							>
-								{ __( 'Skip', 'woocommerce-admin' ) }
 							</Button>
 
 							<p>{ stripeHelp }</p>

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -15,96 +15,96 @@ import { get } from 'lodash';
  * WooCommerce dependencies
  */
 import { Form, Link, TextControl } from '@woocommerce/components';
-import withSelect from 'wc-api/with-select';
-import { WCS_NAMESPACE } from 'wc-api/constants';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { recordEvent } from 'lib/tracks';
+import { WCS_NAMESPACE } from 'wc-api/constants';
+import withSelect from 'wc-api/with-select';
+
+/**
+ * Internal dependencies
+ */
+import { getCountryCode } from 'dashboard/utils';
 
 class Stripe extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.state = {
-			errorMessage: '',
-			connectURL: '',
-			showConnectionButtons:
-				! props.manualConfig && ! props.createAccount,
-			showManualConfiguration: props.manualConfig,
+			autoConnectFailed: false,
+			connectURL: null,
+			errorTitle: null,
+			errorMessage: null,
 		};
 
+		this.autoCreateAccount = this.autoCreateAccount.bind( this );
 		this.updateSettings = this.updateSettings.bind( this );
 	}
 
 	componentDidMount() {
-		const { createAccount, options } = this.props;
-		const { showConnectionButtons } = this.state;
-
+		const { stripeSettings } = this.props;
 		const query = getQuery();
 
 		// Handle redirect back from Stripe.
 		if ( query[ 'stripe-connect' ] && query[ 'stripe-connect' ] === '1' ) {
-			const stripeSettings = get(
-				options,
-				[ 'woocommerce_stripe_settings' ],
-				[]
-			);
 			const isStripeConnected =
 				stripeSettings.publishable_key && stripeSettings.secret_key;
 
 			if ( isStripeConnected ) {
-				recordEvent( 'tasklist_payment_connect_method', {
-					payment_method: 'stripe',
-				} );
-				this.props.markConfigured( 'stripe' );
-				this.props.createNotice(
-					'success',
-					__( 'Stripe connected successfully.', 'woocommerce-admin' )
-				);
+				this.completeMethod();
 				return;
 			}
 
 			/* eslint-disable react/no-did-mount-set-state */
 			this.setState( {
-				showConnectionButtons: false,
-				showManualConfiguration: true,
+				autoConnectFailed: true,
 			} );
 			/* eslint-enable react/no-did-mount-set-state */
-			return;
 		}
 
-		if ( createAccount ) {
-			this.autoCreateAccount();
-		}
-
-		if ( showConnectionButtons ) {
+		if ( ! this.requiresManualConfig() ) {
 			this.fetchOAuthConnectURL();
 		}
 	}
 
-	componentDidUpdate( prevProps, prevState ) {
-		if (
-			prevState.showConnectionButtons === false &&
-			this.state.showConnectionButtons
-		) {
-			this.fetchOAuthConnectURL();
-		}
+	requiresManualConfig() {
+		const { activePlugins, isJetpackConnected } = this.props;
+		const { autoConnectFailed } = this.state;
+
+		return isJetpackConnected &&
+			activePlugins.includes( 'woocommerce-services' ) &&
+			! autoConnectFailed
+			? false
+			: true;
+	}
+
+	completeMethod() {
+		recordEvent( 'tasklist_payment_connect_method', {
+			payment_method: 'stripe',
+		} );
+		this.props.setRequestPending( false );
+		this.props.createNotice(
+			'success',
+			__( 'Stripe connected successfully.', 'woocommerce-admin' )
+		);
+		this.props.markConfigured( 'stripe' );
 	}
 
 	async fetchOAuthConnectURL() {
-		const { returnUrl } = this.props;
 		try {
 			this.props.setRequestPending( true );
 			const result = await apiFetch( {
 				path: WCS_NAMESPACE + '/connect/stripe/oauth/init',
 				method: 'POST',
 				data: {
-					returnUrl,
+					returnUrl: getAdminLink(
+						'admin.php?page=wc-admin&task=payments&method=stripe&stripe-connect=1'
+					),
 				},
 			} );
 			if ( ! result || ! result.oauthUrl ) {
 				this.props.setRequestPending( false );
 				this.setState( {
-					showConnectionButtons: false,
-					showManualConfiguration: true,
+					autoConnectFailed: true,
 				} );
 				return;
 			}
@@ -114,16 +114,17 @@ class Stripe extends Component {
 			} );
 		} catch ( error ) {
 			this.props.setRequestPending( false );
-			// Fallback to manual configuration if the OAuth URL cannot be grabbed.
 			this.setState( {
-				showConnectionButtons: false,
-				showManualConfiguration: true,
+				autoConnectFailed: true,
 			} );
 		}
 	}
 
-	async autoCreateAccount() {
-		const { email, countryCode } = this.props;
+	async autoCreateAccount( values ) {
+		const { countryCode } = this.props;
+		const { connectURL } = this.state;
+		const { email } = values;
+
 		try {
 			this.props.setRequestPending( true );
 			const result = await apiFetch( {
@@ -136,29 +137,13 @@ class Stripe extends Component {
 			} );
 
 			if ( result ) {
-				recordEvent( 'tasklist_payment_connect_method', {
-					payment_method: 'stripe',
-				} );
-				this.props.setRequestPending( false );
-				this.props.markConfigured( 'stripe' );
-				this.props.createNotice(
-					'success',
-					__( 'Stripe connected successfully.', 'woocommerce-admin' )
-				);
+				this.completeMethod();
 				return;
 			}
-		} catch ( error ) {
-			this.props.setRequestPending( false );
-			let errorTitle, errorMessage;
-			// This seems to be the best way to handle this.
-			// github.com/Automattic/woocommerce-services/blob/cfb6173deb3c72897ee1d35b8fdcf29c5a93dea2/woocommerce-services.php#L563-L570
-			if (
-				error.message.indexOf(
-					'Account already exists for the provided email'
-				) === -1
-			) {
-				errorTitle = __( 'Stripe', 'woocommerce-admin' );
-				errorMessage = interpolateComponents( {
+		} catch {
+			if ( ! connectURL ) {
+				const errorTitle = __( 'Stripe', 'woocommerce-admin' );
+				const errorMessage = interpolateComponents( {
 					mixedString: sprintf(
 						__(
 							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but an error occured. Please try connecting manually to continue.',
@@ -170,30 +155,16 @@ class Stripe extends Component {
 						strong: <strong />,
 					},
 				} );
-			} else {
-				errorTitle = __(
-					'You already have a Stripe account',
-					'woocommerce-admin'
-				);
-				errorMessage = interpolateComponents( {
-					mixedString: sprintf(
-						__(
-							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but one already exists. Please sign in and connect to continue.',
-							'woocommerce-admin'
-						),
-						email
-					),
-					components: {
-						strong: <strong />,
-					},
-				} );
-			}
 
-			this.setState( {
-				showConnectionButtons: true,
-				errorTitle,
-				errorMessage,
-			} );
+				this.setState( {
+					autoConnectFailed: true,
+					errorTitle,
+					errorMessage,
+				} );
+			} else {
+				// An account with that email may exist so send them to Stripe to connect via oAuth.
+				window.location = connectURL;
+			}
 		}
 	}
 
@@ -203,7 +174,7 @@ class Stripe extends Component {
 			<Modal
 				title={ errorTitle }
 				onRequestClose={ () =>
-					this.setState( { errorMessage: '', errorTitle: '' } )
+					this.setState( { errorMessage: null, errorTitle: null } )
 				}
 				className="woocommerce-task-payments__stripe-error-modal"
 			>
@@ -216,8 +187,8 @@ class Stripe extends Component {
 						isDefault
 						onClick={ () =>
 							this.setState( {
-								errorMessage: '',
-								errorTitle: '',
+								errorMessage: null,
+								errorTitle: null,
 							} )
 						}
 					>
@@ -228,12 +199,36 @@ class Stripe extends Component {
 		);
 	}
 
-	renderConnectButton() {
-		const { connectURL } = this.state;
+	renderAutoConnect() {
 		return (
-			<Button isPrimary isDefault href={ connectURL }>
-				{ __( 'Connect', 'woocommerce-admin' ) }
-			</Button>
+			<Form
+				initialValues={ {
+					email: '',
+				} }
+				onSubmitCallback={ this.autoCreateAccount }
+				validate={ this.validateAutoConnect }
+			>
+				{ ( { getInputProps, handleSubmit } ) => {
+					return (
+						<div className="woocommerce-task-payments__woocommerce-services-options">
+							<TextControl
+								label={ __(
+									'Email address',
+									'woocommerce-admin'
+								) }
+								{ ...getInputProps( 'email' ) }
+							/>
+							<Button
+								isPrimary
+								isDefault
+								onClick={ handleSubmit }
+							>
+								{ __( 'Connect', 'woocommerce-admin' ) }
+							</Button>
+						</div>
+					);
+				} }
+			</Form>
 		);
 	}
 
@@ -242,13 +237,13 @@ class Stripe extends Component {
 			createNotice,
 			isSettingsError,
 			updateOptions,
-			markConfigured,
+			stripeSettings,
 		} = this.props;
 
 		this.props.setRequestPending( true );
 		await updateOptions( {
 			woocommerce_stripe_settings: {
-				...this.props.options.woocommerce_stripe_settings,
+				...stripeSettings,
 				publishable_key: values.publishable_key,
 				secret_key: values.secret_key,
 				enabled: 'yes',
@@ -256,15 +251,7 @@ class Stripe extends Component {
 		} );
 
 		if ( ! isSettingsError ) {
-			recordEvent( 'tasklist_payment_connect_method', {
-				payment_method: 'stripe',
-			} );
-			this.props.setRequestPending( false );
-			markConfigured( 'stripe' );
-			this.props.createNotice(
-				'success',
-				__( 'Stripe connected successfully.', 'woocommerce-admin' )
-			);
+			this.completeMethod();
 		} else {
 			this.props.setRequestPending( false );
 			createNotice(
@@ -284,7 +271,7 @@ class Stripe extends Component {
 		};
 	}
 
-	validate( values ) {
+	validateManualConfig( values ) {
 		const errors = {};
 
 		if ( ! values.publishable_key ) {
@@ -298,6 +285,16 @@ class Stripe extends Component {
 				'Please enter your secret key',
 				'woocommerce-admin'
 			);
+		}
+
+		return errors;
+	}
+
+	validateAutoConnect( values ) {
+		const errors = {};
+
+		if ( ! values.email ) {
+			errors.email = __( 'Please enter your email', 'woocommerce-admin' );
 		}
 
 		return errors;
@@ -324,7 +321,7 @@ class Stripe extends Component {
 			<Form
 				initialValues={ this.getInitialConfigValues() }
 				onSubmitCallback={ this.updateSettings }
-				validate={ this.validate }
+				validate={ this.validateManualConfig }
 			>
 				{ ( { getInputProps, handleSubmit } ) => {
 					return (
@@ -367,35 +364,43 @@ class Stripe extends Component {
 	}
 
 	render() {
-		const {
-			errorMessage,
-			showConnectionButtons,
-			connectURL,
-			showManualConfiguration,
-		} = this.state;
+		const { errorMessage } = this.state;
 
 		if ( errorMessage ) {
 			return this.renderErrorModal();
 		}
 
-		if ( showConnectionButtons && connectURL ) {
-			return this.renderConnectButton();
+		if ( ! this.requiresManualConfig() ) {
+			return this.renderAutoConnect();
 		}
 
-		if ( showManualConfiguration ) {
-			return this.renderManualConfig();
-		}
-
-		return null;
+		return this.renderManualConfig();
 	}
 }
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getOptions } = select( 'wc-api' );
-		const options = getOptions( [ 'woocommerce_stripe_settings' ] );
-		return {
+		const { isJetpackConnected, getActivePlugins, getOptions } = select(
+			'wc-api'
+		);
+		const options = getOptions( [
+			'woocommerce_stripe_settings',
+			'woocommerce_default_country',
+		] );
+		const countryCode = getCountryCode(
+			options.woocommerce_default_country
+		);
+		const stripeSettings = get(
 			options,
+			[ 'woocommerce_stripe_settings' ],
+			[]
+		);
+
+		return {
+			activePlugins: getActivePlugins(),
+			countryCode,
+			isJetpackConnected: isJetpackConnected(),
+			stripeSettings,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -92,11 +92,11 @@ class Stripe extends Component {
 		const { activePlugins, isJetpackConnected } = this.props;
 		const { autoConnectFailed } = this.state;
 
-		return isJetpackConnected &&
-			activePlugins.includes( 'woocommerce-services' ) &&
-			! autoConnectFailed
-			? false
-			: true;
+		return (
+			! isJetpackConnected ||
+			! activePlugins.includes( 'woocommerce-services' ) ||
+			autoConnectFailed
+		);
 	}
 
 	completeMethod() {

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -313,13 +313,20 @@ class Stripe extends Component {
 		const { isOptionsRequesting } = this.props;
 		const stripeHelp = interpolateComponents( {
 			mixedString: __(
-				'Your API details can be obtained from your {{link}}Stripe account{{/link}}',
+				'Your API details can be obtained from your {{docsLink}}Stripe account{{/docsLink}}.  Don’t have a Stripe account? {{registerLink}}Create one.{{/registerLink}}',
 				'woocommerce-admin'
 			),
 			components: {
-				link: (
+				docsLink: (
 					<Link
-						href="https://stripe.com/docs/account"
+						href="https://stripe.com/docs/keys"
+						target="_blank"
+						type="external"
+					/>
+				),
+				registerLink: (
+					<Link
+						href="https://dashboard.stripe.com/register"
 						target="_blank"
 						type="external"
 					/>
@@ -370,7 +377,7 @@ class Stripe extends Component {
 	}
 
 	getConnectStep() {
-		const { errorMessage } = this.state;
+		const { autoConnectFailed, connectURL, errorMessage } = this.state;
 		const connectStep = {
 			key: 'connect',
 			label: __( 'Connect your Stripe account', 'woocommerce-admin' ),
@@ -384,6 +391,11 @@ class Stripe extends Component {
 		}
 
 		if ( ! this.requiresManualConfig() ) {
+			// We may still be fetching the connect URL.
+			if ( ! autoConnectFailed && ! connectURL ) {
+				return connectStep;
+			}
+
 			return {
 				...connectStep,
 				description: __(
@@ -406,11 +418,14 @@ class Stripe extends Component {
 
 	render() {
 		const { installStep, isOptionsRequesting } = this.props;
+		const { isPending } = this.state;
 
 		return (
 			<Stepper
 				isVertical
-				isPending={ ! installStep.isComplete || isOptionsRequesting }
+				isPending={
+					! installStep.isComplete || isOptionsRequesting || isPending
+				}
 				currentStep={ installStep.isComplete ? 'connect' : 'install' }
 				steps={ [ installStep, this.getConnectStep() ] }
 			/>

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -16,7 +16,6 @@ import { get } from 'lodash';
 import { Form, Link, Stepper, TextControl } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
-import { recordEvent } from 'lib/tracks';
 import { WCS_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 
@@ -102,10 +101,6 @@ class Stripe extends Component {
 
 	completeMethod() {
 		const { createNotice, markConfigured } = this.props;
-
-		recordEvent( 'tasklist_payment_connect_method', {
-			payment_method: 'stripe',
-		} );
 
 		this.setState( { isPending: false } );
 

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -21,4 +21,8 @@ export const pluginNames = {
 		'WooCommerce ShipStation Gateway',
 		'woocommerce-admin'
 	),
+	'woocommerce-gateway-stripe': __(
+		'WooCommerce Stripe',
+		'woocommerce-admin'
+	),
 };

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -12,6 +12,14 @@ export const pluginNames = {
 		'woocommerce-admin'
 	),
 	jetpack: __( 'Jetpack', 'woocommerce-admin' ),
+	'klarna-checkout-for-woocommerce': __(
+		'Klarna Checkout for WooCommerce',
+		'woocommerce-admin'
+	),
+	'klarna-payments-for-woocommerce': __(
+		'Klarna Payments for WooCommerce',
+		'woocommerce-admin'
+	),
 	'mailchimp-for-woocommerce': __(
 		'Mailchimp for WooCommerce',
 		'woocommerce-admin'

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -37,4 +37,5 @@ export const pluginNames = {
 		'WooCommerce ShipStation Gateway',
 		'woocommerce-admin'
 	),
+	'woocommerce-square': __( 'WooCommerce Square', 'woocommerce-admin' ),
 };

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -7,22 +7,26 @@ import { __ } from '@wordpress/i18n';
  * Plugin slugs and names as key/value pairs.
  */
 export const pluginNames = {
-	jetpack: __( 'Jetpack', 'woocommerce-admin' ),
-	'woocommerce-services': __( 'WooCommerce Services', 'woocommerce-admin' ),
-	'mailchimp-for-woocommerce': __(
-		'Mailchimp for WooCommerce',
-		'woocommerce-admin'
-	),
 	'facebook-for-woocommerce': __(
 		'Facebook for WooCommerce',
 		'woocommerce-admin'
 	),
-	'woocommerce-shipstation-integration': __(
-		'WooCommerce ShipStation Gateway',
+	jetpack: __( 'Jetpack', 'woocommerce-admin' ),
+	'mailchimp-for-woocommerce': __(
+		'Mailchimp for WooCommerce',
+		'woocommerce-admin'
+	),
+	'woocommerce-gateway-paypal-express-checkout': __(
+		'WooCommerce PayPal',
 		'woocommerce-admin'
 	),
 	'woocommerce-gateway-stripe': __(
 		'WooCommerce Stripe',
+		'woocommerce-admin'
+	),
+	'woocommerce-services': __( 'WooCommerce Services', 'woocommerce-admin' ),
+	'woocommerce-shipstation-integration': __(
+		'WooCommerce ShipStation Gateway',
 		'woocommerce-admin'
 	),
 };

--- a/client/wc-api/onboarding/constants.js
+++ b/client/wc-api/onboarding/constants.js
@@ -32,6 +32,10 @@ export const pluginNames = {
 		'WooCommerce Stripe',
 		'woocommerce-admin'
 	),
+	'woocommerce-payfast-gateway': __(
+		'WooCommerce PayFast',
+		'woocommerce-admin'
+	),
 	'woocommerce-services': __( 'WooCommerce Services', 'woocommerce-admin' ),
 	'woocommerce-shipstation-integration': __(
 		'WooCommerce ShipStation Gateway',

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -491,7 +491,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 
 		$url = \WooCommerce\Square\Handlers\Connection::CONNECT_URL_PRODUCTION;
 
-		$redirect_url = wp_nonce_url( wc_admin_url( '&task=payments&square-connect-finish=1' ), 'wc_square_connected' );
+		$redirect_url = wp_nonce_url( wc_admin_url( '&task=payments&method=square&square-connect-finish=1' ), 'wc_square_connected' );
 		$args         = array(
 			'redirect' => rawurlencode( rawurlencode( $redirect_url ) ),
 			'scopes'   => implode(

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -317,7 +317,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		$redirect_url = apply_filters( 'woocommerce_admin_onboarding_jetpack_connect_redirect_url', esc_url_raw( $request['redirect_url'] ) );
 		$connect_url  = \Jetpack::init()->build_connect_url( true, $redirect_url, 'woocommerce-onboarding' );
 
-		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
+		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ), true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
 		$connect_url = add_query_arg( array( 'calypso_env' => $calypso_env ), $connect_url );
 
 		return( array(
@@ -372,7 +372,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 			\WC_Helper_API::url( 'oauth/authorize' )
 		);
 
-		if ( defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ) {
+		if ( defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ), true ) ) {
 			$connect_url = add_query_arg(
 				array(
 					'calypso_env' => WOOCOMMERCE_CALYPSO_ENVIRONMENT,
@@ -463,12 +463,12 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 				'env'                     => 'live',
 				'wc_ppec_ips_admin_nonce' => wp_create_nonce( 'wc_ppec_ips' ),
 			),
-			wc_admin_url( '&task=payments&paypal-connect-finish=1' )
+			wc_admin_url( '&task=payments&method=paypal&paypal-connect-finish=1' )
 		);
 
 		// https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blob/b6df13ba035038aac5024d501e8099a37e13d6cf/includes/class-wc-gateway-ppec-ips-handler.php#L79-L93.
 		$query_args  = array(
-			'redirect'    => urlencode( $redirect_url ),
+			'redirect'    => rawurlencode( $redirect_url ),
 			'countryCode' => WC()->countries->get_base_country(),
 			'merchantId'  => md5( site_url( '/' ) . time() ),
 		);
@@ -493,7 +493,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 
 		$redirect_url = wp_nonce_url( wc_admin_url( '&task=payments&square-connect-finish=1' ), 'wc_square_connected' );
 		$args         = array(
-			'redirect' => urlencode( urlencode( $redirect_url ) ),
+			'redirect' => rawurlencode( rawurlencode( $redirect_url ) ),
 			'scopes'   => implode(
 				',',
 				array(

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -620,7 +620,7 @@ class Onboarding {
 	 */
 	public function is_loading( $is_loading ) {
 		$show_profiler = self::should_show_profiler();
-		$is_dashboard  = ! isset( $_GET['path'] ); // WPCS: csrf ok.
+		$is_dashboard  = ! isset( $_GET['path'] ); // phpcs:ignore csrf ok.
 
 		if ( ! $show_profiler || ! $is_dashboard ) {
 			return $is_loading;
@@ -640,7 +640,7 @@ class Onboarding {
 		if ( substr( $location, -strlen( $settings_page ) ) === $settings_page ) {
 			$settings_array = (array) get_option( 'woocommerce_ppec_paypal_settings', array() );
 			$connected      = isset( $settings_array['api_username'] ) && isset( $settings_array['api_password'] ) ? true : false;
-			return wc_admin_url( '&task=payments&paypal-connect=' . $connected );
+			return wc_admin_url( '&task=payments&method=paypal&paypal-connect=' . $connected );
 		}
 		return $location;
 	}
@@ -651,7 +651,7 @@ class Onboarding {
 	public function finish_paypal_connect() {
 		if (
 			! Loader::is_admin_page() ||
-			! isset( $_GET['paypal-connect-finish'] ) // WPCS: CSRF ok.
+			! isset( $_GET['paypal-connect-finish'] ) // phpcs:ignore CSRF ok.
 		) {
 			return;
 		}
@@ -687,7 +687,7 @@ class Onboarding {
 	public function finish_square_connect() {
 		if (
 			! Loader::is_admin_page() ||
-			! isset( $_GET['square-connect-finish'] ) // WPCS: CSRF ok.
+			! isset( $_GET['square-connect-finish'] ) // phpcs:ignore CSRF ok.
 		) {
 			return;
 		}
@@ -834,9 +834,9 @@ class Onboarding {
 	 * Allows quick access to testing the calypso parts of onboarding.
 	 */
 	public static function calypso_tests() {
-		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ) ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
+		$calypso_env = defined( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT' ) && in_array( WOOCOMMERCE_CALYPSO_ENVIRONMENT, array( 'development', 'wpcalypso', 'horizon', 'stage' ), true ) ? WOOCOMMERCE_CALYPSO_ENVIRONMENT : 'production';
 
-		if ( Loader::is_admin_page() && class_exists( 'Jetpack' ) && isset( $_GET['test_wc_jetpack_connect'] ) && 1 === absint( $_GET['test_wc_jetpack_connect'] ) ) { // WPCS: CSRF ok.
+		if ( Loader::is_admin_page() && class_exists( 'Jetpack' ) && isset( $_GET['test_wc_jetpack_connect'] ) && 1 === absint( $_GET['test_wc_jetpack_connect'] ) ) { // phpcs:ignore CSRF ok.
 			$redirect_url = esc_url_raw(
 				add_query_arg(
 					array(
@@ -853,7 +853,7 @@ class Onboarding {
 			exit;
 		}
 
-		if ( Loader::is_admin_page() && isset( $_GET['test_wc_helper_connect'] ) && 1 === absint( $_GET['test_wc_helper_connect'] ) ) { // WPCS: CSRF ok.
+		if ( Loader::is_admin_page() && isset( $_GET['test_wc_helper_connect'] ) && 1 === absint( $_GET['test_wc_helper_connect'] ) ) { // phpcs:ignore CSRF ok.
 			include_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-api.php';
 
 			$redirect_uri = wc_admin_url( '&task=connect&wccom-connected=1' );
@@ -903,12 +903,12 @@ class Onboarding {
 	public static function reset_profiler() {
 		if (
 			! Loader::is_admin_page() ||
-			! isset( $_GET['reset_profiler'] ) // WPCS: CSRF ok.
+			! isset( $_GET['reset_profiler'] ) // phpcs:ignore CSRF ok.
 		) {
 			return;
 		}
 
-		$previous  = 1 === absint( $_GET['reset_profiler'] );
+		$previous  = 1 === absint( $_GET['reset_profiler'] ); // phpcs:ignore CSRF ok.
 		$new_value = ! $previous;
 
 		wc_admin_record_tracks_event(
@@ -939,12 +939,12 @@ class Onboarding {
 	public static function reset_task_list() {
 		if (
 			! Loader::is_admin_page() ||
-			! isset( $_GET['reset_task_list'] ) // WPCS: CSRF ok.
+			! isset( $_GET['reset_task_list'] ) // phpcs:ignore CSRF ok.
 		) {
 			return;
 		}
 
-		$new_value = 1 === absint( $_GET['reset_task_list'] ) ? 'no' : 'yes'; // WPCS: CSRF ok.
+		$new_value = 1 === absint( $_GET['reset_task_list'] ) ? 'no' : 'yes'; // phpcs:ignore CSRF ok.
 		update_option( 'woocommerce_task_list_hidden', $new_value );
 		wp_safe_redirect( wc_admin_url() );
 		exit;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -676,7 +676,7 @@ class Onboarding {
 	public function overwrite_square_redirect( $location, $status ) {
 		$settings_page = 'page=wc-settings&tab=square';
 		if ( substr( $location, -strlen( $settings_page ) ) === $settings_page ) {
-			return wc_admin_url( '&task=payments&square-connect=1' );
+			return wc_admin_url( '&task=payments&method=square&square-connect=1' );
 		}
 		return $location;
 	}


### PR DESCRIPTION
Fixes (part of) #3710 

This PR adds the following:
* Refactors and redesigns the payment methods list.
* Adds in done/skip options for the payments task list.
* Adds events for skip, done, and setup of payments.
* Adds a recommended payment method.
* Fixes some previous issues with error handling and pending states.

This PR does not address the following which will be handled in a follow-up PR:
* Toggles for already set up payment methods and respective events.
* Updating payments configured outside the task list.
* Adding new offline payment methods

### Questions
* Does the copy for payment labels and descriptions look okay @pmcpinto  ?
* Some of the previous methods don't have a "Skip" option, meaning there is no way to return to the payment method options after selecting a specific payment.  Should we add "Skip" options to return to payment options for each method? /cc @jameskoster 

### Screenshots
<img width="728" alt="Screen Shot 2020-02-27 at 8 39 19 PM" src="https://user-images.githubusercontent.com/10561050/75480284-43c7dd80-59a1-11ea-9d15-b2d615aa8fbd.png">

### Detailed test instructions:

1. Delete the option `woocommerce_task_list_payments` if you need to reset progress at any point.
1. Go through each of the payment methods listed below and make sure they work as expected with both configuration options if multiple exist.
1. Make sure the recommended gateway ("Stripe") has a ribbon if not yet configured.
1. Make sure the event `tasklist_payment_done` fires with configured options when clicking "Done."
1. Make sure the event `tasklist_payment_skip_task` fires with available options when clicking "My store doesn’t take payments."
1. Make sure the event `tasklist_payment_setup` fires when clicking "Set up" on a payment with the available options and clicked option.

Payment method requirements:
* Stripe - requires store to be supported Stripe country, e.g. US. Test manual and oauth option by connecting Jetpack and activating WCS.
* Paypal - test oauth and manual connection.  Manual can be forced by setting the state `autoConnectFailed` to `true`.
* Klarna Checkout - requires store country to be 'SE', 'FI', 'NO', or 'NL'. 
* Klarna Payments - requires store country to be 'DK', 'DE', or 'AT'. 
* Square - requires store country to be 'US', 'CA', 'JP', 'GB', or 'AU' and having selected a "brick and mortar" option for the selling venues question in the store profiler.
* PayFast - requires store country to be South Africa.  

### Changelog Note:

Enhancement: Allow individual payment method setup in the onboarding task list
