### PR TITLE
"Personalize your store" reminder: new inbox notification

### DIFF
--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -413,7 +413,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			)
 		);
 
-		if ( ! is_wp_error( $post_id ) ) {
+		if ( ! is_wp_error( $post_id ) && 0 < $post_id ) {
 
 			$template = self::get_homepage_template( $post_id );
 			wp_update_post(

--- a/src/Events.php
+++ b/src/Events.php
@@ -16,6 +16,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Personalize_Store;
 
 /**
  * WC_Admin_Events Class.
@@ -66,5 +67,6 @@ class Events {
 		WC_Admin_Notes_Facebook_Extension::possibly_add_facebook_note();
 		WC_Admin_Notes_Tracking_Opt_In::possibly_add_tracking_opt_in_note();
 		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_onboarding_email_marketing_note();
+		WC_Admin_Notes_Personalize_Store::possibly_add_personalize_store_note();
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * WooCommerce Admin Personalize Your Store Note Provider.
+ *
+ * Adds a note to the merchant's inbox prompting them to personalize their store.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Personalize_Store
+ */
+class WC_Admin_Notes_Personalize_Store {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-personalize-store';
+
+	/**
+	 * Possibly add the note.
+	 */
+	public static function possibly_add_personalize_store_note() {
+		// Only show the note to stores with homepage.
+		$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
+		if ( 0 > $homepage_id ) {
+			return;
+		}
+
+		// Show the note after task list is done
+		$is_task_list_complete = get_option( 'woocommerce_task_list_complete', false );
+
+		// We want to show the note after day 5.
+		$five_days_in_seconds = 5 * DAY_IN_SECONDS;
+
+		if ( ! self::wc_admin_active_for( $five_days_in_seconds ) && ! $is_task_list_complete ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$content = __( 'The homepage is one of the most important entry points in your store. When done right it can lead to higher conversions and engagement. Don\'t forget to personalize the homepage that we created for your store during the onboarding.', 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Personalize your store\'s homepage', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'notice' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce-admin' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+
+		$note->save();
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -35,7 +35,7 @@ class WC_Admin_Notes_Personalize_Store {
 			return;
 		}
 
-		// Show the note after task list is done
+		// Show the note after task list is done.
 		$is_task_list_complete = get_option( 'woocommerce_task_list_complete', false );
 
 		// We want to show the note after day 5.

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -31,7 +31,7 @@ class WC_Admin_Notes_Personalize_Store {
 	public static function possibly_add_personalize_store_note() {
 		// Only show the note to stores with homepage.
 		$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
-		if ( 0 > $homepage_id ) {
+		if ( ! $homepage_id ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #3789

Added note to Personalize Store. It will appear after 5 days from registration or when the user completes the task list.

### Screenshots
![screenshot-personalize](https://user-images.githubusercontent.com/1314156/76626285-a54a8900-6517-11ea-8126-0cd0a4dc1a13.png)


### Detailed test instructions:
- After triggering the cron, go to the WooCommerce Dashboard.
- Press the` Inbox` button in the Navbar
- A note with the text: `Personalize your store's homepage` should be visible.
- Press the` Personalize homepage` button.
- It should redirect to the `Front Page` editor
