### PR TITLE
Don't attempt to create an inbox note before the tables exist.

### DIFF
--- a/src/Features/ActivityPanels.php
+++ b/src/Features/ActivityPanels.php
@@ -46,7 +46,7 @@ class ActivityPanels {
 		add_filter( 'woocommerce_components_settings', array( $this, 'component_settings' ), 20 );
 		// New settings injection.
 		add_filter( 'woocommerce_shared_settings', array( $this, 'component_settings' ), 20 );
-		add_action( 'woocommerce_updated', array( $this, 'woocommerce_updated_note' ) );
+		add_action( 'woocommerce_admin_updated', array( $this, 'woocommerce_updated_note' ) );
 		add_action( 'woocommerce_update_product', array( __CLASS__, 'clear_low_out_of_stock_count_transient' ) );
 	}
 


### PR DESCRIPTION
Found while fixing https://github.com/woocommerce/woocommerce/pull/25891.

This PR fixes a PHP error caused by attempting to create an inbox note before the tables have been created.

It's a simple hook replacement from `woocommerce_updated` to `woocommerce_admin_updated`.

### Detailed test instructions:

- Create a store on WC 3.9.3
- Check out the branch from https://github.com/woocommerce/woocommerce/pull/25891
- Copy this change into `woocommerce/packages/woocommerce-admin/src/Features/ActivityPanels.php`
- Verify that no missing database table errors occur in the upgrade

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: missing database table errors on WooCommerce upgrade.