### PR TITLE
Don't clear WCCOM note when clicking the action button.

### DIFF
--- a/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
@@ -191,7 +191,8 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 		$note->add_action(
 			'connect',
 			__( 'Connect', 'woocommerce-admin' ),
-			'?page=wc-addons&section=helper'
+			'?page=wc-addons&section=helper',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED
 		);
 		$note->save();
 	}


### PR DESCRIPTION
Fixes #3836.

This PR seeks to preserve the "Connect to WooCommerce.com" inbox note after "connect" has been clicked, but the connection doesn't take place.

### Detailed test instructions:

- Disconnect from WCCOM if your store is connected
- If you don't have the "connect" note in your inbox, delete the `wc-admin-wc-helper-connection` row in the `wc_admin_notes` table
- Open Inbox panel
- Click "connect" in "Connect to WooCommerce.com"
- Verify (on the helper page) that the note is still in the inbox
- Connect to WCCOM
- Verify that the note has been removed from the inbox
- Disconnect from WCCOM
- Verify that the note has been added back to the inbox

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Connect to WooCommerce.com note disappears before connecting.