### PR TITLE
Add shipping banner error notice

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/setup-notice/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/setup-notice/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import Gridicon from 'gridicons';
+
+export const setupErrorTypes = {
+	DOWNLOAD: 'download',
+	INSTALL: 'install',
+	ACTIVATE: 'activate',
+	SETUP: 'setup',
+	START: 'start',
+};
+
+const setupErrorDescriptions = {
+	[ setupErrorTypes.DOWNLOAD ]: __( 'download', 'woocommerce-admin' ),
+	[ setupErrorTypes.INSTALL ]: __( 'install', 'woocommerce-admin' ),
+	[ setupErrorTypes.ACTIVATE ]: __( 'activate', 'woocommerce-admin' ),
+	[ setupErrorTypes.SETUP ]: __( 'set up', 'woocommerce-admin' ),
+	[ setupErrorTypes.START ]: __( 'start', 'woocommerce-admin' ),
+};
+
+export default function SetupNotice( { isSetupError, errorReason } ) {
+	const getErrorMessage = ( errorType ) => {
+		// Default to 'set up' description if the error type somehow doesn't exist.
+		const description =
+			errorType in setupErrorDescriptions
+				? setupErrorDescriptions[ errorType ]
+				: setupErrorDescriptions[ setupErrorTypes.SETUP ];
+
+		return sprintf(
+			__(
+				'Unable to %s the plugin. Refresh the page and try again.',
+				'woocommerce-admin'
+			),
+			description
+		);
+	};
+
+	if ( ! isSetupError ) {
+		return null;
+	}
+
+	return (
+		<div className="wc-admin-shipping-banner-install-error">
+			<Gridicon icon="notice" />
+			{ getErrorMessage( errorReason ) }
+		</div>
+	);
+}

--- a/client/wp-admin-scripts/print-shipping-label-banner/setup-notice/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/setup-notice/test/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import SetupNotice, { setupErrorTypes } from '../';
+
+describe( 'SetupNotice', () => {
+	it( 'should be hidden for no error', () => {
+		const notice = mount( <SetupNotice isSetupError={ false } /> );
+		expect( notice.isEmptyRender() ).toBe( true );
+	} );
+
+	it( 'should show div if there is an error', () => {
+		const notice = mount( <SetupNotice isSetupError={ true } /> );
+		const contents = notice.find(
+			'.wc-admin-shipping-banner-install-error'
+		);
+		expect( contents.length ).toBe( 1 );
+	} );
+
+	it( 'should show download message for download error', () => {
+		const notice = mount(
+			<SetupNotice
+				isSetupError={ true }
+				errorReason={ setupErrorTypes.DOWNLOAD }
+			/>
+		);
+		expect(
+			notice.text().includes( 'Unable to download the plugin' )
+		).toBe( true );
+	} );
+
+	it( 'should show default message for unset error', () => {
+		const notice = mount( <SetupNotice isSetupError={ true } /> );
+		expect( notice.text().includes( 'Unable to set up the plugin' ) ).toBe(
+			true
+		);
+	} );
+} );

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -15,6 +15,7 @@ import '../style.scss';
 import DismissModal from '../dismiss-modal';
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import withSelect from 'wc-api/with-select';
+import SetupNotice, { setupErrorTypes } from '../setup-notice';
 
 const wcAdminAssetUrl = getSetting( 'wcAdminAssetUrl', '' );
 
@@ -24,6 +25,8 @@ export class ShippingBanner extends Component {
 		this.state = {
 			showShippingBanner: true, // TODO: update to get state when closedForever is clicked
 			isDismissModalOpen: false,
+			isSetupError: true, // TODO: this should be false by default once we're actually setting the value.
+			setupErrorReason: setupErrorTypes.SETUP,
 		};
 	}
 
@@ -69,7 +72,12 @@ export class ShippingBanner extends Component {
 	};
 
 	render() {
-		const { isDismissModalOpen, showShippingBanner } = this.state;
+		const {
+			isDismissModalOpen,
+			showShippingBanner,
+			isSetupError,
+			setupErrorReason,
+		} = this.state;
 		if ( ! showShippingBanner ) {
 			return null;
 		}
@@ -121,6 +129,10 @@ export class ShippingBanner extends Component {
 							},
 						} ) }
 					</p>
+					<SetupNotice
+						isSetupError={ isSetupError }
+						errorReason={ setupErrorReason }
+					/>
 					<button
 						onClick={ this.openDismissModal }
 						type="button"

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -39,6 +39,20 @@
 		top: 14px;
 		right: 18px;
 	}
+
+	.wc-admin-shipping-banner-install-error {
+		color: #d63638;
+		> .gridicon {
+			width: 16px;
+			height: 16px;
+			margin-right: 3px;
+			vertical-align: middle;
+			margin-top: -2px;
+			path {
+				fill: #d63638;
+			}
+		}
+	}
 }
 
 .components-modal__frame.wc-admin-shipping-banner__dismiss-modal {

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -187,10 +187,12 @@ class ShippingLabelBanner {
 	 * @return array
 	 */
 	public function component_settings( $settings ) {
-		if ( Loader::is_onboarding_enabled() ) {
-			return $settings;
+		if ( ! isset( $settings['onboarding'] ) ) {
+			$settings['onboarding'] = array();
 		}
-		$settings['onboarding']['activePlugins'] = Onboarding::get_active_plugins();
+		if ( ! isset( $settings['onboarding']['activePlugins'] ) ) {
+			$settings['onboarding']['activePlugins'] = Onboarding::get_active_plugins();
+		}
 		return $settings;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/33

Introduces error message to banner: 
<img width="542" alt="image" src="https://user-images.githubusercontent.com/6209518/76663155-68918880-653d-11ea-8a1c-c940947d266e.png">

The PR makes the error message always present, so we'll need to set the state accordingly on a separate PR.

Error message is enabled by setting `isSetupError` state variable to `true`.
And the error reason is controlled by setting the `setupErrorReason` to specific values. e.g. setting to  `setupErrorTypes.DOWNLOAD` means that the download failed.

