### PR TITLE
Onboarding: Remove old development flags

### DIFF
--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -13,10 +13,6 @@ Users of the published WooCommerce Admin plugin need to either opt-in to using t
 
 To enable the new onboarding experience manually, log-in to `wp-admin`, and go to `WooCommerce > Settings > Help > Setup Wizard`. Click `Enable` under the `New onboarding experience` heading.
 
-You can also set the following configuration flag in your `wp-config.php`:
-
-`define( 'WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED', true );`
-
 ## New REST API endpoints
 
 To power the new onboarding flow client side, new REST API endpoints have been introduced. These are purpose built endpoints that exist under the `/wc-admin/onboarding/` namespace, and are not meant to be shipped in the core rest API package. The source is stored in `src/API/OnboardingPlugins.php`, `src/API/OnboardingProfile.php`, and `src/API/OnboardingTasks.php` respectively.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -176,9 +176,8 @@ class Loader {
 
 		$onboarding_opt_in        = 'yes' === get_option( Onboarding::OPT_IN_OPTION, 'no' );
 		$legacy_onboarding_opt_in = 'yes' === get_option( 'wc_onboarding_opt_in', 'no' );
-		$onboarding_filter_opt_in = defined( 'WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED' ) && true === WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED;
 
-		if ( self::is_dev() || $onboarding_filter_opt_in || $onboarding_opt_in || $legacy_onboarding_opt_in ) {
+		if ( $onboarding_opt_in || $legacy_onboarding_opt_in ) {
 			return true;
 		}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,7 +41,7 @@ function wc_admin_install() {
 	\Automattic\WooCommerce\Admin\Install::create_events();
 
 	// Reload capabilities after install, see https://core.trac.wordpress.org/ticket/28374.
-	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
+	$GLOBALS['wp_roles'] = null; // phpcs:ignore override ok.
 	wp_roles();
 
 	echo esc_html( 'Installing woocommerce-admin...' . PHP_EOL );
@@ -89,7 +89,7 @@ function _manually_load_plugin() {
 	define( 'WC_USE_TRANSACTIONS', false );
 	update_option( 'woocommerce_enable_coupons', 'yes' );
 	update_option( 'woocommerce_calc_taxes', 'yes' );
-	define( 'WOOCOMMERCE_ADMIN_ONBOARDING_ENABLED', true );
+	update_option( 'woocommerce_onboarding_opt_in', 'yes' );
 
 	require_once wc_dir() . '/woocommerce.php';
 	require dirname( __DIR__ ) . '/vendor/autoload.php';


### PR DESCRIPTION
Fixes #3808

Removes flags we previously needed to enable onboarding during development.

### Detailed test instructions:

1. Set the option `woocommerce_onboarding_opt_in` to `no`.
1. Set `WP_DEBUG` to true.
1. Make sure onboarding is not enabled.
1. Go to Products->Help->Setup Wizard and enable onboarding.
1. Make sure onboarding works as expected.

### Changelog Note:

Dev: Remove old onboarding development flags
