### PR TITLE
Onboarding: Track selling venue response in business details step

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -85,7 +85,7 @@ class BusinessDetails extends Component {
 
 		recordEvent( 'storeprofiler_store_business_details_continue', {
 			product_number: productCount,
-			already_selling: sellingVenues !== 'no',
+			already_selling: sellingVenues,
 			currency: currency.code,
 			revenue,
 			used_platform: otherPlatform,
@@ -135,7 +135,7 @@ class BusinessDetails extends Component {
 	validate( values ) {
 		const errors = {};
 
-		Object.keys( values ).forEach( name => {
+		Object.keys( values ).forEach( ( name ) => {
 			if ( name === 'other_platform' ) {
 				if (
 					! values.other_platform.length &&


### PR DESCRIPTION
Fixes #3634 

Track the selling venues response in the business details step instead of `true|false`.

### Screenshots
<img width="486" alt="Screen Shot 2020-03-06 at 4 22 26 PM" src="https://user-images.githubusercontent.com/10561050/76096694-cd416600-5fc6-11ea-86c2-712b92be95e8.png">


### Detailed test instructions:

1. Enable the profiler.
1. Enter localStorage.setItem( 'debug', 'wc-admin:*' ); into your console. Leave your console open.
1. Visit the Business Details step of the profiler.
1. Select various options for `Currently selling elsewhere?`.
1. Check that the event `storeprofiler_store_business_details_continue` has the property `already_selling` with the respective value selected instead of a boolean value.