### PR TITLE
OBW Connect: Fix requesting state

### DIFF
--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -19,14 +19,14 @@ class Connect extends Component {
 		super( props );
 
 		this.connectJetpack = this.connectJetpack.bind( this );
-		props.setIsStepPending( true );
+		props.setIsPending( true );
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { createNotice, error, isRequesting, setIsStepPending } = this.props;
+		const { createNotice, error, isRequesting, setIsPending } = this.props;
 
 		if ( prevProps.isRequesting && ! isRequesting ) {
-			setIsStepPending( false );
+			setIsPending( false );
 		}
 
 		if ( error && error !== prevProps.error ) {
@@ -100,11 +100,11 @@ Connect.propTypes = {
 	/**
 	 * Control the `isPending` logic of the parent containing the Stepper.
 	 */
-	setIsStepPending: PropTypes.func,
+	setIsPending: PropTypes.func,
 };
 
 Connect.defaultProps = {
-	setIsStepPending: () => {},
+	setIsPending: () => {},
 };
 
 export default compose(

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -100,7 +100,11 @@ Connect.propTypes = {
 	/**
 	 * Control the `isPending` logic of the parent containing the Stepper.
 	 */
-	setIsPending: PropTypes.func.isRequired,
+	setIsPending: PropTypes.func,
+};
+
+Connect.defaultProps = {
+	setIsPending: () => {},
 };
 
 export default compose(

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -97,6 +97,10 @@ Connect.propTypes = {
 	 * Text used for the skip connection button.
 	 */
 	skipText: PropTypes.string,
+	/**
+	 * Control the `isPending` logic of the parent containing the Stepper.
+	 */
+	setIsPending: PropTypes.func.isRequired,
 };
 
 export default compose(

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -15,14 +15,19 @@ import { withDispatch } from '@wordpress/data';
 import withSelect from 'wc-api/with-select';
 
 class Connect extends Component {
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 
 		this.connectJetpack = this.connectJetpack.bind( this );
+		props.setIsPending( true );
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { createNotice, error } = this.props;
+		const { createNotice, error, isRequesting, setIsPending } = this.props;
+
+		if ( prevProps.isRequesting && ! isRequesting ) {
+			setIsPending( false );
+		}
 
 		if ( error && error !== prevProps.error ) {
 			createNotice( 'error', error );

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -19,14 +19,14 @@ class Connect extends Component {
 		super( props );
 
 		this.connectJetpack = this.connectJetpack.bind( this );
-		props.setIsPending( true );
+		props.setIsStepPending( true );
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { createNotice, error, isRequesting, setIsPending } = this.props;
+		const { createNotice, error, isRequesting, setIsStepPending } = this.props;
 
 		if ( prevProps.isRequesting && ! isRequesting ) {
-			setIsPending( false );
+			setIsStepPending( false );
 		}
 
 		if ( error && error !== prevProps.error ) {
@@ -100,11 +100,11 @@ Connect.propTypes = {
 	/**
 	 * Control the `isPending` logic of the parent containing the Stepper.
 	 */
-	setIsPending: PropTypes.func,
+	setIsStepPending: PropTypes.func,
 };
 
 Connect.defaultProps = {
-	setIsPending: () => {},
+	setIsStepPending: () => {},
 };
 
 export default compose(

--- a/client/dashboard/task-list/tasks/steps/connect.js
+++ b/client/dashboard/task-list/tasks/steps/connect.js
@@ -47,7 +47,7 @@ class Connect extends Component {
 						{ __( 'Retry', 'woocommerce-admin' ) }
 					</Button>
 				) : (
-					<Button isBusy={ isRequesting } isPrimary onClick={ this.connectJetpack }>
+					<Button disabled={ isRequesting } isPrimary onClick={ this.connectJetpack }>
 						{ __( 'Connect', 'woocommerce-admin' ) }
 					</Button>
 				) }

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -37,6 +37,7 @@ class Tax extends Component {
 			automatedTaxEnabled: true,
 			// Cache the value of pluginsToActivate so that we can show/hide tasks based on it, but not have them update mid task.
 			pluginsToActivate: props.pluginsToActivate,
+			isStepPending: false,
 		};
 
 		this.state = this.initialState;
@@ -44,7 +45,7 @@ class Tax extends Component {
 		this.completeStep = this.completeStep.bind( this );
 		this.configureTaxRates = this.configureTaxRates.bind( this );
 		this.updateAutomatedTax = this.updateAutomatedTax.bind( this );
-		this.setIsPending = this.setIsPending.bind( this );
+		this.setIsStepPending = this.setIsStepPending.bind( this );
 	}
 
 	componentDidMount() {
@@ -182,8 +183,8 @@ class Tax extends Component {
 		}
 	}
 
-	setIsPending( value ) {
-		this.setState( { isPending: value } );
+	setIsStepPending( value ) {
+		this.setState( { isStepPending: value } );
 	}
 
 	getSteps() {
@@ -243,7 +244,7 @@ class Tax extends Component {
 				content: (
 					<Connect
 						{ ...this.props }
-						setIsPending={ this.setIsPending }
+						setIsStepPending={ this.setIsStepPending }
 						onConnect={ () => {
 							recordEvent( 'tasklist_tax_connect_store', { connect: true } );
 						} }
@@ -307,7 +308,7 @@ class Tax extends Component {
 	}
 
 	render() {
-		const { isPending, stepIndex } = this.state;
+		const { isPending, stepIndex, isStepPending } = this.state;
 		const { isGeneralSettingsRequesting, isTaxSettingsRequesting } = this.props;
 		const step = this.getSteps()[ stepIndex ];
 
@@ -316,7 +317,9 @@ class Tax extends Component {
 				<Card className="is-narrow">
 					{ step ? (
 						<Stepper
-							isPending={ isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting }
+							isPending={
+								isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting || isStepPending
+							}
 							isVertical={ true }
 							currentStep={ step.key }
 							steps={ this.getSteps() }

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -302,7 +302,11 @@ class Tax extends Component {
 
 	render() {
 		const { isPending, stepIndex } = this.state;
-		const { isGeneralSettingsRequesting, isTaxSettingsRequesting } = this.props;
+		const {
+			isGeneralSettingsRequesting,
+			isTaxSettingsRequesting,
+			isJetpackRequesting,
+		} = this.props;
 		const step = this.getSteps()[ stepIndex ];
 
 		return (
@@ -310,7 +314,12 @@ class Tax extends Component {
 				<Card className="is-narrow">
 					{ step ? (
 						<Stepper
-							isPending={ isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting }
+							isPending={
+								isPending ||
+								isGeneralSettingsRequesting ||
+								isTaxSettingsRequesting ||
+								isJetpackRequesting
+							}
 							isVertical={ true }
 							currentStep={ step.key }
 							steps={ this.getSteps() }
@@ -369,15 +378,21 @@ class Tax extends Component {
 }
 
 export default compose(
-	withSelect( select => {
+	withSelect( ( select, props ) => {
 		const {
 			getActivePlugins,
 			getOptions,
 			getSettings,
 			getSettingsError,
 			isGetSettingsRequesting,
+			isGetJetpackConnectUrlRequesting,
 			isJetpackConnected,
 		} = select( 'wc-api' );
+
+		const jetpackQueryArgs = {
+			redirect_url: props.redirectUrl || window.location.href,
+		};
+		const isJetpackRequesting = isGetJetpackConnectUrlRequesting( jetpackQueryArgs );
 
 		const generalSettings = getSettings( 'general' );
 		const isGeneralSettingsError = Boolean( getSettingsError( 'general' ) );
@@ -404,6 +419,7 @@ export default compose(
 			isJetpackConnected: isJetpackConnected(),
 			pluginsToActivate,
 			tosAccepted,
+			isJetpackRequesting,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -37,7 +37,6 @@ class Tax extends Component {
 			automatedTaxEnabled: true,
 			// Cache the value of pluginsToActivate so that we can show/hide tasks based on it, but not have them update mid task.
 			pluginsToActivate: props.pluginsToActivate,
-			isStepPending: false,
 		};
 
 		this.state = this.initialState;
@@ -45,7 +44,7 @@ class Tax extends Component {
 		this.completeStep = this.completeStep.bind( this );
 		this.configureTaxRates = this.configureTaxRates.bind( this );
 		this.updateAutomatedTax = this.updateAutomatedTax.bind( this );
-		this.setIsStepPending = this.setIsStepPending.bind( this );
+		this.setIsPending = this.setIsPending.bind( this );
 	}
 
 	componentDidMount() {
@@ -183,8 +182,8 @@ class Tax extends Component {
 		}
 	}
 
-	setIsStepPending( value ) {
-		this.setState( { isStepPending: value } );
+	setIsPending( value ) {
+		this.setState( { isPending: value } );
 	}
 
 	getSteps() {
@@ -244,7 +243,7 @@ class Tax extends Component {
 				content: (
 					<Connect
 						{ ...this.props }
-						setIsStepPending={ this.setIsStepPending }
+						setIsPending={ this.setIsPending }
 						onConnect={ () => {
 							recordEvent( 'tasklist_tax_connect_store', { connect: true } );
 						} }
@@ -308,7 +307,7 @@ class Tax extends Component {
 	}
 
 	render() {
-		const { isPending, stepIndex, isStepPending } = this.state;
+		const { isPending, stepIndex } = this.state;
 		const { isGeneralSettingsRequesting, isTaxSettingsRequesting } = this.props;
 		const step = this.getSteps()[ stepIndex ];
 
@@ -317,9 +316,7 @@ class Tax extends Component {
 				<Card className="is-narrow">
 					{ step ? (
 						<Stepper
-							isPending={
-								isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting || isStepPending
-							}
+							isPending={ isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting }
 							isVertical={ true }
 							currentStep={ step.key }
 							steps={ this.getSteps() }

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -63,7 +63,7 @@ class Tax extends Component {
 			woocommerce_default_country,
 			woocommerce_store_postcode,
 		} = generalSettings;
-		const { isPending, stepIndex } = this.state;
+		const { stepIndex } = this.state;
 		const currentStep = this.getSteps()[ stepIndex ];
 		const currentStepKey = currentStep && currentStep.key;
 		const isCompleteAddress = Boolean(
@@ -103,7 +103,10 @@ class Tax extends Component {
 			this.completeStep();
 		}
 
-		if ( isPending && 'yes' === woocommerce_calc_taxes ) {
+		if (
+			'no' === prevProps.generalSettings.woocommerce_calc_taxes &&
+			'yes' === woocommerce_calc_taxes
+		) {
 			window.location = getAdminLink( 'admin.php?page=wc-settings&tab=tax&section=standard' );
 		}
 	}

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -44,6 +44,7 @@ class Tax extends Component {
 		this.completeStep = this.completeStep.bind( this );
 		this.configureTaxRates = this.configureTaxRates.bind( this );
 		this.updateAutomatedTax = this.updateAutomatedTax.bind( this );
+		this.setIsPending = this.setIsPending.bind( this );
 	}
 
 	componentDidMount() {
@@ -181,6 +182,10 @@ class Tax extends Component {
 		}
 	}
 
+	setIsPending( value ) {
+		this.setState( { isPending: value } );
+	}
+
 	getSteps() {
 		const { generalSettings, isGeneralSettingsRequesting, isJetpackConnected } = this.props;
 		const { isPending, pluginsToActivate } = this.state;
@@ -238,6 +243,7 @@ class Tax extends Component {
 				content: (
 					<Connect
 						{ ...this.props }
+						setIsPending={ this.setIsPending }
 						onConnect={ () => {
 							recordEvent( 'tasklist_tax_connect_store', { connect: true } );
 						} }
@@ -302,11 +308,7 @@ class Tax extends Component {
 
 	render() {
 		const { isPending, stepIndex } = this.state;
-		const {
-			isGeneralSettingsRequesting,
-			isTaxSettingsRequesting,
-			isJetpackRequesting,
-		} = this.props;
+		const { isGeneralSettingsRequesting, isTaxSettingsRequesting } = this.props;
 		const step = this.getSteps()[ stepIndex ];
 
 		return (
@@ -314,12 +316,7 @@ class Tax extends Component {
 				<Card className="is-narrow">
 					{ step ? (
 						<Stepper
-							isPending={
-								isPending ||
-								isGeneralSettingsRequesting ||
-								isTaxSettingsRequesting ||
-								isJetpackRequesting
-							}
+							isPending={ isPending || isGeneralSettingsRequesting || isTaxSettingsRequesting }
 							isVertical={ true }
 							currentStep={ step.key }
 							steps={ this.getSteps() }
@@ -378,21 +375,15 @@ class Tax extends Component {
 }
 
 export default compose(
-	withSelect( ( select, props ) => {
+	withSelect( select => {
 		const {
 			getActivePlugins,
 			getOptions,
 			getSettings,
 			getSettingsError,
 			isGetSettingsRequesting,
-			isGetJetpackConnectUrlRequesting,
 			isJetpackConnected,
 		} = select( 'wc-api' );
-
-		const jetpackQueryArgs = {
-			redirect_url: props.redirectUrl || window.location.href,
-		};
-		const isJetpackRequesting = isGetJetpackConnectUrlRequesting( jetpackQueryArgs );
 
 		const generalSettings = getSettings( 'general' );
 		const isGeneralSettingsError = Boolean( getSettingsError( 'general' ) );
@@ -419,7 +410,6 @@ export default compose(
 			isJetpackConnected: isJetpackConnected(),
 			pluginsToActivate,
 			tosAccepted,
-			isJetpackRequesting,
 		};
 	} ),
 	withDispatch( dispatch => {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3785

Fix the Connect step of the stepper such that loading of status is visually displayed by the stepper's number icon and disable the "Connect" button so that it does not lead to bad urls.

### Test

1. Disable Jetpack connection
2. Enable the Task List
3. Click on taxes step
4. See the "Connect" button disabled while connection status is loading
5. See the spinner in the Stepper's number icon

![error](https://user-images.githubusercontent.com/1922453/75406339-16fdd100-5975-11ea-8602-188752fd062e.gif)

