### PR TITLE
remove .jitm-card notice padding

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -293,5 +293,4 @@
 
 .woocommerce-layout__notice-list .jitm-card {
 	margin: 5px 15px 2px;
-	padding: 1px 12px;
 }


### PR DESCRIPTION
Fixes #3628

This PR removes padding for `.jitm-card` classes that was added early on in the project. The styling for these has since been added to Jetpack and our CSS is overriding the JP CSS.

### Detailed test instructions:

1. Create a test site on jurassic.ninja
2. Install WooCommerce Services
3. Connect Jetpack

<img width="1132" alt="Orders ‹ Tasty Stingless — WordPress 2020-01-24 13-07-17" src="https://user-images.githubusercontent.com/22080/73104722-f17c3400-3eab-11ea-87ff-bc0085cd0085.png">

4. Install this build
6. Padding should be consistent with

<img width="1132" alt="Orders ‹ Tasty Stingless — WordPress 2020-01-24 13-07-17" src="https://user-images.githubusercontent.com/22080/73104722-f17c3400-3eab-11ea-87ff-bc0085cd0085.png">

### Changelog Note:

Fix: Padding on Jetpack notices when activity panel is present.