### PR TITLE
Animation slider example fix

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix CompareFilter options format (key prop vs. id).
 - Fix styling of `<Search />` component "clear all" button.
 - Add state classes to `<TextControlWithAffixes />` component.
+- Fix `<AnimationSlider />` example code.
 
 # 4.0.0
 

--- a/packages/components/src/animation-slider/docs/example.js
+++ b/packages/components/src/animation-slider/docs/example.js
@@ -17,7 +17,7 @@ export default class MyAnimationSlider extends Component {
 			animate: null,
 		};
 		this.forward = this.forward.bind( this );
-		this.back = this.forward.bind( this );
+		this.back = this.back.bind( this );
 	}
 
 	forward() {
@@ -53,7 +53,7 @@ export default class MyAnimationSlider extends Component {
 				</button>
 				<button
 					onClick={ this.forward }
-					disabled={ page === pages.length + 1 }
+					disabled={ page === pages.length - 1 }
 				>
 					Forward
 				</button>


### PR DESCRIPTION
Fixes Animation slider example.

### Screenshots

Getting to the end of the pages the navigation would break.
Before: https://d.pr/i/osSm1p
After: https://d.pr/i/V6EBV5

### Detailed test instructions:

- Pull down this branch
- Build
- Go to AnimationSlider devdocs e.g. `wp-admin/admin.php?page=wc-admin&path=/devdocs&component=animation-slider`
- Try the example - notice the forward/back buttons correctly are disabled and the animations go back and forward through all the correct pages (rather than showing empty pages and not being bale to go back)
