### PR TITLE
Keep "Create shipping label" busy until asset is done loading

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -35,6 +35,7 @@ export class ShippingBanner extends Component {
 			orderId: parseInt( orderId, 10 ),
 			wcsAssetsLoaded: false,
 			wcsAssetsLoading: false,
+			isShippingLabelButtonBusy: false,
 		};
 	}
 
@@ -100,11 +101,12 @@ export class ShippingBanner extends Component {
 	createShippingLabelClicked = () => {
 		const { wcsPluginSlug } = this.props;
 		// TODO: open WCS modal
+		this.setState( { isShippingLabelButtonBusy: true } );
 		this.trackElementClicked( 'shipping_banner_create_label' );
 		this.installAndActivatePlugins( wcsPluginSlug );
 	};
 
-	async installAndActivatePlugins( pluginSlug ) {
+	installAndActivatePlugins( pluginSlug ) {
 		// Avoid double activating.
 		const { installPlugins, isRequesting } = this.props;
 		if ( isRequesting ) {
@@ -192,7 +194,11 @@ export class ShippingBanner extends Component {
 				head.appendChild( link );
 			} ),
 		] ).then( () => {
-			this.setState( { wcsAssetsLoaded: true, wcsAssetsLoading: false } );
+			this.setState( {
+				wcsAssetsLoaded: true,
+				wcsAssetsLoading: false,
+				isShippingLabelButtonBusy: false,
+			} );
 			this.openWcsModal();
 		} );
 	}
@@ -229,9 +235,9 @@ export class ShippingBanner extends Component {
 						alt={ __( 'Shipping ', 'woocommerce-admin' ) }
 					/>
 					<Button
-						disabled={ this.props.isRequesting }
+						disabled={ this.state.isShippingLabelButtonBusy }
 						isPrimary
-						isBusy={ this.props.isRequesting }
+						isBusy={ this.state.isShippingLabelButtonBusy }
 						onClick={ this.createShippingLabelClicked }
 					>
 						{ __( 'Create shipping label' ) }
@@ -277,7 +283,7 @@ export class ShippingBanner extends Component {
 						onClick={ this.openDismissModal }
 						type="button"
 						className="notice-dismiss"
-						disabled={ this.props.isRequesting }
+						disabled={ this.state.isShippingLabelButtonBusy }
 					>
 						<span className="screen-reader-text">
 							{ __(

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -71,6 +71,7 @@ describe( 'Tracking clicks in shippingBanner', () => {
 			<ShippingBanner
 				isJetpackConnected={ isJetpackConnected }
 				activePlugins={ activePlugins }
+				installPlugins={ jest.fn() }
 				activatedPlugins={ [] }
 				installedPlugins={ [] }
 				wcsPluginSlug={ 'woocommerce-services' }
@@ -172,16 +173,6 @@ describe( 'Create shipping label button', () => {
 		] );
 	} );
 
-	it( 'should show a busy loading state when installing or activating ', () => {
-		shippingBannerWrapper.setProps( {
-			isRequesting: true,
-		} );
-		const createShippingLabelButton = shippingBannerWrapper.find( Button );
-		expect( createShippingLabelButton.length ).toBe( 1 );
-		expect( createShippingLabelButton.prop( 'disabled' ) ).toBe( true );
-		expect( createShippingLabelButton.prop( 'isBusy' ) ).toBe( true );
-	} );
-
 	it( 'should perform a request to accept the TOS and get WCS assets to load', async () => {
 		const loadWcsAssetsMock = jest.fn();
 		shippingBannerWrapper.instance().loadWcsAssets = loadWcsAssetsMock;
@@ -270,7 +261,7 @@ describe( 'Create shipping label button', () => {
 	} );
 } );
 
-describe( 'In the process of installing or activating WooCommerce Service', () => {
+describe( 'In the process of installing, activating, loading assets for WooCommerce Service', () => {
 	let shippingBannerWrapper;
 	const activePlugins = {
 		includes: jest.fn().mockReturnValue( true ),
@@ -294,6 +285,7 @@ describe( 'In the process of installing or activating WooCommerce Service', () =
 	} );
 
 	it( 'should show a busy loading state on "Create shipping label"', () => {
+		shippingBannerWrapper.setState( { isShippingLabelButtonBusy: true } );
 		const createShippingLabelButton = shippingBannerWrapper.find( Button );
 		expect( createShippingLabelButton.length ).toBe( 1 );
 		expect( createShippingLabelButton.prop( 'disabled' ) ).toBe( true );
@@ -301,6 +293,7 @@ describe( 'In the process of installing or activating WooCommerce Service', () =
 	} );
 
 	it( 'should disable the dismiss button ', () => {
+		shippingBannerWrapper.setState( { isShippingLabelButtonBusy: true } );
 		const dismissButton = shippingBannerWrapper.find( '.notice-dismiss' );
 		expect( dismissButton.length ).toBe( 1 );
 		expect( dismissButton.prop( 'disabled' ) ).toBe( true );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/42

Currently the `isBusy` prop on the "Create shipping label" button relies on the `isRequesting` status from `wc-api`. This status means either installation or activation is in progress.

What we want to do is to have the "Create shipping label" continue to spin even during the assets loading state. 

Change button to rely on a new state `isShippingLabelButtonBusy`. This state is set to `false` only if `loadWcsAssets` finishes loading. 

Note, this state is set outside of `openWcsModal` so there is a brief moment the button goes back to "enable" before the modal is popped up. This should be fixed by https://github.com/woocommerce/woocommerce-admin/pull/3950/files since the panel will be replaced by WCS panel.

If we want the button to look busy until the WCS modal pops up without the slight moment of "enabled" mentioned above, we could just keep the `isBusy` set to true once  "Create shipping label" is clicked, and only set it back to `false` upon error. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
1. Deactivate WCS
2. Delete WCS
3. Click "Create shipping label"
4. The button should continue to show as "busy" until the modal shows up.  


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
