### PR TITLE
Zip: include files instead of exclude

### DIFF
--- a/bin/build-test-zip.sh
+++ b/bin/build-test-zip.sh
@@ -3,6 +3,6 @@
 # Build a test zip from current branch for uploading to test site
 #
 npm run build
-composer install
+composer install --no-dev
 rm woocommerce-admin.zip
 ./bin/make-zip.sh woocommerce-admin.zip

--- a/bin/make-zip.sh
+++ b/bin/make-zip.sh
@@ -21,52 +21,15 @@ output 2 "Creating archive... 🎁"
 
 ZIP_FILE=$1
 
-# Folders listed first then individual files
-zip -r ${ZIP_FILE} . \
-	-x \
-	.git/\* \
-	tests/\* \
-	bin/\* \
-	config/\* \
-	node_modules/\* \
-	vendor/bin/\* \
-	vendor/dealerdirect/\* \
-	vendor/doctrine/\* \
-	vendor/phar-io/\* \
-	vendor/phpcompatibility/\* \
-	vendor/phpdocumentor/\* \
-	vendor/phpspec/\* \
-	vendor/phpunit/\* \
-	vendor/sebastian/\* \
-	vendor/squizlabs/\* \
-	vendor/theseer/\* \
-	vendor/webmozart/\* \
-	vendor/woocommerce/\* \
-	vendor/wp-coding-standards/\* \
-	.distignore \
-	.editorconfig \
-	.gitignore \
-	.gitlab-ci.yml \
-	.travis.yml \
-	.DS_Store \
-	.zipignore \
-	Thumbs.db \
-	behat.yml \
-	circle.yml \
-	composer.json \
-	composer.lock \
-	Gruntfile.js \
-	package.json \
-	package-lock.json \
-	phpunit.xml \
-	phpunit.xml.dist \
-	multisite.xml \
-	multisite.xml.dist \
-	phpcs.xml \
-	phpcs.xml.dist \
-	README.md \
-	wp-cli.local.yml \
-	yarn.lock \
-	*.sql \
-	*.tar.gz \
-	*.zip
+build_files=$(ls dist/*/*.{js,css})
+
+zip -r ${ZIP_FILE} \
+	woocommerce-admin.php \
+	uninstall.php \
+	includes/ \
+	images/ \
+	$build_files \
+	languages/woocommerce-admin.pot \
+	readme.txt \
+	src/ \
+	vendor/


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3889

This PR goes back to explicitly naming which files to add to a zip instead of which files to exclude. Although it means `npm run test:zip` will remove dev packages from your local install, I think the pain point is small compared to the possibility of erroneously adding a file.

I'm open to debate on that point.

The zip goes from 6.4 MB to 1.3 MB

### Test

1. Run `npm run test:zip` and inspect files. It should be the ones from https://github.com/woocommerce/woocommerce-admin/issues/3889.
2. Add the zip to a test site and make sure the app loads correctly.