### PR TITLE
Add showPagePicker, showPerPagePicker props to Pagination component

### DIFF
--- a/packages/components/src/pagination/README.md
+++ b/packages/components/src/pagination/README.md
@@ -26,3 +26,5 @@ Name | Type | Default | Description
 `onPerPageChange` | Function | `noop` | A function to execute when the per page option is changed
 `total` | Number | `null` | (required) The total number of results
 `className` | String | `null` | Additional classNames
+`showPagePicker` | Boolean | `true` | Whether the page picker should be shown.
+`showPerPagePicker` | Boolean | `true` | Whether the per page picker should shown.

--- a/packages/components/src/pagination/README.md
+++ b/packages/components/src/pagination/README.md
@@ -28,3 +28,4 @@ Name | Type | Default | Description
 `className` | String | `null` | Additional classNames
 `showPagePicker` | Boolean | `true` | Whether the page picker should be shown.
 `showPerPagePicker` | Boolean | `true` | Whether the per page picker should shown.
+`showPageArrowsLabel` | Boolean | `true` | Whether the page arrows label should be shown.

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -188,7 +188,7 @@ class Pagination extends Component {
 	}
 
 	render() {
-		const { total, perPage, className } = this.props;
+		const { total, perPage, className, showPagePicker, showPerPagePicker } = this.props;
 		this.pageCount = Math.ceil( total / perPage );
 
 		const classes = classNames( 'woocommerce-pagination', className );
@@ -207,8 +207,8 @@ class Pagination extends Component {
 		return (
 			<div className={ classes }>
 				{ this.renderPageArrows() }
-				{ this.renderPagePicker() }
-				{ this.renderPerPagePicker() }
+				{ showPagePicker && this.renderPagePicker() }
+				{ showPerPagePicker && this.renderPerPagePicker() }
 			</div>
 		);
 	}
@@ -239,11 +239,21 @@ Pagination.propTypes = {
 	 * Additional classNames.
 	 */
 	className: PropTypes.string,
+	/**
+	 * Whether the page picker should be rendered.
+	 */
+	showPagePicker: PropTypes.bool,
+	/**
+	 * Whether the perPage picker should be rendered.
+	 */
+	showPerPagePicker: PropTypes.bool,
 };
 
 Pagination.defaultProps = {
 	onPageChange: noop,
 	onPerPageChange: noop,
+	showPagePicker: true,
+	showPerPagePicker: true,
 };
 
 export default Pagination;

--- a/packages/components/src/pagination/index.js
+++ b/packages/components/src/pagination/index.js
@@ -84,7 +84,7 @@ class Pagination extends Component {
 	}
 
 	renderPageArrows() {
-		const { page } = this.props;
+		const { page, showPageArrowsLabel } = this.props;
 
 		if ( this.pageCount <= 1 ) {
 			return null;
@@ -100,17 +100,19 @@ class Pagination extends Component {
 
 		return (
 			<div className="woocommerce-pagination__page-arrows">
-				<span
-					className="woocommerce-pagination__page-arrows-label"
-					role="status"
-					aria-live="polite"
-				>
-					{ sprintf(
-						__( 'Page %d of %d', 'woocommerce-admin' ),
-						page,
-						this.pageCount
-					) }
-				</span>
+				{ showPageArrowsLabel && (
+					<span
+						className="woocommerce-pagination__page-arrows-label"
+						role="status"
+						aria-live="polite"
+					>
+						{ sprintf(
+							__( 'Page %d of %d', 'woocommerce-admin' ),
+							page,
+							this.pageCount
+						) }
+					</span>
+				) }
 				<div className="woocommerce-pagination__page-arrows-buttons">
 					<IconButton
 						className={ previousLinkClass }
@@ -247,6 +249,10 @@ Pagination.propTypes = {
 	 * Whether the perPage picker should be rendered.
 	 */
 	showPerPagePicker: PropTypes.bool,
+	/**
+	 * Whether the page arrows label should be rendered.
+	 */
+	showPageArrowsLabel: PropTypes.bool,
 };
 
 Pagination.defaultProps = {
@@ -254,6 +260,7 @@ Pagination.defaultProps = {
 	onPerPageChange: noop,
 	showPagePicker: true,
 	showPerPagePicker: true,
+	showPageArrowsLabel: true,
 };
 
 export default Pagination;

--- a/packages/components/src/pagination/stories/index.js
+++ b/packages/components/src/pagination/stories/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { number, boolean } from '@storybook/addon-knobs';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Pagination from '../';
+
+export default {
+	title: 'WooCommerce Admin/components/Pagination',
+	component: Pagination,
+};
+
+export const Default = () => {
+
+	const [ statePage, setPage ] = useState( 2 );
+	const [ statePerPage, setPerPage ] = useState( 50 );
+
+	return (
+		<Pagination
+			page={ statePage }
+			perPage={ statePerPage }
+			total={ number( 'Total', 500 ) }
+			showPagePicker={ boolean( 'Page Picker', true ) }
+			showPerPagePicker={ boolean( 'Per Page Picker', true ) }
+			onPageChange={ ( newPage ) => setPage( newPage ) }
+			onPerPageChange={ ( newPerPage ) => setPerPage( newPerPage )
+			}
+		/>
+	);
+};

--- a/packages/components/src/pagination/stories/index.js
+++ b/packages/components/src/pagination/stories/index.js
@@ -26,6 +26,7 @@ export const Default = () => {
 			total={ number( 'Total', 500 ) }
 			showPagePicker={ boolean( 'Page Picker', true ) }
 			showPerPagePicker={ boolean( 'Per Page Picker', true ) }
+			showPageArrowsLabel={ boolean( 'Page Arrows Label', true ) }
 			onPageChange={ ( newPage ) => setPage( newPage ) }
 			onPerPageChange={ ( newPerPage ) => setPerPage( newPerPage ) }
 		/>

--- a/packages/components/src/pagination/stories/index.js
+++ b/packages/components/src/pagination/stories/index.js
@@ -27,8 +27,7 @@ export const Default = () => {
 			showPagePicker={ boolean( 'Page Picker', true ) }
 			showPerPagePicker={ boolean( 'Per Page Picker', true ) }
 			onPageChange={ ( newPage ) => setPage( newPage ) }
-			onPerPageChange={ ( newPerPage ) => setPerPage( newPerPage )
-			}
+			onPerPageChange={ ( newPerPage ) => setPerPage( newPerPage ) }
 		/>
 	);
 };


### PR DESCRIPTION
I would like to use the Pagination component in the slider I'm working on for the marketing tab (#3953). Rather than duplicate this functionality we can gain a lot by using the existing Pagination component. All we need is to hide the parts we don't need. 

This this RP adds 2 new props `showPagePicker` and `showPerPagePicker` which remove parts of the pagination component that I don't want for the marketing slider.

![Screenshot](https://d.pr/i/a9WSB4+)

The PR adds a story for the Pagination component in 2577879 which you can use to try out the new properties. 

![60NOwo](https://user-images.githubusercontent.com/355014/77506027-ab941a00-6eb4-11ea-96ef-9bce009965c0.png)

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org

### Detailed test instructions:

- Fire up storybook e.g. `npm run storybook`
- Go to the Pagination component
- Enable/disable pickers using the checkboxes for "Page Picker" and "Per Page Picker"