### PR TITLE
remove use of undefined QUEUE_GROUP

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -68,6 +68,7 @@ function wc_admin_update_0230_db_version() {
  */
 function wc_admin_update_0251_remove_unsnooze_action() {
 	as_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, null, 'wc-admin-data' );
+	as_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, null, 'wc-admin-notes' );
 }
 
 /**

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -67,7 +67,7 @@ function wc_admin_update_0230_db_version() {
  * Remove the note unsnoozing scheduled action.
  */
 function wc_admin_update_0251_remove_unsnooze_action() {
-	as_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, null, WC_Admin_Notes::QUEUE_GROUP );
+	as_unschedule_action( WC_Admin_Notes::UNSNOOZE_HOOK, null, 'wc-admin-data' );
 }
 
 /**

--- a/src/Install.php
+++ b/src/Install.php
@@ -396,12 +396,23 @@ class Install {
 						array(
 							'per_page' => 1,
 							'hook'     => 'woocommerce_run_update_callback',
-							'search'   => json_encode( array( $update_callback ) ),
+							'search'   => wp_json_encode( array( $update_callback ) ),
 							'group'    => 'woocommerce-db-updates',
+							'status'   => 'pending',
 						)
 					);
 
-					if ( empty( $pending_jobs ) ) {
+					$complete_jobs = WC()->queue()->search(
+						array(
+							'per_page' => 1,
+							'hook'     => 'woocommerce_run_update_callback',
+							'search'   => wp_json_encode( array( $update_callback ) ),
+							'group'    => 'woocommerce-db-updates',
+							'status'   => 'complete',
+						)
+					);
+
+					if ( empty( $pending_jobs ) && empty( $complete_jobs ) ) {
 						WC()->queue()->schedule_single(
 							time() + $loop,
 							'woocommerce_run_update_callback',


### PR DESCRIPTION
Fixes #3982

This PR replaces the use of the constant with a string literal. It also updates the update action check function to only check for `pending` or `completed` actions. The default queue search retrieves actions with any status. It took a while for me to reproduce the issue for testing because I had a `failed` instance of the remove unsnooze update action from other testing I had been doing with AS.

### Detailed test instructions:

- delete any completed or pending `woocommerce_run_update_callback` actions with  `wc_admin_unsnooze_admin_notes` as the callback
- install WC 3.9.3
- switch to WC Admin to 0.24.0
- update `woocommerce_admin_version` option to 0.24.0
- ensure `wc_admin_unsnooze_notes` action is created
- update WC to 4.0.1
- deactivate WCA
- ensure WCA update action from the first step runs
- check that `wc_admin_unsnooze_notes` action is deleted
- verify no warnings or errors in the debug log

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: Eliminate warning on deleting unsnooze note action