### PR TITLE
Update "WC tested up to" tag to "4.0.0"

### DIFF
--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -12,7 +12,7 @@
  * Requires PHP: 5.6.20
  *
  * WC requires at least: 3.6.0
- * WC tested up to: 3.9.1
+ * WC tested up to: 4.0.0
  *
  * @package WC_Admin
  */


### PR DESCRIPTION
This commit updates the "WC tested up to" tag to the latest WooCommerce core version to avoid showing an erroneous message to the users in the WooCommerce core system status page saying that WC Admin is not tested with the latest WC version.