### PR TITLE
Fix PHP Fatal on Multisite installs.

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -75,7 +75,11 @@ class FeaturePlugin {
 		if ( did_action( 'plugins_loaded' ) ) {
 			self::on_plugins_loaded();
 		} else {
-			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
+			// Make sure we hook into `plugins_loaded` before core's Automattic\WooCommerce\Package::init().
+			// If core is network activated but we aren't, the packaged version of WooCommerce Admin will
+			// attempt to use a data store that hasn't been loaded yet - because we've defined our constants here.
+			// See: https://github.com/woocommerce/woocommerce-admin/issues/3869.
+			add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ), 9 );
 		}
 		add_filter( 'action_scheduler_store_class', array( $this, 'replace_actionscheduler_store_class' ) );
 	}


### PR DESCRIPTION
Fixes #3861.
Fixes #3869.

This PR seeks to resolve PHP Fatal errors encountered on WP Multisite installs where WooCommerce is network activated, but the WooCommerce Admin feature plugin isn't (just active on an individual site basis).

### Detailed test instructions:

- On a multisite, network activate WooCommerce 4.0.0
- On an individual site, activate WooCommerce Admin
- Verify no PHP Fatals
- Network activate WooCommerce Admin
- Verify no PHP Fatals
- Network deactivate WooCommerce and WooCommerce Admin
- Activate WooCommerce and WooCommerce Admin on an individual site
- Verify no PHP Fatals

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: PHP error when WooCommerce core is Network Active on Multisites.