### PR TITLE
Onboarding: Modified the recorded data in profile wizard

### DIFF
--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { filter, get, find, findIndex } from 'lodash';
+import { filter, find, findIndex, forEach, get } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 
 /**
@@ -52,13 +52,19 @@ class Industry extends Component {
 		const selectedIndustriesList = this.state.selected.map(
 			( industry ) => industry.slug
 		);
-		const industriesWithDetail = filter( this.state.selected, ( value ) => {
-			return typeof value.detail !== 'undefined';
+
+		// With this 'forEach' we'll record all the 'industries_with_detail' available.
+		// For now it's only being used for the input 'Other'.
+		forEach( this.state.selected, ( value ) => {
+			if ( typeof value.detail !== 'undefined' ) {
+				recordEvent( 'storeprofiler_store_industry_continue', {
+					industries_with_detail: value.detail,
+				} );
+			}
 		} );
 
 		recordEvent( 'storeprofiler_store_industry_continue', {
 			store_industry: selectedIndustriesList,
-			industries_with_detail: industriesWithDetail,
 		} );
 		await updateProfileItems( { industry: this.state.selected } );
 

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Button, CheckboxControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { filter, find, findIndex, forEach, get } from 'lodash';
+import { filter, find, findIndex, get } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 
 /**
@@ -53,18 +53,15 @@ class Industry extends Component {
 			( industry ) => industry.slug
 		);
 
-		// With this 'forEach' we'll record all the 'industries_with_detail' available.
-		// For now it's only being used for the input 'Other'.
-		forEach( this.state.selected, ( value ) => {
-			if ( typeof value.detail !== 'undefined' ) {
-				recordEvent( 'storeprofiler_store_industry_continue', {
-					industries_with_detail: value.detail,
-				} );
-			}
-		} );
+		// Here the selected industries are converted to a string that is a comma separated list
+		const industriesWithDetail = this.state.selected
+			.map( ( industry ) => industry.detail )
+			.filter( ( n ) => n )
+			.join( ',' );
 
 		recordEvent( 'storeprofiler_store_industry_continue', {
 			store_industry: selectedIndustriesList,
+			industries_with_detail: industriesWithDetail,
 		} );
 		await updateProfileItems( { industry: this.state.selected } );
 


### PR DESCRIPTION
This is a fix for the PR: [3730](https://github.com/woocommerce/woocommerce-admin/pull/3730)

In the second step of the profile wizard, `industries_with_detail` will be recorded as a `string` instead of an `object`.

### Detailed test instructions:
1. Start the onboarding process
2. In the `Industry` step check whether the option `CBD and other hemp-derived products` is visible and works
3. Select the option: `Other`
4. Fill the input with a description.
5. Press the `Continue` button.
6. Check that the value is recorded under `industries_with_detail` value in the `storeprofiler_store_industry_continue` event.