### PR TITLE
WIP: Lazy load order stats fields.

### DIFF
--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -330,6 +330,7 @@ ReportChart.defaultProps = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const {
+			charts,
 			endpoint,
 			filters,
 			isRequesting,
@@ -366,6 +367,8 @@ export default compose(
 			};
 		}
 
+		const fields = charts && charts.map( chart => chart.key ); 
+
 		const primaryData = getReportChartData( {
 			endpoint,
 			dataType: 'primary',
@@ -375,6 +378,7 @@ export default compose(
 			filters,
 			advancedFilters,
 			defaultDateRange,
+			fields,
 		} );
 
 		if ( chartMode === 'item-comparison' ) {
@@ -393,6 +397,7 @@ export default compose(
 			filters,
 			advancedFilters,
 			defaultDateRange,
+			fields,
 		} );
 		return {
 			...newProps,

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -195,6 +195,7 @@ ReportSummary.defaultProps = {
 export default compose(
 	withSelect( ( select, props ) => {
 		const {
+			charts,
 			endpoint,
 			isRequesting,
 			limitProperties,
@@ -218,6 +219,8 @@ export default compose(
 			};
 		}
 
+		const fields = charts && charts.map( chart => chart.key );
+
 		const { woocommerce_default_date_range: defaultDateRange } = select(
 			SETTINGS_STORE_NAME
 		).getSetting( 'wc_admin', 'wcAdminSettings' );
@@ -230,6 +233,7 @@ export default compose(
 			filters,
 			advancedFilters,
 			defaultDateRange,
+			fields,
 		} );
 
 		return {

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -553,6 +553,10 @@ ReportTable.propTypes = {
 	 */
 	searchBy: PropTypes.string,
 	/**
+	 * List of fields used for summary numbers. (Reduces queries)
+	 */
+	summaryFields: PropTypes.arrayOf( PropTypes.string ),
+	/**
 	 * Table data of that report. If it's not provided, it will be automatically
 	 * loaded via the provided `endpoint`.
 	 */
@@ -596,6 +600,7 @@ export default compose(
 			columnPrefsKey,
 			filters,
 			advancedFilters,
+			summaryFields,
 		} = props;
 
 		let userPrefColumns = [];
@@ -638,6 +643,7 @@ export default compose(
 					advancedFilters,
 					tableQuery,
 					defaultDateRange,
+					fields: summaryFields,
 				} )
 			: {};
 		const queriedTableData =

--- a/client/analytics/report/orders/index.js
+++ b/client/analytics/report/orders/index.js
@@ -36,6 +36,7 @@ export default class OrdersReport extends Component {
 					advancedFilters={ advancedFilters }
 				/>
 				<ReportChart
+					charts={ charts }
 					endpoint="orders"
 					path={ path }
 					query={ query }

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -327,6 +327,15 @@ export default class OrdersReportTable extends Component {
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
+				summaryFields={ [
+					'orders_count',
+					'num_new_customers',
+					'num_returning_customers',
+					'products',
+					'num_items_sold',
+					'coupons_count',
+					'net_revenue',
+				] }
 				query={ query }
 				tableQuery={ {
 					extended_info: true,

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -197,7 +197,7 @@ export function isReportDataEmpty( report, endpoint ) {
  * @return {Object} data request query parameters.
  */
 function getRequestQuery( options ) {
-	const { endpoint, dataType, query } = options;
+	const { endpoint, dataType, query, fields } = options;
 	const datesFromQuery = getCurrentDates( query, options.defaultDateRange );
 	const interval = getIntervalForQuery( query );
 	const filterQuery = getFilterQuery( options );
@@ -205,7 +205,7 @@ function getRequestQuery( options ) {
 
 	const noIntervals = includes( noIntervalEndpoints, endpoint );
 	return noIntervals
-		? { ...filterQuery }
+		? { ...filterQuery, fields }
 		: {
 				order: 'asc',
 				interval,
@@ -216,6 +216,7 @@ function getRequestQuery( options ) {
 				),
 				before: appendTimestamp( end, 'end' ),
 				segmentby: query.segmentby,
+				fields,
 				...filterQuery,
 		  };
 }

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -42,15 +42,15 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args             = array();
-		$args['before']   = $request['before'];
-		$args['after']    = $request['after'];
-		$args['interval'] = $request['interval'];
-		$args['page']     = $request['page'];
-		$args['per_page'] = $request['per_page'];
-		$args['orderby']  = $request['orderby'];
-		$args['order']    = $request['order'];
-
+		$args                      = array();
+		$args['before']            = $request['before'];
+		$args['after']             = $request['after'];
+		$args['interval']          = $request['interval'];
+		$args['page']              = $request['page'];
+		$args['per_page']          = $request['per_page'];
+		$args['orderby']           = $request['orderby'];
+		$args['order']             = $request['order'];
+		$args['fields']            = $request['fields'];
 		$args['match']             = $request['match'];
 		$args['status_is']         = (array) $request['status_is'];
 		$args['status_is_not']     = (array) $request['status_is_not'];

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -270,27 +270,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	}
 
 	/**
-	 * Get the time intervals in the database.
-	 *
-	 * @return array Time intervals in the database.
-	 */
-	public function get_db_intervals() {
-		global $wpdb;
-
-		$db_interval_query = new SqlQuery( $this->context . '_db_intervals' );
-		$db_interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
-		$db_interval_query->add_sql_clause( 'from', self::get_db_table_name() );
-		$db_interval_query->add_sql_clause( 'where_time', $this->get_sql_clause( 'where_time' ) );
-		$db_interval_query->add_sql_clause( 'group_by', 'time_interval' );
-
-		$db_intervals = $wpdb->get_col(
-			$db_interval_query->get_query_statement()
-		); // phpcs:ignore cache ok, DB call ok, , unprepared SQL ok.
-
-		return $db_intervals;
-	}
-
-	/**
 	 * Retrieve stats intervals.
 	 *
 	 * @param array $query_args Query parameters.
@@ -301,10 +280,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public function get_intervals( $query_args, $selected_columns, $params, $expected_interval_count ) {
 		global $wpdb;
-
-		// Determine how many intervals of data we have.
-		$db_intervals      = $this->get_db_intervals();
-		$db_interval_count = count( $db_intervals );
 
 		$table_name = self::get_db_table_name();
 		$where_time = $this->get_sql_clause( 'where_time' );
@@ -320,6 +295,11 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
 		$this->interval_query->add_sql_clause( 'where_time', $where_time );
+
+		$db_intervals      = $wpdb->get_col(
+			$this->interval_query->get_query_statement()
+		); // phpcs:ignore cache ok, DB call ok, , unprepared SQL ok.
+		$db_interval_count = count( $db_intervals );
 
 		$this->update_intervals_sql_params( $query_args, $db_interval_count, $expected_interval_count, $table_name );
 		$this->interval_query->add_sql_clause( 'order_by', $this->get_sql_clause( 'order_by' ) );


### PR DESCRIPTION
WIP.

* Order Stats: move coupon join into sql filter function.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Ex: Open page `url`
- Click XYZ…

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
