### PR TITLE
Task List: Verify Stripe key patterns before continuing.

### DIFF
--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -298,15 +298,15 @@ class Stripe extends Component {
 	validateManualConfig( values ) {
 		const errors = {};
 
-		if ( ! values.publishable_key ) {
+		if ( values.publishable_key.match( /^pk_live_/ ) === null ) {
 			errors.publishable_key = __(
-				'Please enter your publishable key',
+				'Please enter a valid publishable key. Valid keys start with "pk_live".',
 				'woocommerce-admin'
 			);
 		}
-		if ( ! values.secret_key ) {
+		if ( values.secret_key.match( /^[rs]k_live_/ ) === null ) {
 			errors.secret_key = __(
-				'Please enter your secret key',
+				'Please enter a valid secret key. Valid keys start with "sk_live" or "rk_live".',
 				'woocommerce-admin'
 			);
 		}


### PR DESCRIPTION
Fixes #3698.

This PR introduces basic client side verification of the Stripe API keys entered into the task list.

It expects publishable keys to start with `pk_live_` and secret keys to start with either `rk_live_` or `sk_live_`.

The error messages were also updated to indicate the expected formats.

### Screenshots

![Screen Shot 2020-03-16 at 2 48 44 PM](https://user-images.githubusercontent.com/63922/76798484-44c87f80-6795-11ea-917d-083f5be70f69.png)

### Detailed test instructions:

- Open the task list on a new store
- Go to the payments step
- Enable Stripe
- Try to enter invalid API keys
- Verify that the correct formats must be met before continuing

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Verify Stripe API keys in payment set up step.