### PR TITLE
Fix/inconsistent wording downloads report

### DIFF
--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -52,7 +52,7 @@ export const advancedFilters = applyFilters(
 		filters: {
 			product: {
 				labels: {
-					add: __( 'Product Title', 'woocommerce-admin' ),
+					add: __( 'Product', 'woocommerce-admin' ),
 					placeholder: __( 'Search', 'woocommerce-admin' ),
 					remove: __( 'Remove product filter', 'woocommerce-admin' ),
 					rule: __(
@@ -61,7 +61,7 @@ export const advancedFilters = applyFilters(
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
-						'{{title}}Product Title{{/title}} {{rule /}} {{filter /}}',
+						'{{title}}Product{{/title}} {{rule /}} {{filter /}}',
 						'woocommerce-admin'
 					),
 					filter: __( 'Select product', 'woocommerce-admin' ),

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -61,7 +61,7 @@ export const advancedFilters = applyFilters(
 					),
 					/* translators: A sentence describing a Product filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
-						'{{title}}Product{{/title}} {{rule /}} {{filter /}}',
+						'{{title}}Product Title{{/title}} {{rule /}} {{filter /}}',
 						'woocommerce-admin'
 					),
 					filter: __( 'Select product', 'woocommerce-admin' ),
@@ -160,7 +160,7 @@ export const advancedFilters = applyFilters(
 					),
 					/* translators: A sentence describing a order number filter. See screen shot for context: https://cloudup.com/ccxhyH2mEDg */
 					title: __(
-						'{{title}}Order number{{/title}} {{rule /}} {{filter /}}',
+						'{{title}}Order #{{/title}} {{rule /}} {{filter /}}',
 						'woocommerce-admin'
 					),
 					filter: __( 'Select order number', 'woocommerce-admin' ),

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -52,7 +52,7 @@ export const advancedFilters = applyFilters(
 		filters: {
 			product: {
 				labels: {
-					add: __( 'Product', 'woocommerce-admin' ),
+					add: __( 'Product Title', 'woocommerce-admin' ),
 					placeholder: __( 'Search', 'woocommerce-admin' ),
 					remove: __( 'Remove product filter', 'woocommerce-admin' ),
 					rule: __(
@@ -145,7 +145,7 @@ export const advancedFilters = applyFilters(
 			},
 			order: {
 				labels: {
-					add: __( 'Order number', 'woocommerce-admin' ),
+					add: __( 'Order #', 'woocommerce-admin' ),
 					placeholder: __(
 						'Search order number',
 						'woocommerce-admin'

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -55,7 +55,7 @@ export default class DownloadsReportTable extends Component {
 				key: 'order_number',
 			},
 			{
-				label: __( 'User Name', 'woocommerce-admin' ),
+				label: __( 'Username', 'woocommerce-admin' ),
 				key: 'user_id',
 			},
 			{
@@ -96,10 +96,7 @@ export default class DownloadsReportTable extends Component {
 			return [
 				{
 					display: (
-						<Date
-							date={ date }
-							visibleFormat={ dateFormat }
-						/>
+						<Date date={ date } visibleFormat={ dateFormat } />
 					),
 					value: date,
 				},


### PR DESCRIPTION
Under Analytics > Downloads, there were some inconsistencies in terms of the capitalization and terminology used on the filters vs. table headers below that. 

This PR fixes that:

#### Filters: 

* Product --> Product Title
* Order number --> Order # 

#### Table:

* User Name --> Username

#### Exception

* Didn't add "Address" after "IP" in the table to save space

![](https://d.pr/i/mowzfp+)
If the image does not load, please click this link: https://d.pr/i/mowzfp.