### PR TITLE
Hide the WC Shipping banner until the create shipping label popup is open

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 	},
 	globals: {
 		wcSettings: true,
+		MutationObserver: true,
 	},
 	plugins: [ 'jest' ],
 	rules: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
 	},
 	globals: {
 		wcSettings: true,
-		MutationObserver: true,
 	},
 	plugins: [ 'jest' ],
 	rules: {

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -297,6 +297,26 @@ export class ShippingBanner extends Component {
 			const { orderId } = this.state;
 			const siteId = state.ui.selectedSiteId;
 
+			const wcsStoreUnsubscribe = wcsStore.subscribe( () => {
+				const latestState = wcsStore.getState();
+				const siteState =
+					latestState.extensions.woocommerce.woocommerceServices[
+						siteId
+					];
+				if ( siteState ) {
+					const orderState = siteState.shippingLabel[ orderId ];
+					if ( orderState ) {
+						if ( orderState.showPurchaseDialog ) {
+							if ( window.jQuery ) {
+								window
+									.jQuery( '#woocommerce-order-label' )
+									.show();
+							}
+							wcsStoreUnsubscribe();
+						}
+					}
+				}
+			} );
 			wcsStore.dispatch( {
 				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
 				orderId,
@@ -316,12 +336,6 @@ export class ShippingBanner extends Component {
 			document.getElementById(
 				'woocommerce-admin-print-label'
 			).style.display = 'none';
-
-			this.whenNodeAdded( 'label-purchase-modal', () => {
-				if ( window.jQuery ) {
-					window.jQuery( '#woocommerce-order-label' ).show();
-				}
-			} );
 		}
 	}
 
@@ -407,30 +421,6 @@ export class ShippingBanner extends Component {
 				/>
 			</div>
 		);
-	}
-
-	whenNodeAdded( nodeId, callback ) {
-		const targetNode = document.getElementsByTagName( 'body' )[ 0 ];
-
-		const config = { attributes: false, childList: true, subtree: true };
-
-		const observer = new MutationObserver(
-			( mutationsList, observerInstance ) => {
-				for ( const mutation of mutationsList ) {
-					if ( mutation.type === 'childList' ) {
-						if (
-							document.getElementsByClassName( nodeId ).length > 0
-						) {
-							callback();
-							observerInstance.disconnect();
-							break;
-						}
-					}
-				}
-			}
-		);
-
-		observer.observe( targetNode, config );
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/51

Hides the WooCommerce Services banner when the "create shipping label" button is pressed. Once WooCommerce Services is installed, activated and the create label popup is open, the WooCommerce Services banner is displayed again.