### PR TITLE
Remove icon-button classes from Tag component

### DIFF
--- a/packages/components/src/tag/style.scss
+++ b/packages/components/src/tag/style.scss
@@ -7,7 +7,7 @@
 	vertical-align: middle;
 
 	.woocommerce-tag__text,
-	.woocommerce-tag__remove.components-icon-button {
+	.woocommerce-tag__remove {
 		display: inline-block;
 		line-height: 24px;
 		background: $core-grey-light-500;
@@ -29,7 +29,7 @@
 		border-radius: 12px 0 0 12px;
 	}
 
-	.woocommerce-tag__remove.components-icon-button {
+	.woocommerce-tag__remove {
 		cursor: pointer;
 		padding: 0 2px;
 		border-radius: 0 12px 12px 0;


### PR DESCRIPTION
Fixes #3992.

Gutenberg is deprecating the `IconButton` component (https://github.com/WordPress/gutenberg/pull/19299). While I don't think it's possible to completely migrate to the `Button` component now because we need to account for users with an old version of Gutenberg, we need to make sure it works with the new versions as well.

This PR removes the CSS classes specific to `IconButton` from the `Tag` stylesheet. So styles work fine both in old and new versions of Gutenberg.

### Detailed test instructions:

- Make sure there are no styling regressions with `Tag` components.

### Sidenote

I noticed there are other instances of `components-icon-button` classes used in the codebase. I think we should migrate out of them for all components, but I left this PR only tackling the issue in the `Tag` component.