### PR TITLE
Onboarding: Add toggles to configured payments in task list

### DIFF
--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -141,7 +141,8 @@ class Payments extends Component {
 				visible: this.isStripeEnabled(),
 				plugins: [ 'woocommerce-gateway-stripe' ],
 				container: <Stripe markConfigured={ this.markConfigured } />,
-				isConfigured: options.woocommerce_stripe_settings.publishable_key && options.woocommerce_stripe_settings.secret_key
+				isConfigured: options.woocommerce_stripe_settings.publishable_key && options.woocommerce_stripe_settings.secret_key,
+				isEnabled: options.woocommerce_stripe_settings.enabled === 'yes',
 			},
 			{
 				key: 'paypal',
@@ -158,7 +159,8 @@ class Payments extends Component {
 				visible: true,
 				plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
 				container: <PayPal markConfigured={ this.markConfigured } />,
-				isConfigured: options.woocommerce_ppec_paypal_settings.api_username && options.woocommerce_ppec_paypal_settings.api_password
+				isConfigured: options.woocommerce_ppec_paypal_settings.api_username && options.woocommerce_ppec_paypal_settings.api_password,
+				isEnabled: options.woocommerce_ppec_paypal_settings.enabled === 'yes',
 			},
 			{
 				key: 'klarna_checkout',
@@ -182,7 +184,8 @@ class Payments extends Component {
 					/>
 				),
 				// @todo This should check actual Klarna connection information.
-				isConfigured: activePlugins.includes( 'klarna-checkout-for-woocommerce' )
+				isConfigured: activePlugins.includes( 'klarna-checkout-for-woocommerce' ),
+				isEnabled: options.woocommerce_kco_settings.enabled === 'yes',
 			},
 			{
 				key: 'klarna_payments',
@@ -206,7 +209,8 @@ class Payments extends Component {
 					/>
 				),
 				// @todo This should check actual Klarna connection information.
-				isConfigured: activePlugins.includes( 'klarna-payments-for-woocommerce' )
+				isConfigured: activePlugins.includes( 'klarna-payments-for-woocommerce' ),
+				isEnabled: options.woocommerce_klarna_payments_settings.enabled === 'yes',
 			},
 			{
 				key: 'square',
@@ -230,6 +234,7 @@ class Payments extends Component {
 				plugins: [ 'woocommerce-square' ],
 				container: <Square markConfigured={ this.markConfigured } />,
 				isConfigured: options.wc_square_refresh_tokens && options.wc_square_refresh_tokens.length,
+				isEnabled: options.woocommerce_square_credit_card_settings.enabled === 'yes',
 			},
 			{
 				key: 'payfast',
@@ -258,6 +263,7 @@ class Payments extends Component {
 				plugins: [ 'woocommerce-payfast-gateway' ],
 				container: <PayFast markConfigured={ this.markConfigured } />,
 				isConfigured: options.woocommerce_payfast_settings.merchant_id && options.woocommerce_payfast_settings.merchant_key && options.woocommerce_payfast_settings.pass_phrase,
+				isEnabled: options.woocommerce_payfast_settings.enabled === 'yes',
 			},
 		];
 
@@ -437,6 +443,9 @@ export default compose(
 			'woocommerce_stripe_settings',
 			'woocommerce_ppec_paypal_settings',
 			'woocommerce_payfast_settings',
+			'woocommerce_square_credit_card_settings',
+			'woocommerce_klarna_payments_settings',
+			'woocommerce_kco_settings',
 			'wc_square_refresh_tokens',
 		] );
 		const countryCode = getCountryCode(

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -174,6 +174,11 @@ class Payments extends Component {
 		enabledMethods[ key ] = ! enabledMethods[ key ];
 		this.setState( { enabledMethods } );
 
+		recordEvent( 'tasklist_payment_toggle', {
+			enabled: ! method.isEnabled,
+			payment_method: key,
+		} );
+
 		updateOptions( {
 			[ method.optionName ]: {
 				...options[ method.optionName ],

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -119,7 +119,13 @@ class Payments extends Component {
 	}
 
 	getMethodOptions() {
-		const { activePlugins, countryCode, options, profileItems } = this.props;
+		const {
+			activePlugins,
+			countryCode,
+			options,
+			profileItems,
+			updateOptions,
+		} = this.props;
 
 		const methods = [
 			{
@@ -141,8 +147,19 @@ class Payments extends Component {
 				visible: this.isStripeEnabled(),
 				plugins: [ 'woocommerce-gateway-stripe' ],
 				container: <Stripe markConfigured={ this.markConfigured } />,
-				isConfigured: options.woocommerce_stripe_settings.publishable_key && options.woocommerce_stripe_settings.secret_key,
-				isEnabled: options.woocommerce_stripe_settings.enabled === 'yes',
+				isConfigured:
+					options.woocommerce_stripe_settings.publishable_key &&
+					options.woocommerce_stripe_settings.secret_key,
+				isEnabled:
+					options.woocommerce_stripe_settings.enabled === 'yes',
+				toggle: ( isEnabled ) => {
+					updateOptions( {
+						woocommerce_stripe_settings: {
+							...options.woocommerce_stripe_settings,
+							enabled: isEnabled ? 'no' : 'yes',
+						},
+					} );
+				},
 			},
 			{
 				key: 'paypal',
@@ -159,8 +176,19 @@ class Payments extends Component {
 				visible: true,
 				plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
 				container: <PayPal markConfigured={ this.markConfigured } />,
-				isConfigured: options.woocommerce_ppec_paypal_settings.api_username && options.woocommerce_ppec_paypal_settings.api_password,
-				isEnabled: options.woocommerce_ppec_paypal_settings.enabled === 'yes',
+				isConfigured:
+					options.woocommerce_ppec_paypal_settings.api_username &&
+					options.woocommerce_ppec_paypal_settings.api_password,
+				isEnabled:
+					options.woocommerce_ppec_paypal_settings.enabled === 'yes',
+				toggle: ( isEnabled ) => {
+					updateOptions( {
+						woocommerce_ppec_paypal_settings: {
+							...options.woocommerce_ppec_paypal_settings,
+							enabled: isEnabled ? 'no' : 'yes',
+						},
+					} );
+				},
 			},
 			{
 				key: 'klarna_checkout',
@@ -184,8 +212,18 @@ class Payments extends Component {
 					/>
 				),
 				// @todo This should check actual Klarna connection information.
-				isConfigured: activePlugins.includes( 'klarna-checkout-for-woocommerce' ),
+				isConfigured: activePlugins.includes(
+					'klarna-checkout-for-woocommerce'
+				),
 				isEnabled: options.woocommerce_kco_settings.enabled === 'yes',
+				toggle: ( isEnabled ) => {
+					updateOptions( {
+						woocommerce_kco_settings: {
+							...options.woocommerce_kco_settings,
+							enabled: isEnabled ? 'no' : 'yes',
+						},
+					} );
+				},
 			},
 			{
 				key: 'klarna_payments',
@@ -209,8 +247,20 @@ class Payments extends Component {
 					/>
 				),
 				// @todo This should check actual Klarna connection information.
-				isConfigured: activePlugins.includes( 'klarna-payments-for-woocommerce' ),
-				isEnabled: options.woocommerce_klarna_payments_settings.enabled === 'yes',
+				isConfigured: activePlugins.includes(
+					'klarna-payments-for-woocommerce'
+				),
+				isEnabled:
+					options.woocommerce_klarna_payments_settings.enabled ===
+					'yes',
+				toggle: ( isEnabled ) => {
+					updateOptions( {
+						woocommerce_klarna_payments_settings: {
+							...options.woocommerce_klarna_payments_settings,
+							enabled: isEnabled ? 'no' : 'yes',
+						},
+					} );
+				},
 			},
 			{
 				key: 'square',
@@ -233,8 +283,20 @@ class Payments extends Component {
 					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ),
 				plugins: [ 'woocommerce-square' ],
 				container: <Square markConfigured={ this.markConfigured } />,
-				isConfigured: options.wc_square_refresh_tokens && options.wc_square_refresh_tokens.length,
-				isEnabled: options.woocommerce_square_credit_card_settings.enabled === 'yes',
+				isConfigured:
+					options.wc_square_refresh_tokens &&
+					options.wc_square_refresh_tokens.length,
+				isEnabled:
+					options.woocommerce_square_credit_card_settings.enabled ===
+					'yes',
+				toggle: ( isEnabled ) => {
+					updateOptions( {
+						woocommerce_square_credit_card_settings: {
+							...options.woocommerce_square_credit_card_settings,
+							enabled: isEnabled ? 'no' : 'yes',
+						},
+					} );
+				},
 			},
 			{
 				key: 'payfast',
@@ -262,8 +324,20 @@ class Payments extends Component {
 				visible: [ 'ZA' ].includes( countryCode ),
 				plugins: [ 'woocommerce-payfast-gateway' ],
 				container: <PayFast markConfigured={ this.markConfigured } />,
-				isConfigured: options.woocommerce_payfast_settings.merchant_id && options.woocommerce_payfast_settings.merchant_key && options.woocommerce_payfast_settings.pass_phrase,
-				isEnabled: options.woocommerce_payfast_settings.enabled === 'yes',
+				isConfigured:
+					options.woocommerce_payfast_settings.merchant_id &&
+					options.woocommerce_payfast_settings.merchant_key &&
+					options.woocommerce_payfast_settings.pass_phrase,
+				isEnabled:
+					options.woocommerce_payfast_settings.enabled === 'yes',
+				toggle: ( isEnabled ) => {
+					updateOptions( {
+						woocommerce_payfast_settings: {
+							...options.woocommerce_payfast_settings,
+							enabled: isEnabled ? 'no' : 'yes',
+						},
+					} );
+				},
 			},
 		];
 
@@ -343,8 +417,10 @@ class Payments extends Component {
 						container,
 						content,
 						isConfigured,
+						isEnabled,
 						key,
 						title,
+						toggle,
 						visible,
 					} = method;
 
@@ -406,7 +482,11 @@ class Payments extends Component {
 										{ __( 'Set up', 'woocommerce-admin' ) }
 									</Button>
 								) : (
-									<FormToggle />
+									<FormToggle
+										checked={ isEnabled }
+										onChange={ () => toggle( isEnabled ) }
+										onClick={ ( e ) => e.stopPropagation() }
+									/>
 								) }
 							</div>
 						</Card>

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -119,7 +119,7 @@ class Payments extends Component {
 	}
 
 	getMethodOptions() {
-		const { countryCode, profileItems } = this.props;
+		const { activePlugins, countryCode, options, profileItems } = this.props;
 
 		const methods = [
 			{
@@ -141,6 +141,7 @@ class Payments extends Component {
 				visible: this.isStripeEnabled(),
 				plugins: [ 'woocommerce-gateway-stripe' ],
 				container: <Stripe markConfigured={ this.markConfigured } />,
+				isConfigured: options.woocommerce_stripe_settings.publishable_key && options.woocommerce_stripe_settings.secret_key
 			},
 			{
 				key: 'paypal',
@@ -157,6 +158,7 @@ class Payments extends Component {
 				visible: true,
 				plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
 				container: <PayPal markConfigured={ this.markConfigured } />,
+				isConfigured: options.woocommerce_ppec_paypal_settings.api_username && options.woocommerce_ppec_paypal_settings.api_password
 			},
 			{
 				key: 'klarna_checkout',
@@ -179,6 +181,8 @@ class Payments extends Component {
 						plugin={ 'checkout' }
 					/>
 				),
+				// @todo This should check actual Klarna connection information.
+				isConfigured: activePlugins.includes( 'klarna-checkout-for-woocommerce' )
 			},
 			{
 				key: 'klarna_payments',
@@ -201,6 +205,8 @@ class Payments extends Component {
 						plugin={ 'payments' }
 					/>
 				),
+				// @todo This should check actual Klarna connection information.
+				isConfigured: activePlugins.includes( 'klarna-payments-for-woocommerce' )
 			},
 			{
 				key: 'square',
@@ -223,6 +229,7 @@ class Payments extends Component {
 					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ),
 				plugins: [ 'woocommerce-square' ],
 				container: <Square markConfigured={ this.markConfigured } />,
+				isConfigured: options.wc_square_refresh_tokens && options.wc_square_refresh_tokens.length,
 			},
 			{
 				key: 'payfast',
@@ -250,6 +257,7 @@ class Payments extends Component {
 				visible: [ 'ZA' ].includes( countryCode ),
 				plugins: [ 'woocommerce-payfast-gateway' ],
 				container: <PayFast markConfigured={ this.markConfigured } />,
+				isConfigured: options.woocommerce_payfast_settings.merchant_id && options.woocommerce_payfast_settings.merchant_key && options.woocommerce_payfast_settings.pass_phrase,
 			},
 		];
 
@@ -328,6 +336,7 @@ class Payments extends Component {
 						before,
 						container,
 						content,
+						isConfigured,
 						key,
 						title,
 						visible,
@@ -365,7 +374,7 @@ class Payments extends Component {
 								</p>
 							</div>
 							<div className="woocommerce-task-payment__after">
-								{ container ? (
+								{ container && ! isConfigured ? (
 									<Button
 										isPrimary={
 											key === this.recommendedMethod
@@ -425,6 +434,10 @@ export default compose(
 		const options = getOptions( [
 			'woocommerce_task_list_payments',
 			'woocommerce_default_country',
+			'woocommerce_stripe_settings',
+			'woocommerce_ppec_paypal_settings',
+			'woocommerce_payfast_settings',
+			'wc_square_refresh_tokens',
 		] );
 		const countryCode = getCountryCode(
 			options.woocommerce_default_country

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -54,9 +54,12 @@ export function getPaymentMethods( {
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
 			isConfigured:
+				options.woocommerce_stripe_settings &&
 				options.woocommerce_stripe_settings.publishable_key &&
 				options.woocommerce_stripe_settings.secret_key,
-			isEnabled: options.woocommerce_stripe_settings.enabled === 'yes',
+			isEnabled:
+				options.woocommerce_stripe_settings &&
+				options.woocommerce_stripe_settings.enabled === 'yes',
 			optionName: 'woocommerce_stripe_settings',
 		},
 		{
@@ -75,9 +78,11 @@ export function getPaymentMethods( {
 			plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
 			container: <PayPal />,
 			isConfigured:
+				options.woocommerce_ppec_paypal_settings &&
 				options.woocommerce_ppec_paypal_settings.api_username &&
 				options.woocommerce_ppec_paypal_settings.api_password,
 			isEnabled:
+				options.woocommerce_ppec_paypal_settings &&
 				options.woocommerce_ppec_paypal_settings.enabled === 'yes',
 			optionName: 'woocommerce_ppec_paypal_settings',
 		},
@@ -98,7 +103,9 @@ export function getPaymentMethods( {
 			isConfigured: activePlugins.includes(
 				'klarna-checkout-for-woocommerce'
 			),
-			isEnabled: options.woocommerce_kco_settings.enabled === 'yes',
+			isEnabled:
+				options.woocommerce_kco_settings &&
+				options.woocommerce_kco_settings.enabled === 'yes',
 			optionName: 'woocommerce_kco_settings',
 		},
 		{
@@ -119,6 +126,7 @@ export function getPaymentMethods( {
 				'klarna-payments-for-woocommerce'
 			),
 			isEnabled:
+				options.woocommerce_klarna_payments_settings &&
 				options.woocommerce_klarna_payments_settings.enabled === 'yes',
 			optionName: 'woocommerce_klarna_payments_settings',
 		},
@@ -143,8 +151,9 @@ export function getPaymentMethods( {
 				options.wc_square_refresh_tokens &&
 				options.wc_square_refresh_tokens.length,
 			isEnabled:
+				options.woocommerce_square_credit_card_settings &&
 				options.woocommerce_square_credit_card_settings.enabled ===
-				'yes',
+					'yes',
 			optionName: 'woocommerce_square_credit_card_settings',
 		},
 		{
@@ -174,10 +183,13 @@ export function getPaymentMethods( {
 			plugins: [ 'woocommerce-payfast-gateway' ],
 			container: <PayFast />,
 			isConfigured:
+				options.woocommerce_payfast_settings &&
 				options.woocommerce_payfast_settings.merchant_id &&
 				options.woocommerce_payfast_settings.merchant_key &&
 				options.woocommerce_payfast_settings.pass_phrase,
-			isEnabled: options.woocommerce_payfast_settings.enabled === 'yes',
+			isEnabled:
+				options.woocommerce_payfast_settings &&
+				options.woocommerce_payfast_settings.enabled === 'yes',
 			optionName: 'woocommerce_payfast_settings',
 		},
 	];

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -1,0 +1,186 @@
+/**
+ * External dependencies
+ */
+
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import { filter } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import {
+	getSetting,
+	WC_ASSET_URL as wcAssetUrl,
+} from '@woocommerce/wc-admin-settings';
+
+/**
+ * Internal dependencies
+ */
+import Stripe from './stripe';
+import Square from './square';
+import PayPal from './paypal';
+import Klarna from './klarna';
+import PayFast from './payfast';
+
+export function getPaymentMethods( {
+	activePlugins,
+	countryCode,
+	options,
+	profileItems,
+} ) {
+	const stripeCountries = getSetting( 'onboarding', {
+		stripeSupportedCountries: [],
+	} ).stripeSupportedCountries;
+
+	const methods = [
+		{
+			key: 'stripe',
+			title: __(
+				'Credit cards - powered by Stripe',
+				'woocommerce-admin'
+			),
+			content: (
+				<Fragment>
+					{ __(
+						'Accept debit and credit cards in 135+ currencies, methods such as Alipay, ' +
+							'and one-touch checkout with Apple Pay.',
+						'woocommerce-admin'
+					) }
+				</Fragment>
+			),
+			before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
+			visible: stripeCountries.includes( countryCode ),
+			plugins: [ 'woocommerce-gateway-stripe' ],
+			container: <Stripe />,
+			isConfigured:
+				options.woocommerce_stripe_settings.publishable_key &&
+				options.woocommerce_stripe_settings.secret_key,
+			isEnabled: options.woocommerce_stripe_settings.enabled === 'yes',
+			optionName: 'woocommerce_stripe_settings',
+		},
+		{
+			key: 'paypal',
+			title: __( 'PayPal Checkout', 'woocommerce-admin' ),
+			content: (
+				<Fragment>
+					{ __(
+						"Safe and secure payments using credit cards or your customer's PayPal account.",
+						'woocommerce-admin'
+					) }
+				</Fragment>
+			),
+			before: <img src={ wcAssetUrl + 'images/paypal.png' } alt="" />,
+			visible: true,
+			plugins: [ 'woocommerce-gateway-paypal-express-checkout' ],
+			container: <PayPal />,
+			isConfigured:
+				options.woocommerce_ppec_paypal_settings.api_username &&
+				options.woocommerce_ppec_paypal_settings.api_password,
+			isEnabled:
+				options.woocommerce_ppec_paypal_settings.enabled === 'yes',
+			optionName: 'woocommerce_ppec_paypal_settings',
+		},
+		{
+			key: 'klarna_checkout',
+			title: __( 'Klarna Checkout', 'woocommerce-admin' ),
+			content: __(
+				'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
+				'woocommerce-admin'
+			),
+			before: (
+				<img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />
+			),
+			visible: [ 'SE', 'FI', 'NO', 'NL' ].includes( countryCode ),
+			plugins: [ 'klarna-checkout-for-woocommerce' ],
+			container: <Klarna plugin={ 'checkout' } />,
+			// @todo This should check actual Klarna connection information.
+			isConfigured: activePlugins.includes(
+				'klarna-checkout-for-woocommerce'
+			),
+			isEnabled: options.woocommerce_kco_settings.enabled === 'yes',
+			optionName: 'woocommerce_kco_settings',
+		},
+		{
+			key: 'klarna_payments',
+			title: __( 'Klarna Payments', 'woocommerce-admin' ),
+			content: __(
+				'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.',
+				'woocommerce-admin'
+			),
+			before: (
+				<img src={ wcAssetUrl + 'images/klarna-black.png' } alt="" />
+			),
+			visible: [ 'DK', 'DE', 'AT' ].includes( countryCode ),
+			plugins: [ 'klarna-payments-for-woocommerce' ],
+			container: <Klarna plugin={ 'payments' } />,
+			// @todo This should check actual Klarna connection information.
+			isConfigured: activePlugins.includes(
+				'klarna-payments-for-woocommerce'
+			),
+			isEnabled:
+				options.woocommerce_klarna_payments_settings.enabled === 'yes',
+			optionName: 'woocommerce_klarna_payments_settings',
+		},
+		{
+			key: 'square',
+			title: __( 'Square', 'woocommerce-admin' ),
+			content: __(
+				'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). ' +
+					'Sell online and in store and track sales and inventory in one place.',
+				'woocommerce-admin'
+			),
+			before: (
+				<img src={ wcAssetUrl + 'images/square-black.png' } alt="" />
+			),
+			visible:
+				[ 'brick-mortar', 'brick-mortar-other' ].includes(
+					profileItems.selling_venues
+				) && [ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ),
+			plugins: [ 'woocommerce-square' ],
+			container: <Square />,
+			isConfigured:
+				options.wc_square_refresh_tokens &&
+				options.wc_square_refresh_tokens.length,
+			isEnabled:
+				options.woocommerce_square_credit_card_settings.enabled ===
+				'yes',
+			optionName: 'woocommerce_square_credit_card_settings',
+		},
+		{
+			key: 'payfast',
+			title: __( 'PayFast', 'woocommerce-admin' ),
+			content: (
+				<Fragment>
+					{ __(
+						'The PayFast extension for WooCommerce enables you to accept payments by Credit Card and EFT via one of South Africa’s most popular payment gateways. No setup fees or monthly subscription costs.',
+						'woocommerce-admin'
+					) }
+					<p>
+						{ __(
+							'Selecting this extension will configure your store to use South African rands as the selected currency.',
+							'woocommerce-admin'
+						) }
+					</p>
+				</Fragment>
+			),
+			before: (
+				<img
+					src={ wcAssetUrl + 'images/payfast.png' }
+					alt="PayFast logo"
+				/>
+			),
+			visible: [ 'ZA' ].includes( countryCode ),
+			plugins: [ 'woocommerce-payfast-gateway' ],
+			container: <PayFast />,
+			isConfigured:
+				options.woocommerce_payfast_settings.merchant_id &&
+				options.woocommerce_payfast_settings.merchant_key &&
+				options.woocommerce_payfast_settings.pass_phrase,
+			isEnabled: options.woocommerce_payfast_settings.enabled === 'yes',
+			optionName: 'woocommerce_payfast_settings',
+		},
+	];
+
+	return filter( methods, ( method ) => method.visible );
+}

--- a/client/dashboard/task-list/tasks/payments/paypal.js
+++ b/client/dashboard/task-list/tasks/payments/paypal.js
@@ -31,7 +31,6 @@ class PayPal extends Component {
 	}
 
 	componentDidMount() {
-		const { autoConnectFailed } = this.state;
 		const { createNotice, markConfigured } = this.props;
 
 		const query = getQuery();
@@ -54,12 +53,35 @@ class PayPal extends Component {
 			return;
 		}
 
-		if ( ! autoConnectFailed ) {
+		this.fetchOAuthConnectURL();
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { activePlugins } = this.props;
+
+		if (
+			! prevProps.activePlugins.includes(
+				'woocommerce-gateway-paypal-express-checkout'
+			) &&
+			activePlugins.includes(
+				'woocommerce-gateway-paypal-express-checkout'
+			)
+		) {
 			this.fetchOAuthConnectURL();
 		}
 	}
 
 	async fetchOAuthConnectURL() {
+		const { activePlugins } = this.props;
+
+		if (
+			! activePlugins.includes(
+				'woocommerce-gateway-paypal-express-checkout'
+			)
+		) {
+			return;
+		}
+
 		this.setState( { isPending: true } );
 		try {
 			const result = await apiFetch( {
@@ -268,13 +290,17 @@ PayPal.defaultProps = {
 
 export default compose(
 	withSelect( ( select ) => {
-		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
+		const { getActivePlugins, getOptions, isGetOptionsRequesting } = select(
+			'wc-api'
+		);
 		const options = getOptions( [ 'woocommerce_ppec_paypal_settings' ] );
 		const isOptionsRequesting = Boolean(
 			isGetOptionsRequesting( [ 'woocommerce_ppec_paypal_settings' ] )
 		);
+		const activePlugins = getActivePlugins();
 
 		return {
+			activePlugins,
 			options,
 			isOptionsRequesting,
 		};

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -68,6 +68,7 @@ class Stripe extends Component {
 
 	componentDidUpdate( prevProps ) {
 		const {
+			activePlugins,
 			createNotice,
 			isOptionsRequesting,
 			hasOptionsError,
@@ -85,6 +86,15 @@ class Stripe extends Component {
 					)
 				);
 			}
+		}
+
+		if (
+			! prevProps.activePlugins.includes(
+				'woocommerce-gateway-stripe'
+			) &&
+			activePlugins.includes( 'woocommerce-gateway-stripe' )
+		) {
+			this.fetchOAuthConnectURL();
 		}
 	}
 
@@ -113,6 +123,11 @@ class Stripe extends Component {
 	}
 
 	async fetchOAuthConnectURL() {
+		const { activePlugins } = this.props;
+		if ( ! activePlugins.includes( 'woocommerce-gateway-stripe' ) ) {
+			return;
+		}
+
 		try {
 			this.setState( { isPending: true } );
 			const result = await apiFetch( {

--- a/client/wc-api/options/operations.js
+++ b/client/wc-api/options/operations.js
@@ -50,7 +50,7 @@ function updateOptions( resourceNames, data, fetch ) {
 		} )
 			.then( () => optionsToResource( data[ resourceName ], true ) )
 			.catch( ( error ) => {
-				return { [ resourceName ]: { error } };
+				return { [ resourceName ]: { data: {}, error } };
 			} );
 	} );
 }

--- a/client/wc-api/options/selectors.js
+++ b/client/wc-api/options/selectors.js
@@ -43,6 +43,11 @@ const getOptionsError = ( getResource ) => ( optionNames ) => {
 	return getResource( getResourceName( 'options', optionNames ) ).error;
 };
 
+const getUpdateOptionsError = ( getResource ) => ( optionNames ) => {
+	return getResource( getResourceName( 'options-update', optionNames ) )
+		.error;
+};
+
 const isGetOptionsRequesting = ( getResource ) => ( optionNames ) => {
 	const { lastReceived, lastRequested } = getResource(
 		getResourceName( 'options', optionNames )
@@ -70,6 +75,7 @@ const isUpdateOptionsRequesting = ( getResource ) => ( optionNames ) => {
 export default {
 	getOptions,
 	getOptionsError,
+	getUpdateOptionsError,
 	isGetOptionsRequesting,
 	isUpdateOptionsRequesting,
 };

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -494,8 +494,11 @@ class Onboarding {
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce_ppec_paypal_settings';
 		$options[] = 'wc_square_refresh_tokens';
+		$options[] = 'woocommerce_square_credit_card_settings';
 		$options[] = 'woocommerce_payfast_settings';
 		$options[] = 'woocommerce_default_country';
+		$options[] = 'woocommerce_kco_settings';
+		$options[] = 'woocommerce_klarna_payments_settings';
 
 		return $options;
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -492,6 +492,9 @@ class Onboarding {
 		$options[] = 'woocommerce_task_list_payments';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
+		$options[] = 'woocommerce_ppec_paypal_settings';
+		$options[] = 'wc_square_refresh_tokens';
+		$options[] = 'woocommerce_payfast_settings';
 		$options[] = 'woocommerce_default_country';
 
 		return $options;

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -64,92 +64,6 @@ class OnboardingTasks {
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_tax_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_product_import_notice_admin_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_onboarding_menu_experience_script' ) );
-
-		// Update payment cache on payment gateways update.
-		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'check_stripe_completion' ), 10, 2 );
-		add_action( 'add_option_woocommerce_stripe_settings', array( $this, 'check_stripe_completion' ), 10, 2 );
-		add_action( 'update_option_woocommerce_ppec_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
-		add_action( 'add_option_woocommerce_ppec_paypal_settings', array( $this, 'check_paypal_completion' ), 10, 2 );
-		add_action( 'add_option_wc_square_refresh_tokens', array( $this, 'check_square_completion' ), 10, 2 );
-	}
-
-	/**
-	 * Check if Square payment settings are complete.
-	 *
-	 * @param string $option Option name.
-	 * @param array  $value Current value.
-	 */
-	public static function check_square_completion( $option, $value ) {
-		if ( empty( $value ) ) {
-			return;
-		}
-
-		self::mark_payment_method_configured( 'square' );
-	}
-
-
-	/**
-	 * Check if Paypal payment settings are complete.
-	 *
-	 * @param mixed $old_value Old value.
-	 * @param array $value Current value.
-	 */
-	public static function check_paypal_completion( $old_value, $value ) {
-		if (
-			! isset( $value['enabled'] ) ||
-			'yes' !== $value['enabled'] ||
-			! isset( $value['api_username'] ) ||
-			empty( $value['api_username'] ) ||
-			! isset( $value['api_password'] ) ||
-			empty( $value['api_password'] )
-		) {
-			return;
-		}
-
-		self::mark_payment_method_configured( 'paypal' );
-	}
-
-	/**
-	 * Check if Stripe payment settings are complete.
-	 *
-	 * @param mixed $old_value Old value.
-	 * @param array $value Current value.
-	 */
-	public static function check_stripe_completion( $old_value, $value ) {
-		if (
-			! isset( $value['enabled'] ) ||
-			'yes' !== $value['enabled'] ||
-			! isset( $value['publishable_key'] ) ||
-			empty( $value['publishable_key'] ) ||
-			! isset( $value['secret_key'] ) ||
-			empty( $value['secret_key'] )
-		) {
-			return;
-		}
-
-		self::mark_payment_method_configured( 'stripe' );
-	}
-
-	/**
-	 * Update the payments cache to complete if not already.
-	 *
-	 * @param string $payment_method Payment method slug.
-	 */
-	public static function mark_payment_method_configured( $payment_method ) {
-		$task_list_payments         = get_option( 'woocommerce_task_list_payments', array() );
-		$payment_methods            = isset( $task_list_payments['methods'] ) ? $task_list_payments['methods'] : array();
-		$configured_payment_methods = isset( $task_list_payments['configured'] ) ? $task_list_payments['configured'] : array();
-
-		if ( ! in_array( $payment_method, $configured_payment_methods, true ) ) {
-			$configured_payment_methods[]     = $payment_method;
-			$task_list_payments['configured'] = $configured_payment_methods;
-		}
-
-		if ( 0 === count( array_diff( $payment_methods, $configured_payment_methods ) ) ) {
-			$task_list_payments['completed'] = 1;
-		}
-
-		update_option( 'woocommerce_task_list_payments', $task_list_payments );
 	}
 
 	/**
@@ -201,8 +115,8 @@ class OnboardingTasks {
 	 * Temporarily store the active task to persist across page loads when neccessary (such as publishing a product). Most tasks do not need to do this.
 	 */
 	public static function set_active_task() {
-		if ( isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ) { // WPCS: csrf ok.
-			$task = sanitize_title_with_dashes( wp_unslash( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) );
+		if ( isset( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ) { // phpcs:ignore csrf ok.
+			$task = sanitize_title_with_dashes( wp_unslash( $_GET[ self::ACTIVE_TASK_TRANSIENT ] ) ); // phpcs:ignore csrf ok.
 
 			if ( self::check_task_completion( $task ) ) {
 				return;
@@ -212,7 +126,7 @@ class OnboardingTasks {
 				self::ACTIVE_TASK_TRANSIENT,
 				$task,
 				DAY_IN_SECONDS
-			); // WPCS: csrf ok.
+			);
 		}
 	}
 


### PR DESCRIPTION
Fixes (part of) #3710

*.Adds payment toggles to already completed payment methods.
* Checks payment configuration client-side
* Moves payment methods to their own file.
* Fxes an error with checking requested settings and errors in wc-api.

### Screenshots
<img width="706" alt="Screen Shot 2020-03-02 at 5 25 00 PM" src="https://user-images.githubusercontent.com/10561050/75696002-2d749700-5cab-11ea-9879-63d728e42910.png">


### Detailed test instructions:

1. Delete the option `woocommerce_task_list_payments` if you need to reset.
1. Configure at least one payment gateway.
1. Make sure the payment gateway's toggle is initially checked.
1. Try toggling this payment gateway on/off and make sure the setting is reflected in `wp-admin/admin.php?page=wc-settings&tab=checkout`