### PR TITLE
Show loading state when installing or activating WCS

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -135,7 +135,9 @@ export class ShippingBanner extends Component {
 						alt={ __( 'Shipping ', 'woocommerce-admin' ) }
 					/>
 					<Button
+						disabled={ this.props.isRequesting }
 						isPrimary
+						isBusy={ this.props.isRequesting }
 						onClick={ this.createShippingLabelClicked }
 					>
 						{ __( 'Create shipping label' ) }
@@ -181,6 +183,7 @@ export class ShippingBanner extends Component {
 						onClick={ this.openDismissModal }
 						type="button"
 						className="notice-dismiss"
+						disabled={ this.props.isRequesting }
 					>
 						<span className="screen-reader-text">
 							{ __(

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -152,7 +152,8 @@ describe( 'In the process of installing or activating WooCommerce Service', () =
 				installPlugins={ jest.fn() }
 				installedPlugins={ [] }
 				wcsPluginSlug={ 'woocommerce-services' }
-				hasErrors={ false }
+				activationErrors={ [] }
+				installationErrors={ [] }
 				isRequesting={ true }
 			/>
 		);

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -101,6 +101,7 @@ describe( 'Create shipping label button', () => {
 				wcsPluginSlug={ 'woocommerce-services' }
 				activationErrors={ [] }
 				installationErrors={ [] }
+				isRequesting={ false }
 			/>
 		);
 	} );
@@ -122,6 +123,52 @@ describe( 'Create shipping label button', () => {
 		expect( activatePlugins ).toHaveBeenCalledWith( [
 			'woocommerce-services',
 		] );
+	} );
+
+	it( 'should show a busy loading state when installing or activating ', () => {
+		shippingBannerWrapper.setProps( {
+			isRequesting: true,
+		} );
+		const createShippingLabelButton = shippingBannerWrapper.find( Button );
+		expect( createShippingLabelButton.length ).toBe( 1 );
+		expect( createShippingLabelButton.prop( 'disabled' ) ).toBe( true );
+		expect( createShippingLabelButton.prop( 'isBusy' ) ).toBe( true );
+	} );
+} );
+
+describe( 'In the process of installing or activating WooCommerce Service', () => {
+	let shippingBannerWrapper;
+	const activePlugins = {
+		includes: jest.fn().mockReturnValue( true ),
+	};
+
+	beforeEach( () => {
+		shippingBannerWrapper = shallow(
+			<ShippingBanner
+				isJetpackConnected={ jest.fn() }
+				activatePlugins={ jest.fn() }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installPlugins={ jest.fn() }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				hasErrors={ false }
+				isRequesting={ true }
+			/>
+		);
+	} );
+
+	it( 'should show a busy loading state on "Create shipping label"', () => {
+		const createShippingLabelButton = shippingBannerWrapper.find( Button );
+		expect( createShippingLabelButton.length ).toBe( 1 );
+		expect( createShippingLabelButton.prop( 'disabled' ) ).toBe( true );
+		expect( createShippingLabelButton.prop( 'isBusy' ) ).toBe( true );
+	} );
+
+	it( 'should disable the dismiss button ', () => {
+		const dismissButton = shippingBannerWrapper.find( '.notice-dismiss' );
+		expect( dismissButton.length ).toBe( 1 );
+		expect( dismissButton.prop( 'disabled' ) ).toBe( true );
 	} );
 } );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/34

Disable and show a "busy" state for the "Create shipping label" button when installing or activating WCS. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Deactivate WooCommerce Service
- Remove the plugin from your plugin folder `wp-content/plugins/woocommerce-admin/woocommerce-services`
- Go to an order page "wp-admin/post.php?post=14&action=edit"
- Click "Create shipping label"
![image](https://user-images.githubusercontent.com/572862/76881377-a7298a80-683e-11ea-8cc1-5e0b2745ca2c.png)
- When it is installing/activating WCS, the button should look like this:
![Kapture 2020-03-17 at 9 43 57](https://user-images.githubusercontent.com/572862/76873794-d981ba80-6833-11ea-8fa6-64658f8714b1.gif)
- Click "dismiss button", nothing should happen during installation/activation.
![image](https://user-images.githubusercontent.com/572862/76881511-dd670a00-683e-11ea-8dab-16d829d27729.png)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
