### PR TITLE
Don't change the banner text during WCS installation/activation

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -39,6 +39,7 @@ export class ShippingBanner extends Component {
 			wcsAssetsLoading: false,
 			wcsSetupError: false,
 			isShippingLabelButtonBusy: false,
+			installText: this.getInstallText(),
 		};
 	}
 
@@ -349,7 +350,7 @@ export class ShippingBanner extends Component {
 					</h3>
 					<p>
 						{ interpolateComponents( {
-							mixedString: this.getInstallText(),
+							mixedString: this.state.installText,
 							components: {
 								tosLink: (
 									<ExternalLink

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -383,3 +383,75 @@ describe( 'Setup error message', () => {
 		);
 	} );
 } );
+
+describe( 'The message in the banner', () => {
+	const createShippingBannerWrapper = ( {
+		activePlugins,
+		installedPlugins,
+	} ) =>
+		shallow(
+			<ShippingBanner
+				isJetpackConnected={ true }
+				activatePlugins={ jest.fn() }
+				activePlugins={ activePlugins }
+				activatedPlugins={ [] }
+				installPlugins={ jest.fn() }
+				installedPlugins={ installedPlugins }
+				wcsPluginSlug={ 'woocommerce-services' }
+				activationErrors={ [] }
+				installationErrors={ [] }
+				isRequesting={ true }
+				itemsCount={ 1 }
+			/>
+		);
+
+	const notActivatedMessage =
+		'By clicking "Create shipping label", WooCommerce Shipping will be installed and you agree to its Terms of Service.';
+	const activatedMessage =
+		'You\'ve already installed WooCommerce Shipping. By clicking "Create shipping label", you agree to its Terms of Service.';
+
+	it( 'should show install text "By clicking "Create shipping label"..." when first loaded.', () => {
+		const shippingBannerWrapper = createShippingBannerWrapper( {
+			activePlugins: [],
+			installedPlugins: [],
+		} );
+		const createShippingLabelText = shippingBannerWrapper.find( 'p' );
+		expect( createShippingLabelText.text() ).toBe( notActivatedMessage );
+	} );
+
+	it( 'should continue to show the initial message "By clicking "Create shipping label"..." after WooCommerce Service is installed successfully.', () => {
+		const shippingBannerWrapper = createShippingBannerWrapper( {
+			activePlugins: [],
+			installedPlugins: [ 'woocommerce-services' ],
+		} );
+		// Mock installation and activation successful
+		shippingBannerWrapper.setProps( {
+			activePlugins: [ 'woocommerce-services' ],
+		} );
+		const createShippingLabelText = shippingBannerWrapper.find( 'p' );
+		expect( createShippingLabelText.text() ).toBe( notActivatedMessage );
+	} );
+
+	it( 'should continue to show the initial message "By clicking "Create shipping label"..." after WooCommerce Service is installed and activated successfully.', () => {
+		const shippingBannerWrapper = createShippingBannerWrapper( {
+			activePlugins: [],
+			installedPlugins: [],
+		} );
+		// Mock installation and activation successful
+		shippingBannerWrapper.setProps( {
+			activePlugins: [ 'woocommerce-services' ],
+			installedPlugins: [ 'woocommerce-services' ],
+		} );
+		const createShippingLabelText = shippingBannerWrapper.find( 'p' );
+		expect( createShippingLabelText.text() ).toBe( notActivatedMessage );
+	} );
+
+	it( 'should show install text "By clicking "You\'ve already installed WooCommerce Shipping."..." when WooCommerce Service is already installed.', () => {
+		const shippingBannerWrapper = createShippingBannerWrapper( {
+			activePlugins: [ 'woocommerce-services' ],
+			installedPlugins: [ 'woocommerce-services' ],
+		} );
+		const createShippingLabelText = shippingBannerWrapper.find( 'p' );
+		expect( createShippingLabelText.text() ).toBe( activatedMessage );
+	} );
+} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/52

When the user click "Create shipping label" button on the banner, the banner message should not change. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Deactivate WooCommerce Services
- Delete WooCommerce Services 
- Go to an order page
- Click "Create shipping label", the banner will now install and activate WCS
- This message should not change throughout:
![image](https://user-images.githubusercontent.com/572862/77371113-27149080-6d28-11ea-8123-d336830bc7ec.png)


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
### 