### PR TITLE
Add Report Extension Example: Add default props to ReportFilters

### DIFF
--- a/client/analytics/components/leaderboard/index.js
+++ b/client/analytics/components/leaderboard/index.js
@@ -49,7 +49,7 @@ export class Leaderboard extends Component {
 	render() {
 		const { isRequesting, isError, totalRows, title } = this.props;
 		const rows = this.getFormattedRows();
-		const classes = 'woocommerce-leaderboard woocommerce-analytics__card';
+		const classes = 'woocommerce-leaderboard';
 
 		if ( isError ) {
 			return <ReportError className={ classes } isError />;

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -355,7 +355,7 @@ class ReportTable extends Component {
 
 		// Hide any headers based on user prefs, if loaded.
 		const filteredHeaders = this.filterShownHeaders( headers, userPrefColumns );
-		const className = classnames( 'woocommerce-report-table', 'woocommerce-analytics__card', {
+		const className = classnames( 'woocommerce-report-table', {
 			'has-compare': !! compareBy,
 			'has-search': !! searchBy,
 		} );

--- a/docs/examples/extensions/add-report/js/index.js
+++ b/docs/examples/extensions/add-report/js/index.js
@@ -18,7 +18,7 @@ const Report = ( { path, query } ) => {
 			<TableCard
 				title="Apples"
 				headers={ [
-					{ label: 'Type', key: 'type', isLeftAligned: true },
+					{ label: 'Type', key: 'type', isLeftAligned: true, required: true },
 					{ label: 'Color', key: 'color' },
 					{ label: 'Taste', key: 'taste' },
 				] }

--- a/docs/examples/extensions/add-report/js/index.js
+++ b/docs/examples/extensions/add-report/js/index.js
@@ -18,7 +18,7 @@ const Report = ( { path, query } ) => {
 			<TableCard
 				title="Apples"
 				headers={ [
-					{ label: 'Type', key: 'type' },
+					{ label: 'Type', key: 'type', isLeftAligned: true },
 					{ label: 'Color', key: 'color' },
 					{ label: 'Taste', key: 'taste' },
 				] }

--- a/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
+++ b/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
@@ -47,4 +47,4 @@ function add_report_add_report_menu_item( $report_pages ) {
 
 	return $report_pages;
 }
-add_filter( 'woocommerce_admin_report_menu_items', 'add_report_add_report_menu_item' );
+add_filter( 'woocommerce_analytics_report_menu_items', 'add_report_add_report_menu_item' );

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -11,6 +11,8 @@ import PropTypes from 'prop-types';
  * WooCommerce dependencies
  */
 import { updateQueryString } from '@woocommerce/navigation';
+import { getDateParamsFromQuery, getCurrentDates } from '@woocommerce/date';
+import Currency from '@woocommerce/currency';
 
 /**
  * Internal dependencies
@@ -82,6 +84,19 @@ class ReportFilters extends Component {
 		onDateSelect( data );
 	}
 
+	getDateQuery( query ) {
+		const { period, compare, before, after } = getDateParamsFromQuery( query );
+		const { primary: primaryDate, secondary: secondaryDate } = getCurrentDates( query );
+		return {
+			period,
+			compare,
+			before,
+			after,
+			primaryDate,
+			secondaryDate,
+		};
+	}
+
 	render() {
 		const {
 			dateQuery,
@@ -100,7 +115,7 @@ class ReportFilters extends Component {
 						{ showDatePicker && (
 							<DateRangeFilterPicker
 								key={ JSON.stringify( query ) }
-								dateQuery={ dateQuery }
+								dateQuery={ dateQuery || this.getDateQuery( query ) }
 								onRangeSelect={ this.onRangeSelect }
 								isoDateFormat={ isoDateFormat }
 							/>
@@ -166,7 +181,7 @@ ReportFilters.propTypes = {
 	/**
 	 * The currency formatting instance for the site.
 	 */
-	currency: PropTypes.object.isRequired,
+	currency: PropTypes.object,
 	/**
 	 * The date query string represented in object form.
 	 */
@@ -182,7 +197,7 @@ ReportFilters.propTypes = {
 		secondaryDate: PropTypes.shape( {
 			label: PropTypes.string.isRequired,
 			range: PropTypes.string.isRequired,
-		} ).isRequired,
+		} ),
 	} ),
 	/**
 	 * ISO date format string.
@@ -197,6 +212,15 @@ ReportFilters.defaultProps = {
 	query: {},
 	showDatePicker: true,
 	onDateSelect: () => {},
+	currency: new Currency( {
+		code: 'USD',
+		precision: 2,
+		symbol: '$',
+		symbolPosition: 'left',
+		decimalSeparator: '.',
+		thousandSeparator: ',',
+		priceFormat: '%1$s%2$s',
+	} ),
 };
 
 export default ReportFilters;

--- a/packages/components/src/table/index.js
+++ b/packages/components/src/table/index.js
@@ -144,7 +144,7 @@ class TableCard extends Component {
 		const allHeaders = this.props.headers;
 		const headers = this.getVisibleHeaders();
 		const rows = this.getVisibleRows();
-		const classes = classnames( 'woocommerce-table', className );
+		const classes = classnames( 'woocommerce-table', 'woocommerce-analytics__card', className );
 
 		return (
 			<Card


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3824

Add Report extension example was broken due to missing props and a hook name that wasn't updated. Those props shouldn't be required so I added some defaults to account for that.

Table headers weren't styled correctly, so I made sure `TableCard` had the appropriate classes

### Screenshots

![Screen Shot 2020-03-05 at 12 22 37 PM](https://user-images.githubusercontent.com/1922453/75932480-5cbe1a80-5edc-11ea-9ce0-bb89d55c40f7.png)

### Detailed test instructions:

1. `npm run example -- --ext=add-report`.
2. Visit to see the Example working: `/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fexample`.


