### PR TITLE
Make WooCommerce breadcrumbs use WooCommerce branding if it is installed

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -124,7 +124,7 @@ class Header extends Component {
 							type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
 							onClick={ this.trackLinkClick }
 						>
-							{ __( 'WooCommerce', 'woocommerce' ) }
+							{ __( 'WooCommerce', 'woocommerce-admin' ) }
 						</Link>
 					</span>
 					{ _sections.map( ( section, i ) => {

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -109,24 +109,9 @@ class Header extends Component {
 			'is-scrolled': isScrolled,
 		} );
 
-		const firstBreadCrumbPath = 'admin.php?page=wc-admin';
-
 		return (
 			<div className={ className } ref={ this.headerRef }>
 				<h1 className="woocommerce-layout__header-breadcrumbs">
-					<span>
-						<Link
-							href={
-								isEmbedded
-									? getAdminLink( firstBreadCrumbPath )
-									: firstBreadCrumbPath
-							}
-							type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
-							onClick={ this.trackLinkClick }
-						>
-							{ __( 'WooCommerce', 'woocommerce-admin' ) }
-						</Link>
-					</span>
 					{ _sections.map( ( section, i ) => {
 						const sectionPiece = Array.isArray( section ) ? (
 							<Link

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -6,8 +6,6 @@ import { Component, createRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { decodeEntities } from '@wordpress/html-entities';
 import PropTypes from 'prop-types';
-import { compose } from '@wordpress/compose';
-import { get, isArray } from 'lodash';
 
 /**
  * WooCommerce dependencies
@@ -22,7 +20,6 @@ import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
 import './style.scss';
 import ActivityPanel from './activity-panel';
 import { recordEvent } from 'lib/tracks';
-import withSelect from 'wc-api/with-select';
 
 class Header extends Component {
 	constructor() {
@@ -102,7 +99,7 @@ class Header extends Component {
 	}
 
 	render() {
-		const { sections, isEmbedded, brandingName } = this.props;
+		const { sections, isEmbedded } = this.props;
 		const { isScrolled } = this.state;
 		const _sections = Array.isArray( sections ) ? sections : [ sections ];
 
@@ -127,7 +124,7 @@ class Header extends Component {
 							type={ isEmbedded ? 'wp-admin' : 'wc-admin' }
 							onClick={ this.trackLinkClick }
 						>
-							{ brandingName }
+							{ __( 'WooCommerce', 'woocommerce' ) }
 						</Link>
 					</span>
 					{ _sections.map( ( section, i ) => {
@@ -164,42 +161,10 @@ class Header extends Component {
 Header.propTypes = {
 	sections: PropTypes.node.isRequired,
 	isEmbedded: PropTypes.bool,
-	brandingName: PropTypes.string,
 };
 
 Header.defaultProps = {
 	isEmbedded: false,
 };
 
-export default compose(
-	withSelect( ( select, props ) => {
-		const { getOptions } = select( 'wc-api' );
-		const options = getOptions( [
-			'woocommerce_branding_name',
-			'active_plugins',
-		] );
-		const activePlugins = get( options, [ 'active_plugins' ], '' ) || [];
-		// So, if there are no disabled plugins in sequence, activePlugins is an
-		// array. If there _are_ disabled plugins, activePlugins is a hash. If it's
-		// not an array, convert it into an array using the hash values.
-		const activePluginsAsArray = isArray( activePlugins )
-			? activePlugins
-			: Object.values( activePlugins );
-		const brandingPluginIsInstalled =
-			activePluginsAsArray.indexOf(
-				'woocommerce-branding/woocommerce-branding.php'
-			) !== -1;
-		const brandingName = get(
-			options,
-			[ 'woocommerce_branding_name' ],
-			__( 'WooCommerce', 'woocommerce-admin' )
-		);
-
-		return {
-			brandingName: brandingPluginIsInstalled
-				? brandingName
-				: __( 'WooCommerce', 'woocommerce-admin' ),
-			...props,
-		};
-	} )
-)( Header );
+export default Header;

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -31,6 +31,10 @@ export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 export const getPages = () => {
 	const pages = [];
 
+	const initialBreadcrumbs = [
+		[ '', __( 'WooCommerce', 'woocommerce-admin' ) ],
+	];
+
 	if ( window.wcAdminFeatures.devdocs ) {
 		pages.push( {
 			container: DevDocs,
@@ -40,10 +44,10 @@ export const getPages = () => {
 				const component = searchParams.get( 'component' );
 
 				if ( component ) {
-					return [ [ '/devdocs', 'Documentation' ], component ];
+					return [ ...initialBreadcrumbs, [ '/devdocs', 'Documentation' ], component ];
 				}
 
-				return [ 'Documentation' ];
+				return [ ...initialBreadcrumbs, 'Documentation' ];
 			},
 			wpOpenMenu: 'toplevel_page_woocommerce',
 		} );
@@ -53,7 +57,7 @@ export const getPages = () => {
 		pages.push( {
 			container: Dashboard,
 			path: '/',
-			breadcrumbs: [ __( 'Dashboard', 'woocommerce-admin' ) ],
+			breadcrumbs: [ ...initialBreadcrumbs, __( 'Dashboard', 'woocommerce-admin' ) ],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 		} );
 	}
@@ -74,7 +78,7 @@ export const getPages = () => {
 		pages.push( {
 			container: AnalyticsReport,
 			path: '/customers',
-			breadcrumbs: [ __( 'Customers', 'woocommerce-admin' ) ],
+			breadcrumbs: [ ...initialBreadcrumbs, __( 'Customers', 'woocommerce-admin' ) ],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 		} );
 		pages.push( {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -30,9 +30,7 @@ export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
 export const getPages = () => {
 	const pages = [];
-	const initialBreadcrumbs = [
-		[ '', wcSettings.woocommerceTranslation ],
-	];
+	const initialBreadcrumbs = [ [ '', wcSettings.woocommerceTranslation ] ];
 
 	if ( window.wcAdminFeatures.devdocs ) {
 		pages.push( {
@@ -43,7 +41,11 @@ export const getPages = () => {
 				const component = searchParams.get( 'component' );
 
 				if ( component ) {
-					return [ ...initialBreadcrumbs, [ '/devdocs', 'Documentation' ], component ];
+					return [
+						...initialBreadcrumbs,
+						[ '/devdocs', 'Documentation' ],
+						component,
+					];
 				}
 
 				return [ ...initialBreadcrumbs, 'Documentation' ];
@@ -56,7 +58,10 @@ export const getPages = () => {
 		pages.push( {
 			container: Dashboard,
 			path: '/',
-			breadcrumbs: [ ...initialBreadcrumbs, __( 'Dashboard', 'woocommerce-admin' ) ],
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				__( 'Dashboard', 'woocommerce-admin' ),
+			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 		} );
 	}
@@ -66,6 +71,7 @@ export const getPages = () => {
 			container: AnalyticsSettings,
 			path: '/analytics/settings',
 			breadcrumbs: [
+				...initialBreadcrumbs,
 				[
 					'/analytics/revenue',
 					__( 'Analytics', 'woocommerce-admin' ),
@@ -77,7 +83,10 @@ export const getPages = () => {
 		pages.push( {
 			container: AnalyticsReport,
 			path: '/customers',
-			breadcrumbs: [ ...initialBreadcrumbs, __( 'Customers', 'woocommerce-admin' ) ],
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				__( 'Customers', 'woocommerce-admin' ),
+			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
 		} );
 		pages.push( {
@@ -91,6 +100,7 @@ export const getPages = () => {
 					return [];
 				}
 				return [
+					...initialBreadcrumbs,
 					[
 						'/analytics/revenue',
 						__( 'Analytics', 'woocommerce-admin' ),

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -30,9 +30,8 @@ export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
 export const getPages = () => {
 	const pages = [];
-
 	const initialBreadcrumbs = [
-		[ '', __( 'WooCommerce', 'woocommerce-admin' ) ],
+		[ '', wcSettings.woocommerceTranslation ],
 	];
 
 	if ( window.wcAdminFeatures.devdocs ) {

--- a/includes/connect-existing-pages.php
+++ b/includes/connect-existing-pages.php
@@ -54,15 +54,23 @@ function wc_admin_get_core_pages_to_connect() {
  * @return array Filtered breadcrumb pieces.
  */
 function wc_admin_filter_core_page_breadcrumbs( $breadcrumbs ) {
-	$screen_id        = PageController::get_instance()->get_current_screen_id();
-	$pages_to_connect = wc_admin_get_core_pages_to_connect();
+	$screen_id              = PageController::get_instance()->get_current_screen_id();
+	$pages_to_connect       = wc_admin_get_core_pages_to_connect();
+	$woocommerce_breadcrumb = array(
+		add_query_arg( 'page', 'wc-admin', 'admin.php' ),
+		__( 'WooCommerce', 'woocommerce-admin' ),
+	);
 
 	foreach ( $pages_to_connect as $page_id => $page_data ) {
 		if ( preg_match( "/^woocommerce_page_{$page_id}\-/", $screen_id ) ) {
 			if ( empty( $page_data['tabs'] ) ) {
-				$new_breadcrumbs = array( $page_data['title'] );
+				$new_breadcrumbs = array(
+					$woocommerce_breadcrumb,
+					$page_data['title'],
+				);
 			} else {
 				$new_breadcrumbs = array(
+					$woocommerce_breadcrumb,
 					array(
 						add_query_arg( 'page', $page_id, 'admin.php' ),
 						$page_data['title'],

--- a/includes/connect-existing-pages.php
+++ b/includes/connect-existing-pages.php
@@ -57,7 +57,7 @@ function wc_admin_filter_core_page_breadcrumbs( $breadcrumbs ) {
 	$screen_id              = PageController::get_instance()->get_current_screen_id();
 	$pages_to_connect       = wc_admin_get_core_pages_to_connect();
 	$woocommerce_breadcrumb = array(
-		admin_url( 'admin.php?page=wc-admin' ),
+		'admin.php?page=wc-admin',
 		__( 'WooCommerce', 'woocommerce-admin' ),
 	);
 

--- a/includes/connect-existing-pages.php
+++ b/includes/connect-existing-pages.php
@@ -57,7 +57,7 @@ function wc_admin_filter_core_page_breadcrumbs( $breadcrumbs ) {
 	$screen_id              = PageController::get_instance()->get_current_screen_id();
 	$pages_to_connect       = wc_admin_get_core_pages_to_connect();
 	$woocommerce_breadcrumb = array(
-		add_query_arg( 'page', 'wc-admin', 'admin.php' ),
+		admin_url( 'admin.php?page=wc-admin' ),
 		__( 'WooCommerce', 'woocommerce-admin' ),
 	);
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -687,8 +687,9 @@ class Loader {
 		$settings['siteUrl']           = site_url();
 		$settings['onboardingEnabled'] = self::is_onboarding_enabled();
 		$settings['dateFormat']        = get_option( 'date_format' );
-		// Plugins that depend on changing the translation work on the server but not the client - looking at
-		// WooCommerce Branding here - so pass through the translation of 'WooCommerce' to wcSettings.
+		// Plugins that depend on changing the translation work on the server but not the client -
+		// WooCommerce Branding is an example of this - so pass through the translation of
+		// 'WooCommerce' to wcSettings.
 		$settings['woocommerceTranslation'] = __( 'WooCommerce', 'woocommerce-admin' );
 
 		if ( ! empty( $preload_data_endpoints ) ) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -497,9 +497,6 @@ class Loader {
 			<div class="woocommerce-layout">
 				<div class="woocommerce-layout__header is-embed-loading">
 					<h1 class="woocommerce-layout__header-breadcrumbs">
-					<span>
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-admin' ) ); ?>"><?php esc_html_e( 'WooCommerce', 'woocommerce-admin' ); ?></a>
-					</span>
 						<?php foreach ( $sections as $section ) : ?>
 							<?php self::output_breadcrumbs( $section ); ?>
 						<?php endforeach; ?>

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -687,6 +687,9 @@ class Loader {
 		$settings['siteUrl']           = site_url();
 		$settings['onboardingEnabled'] = self::is_onboarding_enabled();
 		$settings['dateFormat']        = get_option( 'date_format' );
+		// Plugins that depend on changing the translation work on the server but not the client - looking at
+		// WooCommerce Branding here - so pass through the translation of 'WooCommerce' to wcSettings.
+		$settings['woocommerceTranslation'] = __( 'WooCommerce', 'woocommerce-admin' );
 
 		if ( ! empty( $preload_data_endpoints ) ) {
 			$settings['dataEndpoints'] = isset( $settings['dataEndpoints'] )

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -176,6 +176,10 @@ class PageController {
 			}
 		}
 
+		$woocommerce_breadcrumb = array( 'admin.php?page=wc-admin', __( 'WooCommerce', 'woocommerce-admin' ) );
+
+		array_unshift( $breadcrumbs, $woocommerce_breadcrumb );
+
 		/**
 		 * The navigation breadcrumbs for the current page.
 		 *

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -176,7 +176,7 @@ class PageController {
 			}
 		}
 
-		$woocommerce_breadcrumb = array( 'admin.php?page=wc-admin', __( 'WooCommerce', 'woocommerce-admin' ) );
+		$woocommerce_breadcrumb = array( admin_url( 'admin.php?page=wc-admin' ), __( 'WooCommerce', 'woocommerce-admin' ) );
 
 		array_unshift( $breadcrumbs, $woocommerce_breadcrumb );
 

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -176,7 +176,7 @@ class PageController {
 			}
 		}
 
-		$woocommerce_breadcrumb = array( admin_url( 'admin.php?page=wc-admin' ), __( 'WooCommerce', 'woocommerce-admin' ) );
+		$woocommerce_breadcrumb = array( 'admin.php?page=wc-admin', __( 'WooCommerce', 'woocommerce-admin' ) );
 
 		array_unshift( $breadcrumbs, $woocommerce_breadcrumb );
 


### PR DESCRIPTION
Fixes #3246

This looks for the WooCommerce extension, and if it's installed use the configured store name instead of "WooCommerce".

### Screenshots

![image](https://user-images.githubusercontent.com/224531/75635565-e19dff80-5c62-11ea-988d-5c50cf57d6e9.png)

### Detailed test instructions:

By "breadcrumbs" I'm talking about the breadcrumb links at the top of the shop dashboard for example.

1. Without the WooCommerce Branding extension installed, check that the breadcrumbs use "WooCommerce" 
2. Install and activate the WooCommerce Branding extension, but don't configure it. Check that the breadcrumbs still use "WooCommerce".
3. Configure the WooCommerce Branding extension, giving the store a name. Check that the breadcrumbs change to the configured store name.
4. Deactivate the WooCommerce Branding extension. Check that the breadcrumbs change back to "WooCommerce".

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Make WooCommerce breadcrumbs use WooCommerce Branding if it is installed