### PR TITLE
add left join to sku ordering

### DIFF
--- a/src/API/Reports/Products/DataStore.php
+++ b/src/API/Reports/Products/DataStore.php
@@ -122,7 +122,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$join = " JOIN {$wpdb->posts} AS _products ON {$id_cell} = _products.ID";
 				break;
 			case 'sku':
-				$join = " JOIN {$wpdb->postmeta} AS postmeta ON {$id_cell} = postmeta.post_id AND postmeta.meta_key = '_sku'";
+				$join = " LEFT JOIN {$wpdb->postmeta} AS postmeta ON {$id_cell} = postmeta.post_id AND postmeta.meta_key = '_sku'";
 				break;
 			case 'variations':
 				$type = 'left_join';


### PR DESCRIPTION
Fixes #3840

This PR changes the JOIN on the `sku` ordering query to a LEFT JOIN to include rows where the `_sku` meta row doesn't exist. Since WC 3.9 the `_sku` meta row is no longer created by default.


### Detailed test instructions:

- Remove the `_sku` row from a product 
- Create a `Processing` order with that product
- Check on `version/1.0` that sorting by SKU removes the product from the product report
- Switch to this branch
- Navigate away from Analytics
- Re-check the report

### Changelog Note:

Fix: Product report sorting by SKU when some products don't have SKUs 