### PR TITLE
Add a/b test to enable prompt for 25% of eligible sites.

### DIFF
--- a/src/Features/ShippingLabelBannerDisplayRules.php
+++ b/src/Features/ShippingLabelBannerDisplayRules.php
@@ -109,7 +109,7 @@ class ShippingLabelBannerDisplayRules {
 		// If it doesn't exist yet, generate it for later use and save it, so we always show the same to this user.
 		if ( ! $ab_test ) {
 			$ab_test = 1 !== wp_rand( 1, 4 ) ? 'a' : 'b'; // 25% of users. b gets the prompt.
-			update_option( 'woocommerce_shipping_prompt_ab', $ab_test );
+			update_option( 'woocommerce_shipping_prompt_ab', $ab_test, false );
 		}
 
 		return 'b' === $ab_test;

--- a/src/Features/ShippingLabelBannerDisplayRules.php
+++ b/src/Features/ShippingLabelBannerDisplayRules.php
@@ -101,6 +101,25 @@ class ShippingLabelBannerDisplayRules {
 	 * Determines whether or not the banner should be displayed.
 	 */
 	public function should_display_banner() {
+		if ( ! $this->should_allow_banner() ) {
+			return false;
+		}
+		$ab_test = get_option( 'woocommerce_shipping_prompt_ab' );
+
+		// If it doesn't exist yet, generate it for later use and save it, so we always show the same to this user.
+		if ( ! $ab_test ) {
+			$ab_test = 1 !== wp_rand( 1, 4 ) ? 'a' : 'b'; // 25% of users. b gets the prompt.
+			update_option( 'woocommerce_shipping_prompt_ab', $ab_test );
+		}
+
+		return 'b' === $ab_test;
+	}
+
+
+	/**
+	 * Determines whether banner is eligible for display (does not include a/b logic).
+	 */
+	public function should_allow_banner() {
 		return $this->banner_not_dismissed() &&
 			$this->jetpack_installed_and_active() &&
 			$this->jetpack_up_to_date() &&

--- a/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -34,7 +34,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	private static $modified_options = array(
 		'woocommerce_default_country'              => null,
 		'woocommerce_currency'                     => null,
-		'woocommerce_shipping_ab_active'           => null,
+		'woocommerce_shipping_prompt_ab'           => null,
 		'woocommerce_shipping_dismissed_timestamp' => null,
 	);
 
@@ -91,7 +91,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), true );
 			}
 		);
 	}
@@ -102,7 +102,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	public function test_if_banner_hidden_when_jetpack_disconnected() {
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( null, null, null, null, null );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 	}
 
 	/**
@@ -112,7 +112,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_shipping_dismissed_timestamp', -1 );
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), true );
 			}
 		);
 	}
@@ -149,7 +149,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	public function test_if_banner_hidden_when_no_shippable_product() {
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 	}
 
 	/**
@@ -161,7 +161,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 			}
 		);
 	}
@@ -175,7 +175,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 			}
 		);
 	}
@@ -188,7 +188,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, true );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 			}
 		);
 	}
@@ -201,7 +201,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.3', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 			}
 		);
 	}
@@ -214,7 +214,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', true, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 			}
 		);
 	}
@@ -227,9 +227,27 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.4', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
 			}
 		);
+	}
+
+	/**
+	 * Test if the banner is displayed when site is in 'b' group.
+	 */
+	public function test_display_banner_if_b_flag() {
+		update_option( 'woocommerce_shipping_prompt_ab', 'b' );
+
+		$this->assertEquals( $this->shipping_label_banner_display_rules->should_display_banner(), true );
+	}
+
+	/**
+	 * Test if the banner is displayed when site is in 'a' group.
+	 */
+	public function test_no_display_banner_if_a_flag() {
+		update_option( 'woocommerce_shipping_prompt_ab', 'a' );
+
+		$this->assertEquals( $this->shipping_label_banner_display_rules->should_allow_banner(), false );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/11

Adds A/B test so onboarding prompt enabled for 25% of eligible sites.

This has a 25% of setting the option `woocommerce_shipping_prompt_ab` to `b` which will enable the prompt. A value of `a` will disable the prompt.

We will adjust this percentage and likely turn off the check altogether eventually.

### Detailed test instructions:

- Make sure your site is configured so the `should_allow_banner()` check passes
- Open order page
- You have a 25% chance of seeing the banner
- Delete `woocommerce_shipping_prompt_ab` option and reload order page to try again