### PR TITLE
Fix special character escaping in search.

### DIFF
--- a/src/API/Coupons.php
+++ b/src/API/Coupons.php
@@ -84,9 +84,8 @@ class Coupons extends \WC_REST_Coupons_Controller {
 
 		$search = $wp_query->get( 'search' );
 		if ( $search ) {
-			$search = $wpdb->esc_like( $search );
-			$search = "'%" . $search . "%'";
-			$where .= ' AND ' . $wpdb->posts . '.post_title LIKE ' . $search;
+			$code_like = '%' . $wpdb->esc_like( $search ) . '%';
+			$where    .= $wpdb->prepare( "AND {$wpdb->posts}.post_title LIKE %s", $code_like );
 		}
 
 		return $where;

--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -159,10 +159,9 @@ class Products extends \WC_REST_Products_Controller {
 
 		$search = $wp_query->get( 'search' );
 		if ( $search ) {
-			$search = $wpdb->esc_like( $search );
-			$search = "'%" . $search . "%'";
-			$where .= " AND ({$wpdb->posts}.post_title LIKE {$search}";
-			$where .= wc_product_sku_enabled() ? ' OR wc_product_meta_lookup.sku LIKE ' . $search . ')' : ')';
+			$title_like = '%' . $wpdb->esc_like( $search ) . '%';
+			$where     .= $wpdb->prepare( " AND ({$wpdb->posts}.post_title LIKE %s", $title_like );  // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$where     .= wc_product_sku_enabled() ? $wpdb->prepare( ' OR wc_product_meta_lookup.sku LIKE %s)', $search ) : ')';
 		}
 
 		if ( $wp_query->get( 'low_in_stock' ) ) {

--- a/src/API/Taxes.php
+++ b/src/API/Taxes.php
@@ -99,9 +99,8 @@ class Taxes extends \WC_REST_Taxes_Controller {
 		// Filter by tax code.
 		$tax_code_search = $prepared_args['search'];
 		if ( $tax_code_search ) {
-			$tax_code_search = $wpdb->esc_like( $tax_code_search );
-			$tax_code_search = ' \'%' . $tax_code_search . '%\'';
-			$query          .= ' AND CONCAT_WS( "-", NULLIF(tax_rate_country, ""), NULLIF(tax_rate_state, ""), NULLIF(tax_rate_name, ""), NULLIF(tax_rate_priority, "") ) LIKE ' . $tax_code_search;
+			$code_like = '%' . $wpdb->esc_like( $tax_code_search ) . '%';
+			$query    .= $wpdb->prepare( ' AND CONCAT_WS( "-", NULLIF(tax_rate_country, ""), NULLIF(tax_rate_state, ""), NULLIF(tax_rate_name, ""), NULLIF(tax_rate_priority, "") ) LIKE %s', $code_like );
 		}
 
 		// Filter by included tax rate IDs.


### PR DESCRIPTION
Fixes #3758.

This PR seeks to fix malformed SQL queries resulting from special characters used in search strings - namely single quotes: `'`.

### Detailed test instructions:

- Go to Analytics > Products
- Search for `'` in the report table
- Verify there are no errors in the API response
- Search for a known good product name
- Verify the search works as expected
- Go to Analytics > Coupons
- Search for `'` in the report table
- Verify there are no errors in the API response
- Search for a known good coupon code
- Verify the search works as expected
- Go to Analytics > Taxes
- Search for `'` in the report table
- Verify there are no errors in the API response
- Search for a known good tax code
- Verify the search works as expected

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Special characters in Coupon, Product, and Tax search.