### PR TITLE
Position error message directly under the paragraph

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
+++ b/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js
@@ -382,13 +382,18 @@ export class ShippingBanner extends Component {
 											target="_blank"
 											type="external"
 											onClick={
-												this.woocommerceServiceLinkClicked
+												this
+													.woocommerceServiceLinkClicked
 											}
 										/>
 									),
 								},
 							} ) }
 						</p>
+						<SetupNotice
+							isSetupError={ this.isSetupError() }
+							errorReason={ this.setupErrorReason() }
+						/>
 					</div>
 					<Button
 						disabled={ isShippingLabelButtonBusy }
@@ -398,10 +403,7 @@ export class ShippingBanner extends Component {
 					>
 						{ __( 'Create shipping label', 'woocommerce-admin' ) }
 					</Button>
-					<SetupNotice
-						isSetupError={ this.isSetupError() }
-						errorReason={ this.setupErrorReason() }
-					/>
+
 					<button
 						onClick={ this.openDismissModal }
 						type="button"


### PR DESCRIPTION
Closes https://github.com/Automattic/woocommerce-shipping-issues/issues/60

Reposition `SetupNotice` so that it doesn't flow to the back of the flex box. Instead, move the `SetupNotice` into the text bulb div.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
- Open up the order page
- Make the error show up. If there is no error, you can open `woocommerce-admin/client/wp-admin-scripts/print-shipping-label-banner/shipping-banner/index.js`, go to line 394 and set `isSetupError` to true to force the error to show.
- Resize windows, confirm error message sits below the text. You should see the following:

![image](https://user-images.githubusercontent.com/572862/77698526-66382100-6f76-11ea-8847-ea9f6aa3cb2a.png)

![image](https://user-images.githubusercontent.com/572862/77698540-6c2e0200-6f76-11ea-8abd-9a9033f9fe77.png)


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
