### PR TITLE
Fix/remove address alerts 55

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -300,6 +300,7 @@ export class ShippingBanner extends Component {
 
 			const wcsStoreUnsubscribe = wcsStore.subscribe( () => {
 				const latestState = wcsStore.getState();
+
 				const siteState =
 					latestState.extensions.woocommerce.woocommerceServices[
 						siteId
@@ -307,33 +308,53 @@ export class ShippingBanner extends Component {
 				if ( siteState ) {
 					const orderState = siteState.shippingLabel[ orderId ];
 					if ( orderState ) {
-						if ( orderState.showPurchaseDialog ) {
+						if (
+							! orderState.showPurchaseDialog &&
+							! orderState.isFetching
+						) {
+							wcsStore.dispatch( {
+								type:
+									'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
+								orderId,
+								siteId,
+							} );
+							wcsStore.dispatch( {
+								type: 'NOTICE_CREATE',
+								notice: {
+									duration: 10000,
+									status: 'is-success',
+									text: __(
+										'Plugin installed and activated',
+										'woocommerce-admin'
+									),
+								},
+							} );
+						} else if ( orderState.showPurchaseDialog ) {
 							if ( window.jQuery ) {
 								window
 									.jQuery( '#woocommerce-order-label' )
 									.show();
 							}
 							wcsStoreUnsubscribe();
+							wcsStore.dispatch( {
+								type:
+									'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION',
+								siteId,
+								orderId,
+								group: 'origin',
+							} );
+							wcsStore.dispatch( {
+								type:
+									'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION',
+								siteId,
+								orderId,
+								group: 'destination',
+							} );
 						}
 					}
 				}
 			} );
-			wcsStore.dispatch( {
-				type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
-				orderId,
-				siteId,
-			} );
-			wcsStore.dispatch( {
-				type: 'NOTICE_CREATE',
-				notice: {
-					duration: 10000,
-					status: 'is-success',
-					text: __(
-						'Plugin installed and activated',
-						'woocommerce-admin'
-					),
-				},
-			} );
+
 			document.getElementById(
 				'woocommerce-admin-print-label'
 			).style.display = 'none';

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -8,6 +8,7 @@ import { compose } from '@wordpress/compose';
 import { recordEvent } from 'lib/tracks';
 import interpolateComponents from 'interpolate-components';
 import PropTypes from 'prop-types';
+import { get, isArray } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,6 +41,7 @@ export class ShippingBanner extends Component {
 			wcsSetupError: false,
 			isShippingLabelButtonBusy: false,
 			installText: this.getInstallText(),
+			isWcsModalOpen: false,
 		};
 	}
 
@@ -301,55 +303,87 @@ export class ShippingBanner extends Component {
 			const wcsStoreUnsubscribe = wcsStore.subscribe( () => {
 				const latestState = wcsStore.getState();
 
-				const siteState =
-					latestState.extensions.woocommerce.woocommerceServices[
-						siteId
-					];
-				if ( siteState ) {
-					const orderState = siteState.shippingLabel[ orderId ];
-					if ( orderState ) {
-						if (
-							! orderState.showPurchaseDialog &&
-							! orderState.isFetching
-						) {
-							wcsStore.dispatch( {
-								type:
-									'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
-								orderId,
-								siteId,
-							} );
-							wcsStore.dispatch( {
-								type: 'NOTICE_CREATE',
-								notice: {
-									duration: 10000,
-									status: 'is-success',
-									text: __(
-										'Plugin installed and activated',
-										'woocommerce-admin'
-									),
-								},
-							} );
-						} else if ( orderState.showPurchaseDialog ) {
-							if ( window.jQuery ) {
-								window
-									.jQuery( '#woocommerce-order-label' )
-									.show();
-							}
-							wcsStoreUnsubscribe();
-							wcsStore.dispatch( {
-								type:
-									'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION',
-								siteId,
-								orderId,
-								group: 'origin',
-							} );
-							wcsStore.dispatch( {
-								type:
-									'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_CONFIRM_ADDRESS_SUGGESTION',
-								siteId,
-								orderId,
-								group: 'destination',
-							} );
+				const shippingLabelState = get(
+					latestState,
+					[
+						'extensions',
+						'woocommerce',
+						'woocommerceServices',
+						siteId,
+						'shippingLabel',
+						orderId,
+					],
+					null
+				);
+
+				const labelSettingsState = get(
+					latestState,
+					[
+						'extensions',
+						'woocommerce',
+						'woocommerceServices',
+						siteId,
+						'labelSettings',
+					],
+					null
+				);
+
+				const packageState = get(
+					latestState,
+					[
+						'extensions',
+						'woocommerce',
+						'woocommerceServices',
+						siteId,
+						'packages',
+					],
+					null
+				);
+
+				const locationsState = get( latestState, [
+					'extensions',
+					'woocommerce',
+					'sites',
+					siteId,
+					'data',
+					'locations',
+				] );
+
+				if (
+					shippingLabelState &&
+					labelSettingsState &&
+					labelSettingsState.meta &&
+					packageState &&
+					locationsState
+				) {
+					if (
+						shippingLabelState.loaded &&
+						labelSettingsState.meta.isLoaded &&
+						packageState.isLoaded &&
+						isArray( locationsState ) &&
+						! this.state.isWcsModalOpen
+					) {
+						if ( window.jQuery ) {
+							this.setState( { isWcsModalOpen: true } );
+							window
+								.jQuery( '.shipping-label__new-label-button' )
+								.click();
+						}
+						wcsStore.dispatch( {
+							type: 'NOTICE_CREATE',
+							notice: {
+								duration: 10000,
+								status: 'is-success',
+								text: __(
+									'Plugin installed and activated',
+									'woocommerce-admin'
+								),
+							},
+						} );
+					} else if ( shippingLabelState.showPurchaseDialog ) {
+						wcsStoreUnsubscribe();
+						if ( window.jQuery ) {
+							window.jQuery( '#woocommerce-order-label' ).show();
 						}
 					}
 				}

--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/test/index.js
@@ -257,7 +257,12 @@ describe( 'Create shipping label button', () => {
 		window.wcsGetAppStore = jest.fn();
 		const getState = jest.fn();
 		const dispatch = jest.fn();
-		window.wcsGetAppStore.mockReturnValueOnce( { getState, dispatch } );
+		const subscribe = jest.fn();
+		window.wcsGetAppStore.mockReturnValueOnce( {
+			getState,
+			dispatch,
+			subscribe,
+		} );
 		getState.mockReturnValueOnce( {
 			ui: {
 				selectedSiteId: 'SITE_ID',
@@ -276,11 +281,7 @@ describe( 'Create shipping label button', () => {
 			'wc-connect-create-shipping-label'
 		);
 		expect( getState ).toHaveBeenCalledTimes( 1 );
-		expect( dispatch ).toHaveBeenCalledWith( {
-			type: 'WOOCOMMERCE_SERVICES_SHIPPING_LABEL_OPEN_PRINTING_FLOW',
-			orderId: 1000,
-			siteId: 'SITE_ID',
-		} );
+		expect( subscribe ).toHaveBeenCalledTimes( 1 );
 		expect( getElementByIdMock ).toHaveBeenCalledWith(
 			'woocommerce-admin-print-label'
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/55.

The origin & destination addresses in the WC Services create label modal, were showing some red notifications. The reason was the modal was open before it was fully loaded. This PR takes care of that and makes the banner wait until the extension is fully loaded to open the modal.