### PR TITLE
Added hook to delete woocommerce_onboarding_homepage_post_id

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -983,11 +983,12 @@ class Loader {
 	 * @param int $post_id The deleted post id.
 	 */
 	public static function delete_homepage( $post_id ) {
-		$homepage_id = intval( get_option( 'woocommerce_onboarding_homepage_post_id', false ) );
-		if ( 'page' !== get_post_type( $post_id ) || $homepage_id !== $post_id ) {
+		if ( 'page' !== get_post_type( $post_id ) ) {
 			return;
 		}
-
-		delete_option( 'woocommerce_onboarding_homepage_post_id' );
+		$homepage_id = intval( get_option( 'woocommerce_onboarding_homepage_post_id', false ) );
+		if ( $homepage_id === $post_id ) {
+			delete_option( 'woocommerce_onboarding_homepage_post_id' );
+		}
 	}
 }

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -79,6 +79,9 @@ class Loader {
 		add_action( 'admin_notices', array( __CLASS__, 'inject_before_notices' ), -9999 );
 		add_action( 'admin_notices', array( __CLASS__, 'inject_after_notices' ), PHP_INT_MAX );
 
+		// Added this hook to delete the field woocommerce_onboarding_homepage_post_id when deleting the homepage.
+		add_action( 'trashed_post', array( __CLASS__, 'delete_homepage' ) );
+
 		// priority is 20 to run after https://github.com/woocommerce/woocommerce/blob/a55ae325306fc2179149ba9b97e66f32f84fdd9c/includes/admin/class-wc-admin-menus.php#L165.
 		add_action( 'admin_head', array( __CLASS__, 'remove_app_entry_page_menu_item' ), 20 );
 
@@ -972,5 +975,19 @@ class Loader {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Delete woocommerce_onboarding_homepage_post_id field when the homepage is deleted
+	 *
+	 * @param int $post_id The deleted post id.
+	 */
+	public static function delete_homepage( $post_id ) {
+		$homepage_id = intval( get_option( 'woocommerce_onboarding_homepage_post_id', false ) );
+		if ( 'page' !== get_post_type( $post_id ) || $homepage_id !== $post_id ) {
+			return;
+		}
+
+		delete_option( 'woocommerce_onboarding_homepage_post_id' );
 	}
 }


### PR DESCRIPTION
Fixes #3995

In this PR a hook is added to delete the field `woocommerce_onboarding_homepage_post_id` in the database, when the homepage is removed.

### Detailed test instructions:
The easiest way to test this is:

1. Have a Homepage created. If you don't have one, you can create it here `/wp-admin/admin.php?page=wc-admin&task=appearance`.
2. Execute this sentence in the database:
```
SELECT * FROM `wp_options` 
WHERE `option_name` = 'woocommerce_onboarding_homepage_post_id';
```
3. It should show the homepage id.
4. Go to `/wp-admin/edit.php?post_type=page` and delete the Homepage.
5. Execute the `Step 2` SQL sentence again.
6. The deleted homepage id will still be showing.
