### PR TITLE
Verify coupon dates are DateTime instances before trying to format them.

### DIFF
--- a/src/API/Reports/Coupons/DataStore.php
+++ b/src/API/Reports/Coupons/DataStore.php
@@ -168,25 +168,25 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$gmt_timzone = new \DateTimeZone( 'UTC' );
 
 				$date_expires = $coupon->get_date_expires();
-				if ( null === $date_expires ) {
-					$date_expires     = '';
-					$date_expires_gmt = '';
-				} else {
+				if ( is_a( $date_expires, 'DateTime' ) ) {
 					$date_expires     = $date_expires->format( TimeInterval::$iso_datetime_format );
 					$date_expires_gmt = new \DateTime( $date_expires );
 					$date_expires_gmt->setTimezone( $gmt_timzone );
 					$date_expires_gmt = $date_expires_gmt->format( TimeInterval::$iso_datetime_format );
+				} else {
+					$date_expires     = '';
+					$date_expires_gmt = '';
 				}
 
 				$date_created = $coupon->get_date_created();
-				if ( null === $date_created ) {
-					$date_created     = '';
-					$date_created_gmt = '';
-				} else {
+				if ( is_a( $date_created, 'DateTime' ) ) {
 					$date_created     = $date_created->format( TimeInterval::$iso_datetime_format );
 					$date_created_gmt = new \DateTime( $date_created );
 					$date_created_gmt->setTimezone( $gmt_timzone );
 					$date_created_gmt = $date_created_gmt->format( TimeInterval::$iso_datetime_format );
+				} else {
+					$date_created     = '';
+					$date_created_gmt = '';
 				}
 
 				$extended_info = array(


### PR DESCRIPTION
Fixes the coupon date format error mentioned in https://github.com/woocommerce/woocommerce-admin/issues/3904#issuecomment-602264646

This PR seeks to verify that `WC_Coupon` expiration and creation date values are `DateTime`s (expected to be `WC_DateTime`s) before calling `->format()`.

Addresses these errors:

```
2020-03-22T17:05:54+00:00 CRITICAL Uncaught Error: Call to a member function format() on bool in /home/nginx/domains/[domain]/public/wp-content/plugins/woocommerce/packages/woocommerce-admin/src/API/Reports/Coupons/DataStore.php:175
```

NOTE: I wasn't able to reproduce this without forcing the error to occur. It stands to reason though that an extension could modify/override `WC_Coupon::get_date_expires()` so it returns something other than `null` or a `WC_DateTime`.

### Detailed test instructions:

- On `master`
- Modify this line to be `$date_expires = false;`: https://github.com/woocommerce/woocommerce-admin/blob/master/src/API/Reports/Coupons/DataStore.php#L170
- Clear transients
- Verify you have at least one order that used a coupon
- Go to Analytics > Coupons
- Verify the report table never loads, and there is a PHP error in your logs that matched the one above
- Check out this branch
- Modify this line to be `$date_expires = false;`: https://github.com/woocommerce/woocommerce-admin/blob/master/src/API/Reports/Coupons/DataStore.php#L170
- Clear transients
- Go to Analytics > Coupons
- Verify the report table loads, no PHP errors

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: handle cases where coupon dates are in an unexpected format.