### PR TITLE
Hide scrollbars in dismiss modal

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -1,6 +1,4 @@
 // This is needed so ExternalLinks appear correctly. Should be part of 'wp-components' style but for some reason it's not.
-@import '@wordpress/components/src/visually-hidden/style';
-
 #woocommerce-admin-print-label {
 	min-height: 100px;
 
@@ -142,4 +140,12 @@
 
 .notice.wcs-nux__notice {
 	display: none;
+}
+
+.wc-admin-shipping-banner__dismiss-modal {
+	.components-button {
+		span {
+			display: none;
+		}
+	}
 }

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -1,4 +1,6 @@
 // This is needed so ExternalLinks appear correctly. Should be part of 'wp-components' style but for some reason it's not.
+@import '@wordpress/components/src/visually-hidden/style';
+
 #woocommerce-admin-print-label {
 	min-height: 100px;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/58.

Steps to test it in the linked issue.

This PR is just a workaround. It's actually an issue in `@wordpress/components`. I created a test site that reproduces the issue: https://github.com/Ferdev/wordpress-components-modal-issue

I'll create an issue in the Gutenberg repository to follow up.