### PR TITLE
convert install timestamp to integer

### DIFF
--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -23,9 +23,9 @@ trait NoteTraits {
 	 */
 	public static function wc_admin_active_for( $seconds ) {
 		// Getting install timestamp reference class-wc-admin-install.php.
-		$wc_admin_installed = get_option( 'woocommerce_admin_install_timestamp', false );
+		$wc_admin_installed = (int) get_option( 'woocommerce_admin_install_timestamp', false );
 
-		if ( false === $wc_admin_installed ) {
+		if ( ! $wc_admin_installed ) {
 			update_option( 'woocommerce_admin_install_timestamp', time() );
 
 			return false;


### PR DESCRIPTION
Fixes #3829

This PR casts the install timestamp to an `int` to eliminate a warning in PHP 7.4. The `option_value` column is a string field. Earlier versions of PHP would implicitly convert a numeric value to the appropriate type.

### Detailed test instructions:

- delete the `woocommerce_admin_install_timestamp` option
- refresh the dashboard
- check that `woocommerce_admin_install_timestamp` option was created
- turn off tracking in the WC settings
- delete the `wc-admin-usage-tracking-opt-in` note
- refresh the dashboard
- tracking note should not be added to the DB

### Changelog Note:

Fix: type warning on install timestamp in PHP 7.4