### PR TITLE
Fix calling protected has_satisfied_dependencies on outdated plugin

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -65,7 +65,7 @@ class Package {
 		}
 
 		$feature_plugin_instance = FeaturePlugin::instance();
-		$satisfied_dependencies  = $feature_plugin_instance->has_satisfied_dependencies();
+		$satisfied_dependencies  = is_callable( array( $feature_plugin_instance, 'has_satisfied_dependencies' ) ) && $feature_plugin_instance->has_satisfied_dependencies();
 		if ( ! $satisfied_dependencies ) {
 			return;
 		}

--- a/src/Package.php
+++ b/src/Package.php
@@ -48,17 +48,6 @@ class Package {
 	 * Only initialize for WP 5.3 or greater.
 	 */
 	public static function init() {
-		$feature_plugin_instance = FeaturePlugin::instance();
-		$satisfied_dependencies  = $feature_plugin_instance->has_satisfied_dependencies();
-		if ( ! $satisfied_dependencies ) {
-			return;
-		}
-
-		// Indicate to the feature plugin that the core package exists.
-		if ( ! defined( 'WC_ADMIN_PACKAGE_EXISTS' ) ) {
-			define( 'WC_ADMIN_PACKAGE_EXISTS', true );
-		}
-
 		// Avoid double initialization when the feature plugin is in use.
 		if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 			self::$active_version = WC_ADMIN_VERSION_NUMBER;
@@ -73,6 +62,17 @@ class Package {
 			register_deactivation_hook( WC_ADMIN_PLUGIN_FILE, array( __CLASS__, 'on_deactivation' ) );
 
 			return;
+		}
+
+		$feature_plugin_instance = FeaturePlugin::instance();
+		$satisfied_dependencies  = $feature_plugin_instance->has_satisfied_dependencies();
+		if ( ! $satisfied_dependencies ) {
+			return;
+		}
+
+		// Indicate to the feature plugin that the core package exists.
+		if ( ! defined( 'WC_ADMIN_PACKAGE_EXISTS' ) ) {
+			define( 'WC_ADMIN_PACKAGE_EXISTS', true );
 		}
 
 		self::$package_active = true;


### PR DESCRIPTION
The FeaturePlugin class gets loaded from the active WC Admin plugin not the package in WC so a recent change in `FeaturePlugin` that changes a method to public may or may not be there depending on the version of the plugin.

If Core has 1.0.2 and the plugin has 1.0.0 you will see the error.

The solution is to move the check if the plugin exists earlier. If it does exist, then `Package::init()` exits early and all logic is deferred to the plugin itself.

### Testing

1. In your local install, get the latest from master woocommerce core.
2. Composer install and see that 1.0.2 of wc-admin is loaded.
3. In wc-admin plugin, load master branch (this will be v1.0.0 and more importantly does not yet have changes from https://github.com/woocommerce/woocommerce-admin/pull/3851 which make the method `has_satisfied_dependencies` public)
4. See the following error:
```
PHP Fatal error:  Uncaught Error: Call to protected method Automattic\WooCommerce\Admin\FeaturePlugin::has_satisfied_dependencies() from context 'Automattic\WooCommerce\Admin\Composer\Package' in /Users/ronrennick/Sites/ron/wp-content/plugins/woocommerce/packages/woocommerce-admin/src/Package.php:52
```
5. In `woocommerce/packages/woocommerce-admin/src/Package.php` copy the changes from this PR.
6. See the error disappear.