### PR TITLE
Add feature flag for wcpay (WooCommerce Payments)

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -6,6 +6,7 @@
 		"analytics-dashboard/customizable": true,
 		"devdocs": false,
 		"onboarding": true,
-		"store-alerts": true
+		"store-alerts": true,
+		"wcpay": true
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -6,6 +6,7 @@
 		"analytics-dashboard/customizable": true,
 		"devdocs": true,
 		"onboarding": true,
-		"store-alerts": true
+		"store-alerts": true,
+		"wcpay": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -6,6 +6,7 @@
 		"analytics-dashboard/customizable": true,
 		"devdocs": false,
 		"onboarding": true,
-		"store-alerts": true
+		"store-alerts": true,
+		"wcpay": true
 	}
 }


### PR DESCRIPTION
Fixes #3946 

To allow us to quickly disable wcpay additions to the Payments checklist if needed

### Accessibility

N/A

### Detailed test instructions:

- ensure `npm test` continues to pass
- no behavior changes are introduced/enabled by this change

### Changelog Note:

N/A
