### PR TITLE
Fix "Back to..." link disappearing after editing a term.

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -78,6 +78,7 @@ class Loader {
 		add_action( 'admin_head', array( __CLASS__, 'remove_notices' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_after_notices' ), PHP_INT_MAX );
+		add_action( 'admin_head', array( __CLASS__, 'make_success_and_error_notices_inline' ) );
 
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( __CLASS__, 'remove_app_entry_page_menu_item' ), 20 );
@@ -575,6 +576,26 @@ class Loader {
 			return;
 		}
 		echo '</div>';
+	}
+
+	/**
+	 * Add the 'inline' class to success and error notice divs
+	 * (which appear after saving changes to taxonomies, see edit-tag-form.php).
+	 *
+	 * This is needed because common.js is moving notice divs past the '.wp-header-end' div,
+	 * but we are creating that div inside a hidden div in order to hide all notices
+	 * (see inject_before_notices method in this class);
+	 * however we still want to show the success and error notices after a change is saved.
+	 * Notices having the `inline` class are not moved, so adding that class solves the problem.
+	 */
+	public static function make_success_and_error_notices_inline() {
+		?>
+		<script>
+			jQuery(function() {
+				jQuery('div.notice-success, div.notice-error').addClass('inline');
+			});
+		</script>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
After editing a taxonomy term (e.g. a category or a tag), a success message with a "Back to <taxonomy>es" link appears, but it disappears after a couple of seconds.

The problem is that `Loader.php` defines an `admin_notices` that wraps all notices in a hidden div. This div includes another one with class `wp-header-end`. There's a piece of code in `common.js` in WP core that moves all notices inside that inner div, so as soon as that js executes, the notice is hidden.

Notice divs having the `inline` class are not moved, therefore the fix consists of a one-line JavaScript that adds that class to the notice div before `common.js` executes.

Fixes #3964

### Detailed test instructions

1. Open the WooCommerce categories page (Products > Categories)
2. Open the details for a category or create a new one, save changes.
3. Verify that the "Item updated" with "Back to categories" link doesn't disappear.

### Screenshots

![image](https://user-images.githubusercontent.com/937723/77433725-0ad42a80-6de0-11ea-8cfd-e35cd75a38b2.png)
