### PR TITLE
Abstract onboarding plugin code into a PluginsHelper class

### DIFF
--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -15,6 +15,33 @@ namespace Automattic\WooCommerce\Admin;
 class PluginsHelper {
 
 	/**
+	 * Get the path to the plugin file relative to the plugins directory from the plugin slug.
+	 *
+	 * E.g. 'woocommerce' returns 'woocommerce/woocommerce.php'
+	 *
+	 * @param string $slug
+	 *
+	 * @return string|false
+	 */
+	public static function get_plugin_path_from_slug( $slug ) {
+		$plugins = get_plugins();
+
+		if ( strstr( $slug, '/' ) ) {
+			// The slug is already a plugin path
+			return $slug;
+		}
+
+		foreach ( $plugins as $plugin_path => $data ) {
+			$path_parts = explode( '/', $plugin_path );
+			if ( $path_parts[0] === $slug ) {
+				return $plugin_path;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get an array of installed plugin slugs.
 	 *
 	 * @return array

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -45,6 +45,17 @@ class PluginsHelper {
 	}
 
 	/**
+	 * Checks if a plugin is installed.
+	 *
+	 * @param string $plugin_slug The plugin directory slug e.g. 'facebook-for-woocommerce'
+	 *
+	 * @return bool
+	 */
+	public static function is_plugin_installed( $plugin_slug ) {
+		return in_array( $plugin_slug, self::get_installed_plugin_slugs() );
+	}
+
+	/**
 	 * Checks if a plugin is active.
 	 *
 	 * @param string $plugin_slug The plugin directory slug e.g. 'mailchimp-for-woocommerce'

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * PluginsHelper
+ *
+ * Helper class for the site's plugins.
+ *
+ * @package Woocommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin;
+
+/**
+ * Class PluginsHelper
+ */
+class PluginsHelper {
+
+	/**
+	 * Get an array of installed plugin slugs.
+	 *
+	 * @return array
+	 */
+	public static function get_installed_plugin_slugs() {
+		return array_map(
+			function( $plugin_path ) {
+				$path_parts = explode( '/', $plugin_path );
+				return $path_parts[0];
+			},
+			array_keys( get_plugins() )
+		);
+	}
+
+	/**
+	 * Get an array of active plugin slugs.
+	 *
+	 * @return array
+	 */
+	public static function get_active_plugin_slugs() {
+		return array_map(
+			function( $plugin_path ) {
+				$path_parts = explode( '/', $plugin_path );
+				return $path_parts[0];
+			},
+			get_option( 'active_plugins', array() )
+		);
+	}
+
+}

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -25,7 +25,7 @@ class PluginsHelper {
 	 *
 	 * E.g. 'woocommerce' returns 'woocommerce/woocommerce.php'
 	 *
-	 * @param string $slug
+	 * @param string $slug Plugin slug to get path for.
 	 *
 	 * @return string|false
 	 */
@@ -33,7 +33,7 @@ class PluginsHelper {
 		$plugins = get_plugins();
 
 		if ( strstr( $slug, '/' ) ) {
-			// The slug is already a plugin path
+			// The slug is already a plugin path.
 			return $slug;
 		}
 
@@ -110,7 +110,7 @@ class PluginsHelper {
 	 */
 	public static function get_plugin_data( $plugin ) {
 		$plugin_path = self::get_plugin_path_from_slug( $plugin );
-		$plugins = get_plugins();
+		$plugins     = get_plugins();
 
 		return isset( $plugins[ $plugin_path ] ) ? $plugins[ $plugin_path ] : false;
 	}

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -100,25 +100,19 @@ class PluginsHelper {
 	/**
 	 * Get plugin data.
 	 *
-	 * @param string $plugin_slug The plugin directory slug e.g. 'mailchimp-for-woocommerce'
+	 * @param string $plugin Path to the plugin file relative to the plugins directory or the plugin directory name.
 	 *
-	 * @return array|bool
+	 * @return array|false
 	 */
-	public static function get_plugin_data( $plugin_slug ) {
+	public static function get_plugin_data( $plugin ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		$plugin_path = self::get_plugin_path_from_slug( $plugin );
 		$plugins = get_plugins();
 
-		foreach( $plugins as $plugin_path => $data ) {
-			$path_parts = explode( '/', $plugin_path );
-			if ( $path_parts[0] === $plugin_slug ) {
-				return $data;
-			}
-		}
-
-		return false;
+		return isset( $plugins[ $plugin_path ] ) ? $plugins[ $plugin_path ] : false;
 	}
 
 }

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -44,4 +44,15 @@ class PluginsHelper {
 		);
 	}
 
+	/**
+	 * Checks if a plugin is active.
+	 *
+	 * @param string $plugin_slug The plugin directory slug e.g. 'mailchimp-for-woocommerce'
+	 *
+	 * @return bool
+	 */
+	public static function is_plugin_active( $plugin_slug ) {
+		return in_array( $plugin_slug, self::get_active_plugin_slugs() );
+	}
+
 }

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -9,6 +9,12 @@
 
 namespace Automattic\WooCommerce\Admin;
 
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'get_plugins' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+}
+
 /**
  * Class PluginsHelper
  */
@@ -47,10 +53,6 @@ class PluginsHelper {
 	 * @return array
 	 */
 	public static function get_installed_plugin_slugs() {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
 		return array_map(
 			function( $plugin_path ) {
 				$path_parts = explode( '/', $plugin_path );
@@ -107,10 +109,6 @@ class PluginsHelper {
 	 * @return array|false
 	 */
 	public static function get_plugin_data( $plugin ) {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
 		$plugin_path = self::get_plugin_path_from_slug( $plugin );
 		$plugins = get_plugins();
 

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -78,23 +78,25 @@ class PluginsHelper {
 	/**
 	 * Checks if a plugin is installed.
 	 *
-	 * @param string $plugin_slug The plugin directory slug e.g. 'facebook-for-woocommerce'
+	 * @param string $plugin Path to the plugin file relative to the plugins directory or the plugin directory name.
 	 *
 	 * @return bool
 	 */
-	public static function is_plugin_installed( $plugin_slug ) {
-		return in_array( $plugin_slug, self::get_installed_plugin_slugs() );
+	public static function is_plugin_installed( $plugin ) {
+		$plugin_path = self::get_plugin_path_from_slug( $plugin );
+		return array_key_exists( $plugin_path, get_plugins() );
 	}
 
 	/**
 	 * Checks if a plugin is active.
 	 *
-	 * @param string $plugin_slug The plugin directory slug e.g. 'mailchimp-for-woocommerce'
+	 * @param string $plugin Path to the plugin file relative to the plugins directory or the plugin directory name.
 	 *
 	 * @return bool
 	 */
-	public static function is_plugin_active( $plugin_slug ) {
-		return in_array( $plugin_slug, self::get_active_plugin_slugs() );
+	public static function is_plugin_active( $plugin ) {
+		$plugin_path = self::get_plugin_path_from_slug( $plugin );
+		return in_array( $plugin_path, get_option( 'active_plugins', array() ), true );
 	}
 
 	/**

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -86,7 +86,7 @@ class PluginsHelper {
 	 */
 	public static function is_plugin_installed( $plugin ) {
 		$plugin_path = self::get_plugin_path_from_slug( $plugin );
-		return array_key_exists( $plugin_path, get_plugins() );
+		return $plugin_path ? array_key_exists( $plugin_path, get_plugins() ) : false;
 	}
 
 	/**
@@ -98,7 +98,7 @@ class PluginsHelper {
 	 */
 	public static function is_plugin_active( $plugin ) {
 		$plugin_path = self::get_plugin_path_from_slug( $plugin );
-		return in_array( $plugin_path, get_option( 'active_plugins', array() ), true );
+		return $plugin_path ? in_array( $plugin_path, get_option( 'active_plugins', array() ), true ) : false;
 	}
 
 	/**

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -20,6 +20,10 @@ class PluginsHelper {
 	 * @return array
 	 */
 	public static function get_installed_plugin_slugs() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		return array_map(
 			function( $plugin_path ) {
 				$path_parts = explode( '/', $plugin_path );
@@ -64,6 +68,30 @@ class PluginsHelper {
 	 */
 	public static function is_plugin_active( $plugin_slug ) {
 		return in_array( $plugin_slug, self::get_active_plugin_slugs() );
+	}
+
+	/**
+	 * Get plugin data.
+	 *
+	 * @param string $plugin_slug The plugin directory slug e.g. 'mailchimp-for-woocommerce'
+	 *
+	 * @return array|bool
+	 */
+	public static function get_plugin_data( $plugin_slug ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugins = get_plugins();
+
+		foreach( $plugins as $plugin_path => $data ) {
+			$path_parts = explode( '/', $plugin_path );
+			if ( $path_parts[0] === $plugin_slug ) {
+				return $data;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/tests/plugins-helper.php
+++ b/tests/plugins-helper.php
@@ -61,7 +61,7 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 		// Get facebook plugin path.
 		$fb_path = PluginsHelper::get_plugin_path_from_slug( 'facebook-for-woocommerce' );
 
-		// Activate facebookn plugin.
+		// Activate facebook plugin.
 		activate_plugin( $fb_path );
 
 		// Get active slugs.
@@ -76,11 +76,11 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 	 */
 	public function test_is_plugin_installed() {
 
-		// WooCommerce is installed in the test envrionment.
+		// WooCommerce is installed in the test environment.
 		$installed = PluginsHelper::is_plugin_installed( 'woocommerce' );
 		$this->assertEquals( true, $installed, 'WooCommerce should be installed.' );
 
-		// Invalud plugin is not.
+		// Invalid plugin is not.
 		$installed = PluginsHelper::is_plugin_installed( 'invalid-plugin' );
 		$this->assertEquals( false, $installed, 'Invalid plugins should not be installed.' );
 	}
@@ -97,7 +97,7 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 		// Get facebook plugin path.
 		$fb_path = PluginsHelper::get_plugin_path_from_slug( 'facebook-for-woocommerce' );
 
-		// Activate facebookn plugin.
+		// Activate facebook plugin.
 		activate_plugin( $fb_path );
 
 		// Check if facebook is now active.

--- a/tests/plugins-helper.php
+++ b/tests/plugins-helper.php
@@ -112,28 +112,28 @@ class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
 
 		$actual_data = PluginsHelper::get_plugin_data( 'woocommerce' );
 
-		// Account for different versions being pulled in for tests.
-		unset( $actual_data['Version'] );
-
-		$expected_data = array(
-			'WC requires at least' => '',
-			'WC tested up to'      => '',
-			'Woo'                  => '',
-			'Name'                 => 'WooCommerce',
-			'PluginURI'            => 'https://woocommerce.com/',
-			'Description'          => 'An eCommerce toolkit that helps you sell anything. Beautifully.',
-			'Author'               => 'Automattic',
-			'AuthorURI'            => 'https://woocommerce.com',
-			'TextDomain'           => 'woocommerce',
-			'DomainPath'           => '/i18n/languages/',
-			'Network'              => false,
-			'RequiresWP'           => '',
-			'RequiresPHP'          => '',
-			'Title'                => 'WooCommerce',
-			'AuthorName'           => 'Automattic',
+		$expected_keys = array(
+			'WC requires at least',
+			'WC tested up to',
+			'Woo',
+			'Name',
+			'PluginURI',
+			'Description',
+			'Author',
+			'Version',
+			'AuthorURI',
+			'TextDomain',
+			'DomainPath',
+			'Network',
+			'RequiresWP',
+			'RequiresPHP',
+			'Title',
+			'AuthorName',
 		);
 
-		$this->assertEquals( $expected_data, $actual_data, 'Plugin data does not match expected data.' );
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $actual_data, 'Plugin data does not match expected data.' );
+		}
 
 		// Test not installed plugin response.
 		$actual_data = PluginsHelper::get_plugin_data( 'my-plugin' );

--- a/tests/plugins-helper.php
+++ b/tests/plugins-helper.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Plugins Helper Tests
+ *
+ * @package WooCommerce Admin\Tests\PluginHelper
+ */
+
+use \Automattic\WooCommerce\Admin\PluginsHelper;
+
+/**
+ * WC_Admin_Tests_Plugin_Helper Class
+ *
+ * @package WooCommerce Admin\Tests\PluginHelper
+ */
+class WC_Admin_Tests_Plugins_Helper extends WP_UnitTestCase {
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test get_plugin_path_from_slug()
+	 */
+	public function test_get_plugin_path_from_slug() {
+
+		// Installed plugin checks.
+		$wc_path = PluginsHelper::get_plugin_path_from_slug( 'woocommerce' );
+		$this->assertEquals( 'woocommerce/woocommerce.php', $wc_path, 'Path returned is not as expected.' );
+		$ak_path = PluginsHelper::get_plugin_path_from_slug( 'akismet' );
+		$this->assertEquals( 'akismet/akismet.php', $ak_path, 'Path returned is not as expected.' );
+
+		// Plugin that is not installed.
+		$invalid_path = PluginsHelper::get_plugin_path_from_slug( 'invalid-plugin' );
+		$this->assertEquals( false, $invalid_path, 'False should be returned when no matching plugin is installed.' );
+
+		// Check for when slug already appears to be a path.
+		$wc_path_slug = PluginsHelper::get_plugin_path_from_slug( 'woocommerce/woocommerce' );
+		$this->assertEquals( 'woocommerce/woocommerce', $wc_path_slug, 'Slug should be returned if it appears to already be path.' );
+	}
+
+	/**
+	 * Test get_active_plugin_slugs()
+	 */
+	public function test_get_active_plugin_slugs() {
+
+		// Get active slugs.
+		$active_slugs = PluginsHelper::get_active_plugin_slugs();
+
+		// Phpunit test environment active plugins option is empty.
+		$this->assertEquals( array(), $active_slugs, 'Should not be any active slugs.' );
+
+		// Get facebook plugin path.
+		$fb_path = PluginsHelper::get_plugin_path_from_slug( 'facebook-for-woocommerce' );
+
+		// Activate facebookn plugin.
+		activate_plugin( $fb_path );
+
+		// Get active slugs.
+		$active_slugs = PluginsHelper::get_active_plugin_slugs();
+
+		// Phpunit test environment active plugins option is empty.
+		$this->assertEquals( array( 'facebook-for-woocommerce' ), $active_slugs, 'Facebook for WooCommerce should be listed as active.' );
+	}
+
+	/**
+	 * Test is_plugin_installed()
+	 */
+	public function test_is_plugin_installed() {
+
+		// WooCommerce is installed in the test envrionment.
+		$installed = PluginsHelper::is_plugin_installed( 'woocommerce' );
+		$this->assertEquals( true, $installed, 'WooCommerce should be installed.' );
+
+		// Invalud plugin is not.
+		$installed = PluginsHelper::is_plugin_installed( 'invalid-plugin' );
+		$this->assertEquals( false, $installed, 'Invalid plugins should not be installed.' );
+	}
+
+	/**
+	 * Test is_plugin_active()
+	 */
+	public function test_is_plugin_active() {
+
+		// Check if facebook is not active. Phpunit test environment active plugins option is empty.
+		$active = PluginsHelper::is_plugin_active( 'facebook-for-woocommerce' );
+		$this->assertEquals( false, $active, 'Should not be any active slugs.' );
+
+		// Get facebook plugin path.
+		$fb_path = PluginsHelper::get_plugin_path_from_slug( 'facebook-for-woocommerce' );
+
+		// Activate facebookn plugin.
+		activate_plugin( $fb_path );
+
+		// Check if facebook is now active.
+		$activated = PluginsHelper::is_plugin_active( 'facebook-for-woocommerce' );
+		$this->assertEquals( true, $activated, 'Facebook for WooCommerce should be installed.' );
+	}
+
+	/**
+	 * Test get_plugin_data()
+	 */
+	public function test_get_plugin_data() {
+
+		$actual_data = PluginsHelper::get_plugin_data( 'woocommerce' );
+
+		// Account for different versions being pulled in for tests.
+		unset( $actual_data['Version'] );
+
+		$expected_data = array(
+			'WC requires at least' => '',
+			'WC tested up to'      => '',
+			'Woo'                  => '',
+			'Name'                 => 'WooCommerce',
+			'PluginURI'            => 'https://woocommerce.com/',
+			'Description'          => 'An eCommerce toolkit that helps you sell anything. Beautifully.',
+			'Author'               => 'Automattic',
+			'AuthorURI'            => 'https://woocommerce.com',
+			'TextDomain'           => 'woocommerce',
+			'DomainPath'           => '/i18n/languages/',
+			'Network'              => false,
+			'RequiresWP'           => '',
+			'RequiresPHP'          => '',
+			'Title'                => 'WooCommerce',
+			'AuthorName'           => 'Automattic',
+		);
+
+		$this->assertEquals( $expected_data, $actual_data, 'Plugin data does not match expected data.' );
+
+		// Test not installed plugin response.
+		$actual_data = PluginsHelper::get_plugin_data( 'my-plugin' );
+		$this->assertEquals( false, $actual_data, 'Should return false if plugin is not found.' );
+	}
+}


### PR DESCRIPTION
The Onboarding Feature has some existing plugin functionality for retrieving the active and installed plugins that could be useful to other features (e.g. Marketing Dashboard which also allows installation/activation of plugins).

This PR abstracts out the onboarding code into a PluginsHelper class and adds some additional helpers:
* is_plugin_active()
* is_plugin_installed()
* get_plugin_data()
* get_plugin_path_from_slug()

### Detailed test instructions:

I've added some initial tests in b69652a and the existing [Onboarding Plugins tests](https://github.com/woocommerce/woocommerce-admin/blob/master/tests/api/onboarding-plugins.php) provide some coverage as well.

For manual testing i've put together simple plugin you can use https://gist.github.com/jconroy/daa9751d094dc0a311526f85b5f2c580 to check output of the various functions based on what you are running in your dev environment.

cc @danielbitzer (was most of your work, I'm just spinning it out for review)