### PR TITLE
Shipping banner load in the proper place

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/index.js
@@ -6,6 +6,8 @@ import ShippingBanner from './shipping-banner';
 import './store';
 
 const metaBox = document.getElementById( 'wc-admin-shipping-banner-root' );
+const args =
+	( metaBox.dataset.args && JSON.parse( metaBox.dataset.args ) ) || {};
 
 // Render the header.
-render( <ShippingBanner />, metaBox );
+render( <ShippingBanner itemsCount={ args.shippable_items_count } />, metaBox );

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -264,6 +264,9 @@ export class ShippingBanner extends Component {
 					),
 				},
 			} );
+			document.getElementById(
+				'woocommerce-admin-print-label'
+			).style.display = 'none';
 		}
 	}
 

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -149,6 +149,26 @@ export class ShippingBanner extends Component {
 		}
 	}
 
+	generateMetaBoxHtml( title, args ) {
+		const argsJsonString = JSON.stringify( args ).replace( /"/g, '&quot;' ); // JS has no native html_entities so we just replace.
+
+		const togglePanelText = __( 'Toggle panel:', 'woocommerce-admin' );
+
+		return `
+<div id="woocommerce-order-label" class="postbox ">
+	<button type="button" class="handlediv" aria-expanded="true">
+		<span class="screen-reader-text">${ togglePanelText } ${ title }</span>
+		<span class="toggle-indicator" aria-hidden="true"></span>
+	</button>
+	<h2 class="hndle"><span>${ title }</span></h2>
+	<div class="inside">
+		<div class="wcc-root woocommerce wc-connect-create-shipping-label" data-args="${ argsJsonString }">
+		</div>
+	</div>
+</div>
+`;
+	}
+
 	loadWcsAssets( { assets } ) {
 		if ( this.state.wcsAssetsLoaded || this.state.wcsAssetsLoading ) {
 			this.openWcsModal();
@@ -160,16 +180,38 @@ export class ShippingBanner extends Component {
 		const js = assets.wc_connect_admin_script;
 		const styles = assets.wc_connect_admin_style;
 
-		const shippingLabelContainer = document.createElement( 'div' );
 		const { orderId } = this.state;
+		const { itemsCount } = this.props;
 
-		shippingLabelContainer.className =
-			'wcc-root woocommerce wc-connect-create-shipping-label';
-		shippingLabelContainer.dataset.args = JSON.stringify( {
-			orderId,
-			context: 'shipping_label',
-		} );
-		document.body.appendChild( shippingLabelContainer );
+		const shippingLabelContainerHtml = this.generateMetaBoxHtml(
+			__( 'Shipping Label', 'woocommerce-admin' ),
+			{
+				orderId,
+				context: 'shipping_label',
+				items: itemsCount,
+			}
+		);
+		// Insert shipping label metabox just above main order details box.
+		document
+			.getElementById( 'woocommerce-order-data' )
+			.insertAdjacentHTML( 'beforebegin', shippingLabelContainerHtml );
+
+		const shipmentTrackingHtml = this.generateMetaBoxHtml(
+			__( 'Shipment Tracking', 'woocommerce-admin' ),
+			{
+				orderId,
+				context: 'shipment_tracking',
+				items: itemsCount,
+			}
+		);
+		// Insert tracking metabox in the side after the order actions.
+		document
+			.getElementById( 'woocommerce-order-actions' )
+			.insertAdjacentHTML( 'afterend', shipmentTrackingHtml );
+
+		// Need to refresh so the new metaboxes are sortable.
+		window.jQuery( '#normal-sortables' ).sortable( 'refresh' );
+		window.jQuery( '#side-sortables' ).sortable( 'refresh' );
 
 		Promise.all( [
 			new Promise( ( resolve, reject ) => {
@@ -210,6 +252,17 @@ export class ShippingBanner extends Component {
 				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
 				orderId,
 				siteId,
+			} );
+			wcsStore.dispatch( {
+				type: 'NOTICE_CREATE',
+				notice: {
+					duration: 10000,
+					status: 'is-success',
+					text: __(
+						'Plugin installed and activated',
+						'woocommerce-admin'
+					),
+				},
 			} );
 		}
 	}

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -200,6 +200,12 @@ describe( 'Create shipping label button', () => {
 			script: scriptMock,
 			link: linkMock,
 		};
+
+		window.jQuery = jest.fn();
+		window.jQuery.mockReturnValue( {
+			sortable: jest.fn(),
+		} );
+
 		const createElementMock = jest.fn( ( tagName ) => {
 			return createElementMockReturn[ tagName ];
 		} );
@@ -212,6 +218,11 @@ describe( 'Create shipping label button', () => {
 		};
 		getElementsByTagNameMock.mockReturnValueOnce( [ headMock ] );
 		document.getElementsByTagName = getElementsByTagNameMock;
+		const getElementByIdMock = jest.fn();
+		getElementByIdMock.mockReturnValue( {
+			insertAdjacentHTML: jest.fn(),
+		} );
+		document.getElementById = getElementByIdMock;
 
 		const appendChildMock = jest.fn();
 		document.body.appendChild = appendChildMock;
@@ -227,10 +238,7 @@ describe( 'Create shipping label button', () => {
 		} );
 
 		expect( createElementMock ).toHaveBeenCalledWith( 'script' );
-		expect( createElementMock ).toHaveNthReturnedWith( 1, divMock );
-
-		expect( createElementMock ).toHaveBeenCalledWith( 'script' );
-		expect( createElementMock ).toHaveNthReturnedWith( 2, scriptMock );
+		expect( createElementMock ).toHaveNthReturnedWith( 1, scriptMock );
 		expect( scriptMock.async ).toEqual( true );
 		expect( scriptMock.src ).toEqual( '/path/to/wcs.js' );
 		expect( appendChildMock ).toHaveBeenCalledWith( scriptMock );
@@ -238,7 +246,7 @@ describe( 'Create shipping label button', () => {
 		expect( getElementsByTagNameMock ).toHaveBeenCalledWith( 'head' );
 		expect( getElementsByTagNameMock ).toHaveReturnedWith( [ headMock ] );
 		expect( createElementMock ).toHaveBeenCalledWith( 'link' );
-		expect( createElementMock ).toHaveNthReturnedWith( 3, linkMock );
+		expect( createElementMock ).toHaveNthReturnedWith( 2, linkMock );
 		expect( linkMock.rel ).toEqual( 'stylesheet' );
 		expect( linkMock.type ).toEqual( 'text/css' );
 		expect( linkMock.href ).toEqual( '/path/to/wcs.css' );

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -10,7 +10,7 @@
 	}
 	.wc-admin-shipping-banner-illustration {
 		float: left;
-		margin: -2px 8px 50px -2px;
+		margin: -2px 8px 36px -2px;
 	}
 
 	h3 {

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -99,7 +99,6 @@ class ShippingLabelBanner {
 					'context'               => 'shipping_label',
 					'order_id'              => $post->ID,
 					'shippable_items_count' => $this->count_shippable_items( $order ),
-
 				)
 			);
 			add_action( 'admin_enqueue_scripts', array( $this, 'add_print_shipping_label_script' ) );
@@ -147,8 +146,9 @@ class ShippingLabelBanner {
 		);
 
 		$payload = array(
-			'nonce'   => wp_create_nonce( 'wp_rest' ),
-			'baseURL' => get_rest_url(),
+			'nonce'                 => wp_create_nonce( 'wp_rest' ),
+			'baseURL'               => get_rest_url(),
+			'wcs_server_connection' => true,
 		);
 
 		wp_localize_script( 'print-shipping-label-banner', 'wcConnectData', $payload );
@@ -157,8 +157,8 @@ class ShippingLabelBanner {
 	/**
 	 * Render placeholder metabox.
 	 *
-	 * @param WP_Post $post current post.
-	 * @param array   $args empty args.
+	 * @param \WP_Post $post current post.
+	 * @param array    $args empty args.
 	 */
 	public function meta_box( $post, $args ) {
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/44
and https://github.com/Automattic/woocommerce-shipping-issues/issues/32
Loads WCS into its proper locations. Also hides wc-admin shipping banner when the modal opens.