### PR TITLE
add check for feature-config.php before require

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -65,6 +65,11 @@ class FeaturePlugin {
 
 		$this->define_constants();
 
+		if ( ! is_readable( WC_ADMIN_ABSPATH . '/includes/feature-config.php' ) ) {
+			add_action( 'admin_notices', array( $this, 'render_build_notice' ) );
+			return;
+		}
+
 		require_once WC_ADMIN_ABSPATH . '/includes/core-functions.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/feature-config.php';
 		require_once WC_ADMIN_ABSPATH . '/includes/page-controller-functions.php';


### PR DESCRIPTION
Fixes #3843

This PR adds a check for `includes/feature-config.php` prior to its `require()`. If the file doesn't exist it adds the build notice and exits early.

### Detailed test instructions:

- Rename or delete `includes/feature-config.php`
- In `master` this produces a fatal error
- In this branch the `npm run install && npm run build` notice is shown.

### Changelog Note:

Fix: Error when `feature-config.php` is missing.