### PR TITLE
Onboarding: Create flat rate and free shipping methods from task list

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -70,7 +70,7 @@ class Shipping extends Component {
 						path: `/wc/v3/shipping/zones/${ zone.id }/methods`,
 					} );
 					zone.name = __( 'Rest of the world', 'woocommerce-admin' );
-					zone.toggleEnabled = true;
+					zone.toggleable = true;
 					shippingZones.push( zone );
 					return;
 				}

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -172,11 +172,12 @@ class ShippingRates extends Component {
 
 		this.props.shippingZones.forEach( ( zone ) => {
 			const shippingMethods = this.getShippingMethods( zone );
-			const rate = shippingMethods.length
-				? this.getFormattedRate(
-						shippingMethods[ 0 ].settings.cost.value
-				  )
-				: getCurrencyFormatString( 0 );
+			const rate =
+				shippingMethods.length && shippingMethods[ 0 ].settings.cost
+					? this.getFormattedRate(
+							shippingMethods[ 0 ].settings.cost.value
+					  )
+					: getCurrencyFormatString( 0 );
 			values[ `${ zone.id }_rate` ] = rate;
 
 			if ( shippingMethods.length && shippingMethods[ 0 ].enabled ) {

--- a/client/dashboard/task-list/tasks/shipping/rates.js
+++ b/client/dashboard/task-list/tasks/shipping/rates.js
@@ -66,7 +66,7 @@ class ShippingRates extends Component {
 		shippingZones.forEach( ( zone ) => {
 			if ( zone.id === 0 ) {
 				restOfTheWorld =
-					zone.toggleEnabled && values[ `${ zone.id }_enabled` ];
+					zone.toggleable && values[ `${ zone.id }_enabled` ];
 			} else {
 				shippingCost =
 					values[ `${ zone.id }_rate` ] !== '' &&
@@ -84,7 +84,7 @@ class ShippingRates extends Component {
 				? this.getShippingMethods( zone, methodType )[ 0 ]
 				: null;
 
-			if ( zone.toggleEnabled && ! values[ `${ zone.id }_enabled` ] ) {
+			if ( zone.toggleable && ! values[ `${ zone.id }_enabled` ] ) {
 				// Disable any shipping methods that exist if toggled off.
 				this.disableShippingMethods( zone, shippingMethods );
 				return;
@@ -261,7 +261,7 @@ class ShippingRates extends Component {
 										<div className="woocommerce-shipping-rate__main">
 											<div className="woocommerce-shipping-rate__name">
 												{ zone.name }
-												{ zone.toggleEnabled && (
+												{ zone.toggleable && (
 													<FormToggle
 														{ ...getInputProps(
 															`${ zone.id }_enabled`
@@ -269,7 +269,7 @@ class ShippingRates extends Component {
 													/>
 												) }
 											</div>
-											{ ( ! zone.toggleEnabled ||
+											{ ( ! zone.toggleable ||
 												values[
 													`${ zone.id }_enabled`
 												] ) && (


### PR DESCRIPTION
Fixes #3761

Changes the shipping methods to flat rate or shipping depending on whether or not the shipping zone is set to `0` cost or greater.

This PR also disables all other zones when updating a method, which I think is the best way to handle this without too much confusion.  For example, if you already have a free method and you set a shipping cost to `5.00` in the list, it will create a new flat rate method and disable the free one.  If you update again to `6.00` from the list, it will modify the existing method. /cc @pmcpinto @jameskoster if you have a different opinion on how this should work when previous methods exist.

### Detailed test instructions:

1. Visit the shipping task.
1. Try adding free (0.00) shipping method costs to your store's zone or the Rest of World zone.
1. Check `wp-admin/admin.php?page=wc-settings&tab=shipping` to make sure methods are updated correctly.
1. Revisit the shipping task and try alternating the costs to be free or a flat rate.
1. Make sure that if a free/flat rate does not exist that one is created and if one already exists, the first one matching the method type (free/flat) is edited.
1. Try adding multiple zones of the same type in `wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=1`.
1. Revisit the shipping task and make sure that all zones except the one created/edited from the task list is updated. 

### Changelog Note:

Fix: Create flat rate or free shipping methods from the onboarding task list
