### PR TITLE
Install and acitvate WCS from banner

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -16,6 +16,7 @@ import DismissModal from '../dismiss-modal';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import withSelect from 'wc-api/with-select';
 import SetupNotice, { setupErrorTypes } from '../setup-notice';
+import { withDispatch } from '@wordpress/data';
 
 const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
 
@@ -54,7 +55,17 @@ export class ShippingBanner extends Component {
 		// TODO: install and activate WCS
 		// TODO: open WCS modal
 		this.trackBannerEvent( 'shipping_banner_create_label_click' );
+		this.installAndActivatePlugins( 'woocommerce-services' );
 	};
+
+	async installAndActivatePlugins( pluginSlug ) {
+		// Avoid double activating.
+		const { installPlugins } = this.props;
+		// if ( isRequesting ) {
+		// 	return false;
+		// }
+		installPlugins( [ pluginSlug ] );
+	}
 
 	woocommerceServiceLinkClicked = () => {
 		this.trackBannerEvent(
@@ -163,6 +174,14 @@ export default compose(
 		return {
 			activePlugins: getActivePlugins(),
 			isJetpackConnected: isJetpackConnected(),
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { activatePlugins, installPlugins } = dispatch( 'wc-api' );
+
+		return {
+			activatePlugins,
+			installPlugins,
 		};
 	} )
 )( ShippingBanner );

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -75,9 +75,10 @@ export class ShippingBanner extends Component {
 	};
 
 	createShippingLabelClicked = () => {
+		const { wcsPluginSlug } = this.props;
 		// TODO: open WCS modal
 		this.trackBannerEvent( 'shipping_banner_create_label_click' );
-		this.installAndActivatePlugins( this.props.wcsPluginSlug );
+		this.installAndActivatePlugins( wcsPluginSlug );
 	};
 
 	async installAndActivatePlugins( pluginSlug ) {
@@ -96,11 +97,11 @@ export class ShippingBanner extends Component {
 	};
 
 	trackBannerEvent = ( eventName ) => {
-		const { activePlugins, isJetpackConnected } = this.props;
+		const { activePlugins, isJetpackConnected, wcsPluginSlug } = this.props;
 		recordEvent( eventName, {
 			jetpack_installed: activePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
-			wcs_installed: activePlugins.includes( this.props.wcsPluginSlug ),
+			wcs_installed: activePlugins.includes( wcsPluginSlug ),
 		} );
 	};
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -79,3 +79,46 @@ describe( 'Tracking events in shippingBanner', () => {
 		);
 	} );
 } );
+
+describe( 'Create shipping label button', () => {
+	let shippingBannerWrapper;
+	const installPlugins = jest.fn();
+	const activatePlugins = jest.fn();
+	const activePlugins = {
+		includes: jest.fn().mockReturnValue( true ),
+	};
+
+	beforeEach( () => {
+		shippingBannerWrapper = shallow(
+			<ShippingBanner
+				isJetpackConnected={ jest.fn() }
+				activatePlugins={ activatePlugins }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installPlugins={ installPlugins }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				hasErrors={ false }
+			/>
+		);
+	} );
+
+	it( 'should install WooCommerce Services when button is clicked', () => {
+		const createShippingLabelButton = shippingBannerWrapper.find( Button );
+		expect( createShippingLabelButton.length ).toBe( 1 );
+		createShippingLabelButton.simulate( 'click' );
+		expect( installPlugins ).toHaveBeenCalledWith( [
+			'woocommerce-services',
+		] );
+	} );
+
+	it( 'should activate WooCommerce Services when installation finishes', () => {
+		// Cause a 'componentDidUpdate' by changing the props.
+		shippingBannerWrapper.setProps( {
+			installedPlugins: [ 'woocommerce-services' ],
+		} );
+		expect( activatePlugins ).toHaveBeenCalledWith( [
+			'woocommerce-services',
+		] );
+	} );
+} );

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -30,6 +30,10 @@ describe( 'Tracking events in shippingBanner', () => {
 			<ShippingBanner
 				isJetpackConnected={ isJetpackConnected }
 				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				hasErrors={ false }
 			/>
 		);
 	} );

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -74,7 +74,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\Themes',
 		);
 
-		if ( Loader::is_onboarding_enabled() ) {
+		if ( Loader::is_onboarding_enabled() || Loader::is_feature_enabled( 'shipping-label-banner' ) ) {
 			$controllers = array_merge(
 				$controllers,
 				array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/12

This change is based on the existing work from plugins https://github.com/woocommerce/woocommerce-admin/blob/master/client/dashboard/task-list/tasks/steps/plugins.js. It is to add similar behaviour to shipping banner such that clicking "Create shipping label" allows us to automate WCS installation and activation.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
- Deactivate WooCommerce Services (aka WCS)
- Delete WCS from `wordpress/wp-content/plugins`
- Open up an order page (ie. wp-admin/post.php?post=14&action=edit)
- Click "Create shipping label"
- Wait a bit
- Go to plugins page and confirm WCS is installed and activated (ie. wp-admin/plugins.php?plugin_status=all&paged=1&s)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
