### PR TITLE
Create database tables earlier - like core.

### DIFF
--- a/src/Install.php
+++ b/src/Install.php
@@ -62,7 +62,7 @@ class Install {
 	 * Hook in tabs.
 	 */
 	public static function init() {
-		add_action( 'admin_init', array( __CLASS__, 'check_version' ), 5 );
+		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 
 		// Add wc-admin report tables to list of WooCommerce tables.


### PR DESCRIPTION
Decided this needed to change in solving https://github.com/woocommerce/woocommerce/issues/25876.

See: https://github.com/woocommerce/woocommerce/pull/25891 for discussion.

This PR seeks to align the database table creation timing with core by hooking into `init` rather than `admin_init`. Coupled with https://github.com/woocommerce/woocommerce/pull/25891, this alleviates one of the "table does not exist" errors users are having upgrading to `4.0.0`.

### Detailed test instructions:

- Create a new store or force an upgrade on an existing on using this branch
- Verify database tables are created and no errors are encountered

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Tweak: create database tables on an earlier hook to avoid conflicts with core WooCommerce.