### PR TITLE
Fix tracking on migrated options

### DIFF
--- a/includes/core-functions.php
+++ b/includes/core-functions.php
@@ -51,10 +51,16 @@ function wc_admin_url( $path = null, $query = array() ) {
  * @param array  $properties Properties to pass along with event.
  */
 function wc_admin_record_tracks_event( $event_name, $properties = array() ) {
+	// WC post types must be registered first for WC_Tracks to work.
+	if ( ! post_type_exists( 'product' ) ) {
+		return;
+	}
+
 	if ( ! class_exists( 'WC_Tracks' ) ) {
 		if ( ! defined( 'WC_ABSPATH' ) || ! file_exists( WC_ABSPATH . 'includes/tracks/class-wc-tracks.php' ) ) {
 			return;
 		}
+
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -791,6 +791,10 @@ class Onboarding {
 	 * @param string $value Value of the updated option.
 	 */
 	public static function track_onboarding_toggle( $mixed, $value ) {
+		if ( defined( 'WC_ADMIN_MIGRATING_OPTIONS' ) && WC_ADMIN_MIGRATING_OPTIONS ) {
+			return;
+		};
+
 		wc_admin_record_tracks_event(
 			'onboarding_toggled',
 			array(

--- a/src/Install.php
+++ b/src/Install.php
@@ -86,6 +86,8 @@ class Install {
 	 */
 	public static function handle_option_migration( $default, $new_option ) {
 		if ( isset( self::$migrated_options[ $new_option ] ) ) {
+			wc_maybe_define_constant( 'WC_ADMIN_MIGRATING_OPTIONS', true );
+
 			// Avoid infinite loops - this filter is applied in add_option(), update_option(), and get_option().
 			remove_filter( "default_option_{$new_option}", array( __CLASS__, 'handle_option_migration' ), 10, 2 );
 


### PR DESCRIPTION
* Adds a constant to `handle_migrated_options` to avoid firing an event when migration occurs.
* Checks to see if post types are registered before attempting to record an event with `WC_Tracks` since it's possibly to fire an event before post types are registered.

I had a difficult time recreating the original error, but this takes 2 preventative measures against it.  /cc @peterfabian or @ObliviousHarmony if you have time to test this.

### Detailed test instructions:

1. Watch for the event `wcadmin_onboarding_toggled` or add error logging to the events fired in `track_onboarding_toggle()`.
1. Remove the option `woocommerce_onboarding_opt_in` from `wp_options`.
1. Visit any admin page to trigger the option migration.
1. `woocommerce_onboarding_opt_in` should be added to `wp_options` but the event in `track_onboarding_toggle()` should not be recorded.
1. Attempt the steps noted in [this issue]( https://github.com/woocommerce/woocommerce/issues/25766) and make sure it cannot be recreated.