### PR TITLE
Order page prompt: use an isset check to add activePlugins data for robustness

### DIFF
--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -187,10 +187,12 @@ class ShippingLabelBanner {
 	 * @return array
 	 */
 	public function component_settings( $settings ) {
-		if ( Loader::is_onboarding_enabled() ) {
-			return $settings;
+		if ( ! isset( $settings['onboarding'] ) ) {
+			$settings['onboarding'] = array();
 		}
-		$settings['onboarding']['activePlugins'] = Onboarding::get_active_plugins();
+		if ( ! isset( $settings['onboarding']['activePlugins'] ) ) {
+			$settings['onboarding']['activePlugins'] = Onboarding::get_active_plugins();
+		}
 		return $settings;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/35

The on-boarding data is not always added when onboarding is enabled, so it's more robust to use an isset check.