### PR TITLE
Launch WCS label modal from wc-admin

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/index.js
@@ -3,6 +3,7 @@
  */
 import { render } from '@wordpress/element';
 import ShippingBanner from './shipping-banner';
+import './store';
 
 const metaBox = document.getElementById( 'wc-admin-shipping-banner-root' );
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -137,7 +137,7 @@ export class ShippingBanner extends Component {
 				script.src = js;
 				script.async = true;
 				script.onload = resolve;
-				script.onerror = reject;
+				script.onerror = reject; //TODO: handle errors
 				document.body.appendChild( script );
 			} ),
 			new Promise( ( resolve, reject ) => {
@@ -148,7 +148,7 @@ export class ShippingBanner extends Component {
 				link.href = css;
 				link.media = 'all';
 				link.onload = resolve;
-				link.onerror = reject;
+				link.onerror = reject; //TODO: handle errors
 				head.appendChild( link );
 			} ),
 		] ).then( () => {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -167,7 +167,7 @@ export class ShippingBanner extends Component {
 				script.src = js;
 				script.async = true;
 				script.onload = resolve;
-				script.onerror = reject; //TODO: handle errors
+				script.onerror = reject;
 				document.body.appendChild( script );
 			} ),
 			new Promise( ( resolve, reject ) => {
@@ -178,7 +178,7 @@ export class ShippingBanner extends Component {
 				link.href = styles;
 				link.media = 'all';
 				link.onload = resolve;
-				link.onerror = reject; //TODO: handle errors
+				link.onerror = reject;
 				head.appendChild( link );
 			} ),
 		] ).then( () => {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -40,7 +40,6 @@ export class ShippingBanner extends Component {
 			activatedPlugins,
 			installedPlugins,
 			wcsPluginSlug,
-			hasErrors,
 			wcsAssetsPaths,
 			// errors
 		} = this.props;
@@ -50,15 +49,10 @@ export class ShippingBanner extends Component {
 		}
 		if ( activatedPlugins.includes( wcsPluginSlug ) ) {
 			// TODO: Add success notice after installation #32
-			// console.log("Successfully activated wcs.");
 			this.acceptTosAndGetWCSAssets();
 		}
 		if ( wcsAssetsPaths ) {
 			this.loadWcsAssets( wcsAssetsPaths );
-		}
-		if ( hasErrors ) {
-			// TODO: Add error handling #33
-			// console.log("Errors during activation or installation", errors);
 		}
 	}
 
@@ -134,9 +128,9 @@ export class ShippingBanner extends Component {
 	acceptTosAndGetWCSAssets() {
 		const { acceptTos, getWcsAssets } = this.props;
 
-		Promise.all( [ acceptTos(), getWcsAssets() ] ).then(
+		return Promise.all( [ acceptTos(), getWcsAssets() ] ).then(
 			( [ , wcsAssets ] ) => {
-				this.setProps( 'wcsAssets', wcsAssets );
+				this.loadWcsAssets( wcsAssets );
 			}
 		);
 	}

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -128,16 +128,15 @@ export class ShippingBanner extends Component {
 		} );
 	};
 
-	acceptTosAndGetWCSAssets() {
+	async acceptTosAndGetWCSAssets() {
 		const { acceptTos, getWcsAssets } = this.props;
 
-		return Promise.all( [ acceptTos(), getWcsAssets() ] ).then(
-			( [ , wcsAssets ] ) => {
-				if ( wcsAssets ) {
-					this.loadWcsAssets( wcsAssets );
-				}
-			}
-		);
+		const accepted = await acceptTos();
+
+		if ( accepted ) {
+			const wcsAssets = await getWcsAssets();
+			this.loadWcsAssets( wcsAssets );
+		}
 	}
 
 	loadWcsAssets( { assets } ) {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -51,6 +51,7 @@ export class ShippingBanner extends Component {
 		if ( activatedPlugins.includes( wcsPluginSlug ) ) {
 			// TODO: Add success notice after installation #32
 			// console.log("Successfully activated wcs.");
+			this.acceptTosAndGetWCSAssets();
 		}
 		if ( wcsAssetsPaths ) {
 			this.loadWcsAssets( wcsAssetsPaths );
@@ -130,6 +131,16 @@ export class ShippingBanner extends Component {
 		} );
 	};
 
+	acceptTosAndGetWCSAssets() {
+		const { acceptTos, getWcsAssets } = this.props;
+
+		Promise.all( [ acceptTos(), getWcsAssets() ] ).then(
+			( [ , wcsAssets ] ) => {
+				this.setProps( 'wcsAssets', wcsAssets );
+			}
+		);
+	}
+
 	loadWcsAssets( { js, css } ) {
 		Promise.all( [
 			new Promise( ( resolve, reject ) => {
@@ -158,7 +169,9 @@ export class ShippingBanner extends Component {
 
 	openWcsModal() {
 		if ( window.wcsGetAppStore ) {
-			const { orderId } = this.props;
+			const orderId = new URL( window.location.href ).searchParams.get(
+				'post'
+			);
 
 			const wcsStore = window.wcsGetAppStore(
 				'wc-connect-create-shipping-label'
@@ -274,6 +287,10 @@ export default compose(
 			isPluginActivateRequesting,
 			isPluginInstallRequesting,
 		} = select( 'wc-api' );
+		const { acceptTos, getWcsAssets } = select(
+			'print-shipping-label-banner'
+		);
+
 		const isRequesting =
 			isPluginActivateRequesting() || isPluginInstallRequesting();
 		const allInstallationErrors = getPluginInstallationErrors( [
@@ -305,6 +322,8 @@ export default compose(
 			wcsPluginSlug,
 			activationErrors,
 			installationErrors,
+			acceptTos,
+			getWcsAssets,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -33,6 +33,8 @@ export class ShippingBanner extends Component {
 			isDismissModalOpen: false,
 			setupErrorReason: setupErrorTypes.SETUP,
 			orderId: parseInt( orderId, 10 ),
+			wcsAssetsLoaded: false,
+			wcsAssetsLoading: false,
 		};
 	}
 
@@ -139,11 +141,19 @@ export class ShippingBanner extends Component {
 	}
 
 	loadWcsAssets( { assets } ) {
+		if ( this.state.wcsAssetsLoaded || this.state.wcsAssetsLoading ) {
+			this.openWcsModal();
+			return;
+		}
+
+		this.setState( { wcsAssetsLoading: true } );
+
 		const js = assets.wc_connect_admin_script;
 		const styles = assets.wc_connect_admin_style;
 
 		const shippingLabelContainer = document.createElement( 'div' );
 		const { orderId } = this.state;
+
 		shippingLabelContainer.className =
 			'wcc-root woocommerce wc-connect-create-shipping-label';
 		shippingLabelContainer.dataset.args = JSON.stringify( {
@@ -173,6 +183,7 @@ export class ShippingBanner extends Component {
 				head.appendChild( link );
 			} ),
 		] ).then( () => {
+			this.setState( { wcsAssetsLoaded: true, wcsAssetsLoading: false } );
 			this.openWcsModal();
 		} );
 	}

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -169,11 +169,8 @@ export class ShippingBanner extends Component {
 				'wc-connect-create-shipping-label'
 			);
 			const state = wcsStore.getState();
-			const siteId = state.ui.selectedSiteId; // TODO: it feels messy to extract siteid here. Maybe WCS could expose something to handle this bit internally.
+			const siteId = state.ui.selectedSiteId;
 
-			// TODO: we need to test whether or not WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW works in
-			// all cases. Calling this event directly skips some of the normal initialization that would work so
-			// we may need to introduce a special event for this purpose.
 			wcsStore.dispatch( {
 				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
 				orderId,

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -40,6 +40,9 @@ export class ShippingBanner extends Component {
 			activatedPlugins,
 			installedPlugins,
 			wcsPluginSlug,
+			hasErrors,
+			wcsAssetsPaths,
+			// errors
 		} = this.props;
 
 		if ( installedPlugins.length > prevProps.installedPlugins.length ) {
@@ -48,6 +51,13 @@ export class ShippingBanner extends Component {
 		if ( activatedPlugins.includes( wcsPluginSlug ) ) {
 			// TODO: Add success notice after installation #32
 			// console.log("Successfully activated wcs.");
+		}
+		if ( wcsAssetsPaths ) {
+			this.loadWcsAssets( wcsAssetsPaths );
+		}
+		if ( hasErrors ) {
+			// TODO: Add error handling #33
+			// console.log("Errors during activation or installation", errors);
 		}
 	}
 
@@ -119,6 +129,53 @@ export class ShippingBanner extends Component {
 			wcs_installed: activePlugins.includes( wcsPluginSlug ),
 		} );
 	};
+
+	loadWcsAssets( { js, css } ) {
+		Promise.all( [
+			new Promise( ( resolve, reject ) => {
+				const script = document.createElement( 'script' );
+				script.src = js;
+				script.async = true;
+				script.onload = resolve;
+				script.onerror = reject;
+				document.body.appendChild( script );
+			} ),
+			new Promise( ( resolve, reject ) => {
+				const head = document.getElementsByTagName( 'head' )[ 0 ];
+				const link = document.createElement( 'link' );
+				link.rel = 'stylesheet';
+				link.type = 'text/css';
+				link.href = css;
+				link.media = 'all';
+				link.onload = resolve;
+				link.onerror = reject;
+				head.appendChild( link );
+			} ),
+		] ).then( () => {
+			this.openWcsModal();
+		} );
+	}
+
+	openWcsModal() {
+		if ( window.wcsGetAppStore ) {
+			const { orderId } = this.props;
+
+			const wcsStore = window.wcsGetAppStore(
+				'wc-connect-create-shipping-label'
+			);
+			const state = wcsStore.getState();
+			const siteId = state.ui.selectedSiteId; // TODO: it feels messy to extract siteid here. Maybe WCS could expose something to handle this bit internally.
+
+			// TODO: we need to test whether or not WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW works in
+			// all cases. Calling this event directly skips some of the normal initialization that would work so
+			// we may need to introduce a special event for this purpose.
+			wcsStore.dispatch( {
+				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
+				orderId,
+				siteId,
+			} );
+		}
+	}
 
 	render() {
 		const { isDismissModalOpen, showShippingBanner } = this.state;

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -40,8 +40,6 @@ export class ShippingBanner extends Component {
 			activatedPlugins,
 			installedPlugins,
 			wcsPluginSlug,
-			wcsAssetsPaths,
-			// errors
 		} = this.props;
 
 		if ( installedPlugins.length > prevProps.installedPlugins.length ) {
@@ -50,9 +48,6 @@ export class ShippingBanner extends Component {
 		if ( activatedPlugins.includes( wcsPluginSlug ) ) {
 			// TODO: Add success notice after installation #32
 			this.acceptTosAndGetWCSAssets();
-		}
-		if ( wcsAssetsPaths ) {
-			this.loadWcsAssets( wcsAssetsPaths );
 		}
 	}
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -135,7 +135,10 @@ export class ShippingBanner extends Component {
 		);
 	}
 
-	loadWcsAssets( { js, css } ) {
+	loadWcsAssets( { assets } ) {
+		const js = assets.wc_connect_admin_script;
+		const styles = assets.wc_connect_admin_style;
+
 		Promise.all( [
 			new Promise( ( resolve, reject ) => {
 				const script = document.createElement( 'script' );
@@ -150,7 +153,7 @@ export class ShippingBanner extends Component {
 				const link = document.createElement( 'link' );
 				link.rel = 'stylesheet';
 				link.type = 'text/css';
-				link.href = css;
+				link.href = styles;
 				link.media = 'all';
 				link.onload = resolve;
 				link.onerror = reject; //TODO: handle errors

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -13,116 +13,154 @@ import { ShippingBanner } from '../index.js';
 jest.mock( 'lib/tracks' );
 jest.mock( '@woocommerce/wc-admin-settings' );
 
-describe( 'Tracking events in shippingBanner', () => {
-	const expectedTrackingData = {
-		jetpack_connected: true,
-		jetpack_installed: true,
-		wcs_installed: true,
-	};
-	const isJetpackConnected = true;
-	const activePlugins = {
-		includes: jest.fn().mockReturnValue( true ),
-	};
-	let shippingBannerWrapper;
+describe( 'ShippingBanner', () => {
+	describe( 'events tracking', () => {
+		const expectedTrackingData = {
+			jetpack_connected: true,
+			jetpack_installed: true,
+			wcs_installed: true,
+		};
+		const isJetpackConnected = true;
+		const activePlugins = {
+			includes: jest.fn().mockReturnValue( true ),
+		};
+		let shippingBannerWrapper;
 
-	beforeEach( () => {
-		shippingBannerWrapper = shallow(
-			<ShippingBanner
-				isJetpackConnected={ isJetpackConnected }
-				activePlugins={ activePlugins }
-				activatedPlugins={ [] }
-				installedPlugins={ [] }
-				wcsPluginSlug={ 'woocommerce-services' }
-				activationErrors={ [] }
-				installationErrors={ [] }
-			/>
-		);
-	} );
-
-	it( 'should record an event when user sees banner loaded', () => {
-		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_show',
-			expectedTrackingData
-		);
-	} );
-
-	it( 'should record an event when user clicks "Create shipping label"', () => {
-		const createShippingLabelButton = shippingBannerWrapper.find( Button );
-		expect( createShippingLabelButton.length ).toBe( 1 );
-		createShippingLabelButton.simulate( 'click' );
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_create_label_click',
-			expectedTrackingData
-		);
-	} );
-
-	it( 'should record an event when user clicks "WooCommerce Service"', () => {
-		const links = shippingBannerWrapper.find( ExternalLink );
-		expect( links.length ).toBe( 2 );
-		const wcsLink = links.first();
-		wcsLink.simulate( 'click' );
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_woocommerce_service_link_click',
-			expectedTrackingData
-		);
-	} );
-
-	it( 'should record an event when user clicks "x" to dismiss the banner', () => {
-		const noticeDimissButton = shippingBannerWrapper.find(
-			'.notice-dismiss'
-		);
-		expect( noticeDimissButton.length ).toBe( 1 );
-		noticeDimissButton.simulate( 'click' );
-		expect( recordEvent ).toHaveBeenCalledWith(
-			'shipping_banner_dimiss_click',
-			expectedTrackingData
-		);
-	} );
-} );
-
-describe( 'Create shipping label button', () => {
-	let shippingBannerWrapper;
-	const installPlugins = jest.fn();
-	const activatePlugins = jest.fn();
-	const activePlugins = {
-		includes: jest.fn().mockReturnValue( true ),
-	};
-
-	beforeEach( () => {
-		shippingBannerWrapper = shallow(
-			<ShippingBanner
-				isJetpackConnected={ jest.fn() }
-				activatePlugins={ activatePlugins }
-				activePlugins={ activePlugins }
-				activatedPlugins={ [] }
-				installPlugins={ installPlugins }
-				installedPlugins={ [] }
-				wcsPluginSlug={ 'woocommerce-services' }
-				activationErrors={ [] }
-				installationErrors={ [] }
-				isRequesting={ false }
-			/>
-		);
-	} );
-
-	it( 'should install WooCommerce Services when button is clicked', () => {
-		const createShippingLabelButton = shippingBannerWrapper.find( Button );
-		expect( createShippingLabelButton.length ).toBe( 1 );
-		createShippingLabelButton.simulate( 'click' );
-		expect( installPlugins ).toHaveBeenCalledWith( [
-			'woocommerce-services',
-		] );
-	} );
-
-	it( 'should activate WooCommerce Services when installation finishes', () => {
-		// Cause a 'componentDidUpdate' by changing the props.
-		shippingBannerWrapper.setProps( {
-			installedPlugins: [ 'woocommerce-services' ],
+		beforeEach( () => {
+			shippingBannerWrapper = shallow(
+				<ShippingBanner
+					isJetpackConnected={ isJetpackConnected }
+					activePlugins={ activePlugins }
+					activatedPlugins={ [] }
+					installedPlugins={ [] }
+					wcsPluginSlug={ 'woocommerce-services' }
+					hasErrors={ false }
+				/>
+			);
 		} );
-		expect( activatePlugins ).toHaveBeenCalledWith( [
-			'woocommerce-services',
-		] );
+
+		it( 'should record an event when user sees banner loaded', () => {
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_banner_show',
+				expectedTrackingData
+			);
+		} );
+
+		it( 'should record an event when user clicks "Create shipping label"', () => {
+			const createShippingLabelButton = shippingBannerWrapper.find(
+				Button
+			);
+			expect( createShippingLabelButton.length ).toBe( 1 );
+			createShippingLabelButton.simulate( 'click' );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_banner_create_label_click',
+				expectedTrackingData
+			);
+		} );
+
+		it( 'should record an event when user clicks "WooCommerce Service"', () => {
+			const links = shippingBannerWrapper.find( ExternalLink );
+			expect( links.length ).toBe( 2 );
+			const wcsLink = links.first();
+			wcsLink.simulate( 'click' );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_banner_woocommerce_service_link_click',
+				expectedTrackingData
+			);
+		} );
+
+		it( 'should record an event when user clicks "x" to dismiss the banner', () => {
+			const noticeDimissButton = shippingBannerWrapper.find(
+				'.notice-dismiss'
+			);
+			expect( noticeDimissButton.length ).toBe( 1 );
+			noticeDimissButton.simulate( 'click' );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'shipping_banner_dimiss_click',
+				expectedTrackingData
+			);
+		} );
+	} );
+
+	describe( 'create shipping label button', () => {
+		let shippingBannerWrapper;
+		const installPlugins = jest.fn();
+		const activatePlugins = jest.fn();
+		const activePlugins = {
+			includes: jest.fn().mockReturnValue( true ),
+		};
+
+		beforeEach( () => {
+			shippingBannerWrapper = shallow(
+				<ShippingBanner
+					isJetpackConnected={ jest.fn() }
+					activatePlugins={ activatePlugins }
+					activePlugins={ activePlugins }
+					activatedPlugins={ [] }
+					installPlugins={ installPlugins }
+					installedPlugins={ [] }
+					wcsPluginSlug={ 'woocommerce-services' }
+					hasErrors={ false }
+					wcsAssetsPaths={ {
+						js: '/path/to/wcs.js',
+						css: '/path/to/wcs.css',
+					} }
+					orderId={ 'ORDER_ID' }
+				/>
+			);
+		} );
+
+		it( 'should install WooCommerce Services when button is clicked', () => {
+			const createShippingLabelButton = shippingBannerWrapper.find(
+				Button
+			);
+			expect( createShippingLabelButton.length ).toBe( 1 );
+			createShippingLabelButton.simulate( 'click' );
+			expect( installPlugins ).toHaveBeenCalledWith( [
+				'woocommerce-services',
+			] );
+		} );
+
+		it( 'should activate WooCommerce Services when installation finishes', () => {
+			// Cause a 'componentDidUpdate' by changing the props.
+			shippingBannerWrapper.setProps( {
+				installedPlugins: [ 'woocommerce-services' ],
+			} );
+			expect( activatePlugins ).toHaveBeenCalledWith( [
+				'woocommerce-services',
+			] );
+		} );
+
+		beforeEach( () => {} );
+
+		it.todo(
+			'should perform a request to accept the TOS and get WCS assets to load'
+		);
+
+		it.todo( 'should load WCS assets when a path is provided' );
+
+		it( 'should open WCS modal', () => {
+			window.wcsGetAppStore = jest.fn();
+			const getState = jest.fn();
+			const dispatch = jest.fn();
+			window.wcsGetAppStore.mockReturnValueOnce( { getState, dispatch } );
+			getState.mockReturnValueOnce( {
+				ui: {
+					selectedSiteId: 'SITE_ID',
+				},
+			} );
+			shippingBannerWrapper.instance().openWcsModal();
+			expect( window.wcsGetAppStore ).toHaveBeenCalledWith(
+				'wc-connect-create-shipping-label'
+			);
+			expect( getState ).toHaveBeenCalledTimes( 1 );
+			expect( dispatch ).toHaveBeenCalledWith( {
+				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
+				orderId: 'ORDER_ID',
+				siteId: 'SITE_ID',
+			} );
+		} );
 	} );
 
 	it( 'should show a busy loading state when installing or activating ', () => {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -88,7 +88,7 @@ describe( 'Create shipping label button', () => {
 	const activePlugins = {
 		includes: jest.fn().mockReturnValue( true ),
 	};
-	const acceptTos = jest.fn( () => Promise.resolve() );
+	const acceptTos = jest.fn( () => Promise.resolve( true ) );
 	const wcsAssets = {};
 	const getWcsAssets = jest.fn( () => {
 		return Promise.resolve( wcsAssets );

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -13,198 +13,123 @@ import { ShippingBanner } from '../index.js';
 jest.mock( 'lib/tracks' );
 jest.mock( '@woocommerce/wc-admin-settings' );
 
-describe( 'ShippingBanner', () => {
-	describe( 'events tracking', () => {
-		const expectedTrackingData = {
-			jetpack_connected: true,
-			jetpack_installed: true,
-			wcs_installed: true,
-		};
-		const isJetpackConnected = true;
-		const activePlugins = {
-			includes: jest.fn().mockReturnValue( true ),
-		};
-		let shippingBannerWrapper;
+describe( 'Tracking events in shippingBanner', () => {
+	const expectedTrackingData = {
+		jetpack_connected: true,
+		jetpack_installed: true,
+		wcs_installed: true,
+	};
+	const isJetpackConnected = true;
+	const activePlugins = {
+		includes: jest.fn().mockReturnValue( true ),
+	};
+	let shippingBannerWrapper;
 
-		beforeEach( () => {
-			shippingBannerWrapper = shallow(
-				<ShippingBanner
-					isJetpackConnected={ isJetpackConnected }
-					activePlugins={ activePlugins }
-					activatedPlugins={ [] }
-					installedPlugins={ [] }
-					wcsPluginSlug={ 'woocommerce-services' }
-					hasErrors={ false }
-				/>
-			);
-		} );
-
-		it( 'should record an event when user sees banner loaded', () => {
-			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
-			expect( recordEvent ).toHaveBeenCalledWith(
-				'shipping_banner_show',
-				expectedTrackingData
-			);
-		} );
-
-		it( 'should record an event when user clicks "Create shipping label"', () => {
-			const createShippingLabelButton = shippingBannerWrapper.find(
-				Button
-			);
-			expect( createShippingLabelButton.length ).toBe( 1 );
-			createShippingLabelButton.simulate( 'click' );
-			expect( recordEvent ).toHaveBeenCalledWith(
-				'shipping_banner_create_label_click',
-				expectedTrackingData
-			);
-		} );
-
-		it( 'should record an event when user clicks "WooCommerce Service"', () => {
-			const links = shippingBannerWrapper.find( ExternalLink );
-			expect( links.length ).toBe( 2 );
-			const wcsLink = links.first();
-			wcsLink.simulate( 'click' );
-			expect( recordEvent ).toHaveBeenCalledWith(
-				'shipping_banner_woocommerce_service_link_click',
-				expectedTrackingData
-			);
-		} );
-
-		it( 'should record an event when user clicks "x" to dismiss the banner', () => {
-			const noticeDimissButton = shippingBannerWrapper.find(
-				'.notice-dismiss'
-			);
-			expect( noticeDimissButton.length ).toBe( 1 );
-			noticeDimissButton.simulate( 'click' );
-			expect( recordEvent ).toHaveBeenCalledWith(
-				'shipping_banner_dimiss_click',
-				expectedTrackingData
-			);
-		} );
+	beforeEach( () => {
+		shippingBannerWrapper = shallow(
+			<ShippingBanner
+				isJetpackConnected={ isJetpackConnected }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				activationErrors={ [] }
+				installationErrors={ [] }
+			/>
+		);
 	} );
 
-	describe( 'create shipping label button', () => {
-		let shippingBannerWrapper;
-		const installPlugins = jest.fn();
-		const activatePlugins = jest.fn();
-		const activePlugins = {
-			includes: jest.fn().mockReturnValue( true ),
-		};
-
-		beforeEach( () => {
-			shippingBannerWrapper = shallow(
-				<ShippingBanner
-					isJetpackConnected={ jest.fn() }
-					activatePlugins={ activatePlugins }
-					activePlugins={ activePlugins }
-					activatedPlugins={ [] }
-					installPlugins={ installPlugins }
-					installedPlugins={ [] }
-					wcsPluginSlug={ 'woocommerce-services' }
-					hasErrors={ false }
-					wcsAssetsPaths={ {
-						js: '/path/to/wcs.js',
-						css: '/path/to/wcs.css',
-					} }
-					orderId={ 'ORDER_ID' }
-				/>
-			);
-		} );
-
-		it( 'should install WooCommerce Services when button is clicked', () => {
-			const createShippingLabelButton = shippingBannerWrapper.find(
-				Button
-			);
-			expect( createShippingLabelButton.length ).toBe( 1 );
-			createShippingLabelButton.simulate( 'click' );
-			expect( installPlugins ).toHaveBeenCalledWith( [
-				'woocommerce-services',
-			] );
-		} );
-
-		it( 'should activate WooCommerce Services when installation finishes', () => {
-			// Cause a 'componentDidUpdate' by changing the props.
-			shippingBannerWrapper.setProps( {
-				installedPlugins: [ 'woocommerce-services' ],
-			} );
-			expect( activatePlugins ).toHaveBeenCalledWith( [
-				'woocommerce-services',
-			] );
-		} );
-
-		it.todo(
-			'should perform a request to accept the TOS and get WCS assets to load'
+	it( 'should record an event when user sees banner loaded', () => {
+		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'shipping_banner_show',
+			expectedTrackingData
 		);
+	} );
 
-		it( 'should load WCS assets when a path is provided', () => {
-			const scriptMock = {};
-			const linkMock = {};
-			const createElementMockReturn = {
-				script: scriptMock,
-				link: linkMock,
-			};
-			const createElementMock = jest.fn( ( tagName ) => {
-				return createElementMockReturn[ tagName ];
-			} );
-			document.createElement = createElementMock;
+	it( 'should record an event when user clicks "Create shipping label"', () => {
+		const createShippingLabelButton = shippingBannerWrapper.find( Button );
+		expect( createShippingLabelButton.length ).toBe( 1 );
+		createShippingLabelButton.simulate( 'click' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'shipping_banner_create_label_click',
+			expectedTrackingData
+		);
+	} );
 
-			const getElementsByTagNameMock = jest.fn();
-			const headMock = {
-				appendChild: jest.fn(),
-			};
-			getElementsByTagNameMock.mockReturnValueOnce( [ headMock ] );
-			document.getElementsByTagName = getElementsByTagNameMock;
+	it( 'should record an event when user clicks "WooCommerce Service"', () => {
+		const links = shippingBannerWrapper.find( ExternalLink );
+		expect( links.length ).toBe( 2 );
+		const wcsLink = links.first();
+		wcsLink.simulate( 'click' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'shipping_banner_woocommerce_service_link_click',
+			expectedTrackingData
+		);
+	} );
 
-			const appendChildMock = jest.fn();
-			document.body.appendChild = appendChildMock;
+	it( 'should record an event when user clicks "x" to dismiss the banner', () => {
+		const noticeDimissButton = shippingBannerWrapper.find(
+			'.notice-dismiss'
+		);
+		expect( noticeDimissButton.length ).toBe( 1 );
+		noticeDimissButton.simulate( 'click' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'shipping_banner_dimiss_click',
+			expectedTrackingData
+		);
+	} );
+} );
 
-			const openWcsModalMock = jest.fn();
-			shippingBannerWrapper.instance().openWcsModal = openWcsModalMock;
+describe( 'Create shipping label button', () => {
+	let shippingBannerWrapper;
+	const installPlugins = jest.fn();
+	const activatePlugins = jest.fn();
+	const activePlugins = {
+		includes: jest.fn().mockReturnValue( true ),
+	};
+	const acceptTos = jest.fn();
+	const wcsAssets = {};
+	const getWcsAssets = jest.fn( () => {
+		return wcsAssets;
+	} );
 
-			shippingBannerWrapper.instance().loadWcsAssets( {
-				js: '/path/to/wcs.js',
-				css: '/path/to/wcs.css',
-			} );
+	beforeEach( () => {
+		shippingBannerWrapper = shallow(
+			<ShippingBanner
+				isJetpackConnected={ jest.fn() }
+				activatePlugins={ activatePlugins }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installPlugins={ installPlugins }
+				installedPlugins={ [] }
+				wcsPluginSlug={ 'woocommerce-services' }
+				activationErrors={ [] }
+				installationErrors={ [] }
+				isRequesting={ false }
+				acceptTos={ acceptTos }
+				getWcsAssets={ getWcsAssets }
+			/>
+		);
+	} );
 
-			expect( createElementMock ).toHaveBeenCalledWith( 'script' );
-			expect( createElementMock ).toHaveNthReturnedWith( 1, scriptMock );
-			expect( scriptMock.async ).toEqual( true );
-			expect( scriptMock.src ).toEqual( '/path/to/wcs.js' );
-			expect( appendChildMock ).toHaveBeenCalledWith( scriptMock );
+	it( 'should install WooCommerce Services when button is clicked', () => {
+		const createShippingLabelButton = shippingBannerWrapper.find( Button );
+		expect( createShippingLabelButton.length ).toBe( 1 );
+		createShippingLabelButton.simulate( 'click' );
+		expect( installPlugins ).toHaveBeenCalledWith( [
+			'woocommerce-services',
+		] );
+	} );
 
-			expect( getElementsByTagNameMock ).toHaveBeenCalledWith( 'head' );
-			expect( getElementsByTagNameMock ).toHaveReturnedWith( [
-				headMock,
-			] );
-			expect( createElementMock ).toHaveBeenCalledWith( 'link' );
-			expect( createElementMock ).toHaveNthReturnedWith( 2, linkMock );
-			expect( linkMock.rel ).toEqual( 'stylesheet' );
-			expect( linkMock.type ).toEqual( 'text/css' );
-			expect( linkMock.href ).toEqual( '/path/to/wcs.css' );
-			expect( linkMock.media ).toEqual( 'all' );
+	it( 'should activate WooCommerce Services when installation finishes', () => {
+		// Cause a 'componentDidUpdate' by changing the props.
+		shippingBannerWrapper.setProps( {
+			installedPlugins: [ 'woocommerce-services' ],
 		} );
-
-		it( 'should open WCS modal', () => {
-			window.wcsGetAppStore = jest.fn();
-			const getState = jest.fn();
-			const dispatch = jest.fn();
-			window.wcsGetAppStore.mockReturnValueOnce( { getState, dispatch } );
-			getState.mockReturnValueOnce( {
-				ui: {
-					selectedSiteId: 'SITE_ID',
-				},
-			} );
-			shippingBannerWrapper.instance().openWcsModal();
-			expect( window.wcsGetAppStore ).toHaveBeenCalledWith(
-				'wc-connect-create-shipping-label'
-			);
-			expect( getState ).toHaveBeenCalledTimes( 1 );
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
-				orderId: 'ORDER_ID',
-				siteId: 'SITE_ID',
-			} );
-		} );
+		expect( activatePlugins ).toHaveBeenCalledWith( [
+			'woocommerce-services',
+		] );
 	} );
 
 	it( 'should show a busy loading state when installing or activating ', () => {
@@ -215,6 +140,83 @@ describe( 'ShippingBanner', () => {
 		expect( createShippingLabelButton.length ).toBe( 1 );
 		expect( createShippingLabelButton.prop( 'disabled' ) ).toBe( true );
 		expect( createShippingLabelButton.prop( 'isBusy' ) ).toBe( true );
+	} );
+
+	it( 'should perform a request to accept the TOS and get WCS assets to load', async () => {
+		const loadWcsAssetsMock = jest.fn();
+		shippingBannerWrapper.instance().loadWcsAssets = loadWcsAssetsMock;
+		await shippingBannerWrapper.instance().acceptTosAndGetWCSAssets();
+		expect( acceptTos ).toHaveBeenCalled();
+		expect( getWcsAssets ).toHaveBeenCalled();
+		expect( loadWcsAssetsMock ).toHaveBeenCalledWith( wcsAssets );
+	} );
+
+	it( 'should load WCS assets when a path is provided', () => {
+		const scriptMock = {};
+		const linkMock = {};
+		const createElementMockReturn = {
+			script: scriptMock,
+			link: linkMock,
+		};
+		const createElementMock = jest.fn( ( tagName ) => {
+			return createElementMockReturn[ tagName ];
+		} );
+		document.createElement = createElementMock;
+
+		const getElementsByTagNameMock = jest.fn();
+		const headMock = {
+			appendChild: jest.fn(),
+		};
+		getElementsByTagNameMock.mockReturnValueOnce( [ headMock ] );
+		document.getElementsByTagName = getElementsByTagNameMock;
+
+		const appendChildMock = jest.fn();
+		document.body.appendChild = appendChildMock;
+
+		const openWcsModalMock = jest.fn();
+		shippingBannerWrapper.instance().openWcsModal = openWcsModalMock;
+
+		shippingBannerWrapper.instance().loadWcsAssets( {
+			js: '/path/to/wcs.js',
+			css: '/path/to/wcs.css',
+		} );
+
+		expect( createElementMock ).toHaveBeenCalledWith( 'script' );
+		expect( createElementMock ).toHaveNthReturnedWith( 1, scriptMock );
+		expect( scriptMock.async ).toEqual( true );
+		expect( scriptMock.src ).toEqual( '/path/to/wcs.js' );
+		expect( appendChildMock ).toHaveBeenCalledWith( scriptMock );
+
+		expect( getElementsByTagNameMock ).toHaveBeenCalledWith( 'head' );
+		expect( getElementsByTagNameMock ).toHaveReturnedWith( [ headMock ] );
+		expect( createElementMock ).toHaveBeenCalledWith( 'link' );
+		expect( createElementMock ).toHaveNthReturnedWith( 2, linkMock );
+		expect( linkMock.rel ).toEqual( 'stylesheet' );
+		expect( linkMock.type ).toEqual( 'text/css' );
+		expect( linkMock.href ).toEqual( '/path/to/wcs.css' );
+		expect( linkMock.media ).toEqual( 'all' );
+	} );
+
+	it( 'should open WCS modal', () => {
+		window.wcsGetAppStore = jest.fn();
+		const getState = jest.fn();
+		const dispatch = jest.fn();
+		window.wcsGetAppStore.mockReturnValueOnce( { getState, dispatch } );
+		getState.mockReturnValueOnce( {
+			ui: {
+				selectedSiteId: 'SITE_ID',
+			},
+		} );
+		shippingBannerWrapper.instance().openWcsModal();
+		expect( window.wcsGetAppStore ).toHaveBeenCalledWith(
+			'wc-connect-create-shipping-label'
+		);
+		expect( getState ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
+			orderId: 'ORDER_ID',
+			siteId: 'SITE_ID',
+		} );
 	} );
 } );
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -161,6 +161,7 @@ describe( 'Create shipping label button', () => {
 		const createElementMock = jest.fn( ( tagName ) => {
 			return createElementMockReturn[ tagName ];
 		} );
+		const createElement = document.createElement;
 		document.createElement = createElementMock;
 
 		const getElementsByTagNameMock = jest.fn();
@@ -177,8 +178,10 @@ describe( 'Create shipping label button', () => {
 		shippingBannerWrapper.instance().openWcsModal = openWcsModalMock;
 
 		shippingBannerWrapper.instance().loadWcsAssets( {
-			js: '/path/to/wcs.js',
-			css: '/path/to/wcs.css',
+			assets: {
+				wc_connect_admin_script: '/path/to/wcs.js',
+				wc_connect_admin_style: '/path/to/wcs.css',
+			},
 		} );
 
 		expect( createElementMock ).toHaveBeenCalledWith( 'script' );
@@ -195,6 +198,8 @@ describe( 'Create shipping label button', () => {
 		expect( linkMock.type ).toEqual( 'text/css' );
 		expect( linkMock.href ).toEqual( '/path/to/wcs.css' );
 		expect( linkMock.media ).toEqual( 'all' );
+
+		document.createElement = createElement;
 	} );
 
 	it( 'should open WCS modal', () => {
@@ -202,6 +207,11 @@ describe( 'Create shipping label button', () => {
 		const getState = jest.fn();
 		const dispatch = jest.fn();
 		window.wcsGetAppStore.mockReturnValueOnce( { getState, dispatch } );
+		delete window.location; // jsdom won't allow to rewrite window.location unless deleted first
+		window.location = {
+			href:
+				'http://wcship.test/wp-admin/post.php?post=ORDER_ID&action=edit',
+		};
 		getState.mockReturnValueOnce( {
 			ui: {
 				selectedSiteId: 'SITE_ID',

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -132,13 +132,57 @@ describe( 'ShippingBanner', () => {
 			] );
 		} );
 
-		beforeEach( () => {} );
-
 		it.todo(
 			'should perform a request to accept the TOS and get WCS assets to load'
 		);
 
-		it.todo( 'should load WCS assets when a path is provided' );
+		it( 'should load WCS assets when a path is provided', () => {
+			const scriptMock = {};
+			const linkMock = {};
+			const createElementMockReturn = {
+				script: scriptMock,
+				link: linkMock,
+			};
+			const createElementMock = jest.fn( ( tagName ) => {
+				return createElementMockReturn[ tagName ];
+			} );
+			document.createElement = createElementMock;
+
+			const getElementsByTagNameMock = jest.fn();
+			const headMock = {
+				appendChild: jest.fn(),
+			};
+			getElementsByTagNameMock.mockReturnValueOnce( [ headMock ] );
+			document.getElementsByTagName = getElementsByTagNameMock;
+
+			const appendChildMock = jest.fn();
+			document.body.appendChild = appendChildMock;
+
+			const openWcsModalMock = jest.fn();
+			shippingBannerWrapper.instance().openWcsModal = openWcsModalMock;
+
+			shippingBannerWrapper.instance().loadWcsAssets( {
+				js: '/path/to/wcs.js',
+				css: '/path/to/wcs.css',
+			} );
+
+			expect( createElementMock ).toHaveBeenCalledWith( 'script' );
+			expect( createElementMock ).toHaveNthReturnedWith( 1, scriptMock );
+			expect( scriptMock.async ).toEqual( true );
+			expect( scriptMock.src ).toEqual( '/path/to/wcs.js' );
+			expect( appendChildMock ).toHaveBeenCalledWith( scriptMock );
+
+			expect( getElementsByTagNameMock ).toHaveBeenCalledWith( 'head' );
+			expect( getElementsByTagNameMock ).toHaveReturnedWith( [
+				headMock,
+			] );
+			expect( createElementMock ).toHaveBeenCalledWith( 'link' );
+			expect( createElementMock ).toHaveNthReturnedWith( 2, linkMock );
+			expect( linkMock.rel ).toEqual( 'stylesheet' );
+			expect( linkMock.type ).toEqual( 'text/css' );
+			expect( linkMock.href ).toEqual( '/path/to/wcs.css' );
+			expect( linkMock.media ).toEqual( 'all' );
+		} );
 
 		it( 'should open WCS modal', () => {
 			window.wcsGetAppStore = jest.fn();

--- a/client/wp-admin-scripts/print-shipping-label-banner/store.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/store.js
@@ -4,10 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { registerStore } from '@wordpress/data';
 
-const DEFAULT_STATE = {
-	wcsAssets: {},
-	tosAccepted: false,
-};
+const DEFAULT_STATE = {};
 
 const actions = {
 	updateTos( accepted ) {
@@ -24,10 +21,12 @@ const actions = {
 		};
 	},
 
-	fetchFromAPI( path ) {
+	fetchFromAPI( path, method = 'GET', data = null ) {
 		return {
 			type: 'FETCH_FROM_API',
 			path,
+			method,
+			data,
 		};
 	},
 };
@@ -68,20 +67,26 @@ registerStore( 'print-shipping-label-banner', {
 
 	controls: {
 		FETCH_FROM_API( action ) {
-			return apiFetch( { path: action.path } );
+			return apiFetch( {
+				path: action.path,
+				method: action.method,
+				data: action.data,
+			} );
 		},
 	},
 
 	resolvers: {
 		*acceptTos() {
-			const path = '/accept/tos';
-			const tosAccepted = yield actions.fetchFromAPI( path );
-			return actions.updateTos( tosAccepted );
+			const path = '/wc/v1/connect/tos';
+			const { accepted } = yield actions.fetchFromAPI( path, 'POST', {
+				accepted: true,
+			} );
+			return actions.updateTos( accepted );
 		},
 		*getWcsAssets() {
-			const path = '/get/wcs/assets';
+			const path = '/wc/v1/connect/assets';
 			const wcsAssets = yield actions.fetchFromAPI( path );
-			return actions.updateAssets( wcsAssets );
+			return actions.updateWcsAssets( wcsAssets );
 		},
 	},
 } );

--- a/client/wp-admin-scripts/print-shipping-label-banner/store.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/store.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { registerStore } from '@wordpress/data';
+
+const DEFAULT_STATE = {
+	wcsAssets: {},
+	tosAccepted: false,
+};
+
+const actions = {
+	updateTos( accepted ) {
+		return {
+			type: 'UPDATE_WCS_TOS',
+			accepted,
+		};
+	},
+
+	updateWcsAssets( assets ) {
+		return {
+			type: 'UPDATE_WCS_ASSETS',
+			assets,
+		};
+	},
+
+	fetchFromAPI( path ) {
+		return {
+			type: 'FETCH_FROM_API',
+			path,
+		};
+	},
+};
+
+registerStore( 'print-shipping-label-banner', {
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case 'UPDATE_WCS_TOS':
+				return {
+					...state,
+					tosAccepted: action.accepted,
+				};
+			case 'UPDATE_WCS_ASSETS':
+				return {
+					...state,
+					wcsAssets: action.assets,
+				};
+		}
+
+		return state;
+	},
+
+	actions,
+
+	selectors: {
+		acceptTos( state ) {
+			const { tosAccepted } = state;
+
+			return tosAccepted;
+		},
+
+		getWcsAssets( state ) {
+			const { wcsAssets } = state;
+
+			return wcsAssets;
+		},
+	},
+
+	controls: {
+		FETCH_FROM_API( action ) {
+			return apiFetch( { path: action.path } );
+		},
+	},
+
+	resolvers: {
+		*acceptTos() {
+			const path = '/accept/tos';
+			const tosAccepted = yield actions.fetchFromAPI( path );
+			return actions.updateTos( tosAccepted );
+		},
+		*getWcsAssets() {
+			const path = '/get/wcs/assets';
+			const wcsAssets = yield actions.fetchFromAPI( path );
+			return actions.updateAssets( wcsAssets );
+		},
+	},
+} );

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -141,6 +141,13 @@ class ShippingLabelBanner {
 			Loader::get_file_version( 'wp-admin-scripts/print-shipping-label-banner.js' ),
 			true
 		);
+
+		$payload = array(
+			'nonce'   => wp_create_nonce( 'wp_rest' ),
+			'baseURL' => get_rest_url(),
+		);
+
+		wp_localize_script( 'print-shipping-label-banner', 'wcConnectData', $payload );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/17.

Adds this functionality to the Shipping Label banner:

- Calls the WooCommerce Services API to accept its Terms of Service and get the URL of the WooCommerce Services assets.
- Loads and adds to the page the WooCommerce Services assets.
- Opens the WooCommerce Services shipping label creation modal.

### Instructions to test:

With WooCommerce Services active, just press the "Create shipping label" button in the banner.
