### PR TITLE
Update prestart script so readme.txt stable tag is updated

### DIFF
--- a/bin/update-version.php
+++ b/bin/update-version.php
@@ -22,6 +22,9 @@ function replace_version( $filename, $package_json ) {
 		if ( stripos( $line, "const VERSION =" ) !== false ) {
 			$line = "\tconst VERSION = '{$package_json->version}';\n";
 		}
+		if ( stripos( $line, 'Stable tag: ' ) !== false ) {
+			$line = "Stable tag: {$package_json->version}\n";
+		}
 		$lines[] = $line;
 	}
 	file_put_contents( $filename, $lines );
@@ -30,3 +33,4 @@ function replace_version( $filename, $package_json ) {
 replace_version( 'woocommerce-admin.php', $package );
 replace_version( 'src/FeaturePlugin.php', $package );
 replace_version( 'src/Package.php', $package );
+replace_version( 'readme.txt', $package );


### PR DESCRIPTION
We've always had a `Stable tag: 1.0.0` in readme.txt and now that we're above 1.0.0, this property needs to be updated with the current version number. Otherwise, users won't be able to get wc-admin from .org.

### Detailed test instructions:

1. Update the version number in package.json
2. `npm run prestart`
3. view the changed files, including readme.txt and make sure the version number was appropriately updated.