### PR TITLE
Display error if there are errors sent back by wc-api

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -33,7 +33,8 @@ describe( 'Tracking events in shippingBanner', () => {
 				activatedPlugins={ [] }
 				installedPlugins={ [] }
 				wcsPluginSlug={ 'woocommerce-services' }
-				hasErrors={ false }
+				activationErrors={ [] }
+				installationErrors={ [] }
 			/>
 		);
 	} );
@@ -98,7 +99,8 @@ describe( 'Create shipping label button', () => {
 				installPlugins={ installPlugins }
 				installedPlugins={ [] }
 				wcsPluginSlug={ 'woocommerce-services' }
-				hasErrors={ false }
+				activationErrors={ [] }
+				installationErrors={ [] }
 			/>
 		);
 	} );
@@ -120,5 +122,64 @@ describe( 'Create shipping label button', () => {
 		expect( activatePlugins ).toHaveBeenCalledWith( [
 			'woocommerce-services',
 		] );
+	} );
+} );
+
+describe( 'Setup error message', () => {
+	let shippingBannerWrapper;
+	const activePlugins = {
+		includes: jest.fn().mockReturnValue( true ),
+	};
+
+	beforeEach( () => {
+		shippingBannerWrapper = shallow(
+			<ShippingBanner
+				isJetpackConnected={ jest.fn() }
+				activatePlugins={ jest.fn() }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installPlugins={ jest.fn() }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				activationErrors={ [] }
+				installationErrors={ [] }
+			/>
+		);
+	} );
+
+	it( 'should not show if there is no error', () => {
+		expect( shippingBannerWrapper.instance().isSetupError() ).toBe( false );
+		expect( shippingBannerWrapper.instance().hasActivationError() ).toBe(
+			false
+		);
+		expect( shippingBannerWrapper.instance().hasInstallationError() ).toBe(
+			false
+		);
+	} );
+
+	it( 'should show if there is activation error', () => {
+		shippingBannerWrapper.setProps( {
+			activationErrors: [ 'Can not activate' ],
+		} );
+		expect( shippingBannerWrapper.instance().isSetupError() ).toBe( true );
+		expect( shippingBannerWrapper.instance().hasActivationError() ).toBe(
+			true
+		);
+		expect( shippingBannerWrapper.instance().hasInstallationError() ).toBe(
+			false
+		);
+	} );
+
+	it( 'should show if there is installation error', () => {
+		shippingBannerWrapper.setProps( {
+			installationErrors: [ 'Can not activate' ],
+		} );
+		expect( shippingBannerWrapper.instance().isSetupError() ).toBe( true );
+		expect( shippingBannerWrapper.instance().hasActivationError() ).toBe(
+			false
+		);
+		expect( shippingBannerWrapper.instance().hasInstallationError() ).toBe(
+			true
+		);
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/37

Display the setup-notice error message if there are activation/installation errors.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
- The error messages relies on wc-api. In order for us to test this, we will need to trigger an error there.
- You can also test by adding error messages the `ShippingBanner`'s props: `activationErrors` and `installationErrors`.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
