### PR TITLE
Reduce queries in Orders Panel.

### DIFF
--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -358,6 +358,15 @@ export default compose(
 				per_page: QUERY_DEFAULTS.pageSize,
 				extended_info: true,
 				order_includes: map( actionableOrders, 'id' ),
+				_fields: [
+					'order_id',
+					'order_number',
+					'status',
+					'data_created_gmt',
+					'total_sales',
+					'extended_info.customer',
+					'extended_info.products',
+				],
 			};
 
 			const reportOrders = getReportItems( 'orders', ordersQuery ).data;

--- a/src/API/Orders.php
+++ b/src/API/Orders.php
@@ -76,4 +76,117 @@ class Orders extends \WC_REST_Orders_Controller {
 
 		return $args;
 	}
+
+	/**
+	 * Get formatted item data. 
+	 *
+	 * @param  WC_Data $object WC_Data instance.
+	 * @return array
+	 */
+	protected function get_formatted_item_data( $object ) {
+		$fields = false;
+		// Determine if the response fields were specified.
+		if ( ! empty( $this->request['_fields'] ) ) {
+			$fields = wp_parse_list( $this->request['_fields'] );
+
+			if ( 0 === count( $fields ) ) {
+				$fields = false;
+			} else {
+				$fields = array_map( 'trim', $fields );
+			}
+		}
+
+		// Initially skip line items if we can.
+		$using_order_class_override = is_a( $object, '\Automattic\WooCommerce\Admin\Overrides\Order' );
+		if ( $using_order_class_override ) {
+			$data = $object->get_data_without_line_items();
+		} else {
+			$data = $object->get_data();
+		}
+
+		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
+		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
+		$format_line_items = array( 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines' );
+
+		// Format decimal values.
+		foreach ( $format_decimal as $key ) {
+			$data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
+		}
+
+		// Format date values.
+		foreach ( $format_date as $key ) {
+			$datetime              = $data[ $key ];
+			$data[ $key ]          = wc_rest_prepare_date_response( $datetime, false );
+			$data[ $key . '_gmt' ] = wc_rest_prepare_date_response( $datetime );
+		}
+
+		// Format the order status.
+		$data['status'] = 'wc-' === substr( $data['status'], 0, 3 ) ? substr( $data['status'], 3 ) : $data['status'];
+
+		// Format requested line items.
+		$formatted_line_items = array();
+
+		foreach ( $format_line_items as $key ) {
+			if ( false === $fields || in_array( $key, $fields ) ) {
+				if ( $using_order_class_override ) {
+					$line_item_data = $object->get_line_item_data( $key );
+				} else {
+					$line_item_data = $data[ $key ];
+				}
+				$formatted_line_items[ $key ] = array_values( array_map( array( $this, 'get_order_item_data' ), $line_item_data ) );
+			}
+		}
+
+		// Refunds.
+		$data['refunds'] = array();
+		foreach ( $object->get_refunds() as $refund ) {
+			$data['refunds'][] = array(
+				'id'     => $refund->get_id(),
+				'reason' => $refund->get_reason() ? $refund->get_reason() : '',
+				'total'  => '-' . wc_format_decimal( $refund->get_amount(), $this->request['dp'] ),
+			);
+		}
+
+		return array_merge(
+			array(
+				'id'                   => $object->get_id(),
+				'parent_id'            => $data['parent_id'],
+				'number'               => $data['number'],
+				'order_key'            => $data['order_key'],
+				'created_via'          => $data['created_via'],
+				'version'              => $data['version'],
+				'status'               => $data['status'],
+				'currency'             => $data['currency'],
+				'date_created'         => $data['date_created'],
+				'date_created_gmt'     => $data['date_created_gmt'],
+				'date_modified'        => $data['date_modified'],
+				'date_modified_gmt'    => $data['date_modified_gmt'],
+				'discount_total'       => $data['discount_total'],
+				'discount_tax'         => $data['discount_tax'],
+				'shipping_total'       => $data['shipping_total'],
+				'shipping_tax'         => $data['shipping_tax'],
+				'cart_tax'             => $data['cart_tax'],
+				'total'                => $data['total'],
+				'total_tax'            => $data['total_tax'],
+				'prices_include_tax'   => $data['prices_include_tax'],
+				'customer_id'          => $data['customer_id'],
+				'customer_ip_address'  => $data['customer_ip_address'],
+				'customer_user_agent'  => $data['customer_user_agent'],
+				'customer_note'        => $data['customer_note'],
+				'billing'              => $data['billing'],
+				'shipping'             => $data['shipping'],
+				'payment_method'       => $data['payment_method'],
+				'payment_method_title' => $data['payment_method_title'],
+				'transaction_id'       => $data['transaction_id'],
+				'date_paid'            => $data['date_paid'],
+				'date_paid_gmt'        => $data['date_paid_gmt'],
+				'date_completed'       => $data['date_completed'],
+				'date_completed_gmt'   => $data['date_completed_gmt'],
+				'cart_hash'            => $data['cart_hash'],
+				'meta_data'            => $data['meta_data'],
+				'refunds'              => $data['refunds'],
+			),
+			$formatted_line_items
+		);
+	}
 }

--- a/src/API/Orders.php
+++ b/src/API/Orders.php
@@ -78,7 +78,7 @@ class Orders extends \WC_REST_Orders_Controller {
 	}
 
 	/**
-	 * Get formatted item data. 
+	 * Get formatted item data.
 	 *
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array

--- a/src/Overrides/Order.php
+++ b/src/Overrides/Order.php
@@ -31,6 +31,46 @@ class Order extends \WC_Order {
 	protected $refunded_line_items;
 
 	/**
+	 * Get only core class data in array format.
+	 *
+	 * @return array
+	 */
+	public function get_data_without_line_items() {
+		return array_merge(
+			array(
+				'id' => $this->get_id(),
+			),
+			$this->data,
+			array(
+				'number'         => $this->get_order_number(),
+				'meta_data'      => $this->get_meta_data(),
+			)
+		);
+	}
+
+	/**
+	 * Get order line item data by type.
+	 *
+	 * @param string $type Order line item type.
+	 * @return array|bool Array of line items on success, boolean false on failure.
+	 */
+	public function get_line_item_data( $type ) {
+		$type_to_items = array(
+			'line_items'     => 'line_item',
+			'tax_lines'      => 'tax',
+			'shipping_lines' => 'shipping',
+			'fee_lines'      => 'fee',
+			'coupon_lines'   => 'coupon',
+		);
+
+		if ( isset( $type_to_items[ $type ] ) ) {
+			return $this->get_items( $type_to_items[ $type ] );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Add filter(s) required to hook this class to substitute WC_Order.
 	 */
 	public static function add_filters() {


### PR DESCRIPTION
This PR seeks to improve the performance of the Orders Panel by skipping queries for order line items (since they aren't used in the panel).

It does so by processing the `_fields` parameter and determining if any order line items were requested - also by specifying the necessary fields in the request made from the panel.

### Detailed test instructions:

- Verify that all Orders Panel functionality works

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Performance: only query necessary data in Orders Panel.