### PR TITLE
Hide the shipping banner when dismiss is clicked

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
@@ -19,11 +19,17 @@ export class DismissModal extends Component {
 		} );
 	};
 
+	hideBanner = () => {
+		document.getElementById(
+			'woocommerce-admin-print-label'
+		).style.display = 'none';
+	};
+
 	remindMeLaterClicked = () => {
 		const { onCloseAll, trackElementClicked } = this.props;
 		this.setDismissed( Date.now() );
 		onCloseAll();
-
+		this.hideBanner();
 		trackElementClicked( 'shipping_banner_dismiss_modal_remind_me_later' );
 	};
 
@@ -31,6 +37,7 @@ export class DismissModal extends Component {
 		const { onCloseAll, trackElementClicked } = this.props;
 		this.setDismissed( -1 );
 		onCloseAll();
+		this.hideBanner();
 		trackElementClicked( 'shipping_banner_dismiss_modal_close_forever' );
 	};
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/test/index.js
@@ -15,6 +15,9 @@ describe( 'Option Save events in DismissModal', () => {
 	let dismissModalWrapper;
 
 	beforeEach( () => {
+		document.body.innerHTML =
+			document.body.innerHTML +
+			'<div id="woocommerce-admin-print-label">';
 		dismissModalWrapper = shallow(
 			<DismissModal
 				visible={ true }
@@ -91,5 +94,48 @@ describe( 'Tracking events in DismissModal', () => {
 		expect( trackElementClicked ).toHaveBeenCalledWith(
 			'shipping_banner_dismiss_modal_remind_me_later'
 		);
+	} );
+} );
+
+describe( 'Dismissing modal', () => {
+	let dismissModalWrapper;
+
+	beforeEach( () => {
+		document.body.innerHTML =
+			document.body.innerHTML +
+			'<div id="woocommerce-admin-print-label">';
+		dismissModalWrapper = shallow(
+			<DismissModal
+				visible={ true }
+				onClose={ jest.fn() }
+				onCloseAll={ jest.fn() }
+				trackElementClicked={ jest.fn() }
+				updateOptions={ jest.fn() }
+			/>
+		);
+	} );
+
+	test( 'Should hide the banner by clicking permanent dismissal', () => {
+		const actionButtons = dismissModalWrapper.find( Button );
+		expect( actionButtons.length ).toBe( 2 );
+		const permanenttDismissButton = actionButtons.last();
+		permanenttDismissButton.simulate( 'click' );
+
+		const bannerStyle = document.getElementById(
+			'woocommerce-admin-print-label'
+		).style;
+		expect( bannerStyle.display ).toBe( 'none' );
+	} );
+
+	test( 'Should hide the banner by clicking  temporary dismissal', () => {
+		const actionButtons = dismissModalWrapper.find( Button );
+		expect( actionButtons.length ).toBe( 2 );
+		const remindMeLaterButton = actionButtons.first();
+		remindMeLaterButton.simulate( 'click' );
+
+		const bannerStyle = document.getElementById(
+			'woocommerce-admin-print-label'
+		).style;
+		expect( bannerStyle.display ).toBe( 'none' );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/41

When we click "Remind me later" or "I don't need this", hide the meta box that the react component mount on.

The mount point `<div id="woocommerce-admin-print-label">` is created in PHP via `add_meta_box()`. Hiding the React components will not remove/hide this container created from PHP.

I see a couple of ways to do this.
1. When the event is called, make a API call to PHP so that it can trigger `remove_meta_box`.  This will not be simple since this will need to trigger a PHP page refersh/partial template rendering. 

2. Have the React component to *delete* the `<div>` directly in the DOM. Once the node is deleted, it will not show up again until the next page refresh. React wouldn't know that it is deleted. We can dismount it first before we delete.

3. Similar to 2) above, but instead of deleting, add a "display: none" property to the DOM node so that it is hidden from view, but it is still there. 

I went with 3 since hiding the meta box is the least effort and least impact. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
1. Open up the order page
2. Click 'x', click "Remind me later". The meta box should disappear
3. Click 'x', click "I don't need this". The meta box should disappear.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
