### PR TITLE
Update copy to WooCommerce Shipping

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/dismiss-modal/index.js
@@ -56,7 +56,7 @@ export class DismissModal extends Component {
 			>
 				<p className="wc-admin-shipping-banner__dismiss-modal-help-text">
 					{ __(
-						'With WooCommerce Services you can Print shipping labels from your WooCommerce dashboard at the lowest USPS rates.',
+						'With WooCommerce Shipping you can Print shipping labels from your WooCommerce dashboard at the lowest USPS rates.',
 						'woocommerce-admin'
 					) }
 				</p>

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -245,7 +245,7 @@ export class ShippingBanner extends Component {
 					<p>
 						{ interpolateComponents( {
 							mixedString: __(
-								'By clicking "Create shipping label", {{wcsLink}}WooCommerce Services{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
+								'By clicking "Create shipping label", {{wcsLink}}WooCommerce Shipping{{/wcsLink}} will be installed and you agree to its {{tosLink}}Terms of Service{{/tosLink}}.',
 								'woocommerce-admin'
 							),
 							components: {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -153,7 +153,7 @@ describe( 'Create shipping label button', () => {
 		);
 	} );
 
-	it( 'should install WooCommerce Services when button is clicked', () => {
+	it( 'should install WooCommerce Shipping when button is clicked', () => {
 		const createShippingLabelButton = shippingBannerWrapper.find( Button );
 		expect( createShippingLabelButton.length ).toBe( 1 );
 		createShippingLabelButton.simulate( 'click' );
@@ -162,7 +162,7 @@ describe( 'Create shipping label button', () => {
 		] );
 	} );
 
-	it( 'should activate WooCommerce Services when installation finishes', () => {
+	it( 'should activate WooCommerce Shipping when installation finishes', () => {
 		// Cause a 'componentDidUpdate' by changing the props.
 		shippingBannerWrapper.setProps( {
 			installedPlugins: [ 'woocommerce-services' ],


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/45

Update all `WooCommerce Services` to `WooCommerce Shipping`

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
- Open order page
- Confirm text prints "WooCommerce Shipping" 
![image](https://user-images.githubusercontent.com/572862/77105978-0b398380-69e4-11ea-85a7-553bf0fb0588.png)


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
