### PR TITLE
Fix/issue 29 tracking

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
@@ -20,20 +20,18 @@ export class DismissModal extends Component {
 	};
 
 	remindMeLaterClicked = () => {
-		const { onCloseAll, trackBannerEvent } = this.props;
+		const { onCloseAll, trackElementClicked } = this.props;
 		this.setDismissed( Date.now() );
 		onCloseAll();
 
-		trackBannerEvent(
-			'shipping_banner_dismiss_modal_remind_me_later_click'
-		);
+		trackElementClicked( 'shipping_banner_dismiss_modal_remind_me_later' );
 	};
 
 	closeForeverClicked = () => {
-		const { onCloseAll, trackBannerEvent } = this.props;
+		const { onCloseAll, trackElementClicked } = this.props;
 		this.setDismissed( -1 );
 		onCloseAll();
-		trackBannerEvent( 'shipping_banner_dismiss_modal_close_forever_click' );
+		trackElementClicked( 'shipping_banner_dismiss_modal_close_forever' );
 	};
 
 	render() {
@@ -44,7 +42,11 @@ export class DismissModal extends Component {
 		}
 
 		return (
-			<Modal title="Are you sure?" onRequestClose={ onClose } className="wc-admin-shipping-banner__dismiss-modal">
+			<Modal
+				title="Are you sure?"
+				onRequestClose={ onClose }
+				className="wc-admin-shipping-banner__dismiss-modal"
+			>
 				<p className="wc-admin-shipping-banner__dismiss-modal-help-text">
 					{ __(
 						'With WooCommerce Services you can Print shipping labels from your WooCommerce dashboard at the lowest USPS rates.',

--- a/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/test/index.js
@@ -20,7 +20,7 @@ describe( 'Option Save events in DismissModal', () => {
 				visible={ true }
 				onClose={ jest.fn() }
 				onCloseAll={ jest.fn() }
-				trackBannerEvent={ jest.fn() }
+				trackElementClicked={ jest.fn() }
 				updateOptions={ spyUpdateOptions }
 			/>
 		);
@@ -57,7 +57,7 @@ describe( 'Option Save events in DismissModal', () => {
 } );
 
 describe( 'Tracking events in DismissModal', () => {
-	const trackBannerEvent = jest.fn();
+	const trackElementClicked = jest.fn();
 
 	let dismissModalWrapper;
 
@@ -67,7 +67,7 @@ describe( 'Tracking events in DismissModal', () => {
 				visible={ true }
 				onClose={ jest.fn() }
 				onCloseAll={ jest.fn() }
-				trackBannerEvent={ trackBannerEvent }
+				trackElementClicked={ trackElementClicked }
 				updateOptions={ jest.fn() }
 			/>
 		);
@@ -78,8 +78,8 @@ describe( 'Tracking events in DismissModal', () => {
 		expect( actionButtons.length ).toBe( 2 );
 		const iDoNotNeedThisButton = actionButtons.last();
 		iDoNotNeedThisButton.simulate( 'click' );
-		expect( trackBannerEvent ).toHaveBeenCalledWith(
-			'shipping_banner_dismiss_modal_close_forever_click'
+		expect( trackElementClicked ).toHaveBeenCalledWith(
+			'shipping_banner_dismiss_modal_close_forever'
 		);
 	} );
 
@@ -88,8 +88,8 @@ describe( 'Tracking events in DismissModal', () => {
 		expect( actionButtons.length ).toBe( 2 );
 		const remindMeLaterButton = actionButtons.first();
 		remindMeLaterButton.simulate( 'click' );
-		expect( trackBannerEvent ).toHaveBeenCalledWith(
-			'shipping_banner_dismiss_modal_remind_me_later_click'
+		expect( trackElementClicked ).toHaveBeenCalledWith(
+			'shipping_banner_dismiss_modal_remind_me_later'
 		);
 	} );
 } );

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -31,7 +31,7 @@ export class ShippingBanner extends Component {
 	}
 
 	componentDidMount() {
-		this.trackBannerEvent( 'shipping_banner_show' );
+		this.trackImpression();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -75,14 +75,14 @@ export class ShippingBanner extends Component {
 
 	closeDismissModal = () => {
 		this.setState( { isDismissModalOpen: false } );
-		this.trackBannerEvent(
-			'shipping_banner_dismiss_modal_close_button_click'
+		this.trackElementClicked(
+			'shipping_banner_dismiss_modal_close_button'
 		);
 	};
 
 	openDismissModal = () => {
 		this.setState( { isDismissModalOpen: true } );
-		this.trackBannerEvent( 'shipping_banner_dimiss_click' );
+		this.trackElementClicked( 'shipping_banner_dimiss' );
 	};
 
 	hideBanner = () => {
@@ -92,7 +92,7 @@ export class ShippingBanner extends Component {
 	createShippingLabelClicked = () => {
 		const { wcsPluginSlug } = this.props;
 		// TODO: open WCS modal
-		this.trackBannerEvent( 'shipping_banner_create_label_click' );
+		this.trackElementClicked( 'shipping_banner_create_label' );
 		this.installAndActivatePlugins( wcsPluginSlug );
 	};
 
@@ -106,17 +106,27 @@ export class ShippingBanner extends Component {
 	}
 
 	woocommerceServiceLinkClicked = () => {
-		this.trackBannerEvent(
-			'shipping_banner_woocommerce_service_link_click'
-		);
+		this.trackElementClicked( 'shipping_banner_woocommerce_service_link' );
 	};
 
-	trackBannerEvent = ( eventName ) => {
+	trackBannerEvent = ( eventName, trackingProps = {} ) => {
 		const { activePlugins, isJetpackConnected, wcsPluginSlug } = this.props;
 		recordEvent( eventName, {
+			banner_name: 'wcadmin_install_wcs_prompt',
 			jetpack_installed: activePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
 			wcs_installed: activePlugins.includes( wcsPluginSlug ),
+			...trackingProps,
+		} );
+	};
+
+	trackImpression = () => {
+		this.trackBannerEvent( 'banner_impression' );
+	};
+
+	trackElementClicked = ( element ) => {
+		this.trackBannerEvent( 'banner_element_clicked', {
+			element,
 		} );
 	};
 
@@ -194,7 +204,7 @@ export class ShippingBanner extends Component {
 					visible={ isDismissModalOpen }
 					onClose={ this.closeDismissModal }
 					onCloseAll={ this.hideBanner }
-					trackBannerEvent={ this.trackBannerEvent }
+					trackElementClicked={ this.trackElementClicked }
 				/>
 			</div>
 		);

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -109,14 +109,14 @@ export class ShippingBanner extends Component {
 		this.trackElementClicked( 'shipping_banner_woocommerce_service_link' );
 	};
 
-	trackBannerEvent = ( eventName, trackingProps = {} ) => {
+	trackBannerEvent = ( eventName, customProps = {} ) => {
 		const { activePlugins, isJetpackConnected, wcsPluginSlug } = this.props;
 		recordEvent( eventName, {
 			banner_name: 'wcadmin_install_wcs_prompt',
 			jetpack_installed: activePlugins.includes( 'jetpack' ),
 			jetpack_connected: isJetpackConnected,
 			wcs_installed: activePlugins.includes( wcsPluginSlug ),
-			...trackingProps,
+			...customProps,
 		} );
 	};
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -13,20 +13,21 @@ import { ShippingBanner } from '../index.js';
 jest.mock( 'lib/tracks' );
 jest.mock( '@woocommerce/wc-admin-settings' );
 
-describe( 'Tracking events in shippingBanner', () => {
+describe( 'Tracking impression in shippingBanner', () => {
 	const expectedTrackingData = {
+		banner_name: 'wcadmin_install_wcs_prompt',
 		jetpack_connected: true,
 		jetpack_installed: true,
 		wcs_installed: true,
 	};
+
 	const isJetpackConnected = true;
 	const activePlugins = {
 		includes: jest.fn().mockReturnValue( true ),
 	};
-	let shippingBannerWrapper;
 
 	beforeEach( () => {
-		shippingBannerWrapper = shallow(
+		shallow(
 			<ShippingBanner
 				isJetpackConnected={ isJetpackConnected }
 				activePlugins={ activePlugins }
@@ -42,8 +43,40 @@ describe( 'Tracking events in shippingBanner', () => {
 	it( 'should record an event when user sees banner loaded', () => {
 		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_show',
+			'banner_impression',
 			expectedTrackingData
+		);
+	} );
+} );
+
+describe( 'Tracking clicks in shippingBanner', () => {
+	const isJetpackConnected = true;
+	const activePlugins = {
+		includes: jest.fn().mockReturnValue( true ),
+	};
+	let shippingBannerWrapper;
+
+	const getExpectedTrackingData = ( element ) => {
+		return {
+			banner_name: 'wcadmin_install_wcs_prompt',
+			jetpack_connected: true,
+			jetpack_installed: true,
+			wcs_installed: true,
+			element,
+		};
+	};
+
+	beforeEach( () => {
+		shippingBannerWrapper = shallow(
+			<ShippingBanner
+				isJetpackConnected={ isJetpackConnected }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				activationErrors={ [] }
+				installationErrors={ [] }
+			/>
 		);
 	} );
 
@@ -52,8 +85,8 @@ describe( 'Tracking events in shippingBanner', () => {
 		expect( createShippingLabelButton.length ).toBe( 1 );
 		createShippingLabelButton.simulate( 'click' );
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_create_label_click',
-			expectedTrackingData
+			'banner_element_clicked',
+			getExpectedTrackingData( 'shipping_banner_create_label' )
 		);
 	} );
 
@@ -63,8 +96,10 @@ describe( 'Tracking events in shippingBanner', () => {
 		const wcsLink = links.first();
 		wcsLink.simulate( 'click' );
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_woocommerce_service_link_click',
-			expectedTrackingData
+			'banner_element_clicked',
+			getExpectedTrackingData(
+				'shipping_banner_woocommerce_service_link'
+			)
 		);
 	} );
 
@@ -75,8 +110,8 @@ describe( 'Tracking events in shippingBanner', () => {
 		expect( noticeDimissButton.length ).toBe( 1 );
 		noticeDimissButton.simulate( 'click' );
 		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_dimiss_click',
-			expectedTrackingData
+			'banner_element_clicked',
+			getExpectedTrackingData( 'shipping_banner_dimiss' )
 		);
 	} );
 } );


### PR DESCRIPTION
Fixes #https://github.com/Automattic/woocommerce-shipping-issues/issues/29

Consolidate how we track by reducing 7 different events to just 2 events. There will now be two events. One to track impression (`wc_banner_impression`), the other to track click interaction (`banner_element_clicked`). Both events will have the same property name `banner_name` with value `wcadmin_install_wcs_prompt`. This allows us to create funnel to link the 2 events.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
1. Open up console.log
2. Run this `localStorage.setItem( 'debug', 'wc-admin:*' );` for debugging
3. Interact with these 3 items, there should be an entry shows in console.log, verify the `element` property.
![image](https://user-images.githubusercontent.com/572862/77004983-a0c20e00-6925-11ea-9932-da978615d4e2.png)
4. Confirm there is 1 `impression` event with no `element` property
5. Click  dismiss (x), a modal should open up. Interact with these 3 items
![image](https://user-images.githubusercontent.com/572862/77005135-ed0d4e00-6925-11ea-8d1b-5e3a21be3dfd.png)
6. There should be event track for each with `element` as property. 

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
