### PR TITLE
Add flex to banner to center vertical text alignment

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -334,6 +334,38 @@ export class ShippingBanner extends Component {
 						src={ wcAdminAssetUrl + 'shippingillustration.svg' }
 						alt={ __( 'Shipping ', 'woocommerce-admin' ) }
 					/>
+					<div className="wc-admin-shipping-banner-blob">
+						<h3>
+							{ __(
+								'Print discounted shipping labels with a click.',
+								'woocommerce-admin'
+							) }
+						</h3>
+						<p>
+							{ interpolateComponents( {
+								mixedString: this.state.installText,
+								components: {
+									tosLink: (
+										<ExternalLink
+											href="https://wordpress.com/tos"
+											target="_blank"
+											type="external"
+										/>
+									),
+									wcsLink: (
+										<ExternalLink
+											href="https://woocommerce.com/products/shipping/"
+											target="_blank"
+											type="external"
+											onClick={
+												this.woocommerceServiceLinkClicked
+											}
+										/>
+									),
+								},
+							} ) }
+						</p>
+					</div>
 					<Button
 						disabled={ isShippingLabelButtonBusy }
 						isPrimary
@@ -342,36 +374,6 @@ export class ShippingBanner extends Component {
 					>
 						{ __( 'Create shipping label', 'woocommerce-admin' ) }
 					</Button>
-					<h3>
-						{ __(
-							'Print discounted shipping labels with a click.',
-							'woocommerce-admin'
-						) }
-					</h3>
-					<p>
-						{ interpolateComponents( {
-							mixedString: this.state.installText,
-							components: {
-								tosLink: (
-									<ExternalLink
-										href="https://wordpress.com/tos"
-										target="_blank"
-										type="external"
-									/>
-								),
-								wcsLink: (
-									<ExternalLink
-										href="https://woocommerce.com/products/shipping/"
-										target="_blank"
-										type="external"
-										onClick={
-											this.woocommerceServiceLinkClicked
-										}
-									/>
-								),
-							},
-						} ) }
-					</p>
 					<SetupNotice
 						isSetupError={ this.isSetupError() }
 						errorReason={ this.setupErrorReason() }

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -8,26 +8,30 @@
 	.handlediv {
 		display: none;
 	}
+
+	.wc-admin-shipping-banner-container {
+		display: flex;
+		align-items: center;
+		margin-top: 18px;
+	}
+
 	.wc-admin-shipping-banner-illustration {
-		float: left;
-		margin: -2px 8px 36px -2px;
+		margin-right: 8px;
 	}
 
 	h3 {
-		margin: 17px 0 0;
+		margin: 0;
 		font-size: 1.15em;
 	}
 
 	p {
-		max-width: 75%;
 		margin: 2px 0 11px;
 		font-size: 15px;
 		line-height: 19px;
 	}
 
 	.components-button.is-button {
-		float: right;
-		margin: 18px 61px 10px 25px;
+		margin: 10px 61px 10px auto;
 		padding: 0 30px;
 		font-size: 14px;
 		font-weight: 500;
@@ -119,19 +123,17 @@
 		min-height: 169px;
 		text-align: center;
 		padding-bottom: 55px;
-		.components-button.is-button {
-			float: none;
-			left: 50%;
-			-webkit-transform: translateX(-50%);
-			transform: translateX(-50%);
-			position: absolute;
-			bottom: -30px;
-			margin: 0;
+
+		.wc-admin-shipping-banner-container {
+			flex-wrap: wrap;
+			justify-content: center;
 		}
-		.wc-admin-shipping-banner-illustration {
-			float: none;
-			margin: 11px auto 0;
-			display: block;
+
+		.components-button.is-button {
+			margin: 10px 0 0 0;
+		}
+		.wc-admin-shipping-banner-blob {
+			margin-right: 40px;
 		}
 		p {
 			margin: 5px 15px;

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -13,6 +13,7 @@
 		display: flex;
 		align-items: center;
 		margin-top: 18px;
+		margin-bottom: 6px;
 	}
 
 	.wc-admin-shipping-banner-illustration {
@@ -126,12 +127,8 @@
 			flex-wrap: wrap;
 			justify-content: center;
 		}
-
 		.components-button.is-button {
 			margin: 10px 0 0 0;
-		}
-		.wc-admin-shipping-banner-blob {
-			margin-right: 40px;
 		}
 		p {
 			margin: 5px 15px;

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -120,9 +120,7 @@
 
 @media (max-width: 1080px) {
 	#woocommerce-admin-print-label {
-		min-height: 169px;
 		text-align: center;
-		padding-bottom: 55px;
 
 		.wc-admin-shipping-banner-container {
 			flex-wrap: wrap;


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/50

Align text to center. From:
https://user-images.githubusercontent.com/572862/77210358-7065a580-6ac6-11ea-812b-0c9d2022b2e3.png

To:
![image](https://user-images.githubusercontent.com/572862/77348490-26b3cf80-6cff-11ea-9480-cdbbcf875fe2.png)

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![image](https://user-images.githubusercontent.com/572862/77348924-e0ab3b80-6cff-11ea-8c15-e05875352106.png)
![image](https://user-images.githubusercontent.com/572862/77348933-e30d9580-6cff-11ea-8b47-c01c502bb355.png)
![image](https://user-images.githubusercontent.com/572862/77348944-e739b300-6cff-11ea-9e8c-5c856052be74.png)
![image](https://user-images.githubusercontent.com/572862/77348948-e9037680-6cff-11ea-81c2-a7c9aa99dabd.png)


### Detailed test instructions:
- Open order page
- Resize window to make sure text is vertically align and visible. Should match above screenshots./


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
