### PR TITLE
Onboarding: Add task completion and task list completion tracks

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { partial, filter, get } from 'lodash';
+import { partial, get } from 'lodash';
 import { IconButton, Icon, Dropdown, Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
@@ -23,7 +23,6 @@ import Section from './section';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 import TaskList from './task-list';
-import { getAllTasks } from './task-list/tasks';
 import { isOnboardingEnabled } from 'dashboard/utils';
 import {
 	getCurrentDates,
@@ -299,7 +298,7 @@ class CustomizableDashboard extends Component {
 		const {
 			query,
 			taskListHidden,
-			taskListCompleted,
+			taskListComplete,
 			doThisLater,
 		} = this.props;
 
@@ -307,7 +306,7 @@ class CustomizableDashboard extends Component {
 
 		const isDashboardShown =
 			! isTaskListEnabled ||
-			( ! query.task && ( doThisLater || taskListCompleted ) );
+			( ! query.task && ( doThisLater || taskListComplete ) );
 
 		return (
 			<Fragment>
@@ -321,10 +320,9 @@ class CustomizableDashboard extends Component {
 }
 
 export default compose(
-	withSelect( ( select, props ) => {
+	withSelect( ( select ) => {
 		const {
 			getCurrentUserData,
-			getProfileItems,
 			isGetProfileItemsRequesting,
 			getOptions,
 			isGetOptionsRequesting,
@@ -336,28 +334,19 @@ export default compose(
 		};
 
 		if ( isOnboardingEnabled() ) {
-			const profileItems = getProfileItems();
-			const tasks = getAllTasks( {
-				profileItems,
-				options: getOptions( [ 'woocommerce_task_list_payments' ] ),
-				query: props.query,
-			} );
-			const visibleTasks = filter( tasks, ( task ) => task.visible );
-			const completedTasks = filter(
-				tasks,
-				( task ) => task.visible && task.completed
-			);
-
-			withSelectData.taskListCompleted =
-				visibleTasks.length === completedTasks.length;
-
 			const options = getOptions( [
+				'woocommerce_task_list_complete',
 				'woocommerce_task_list_hidden',
 				'woocommerce_task_list_do_this_later',
 			] );
 			withSelectData.taskListHidden =
 				get( options, [ 'woocommerce_task_list_hidden' ], 'no' ) ===
 				'yes';
+			withSelectData.taskListComplete = get(
+				options,
+				[ 'woocommerce_task_list_complete' ],
+				false
+			);
 			withSelectData.doThisLater = get(
 				options,
 				[ 'woocommerce_task_list_do_this_later' ],

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -224,25 +224,9 @@ class CustomizableDashboard extends Component {
 		);
 	}
 
-	render() {
-		const {
-			query,
-			path,
-			taskListHidden,
-			taskListCompleted,
-			doThisLater,
-		} = this.props;
+	renderDashboardReports() {
+		const { query, path } = this.props;
 		const { sections } = this.state;
-
-		if (
-			isOnboardingEnabled() &&
-			! taskListHidden &&
-			( query.task || ! taskListCompleted ) &&
-			! doThisLater
-		) {
-			return <TaskList query={ query } />;
-		}
-
 		const { period, compare, before, after } = getDateParamsFromQuery(
 			query
 		);
@@ -258,17 +242,12 @@ class CustomizableDashboard extends Component {
 			primaryDate,
 			secondaryDate,
 		};
-		const showTaskList =
-			isOnboardingEnabled() && ! taskListHidden && ! taskListCompleted;
-
 		const visibleSectionKeys = sections
 			.filter( ( section ) => section.isVisible )
 			.map( ( section ) => section.key );
 
 		return (
 			<Fragment>
-				{ showTaskList && <TaskList query={ query } inline /> }
-
 				<ReportFilters
 					report="dashboard"
 					query={ query }
@@ -312,6 +291,30 @@ class CustomizableDashboard extends Component {
 					return null;
 				} ) }
 				{ this.renderAddMore() }
+			</Fragment>
+		);
+	}
+
+	render() {
+		const {
+			query,
+			taskListHidden,
+			taskListCompleted,
+			doThisLater,
+		} = this.props;
+
+		const isTaskListEnabled = isOnboardingEnabled() && ! taskListHidden;
+
+		const isDashboardShown =
+			! isTaskListEnabled ||
+			( ! query.task && ( doThisLater || taskListCompleted ) );
+
+		return (
+			<Fragment>
+				{ isTaskListEnabled && (
+					<TaskList query={ query } inline={ isDashboardShown } />
+				) }
+				{ isDashboardShown && this.renderDashboardReports() }
 			</Fragment>
 		);
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -490,6 +490,7 @@ class Onboarding {
 		$options[] = 'woocommerce_task_list_welcome_modal_dismissed';
 		$options[] = 'woocommerce_task_list_prompt_shown';
 		$options[] = 'woocommerce_task_list_payments';
+		$options[] = 'woocommerce_task_list_tracked_completed_tasks';
 		$options[] = 'woocommerce_allow_tracking';
 		$options[] = 'woocommerce_stripe_settings';
 		$options[] = 'woocommerce_ppec_paypal_settings';

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -47,6 +47,8 @@ class OnboardingTasks {
 		// This hook needs to run when options are updated via REST.
 		add_action( 'add_option_woocommerce_task_list_complete', array( $this, 'add_completion_note' ), 10, 2 );
 		add_action( 'add_option_woocommerce_task_list_complete', array( $this, 'track_completion' ), 10, 2 );
+		add_action( 'add_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
+		add_action( 'update_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -301,6 +303,21 @@ class OnboardingTasks {
 	public static function track_completion( $old_value, $new_value ) {
 		if ( $new_value ) {
 			wc_admin_record_tracks_event( 'tasklist_tasks_completed' );
+		}
+	}
+
+	/**
+	 * Records an event for individual task completion.
+	 *
+	 * @param mixed $old_value Old value.
+	 * @param mixed $new_value New value.
+	 */
+	public static function track_task_completion( $old_value, $new_value ) {
+		$old_value       = is_array( $old_value ) ? $old_value : array();
+		$untracked_tasks = array_diff( $new_value, $old_value );
+
+		foreach ( $untracked_tasks as $task ) {
+			wc_admin_record_tracks_event( 'tasklist_task_completed', array( 'task_name' => $task ) );
 		}
 	}
 }

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -46,6 +46,7 @@ class OnboardingTasks {
 	public function __construct() {
 		// This hook needs to run when options are updated via REST.
 		add_action( 'add_option_woocommerce_task_list_complete', array( $this, 'add_completion_note' ), 10, 2 );
+		add_action( 'add_option_woocommerce_task_list_complete', array( $this, 'track_completion' ), 10, 2 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -288,6 +289,18 @@ class OnboardingTasks {
 	public static function add_completion_note( $old_value, $new_value ) {
 		if ( $new_value ) {
 			WC_Admin_Notes_Onboarding::add_task_list_complete_note();
+		}
+	}
+
+	/**
+	 * Records an event when all tasks are completed in the task list.
+	 *
+	 * @param mixed $old_value Old value.
+	 * @param mixed $new_value New value.
+	 */
+	public static function track_completion( $old_value, $new_value ) {
+		if ( $new_value ) {
+			wc_admin_record_tracks_event( 'tasklist_tasks_completed' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3907

* Refactors the dashboard rendering to be more readable.
* Records task list completion event.
* Records completed events in an option so we can track tasks completed outside the task list.

### Detailed test instructions:

1. Make sure the dashboard and task list continues rendering correctly depending on whether or not the task list is hidden, completed, or chosen to complete later.
1. Add an `error_log` in https://github.com/woocommerce/woocommerce-admin/blob/6b6140fe4ede88bb3e75f88d3bf059f415bf9ba4/src/Features/OnboardingTasks.php#L320 and https://github.com/woocommerce/woocommerce-admin/blob/6b6140fe4ede88bb3e75f88d3bf059f415bf9ba4/src/Features/OnboardingTasks.php#L305 to see untracked events get tracked.
1. Load the task list with some tasks already completed and note that completed tasks get tracked.
1. Complete a task and make sure the event is tracked.
1. Check that `tasklist_tasks_completed` is fired on task list completion.