### PR TITLE
fix undefined const WC_ADMIN_VERSION_NUMBER when WP < 5.3

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -258,7 +258,7 @@ class FeaturePlugin {
 	 *
 	 * @return bool
 	 */
-	protected function has_satisfied_dependencies() {
+	public function has_satisfied_dependencies() {
 		$dependency_errors = $this->get_dependency_errors();
 		return 0 === count( $dependency_errors );
 	}

--- a/src/Package.php
+++ b/src/Package.php
@@ -36,13 +36,21 @@ class Package {
 	private static $package_active = false;
 
 	/**
+	 * Active version
+	 *
+	 * @var bool
+	 */
+	private static $active_version = null;
+
+	/**
 	 * Init the package.
 	 *
 	 * Only initialize for WP 5.3 or greater.
 	 */
 	public static function init() {
-		$wordpress_minimum_met = version_compare( get_bloginfo( 'version' ), '5.3', '>=' );
-		if ( ! $wordpress_minimum_met ) {
+		$feature_plugin_instance = FeaturePlugin::instance();
+		$satisfied_dependencies  = $feature_plugin_instance->has_satisfied_dependencies();
+		if ( ! $satisfied_dependencies ) {
 			return;
 		}
 
@@ -53,7 +61,8 @@ class Package {
 
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
-			$update_version = new WC_Admin_Notes_Deactivate_Plugin();
+			self::$active_version = WC_ADMIN_VERSION_NUMBER;
+			$update_version       = new WC_Admin_Notes_Deactivate_Plugin();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
 				$update_version::add_note();
 			} else {
@@ -67,7 +76,8 @@ class Package {
 		}
 
 		self::$package_active = true;
-		FeaturePlugin::instance()->init();
+		self::$active_version = self::VERSION;
+		$feature_plugin_instance->init();
 	}
 
 	/**
@@ -85,7 +95,7 @@ class Package {
 	 * @return string
 	 */
 	public static function get_active_version() {
-		return self::$package_active ? self::VERSION : WC_ADMIN_VERSION_NUMBER;
+		return self::$active_version;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3841

>`\Automattic\WooCommerce\Admin\Composer\Package::get_active_version()` will cause a PHP notice in case when wc-admin plugin is not installed && package is inactive (either when running on WP 5.2 or when disabled via filter on later WP), as WC_ADMIN_VERSION_NUMBER is not defined.

Changes in this PR makes sure `\Automattic\WooCommerce\Admin\Composer\Package::get_active_version()` does not access `WC_ADMIN_VERSION_NUMBER` when the plugin is disabled due to minimum requirements not met.

### Detailed test instructions:

1. Downgrade to WP 5.2 and see wc-admin disabled due to minimum requirements not met.
2. In any plugin you have access to, add this line:
```
error_log( \Automattic\WooCommerce\Admin\Composer\Package::get_active_version() );
```
3. Refresh the page and see and error `Use of undefined constant WC_ADMIN_VERSION_NUMBER` appear in the logs.
3. Copy `src/Package.php` from this PR into Core's packages, ie `woocommerce/packages/woocommerce-admin/src/`
4. Check your logs and see the result be `Inactive` and no error appears.