### PR TITLE
Update Country Labeling to Match Core

### DIFF
--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -97,14 +97,14 @@ export const advancedFilters = applyFilters( CUSTOMERS_REPORT_ADVANCED_FILTERS_F
 			labels: {
 				add: __( 'Country / Region', 'woocommerce-admin' ),
 				placeholder: __( 'Search', 'woocommerce-admin' ),
-				remove: __( 'Remove country filter', 'woocommerce-admin' ),
-				rule: __( 'Select a country filter match', 'woocommerce-admin' ),
+				remove: __( 'Remove country / region filter', 'woocommerce-admin' ),
+				rule: __( 'Select a country / region filter match', 'woocommerce-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
 				title: __(
 					'{{title}}Country / Region{{/title}} {{rule /}} {{filter /}}',
 					'woocommerce-admin'
 				),
-				filter: __( 'Select country', 'woocommerce-admin' ),
+				filter: __( 'Select country / region', 'woocommerce-admin' ),
 			},
 			rules: [
 				{

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -95,12 +95,15 @@ export const advancedFilters = applyFilters( CUSTOMERS_REPORT_ADVANCED_FILTERS_F
 		},
 		country: {
 			labels: {
-				add: __( 'Country', 'woocommerce-admin' ),
+				add: __( 'Country / Region', 'woocommerce-admin' ),
 				placeholder: __( 'Search', 'woocommerce-admin' ),
 				remove: __( 'Remove country filter', 'woocommerce-admin' ),
 				rule: __( 'Select a country filter match', 'woocommerce-admin' ),
 				/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/cCsm3GeXJbE */
-				title: __( '{{title}}Country{{/title}} {{rule /}} {{filter /}}', 'woocommerce-admin' ),
+				title: __(
+					'{{title}}Country / Region{{/title}} {{rule /}} {{filter /}}',
+					'woocommerce-admin'
+				),
 				filter: __( 'Select country', 'woocommerce-admin' ),
 			},
 			rules: [

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -79,7 +79,7 @@ export default class CustomersReportTable extends Component {
 				isNumeric: true,
 			},
 			{
-				label: __( 'Country', 'woocommerce-admin' ),
+				label: __( 'Country / Region', 'woocommerce-admin' ),
 				key: 'country',
 				isSortable: true,
 			},

--- a/client/dashboard/components/settings/general/store-address.js
+++ b/client/dashboard/components/settings/general/store-address.js
@@ -28,7 +28,7 @@ export function validateStoreAddress( values ) {
 		errors.addressLine1 = __( 'Please add an address', 'woocommerce-admin' );
 	}
 	if ( ! values.countryState.length ) {
-		errors.countryState = __( 'Please select a country and state', 'woocommerce-admin' );
+		errors.countryState = __( 'Please select a country / region', 'woocommerce-admin' );
 	}
 	if ( ! values.city.length ) {
 		errors.city = __( 'Please add a city', 'woocommerce-admin' );
@@ -174,7 +174,7 @@ export function StoreAddress( props ) {
 			/>
 
 			<SelectControl
-				label={ __( 'Country / State', 'woocommerce-admin' ) }
+				label={ __( 'Country / Region', 'woocommerce-admin' ) }
 				required
 				options={ countryStateOptions }
 				excludeSelectedOptions={ false }

--- a/docs/woocommerce.com/analytics-customers-report.md
+++ b/docs/woocommerce.com/analytics-customers-report.md
@@ -17,7 +17,7 @@ This option loads the report for the customer you have selected.
 There are several filters available to the Customers Report:
 
 - Name
-- Country
+- Country / Region
 - Username
 - Email
 - Orders (count)
@@ -28,7 +28,7 @@ There are several filters available to the Customers Report:
 
 ![Customers Report Advanced Filters](images/analytics-customers-report-advanced-filters.png)
 
-A special note about the Name, Username, Country, and Email filters:
+A special note about the Name, Username, Country / Region, and Email filters:
 
 ![Customers Report Advanced Name Filter](images/analytics-customers-report-name-filter.png)
 
@@ -53,7 +53,7 @@ The report table allows sorting by the following columns:
 - Sign Up
 - Orders
 - Total Spend
-- Country
+- Country / Region
 - City
 - Region
 - Postal Code

--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -579,7 +579,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'orders_count'    => __( 'Orders', 'woocommerce-admin' ),
 			'total_spend'     => __( 'Total Spend', 'woocommerce-admin' ),
 			'avg_order_value' => __( 'AOV', 'woocommerce-admin' ),
-			'country'         => __( 'Country', 'woocommerce-admin' ),
+			'country'         => __( 'Country / Region', 'woocommerce-admin' ),
 			'city'            => __( 'City', 'woocommerce-admin' ),
 			'region'          => __( 'Region', 'woocommerce-admin' ),
 			'postcode'        => __( 'Postal Code', 'woocommerce-admin' ),

--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -248,7 +248,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 					'readonly'    => true,
 				),
 				'country'              => array(
-					'description' => __( 'Country.', 'woocommerce-admin' ),
+					'description' => __( 'Country / Region.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/src/API/Reports/Taxes/Controller.php
+++ b/src/API/Reports/Taxes/Controller.php
@@ -175,7 +175,7 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 					'readonly'    => true,
 				),
 				'country'      => array(
-					'description' => __( 'Country.', 'woocommerce-admin' ),
+					'description' => __( 'Country / Region.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,


### PR DESCRIPTION
Fixes #3781

Country labeling on `Customer Report` was updated.

### Screenshots
![screenshot-labeling](https://user-images.githubusercontent.com/1314156/75461517-ae592900-5961-11ea-966d-ebef1c0381e9.png)


### Detailed test instructions:
Table
- Go to: `WooCommerce` | `Customers` (URL => `admin.php?page=wc-admin&path=%2Fcustomers`)
- It's necessary to have some registered customers.
- The column name `Country / Region` should be visible on the customers' table, instead of `Country`.

Download
- On the same page, press `Download`.
- It should download the list as a `csv`.
- In this file, the column name should be `Country / Region` too.

Filtering
- On the same page, press the dropdown menu: `Show`.
- Select the option: `Advanced Filters`.
- Press the button: `Add a Filter`.
- A list of filters should be visible. The option name `Country / Region` should be visible, instead of `Country`

Onboarding
- In the Oboarding's first step (`Store Details`), it should say `Country / Region` instead of `Country / State`.

General
- Also, any error message or other translated strings that contain `country` should say `country / region` 
- We can find these messages (`Remove country / region filter` and `Select a country / region filter match`) in the filtering. And the message: `Please select a country / region` in the onboarding.