### PR TITLE
Add WooCommerce support if store is using default theme

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -309,6 +309,11 @@ class Onboarding {
 				$themes[ $slug ]  = $theme_data;
 			}
 
+			// Add the WooCommerce support tag for default themes that don't explicitly declare support.
+			if ( wc_is_wp_default_theme_active() ) {
+				$themes[ $active_theme ]['has_woocommerce_support'] = true;
+			}
+
 			$themes = array( $active_theme => $themes[ $active_theme ] ) + $themes;
 
 			set_transient( self::THEMES_TRANSIENT, $themes, DAY_IN_SECONDS );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -310,7 +310,7 @@ class Onboarding {
 			}
 
 			// Add the WooCommerce support tag for default themes that don't explicitly declare support.
-			if ( wc_is_wp_default_theme_active() ) {
+			if ( function_exists( 'wc_is_wp_default_theme_active' ) && wc_is_wp_default_theme_active() ) {
 				$themes[ $active_theme ]['has_woocommerce_support'] = true;
 			}
 


### PR DESCRIPTION
Fixes #3630 

Adds the WooCommerce support tag in the profiler when a default theme is active since WC support is added directly via core for these themes.


### Before
<img width="419" alt="Screen Shot 2020-03-16 at 2 03 19 PM" src="https://user-images.githubusercontent.com/10561050/76780380-a13b9700-67b5-11ea-8d24-c15f3b92b732.png">


### After
<img width="410" alt="Screen Shot 2020-03-16 at 2 14 45 PM" src="https://user-images.githubusercontent.com/10561050/76780388-a39df100-67b5-11ea-8828-b2eb00398dbd.png">


### Detailed test instructions:

1. Activate a default Twenty-* theme.
2. Delete the `wc_onboarding_themes` transient.
3. Visit the “Themes” step of the profiler.
4. Make sure the red icon stating the theme does not support WooCommerce is not shown.
5. Activate a theme that does not have WC support.
6. Make sure the icon is shown.
