### PR TITLE
Onboarding: Use full width template for homepage in stores using Storefront

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -427,6 +427,11 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			update_option( 'page_on_front', $post_id );
 			update_option( 'woocommerce_onboarding_homepage_post_id', $post_id );
 
+			// Use the full width template on stores using Storefront.
+			if ( 'storefront' === get_stylesheet() ) {
+				update_post_meta( $post_id, '_wp_page_template', 'template-fullwidth.php' );
+			}
+
 			return array(
 				'status'         => 'success',
 				'message'        => __( 'Homepage created.', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #3626 

Uses the full width layout for Storefront themed sites, which also fixes the heading spacing issues noted in #3636.


### Screenshots
<img width="1142" alt="Screen Shot 2020-03-06 at 4 10 53 PM" src="https://user-images.githubusercontent.com/10561050/76095943-77b88980-5fc5-11ea-8fd9-61bea753212e.png">


### Detailed test instructions:

1. Activate the `storefront` theme.
1. Delete any old homepages created through the onboarding task list.
1. Visit the task list and go to the Customize Appearance step.
1. Create a homepage through the task list.
1. View the homepage and make sure its full width and the heading margins are correct (not flush against the previous section).