### PR TITLE
OBW: Fix retry plugin install button disappearing

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -93,15 +93,15 @@ class BusinessDetails extends Component {
 		await updateProfileItems( updates );
 
 		if ( ! isError ) {
-			if ( 0 === businessExtensions.length ) {
-				goToNextStep();
-				return;
-			}
-
-			this.setState( {
-				installExtensions: true,
-				isInstallingExtensions: true,
-			} );
+			this.setState(
+				{
+					installExtensions: true,
+					isInstallingExtensions: true,
+				},
+				() => {
+					goToNextStep();
+				}
+			);
 		} else {
 			createNotice(
 				'error',
@@ -238,8 +238,7 @@ class BusinessDetails extends Component {
 	}
 
 	renderBusinessExtensions( values, getInputProps ) {
-		const { installExtensions, extensionInstallError } = this.state;
-		const { goToNextStep } = this.props;
+		const { installExtensions } = this.state;
 		const extensionsToInstall = this.getBusinessExtensions( values );
 		const extensionBenefits = [
 			{
@@ -288,10 +287,10 @@ class BusinessDetails extends Component {
 					<div className="woocommerce-profile-wizard__card-actions">
 						<Plugins
 							onComplete={ () => {
-								goToNextStep();
+								this.onContinue( values );
 							} }
 							onSkip={ () => {
-								goToNextStep();
+								this.onContinue( values );
 							} }
 							onError={ () => {
 								this.setState( {
@@ -299,7 +298,6 @@ class BusinessDetails extends Component {
 									isInstallingExtensions: false,
 								} );
 							} }
-							autoInstall={ ! extensionInstallError }
 							pluginSlugs={ extensionsToInstall }
 						/>
 					</div>

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -238,7 +238,7 @@ class BusinessDetails extends Component {
 	}
 
 	renderBusinessExtensions( values, getInputProps ) {
-		const { installExtensions } = this.state;
+		const { installExtensions, extensionInstallError } = this.state;
 		const { goToNextStep } = this.props;
 		const extensionsToInstall = this.getBusinessExtensions( values );
 		const extensionBenefits = [
@@ -299,7 +299,7 @@ class BusinessDetails extends Component {
 									isInstallingExtensions: false,
 								} );
 							} }
-							autoInstall
+							autoInstall={ ! extensionInstallError }
 							pluginSlugs={ extensionsToInstall }
 						/>
 					</div>

--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -93,15 +93,15 @@ class BusinessDetails extends Component {
 		await updateProfileItems( updates );
 
 		if ( ! isError ) {
-			this.setState(
-				{
-					installExtensions: true,
-					isInstallingExtensions: true,
-				},
-				() => {
-					goToNextStep();
-				}
-			);
+			if ( 0 === businessExtensions.length ) {
+				goToNextStep();
+				return;
+			}
+
+			this.setState( {
+				installExtensions: true,
+				isInstallingExtensions: true,
+			} );
 		} else {
 			createNotice(
 				'error',
@@ -238,7 +238,8 @@ class BusinessDetails extends Component {
 	}
 
 	renderBusinessExtensions( values, getInputProps ) {
-		const { installExtensions } = this.state;
+		const { installExtensions, extensionInstallError } = this.state;
+		const { goToNextStep } = this.props;
 		const extensionsToInstall = this.getBusinessExtensions( values );
 		const extensionBenefits = [
 			{
@@ -287,10 +288,10 @@ class BusinessDetails extends Component {
 					<div className="woocommerce-profile-wizard__card-actions">
 						<Plugins
 							onComplete={ () => {
-								this.onContinue( values );
+								goToNextStep();
 							} }
 							onSkip={ () => {
-								this.onContinue( values );
+								goToNextStep();
 							} }
 							onError={ () => {
 								this.setState( {
@@ -298,6 +299,7 @@ class BusinessDetails extends Component {
 									isInstallingExtensions: false,
 								} );
 							} }
+							autoInstall={ ! extensionInstallError }
 							pluginSlugs={ extensionsToInstall }
 						/>
 					</div>

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -379,7 +379,6 @@ class Payments extends Component {
 							this.completePluginInstall();
 							recordEvent( 'tasklist_payment_install_method' );
 						} }
-						autoInstall
 						pluginSlugs={ this.getPluginsToInstall() }
 					/>
 				),

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -379,6 +379,7 @@ class Payments extends Component {
 							this.completePluginInstall();
 							recordEvent( 'tasklist_payment_install_method' );
 						} }
+						autoInstall
 						pluginSlugs={ this.getPluginsToInstall() }
 					/>
 				),

--- a/client/dashboard/task-list/tasks/steps/plugins.js
+++ b/client/dashboard/task-list/tasks/steps/plugins.js
@@ -24,11 +24,7 @@ class Plugins extends Component {
 	}
 
 	componentDidMount() {
-		const { autoInstall } = this.props;
-
-		if ( autoInstall ) {
-			this.installAndActivatePlugins();
-		}
+		this.installAndActivatePlugins();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -89,7 +85,7 @@ class Plugins extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting, skipText, autoInstall, pluginSlugs } = this.props;
+		const { hasErrors, isRequesting, skipText } = this.props;
 
 		if ( hasErrors ) {
 			return (
@@ -99,20 +95,6 @@ class Plugins extends Component {
 					</Button>
 					<Button onClick={ this.skipInstaller }>
 						{ __( 'Continue without installing', 'woocommerce-admin' ) }
-					</Button>
-				</Fragment>
-			);
-		}
-
-		if ( autoInstall ) {
-			return null;
-		}
-
-		if ( 0 === pluginSlugs.length ) {
-			return (
-				<Fragment>
-					<Button isPrimary isBusy={ isRequesting } onClick={ this.skipInstaller }>
-						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
 				</Fragment>
 			);
@@ -147,15 +129,10 @@ Plugins.propTypes = {
 	/**
 	 * If installation should happen automatically, or require user confirmation.
 	 */
-	autoInstall: PropTypes.bool,
-	/**
-	 * An array of plugin slugs to install. Must be supported by the onboarding plugins API.
-	 */
 	pluginSlugs: PropTypes.arrayOf( PropTypes.string ),
 };
 
 Plugins.defaultProps = {
-	autoInstall: false,
 	onError: noop,
 	pluginSlugs: [ 'jetpack', 'woocommerce-services' ],
 };

--- a/client/dashboard/task-list/tasks/steps/plugins.js
+++ b/client/dashboard/task-list/tasks/steps/plugins.js
@@ -24,7 +24,11 @@ class Plugins extends Component {
 	}
 
 	componentDidMount() {
-		this.installAndActivatePlugins();
+		const { autoInstall } = this.props;
+
+		if ( autoInstall ) {
+			this.installAndActivatePlugins();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -85,7 +89,7 @@ class Plugins extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting, skipText } = this.props;
+		const { hasErrors, isRequesting, skipText, autoInstall, pluginSlugs } = this.props;
 
 		if ( hasErrors ) {
 			return (
@@ -95,6 +99,20 @@ class Plugins extends Component {
 					</Button>
 					<Button onClick={ this.skipInstaller }>
 						{ __( 'Continue without installing', 'woocommerce-admin' ) }
+					</Button>
+				</Fragment>
+			);
+		}
+
+		if ( autoInstall ) {
+			return null;
+		}
+
+		if ( 0 === pluginSlugs.length ) {
+			return (
+				<Fragment>
+					<Button isPrimary isBusy={ isRequesting } onClick={ this.skipInstaller }>
+						{ __( 'Continue', 'woocommerce-admin' ) }
 					</Button>
 				</Fragment>
 			);
@@ -129,10 +147,15 @@ Plugins.propTypes = {
 	/**
 	 * If installation should happen automatically, or require user confirmation.
 	 */
+	autoInstall: PropTypes.bool,
+	/**
+	 * An array of plugin slugs to install. Must be supported by the onboarding plugins API.
+	 */
 	pluginSlugs: PropTypes.arrayOf( PropTypes.string ),
 };
 
 Plugins.defaultProps = {
+	autoInstall: false,
 	onError: noop,
 	pluginSlugs: [ 'jetpack', 'woocommerce-services' ],
 };

--- a/client/dashboard/task-list/tasks/steps/plugins.js
+++ b/client/dashboard/task-list/tasks/steps/plugins.js
@@ -57,7 +57,7 @@ class Plugins extends Component {
 			activatePlugins( pluginSlugs );
 		}
 
-		if ( activatedPlugins.length === pluginSlugs.length ) {
+		if ( pluginSlugs.length > 0 && activatedPlugins.length === pluginSlugs.length ) {
 			createNotice(
 				'success',
 				__( 'Plugins were successfully installed and activated.', 'woocommerce-admin' )
@@ -89,7 +89,7 @@ class Plugins extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting, skipText, autoInstall } = this.props;
+		const { hasErrors, isRequesting, skipText, autoInstall, pluginSlugs } = this.props;
 
 		if ( hasErrors ) {
 			return (
@@ -106,6 +106,16 @@ class Plugins extends Component {
 
 		if ( autoInstall ) {
 			return null;
+		}
+
+		if ( 0 === pluginSlugs.length ) {
+			return (
+				<Fragment>
+					<Button isPrimary isBusy={ isRequesting } onClick={ this.skipInstaller }>
+						{ __( 'Continue', 'woocommerce-admin' ) }
+					</Button>
+				</Fragment>
+			);
 		}
 
 		return (


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3780

When an API request to install a plugin fails, the button behaviour was off:

* "Retry" button would disappear if you untoggled the failing plugin.
* If you untoggled all plugins, you'd proceed to the next step with a success message.

### Detailed test instructions:

1. Add `return new \WP_Error( 'plugin Oopsie' );` as the first line in this function to simulate a failed install.
https://github.com/woocommerce/woocommerce-admin/blob/fix/obw-retry-btn/src/API/OnboardingPlugins.php#L165
2. Go to the Business Details step of the OBW.
3. Attempt to install some plugins.
4. When it fails, make sure the button behaviour is as expected.
5. Remove the forced error line and make sure you can install plugins.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

