### PR TITLE
Add caching to performance indicators.

### DIFF
--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -262,19 +262,13 @@ export default compose(
 
 		const primaryQuery = {
 			after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
-			before: appendTimestamp(
-				endPrimary,
-				endPrimary.isSame( moment(), 'day' ) ? 'now' : 'end'
-			),
+			before: appendTimestamp( endPrimary, 'end' ),
 			stats: statKeys,
 		};
 
 		const secondaryQuery = {
 			after: appendTimestamp( datesFromQuery.secondary.after, 'start' ),
-			before: appendTimestamp(
-				endSecondary,
-				endSecondary.isSame( moment(), 'day' ) ? 'now' : 'end'
-			),
+			before: appendTimestamp( endSecondary, 'end' ),
 			stats: statKeys,
 		};
 

--- a/src/API/Reports/CacheableTraits.php
+++ b/src/API/Reports/CacheableTraits.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * REST API Reports cacheable traits
+ *
+ * Collection of utility methods for caching reports.
+ *
+ * @package WooCommerce Admin/API
+ */
+
+namespace Automattic\WooCommerce\Admin\API\Reports;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CacheableTraits class.
+ */
+trait CacheableTraits {
+	/**
+	 * Whether or not the report should use the caching layer.
+	 *
+	 * Provides an opportunity for plugins to prevent reports from using cache.
+	 *
+	 * @return boolean Whether or not to utilize caching.
+	 */
+	protected function should_use_cache() {
+		/**
+		 * Determines if a report will utilize caching.
+		 *
+		 * @param bool $use_cache Whether or not to use cache.
+		 * @param string $cache_key The report's cache key. Used to identify the report.
+		 */
+		return (bool) apply_filters( 'woocommerce_analytics_report_should_use_cache', true, $this->cache_key );
+	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return implode(
+			'_',
+			array(
+				'wc_report',
+				$this->cache_key,
+				md5( wp_json_encode( $params ) ),
+			)
+		);
+	}
+
+	/**
+	 * Wrapper around Cache::get().
+	 *
+	 * @param string $cache_key Cache key.
+	 * @return mixed
+	 */
+	protected function get_cached_data( $cache_key ) {
+		if ( $this->should_use_cache() ) {
+			return Cache::get( $cache_key );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Wrapper around Cache::set().
+	 *
+	 * @param string $cache_key Cache key.
+	 * @param mixed  $value     New value.
+	 * @return bool
+	 */
+	protected function set_cached_data( $cache_key, $value ) {
+		if ( $this->should_use_cache() ) {
+			return Cache::set( $cache_key, $value );
+		}
+
+		return true;
+	}
+}

--- a/src/API/Reports/DataStore.php
+++ b/src/API/Reports/DataStore.php
@@ -12,11 +12,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+use \Automattic\WooCommerce\Admin\API\Reports\CacheableTraits;
 
 /**
  * Admin\API\Reports\DataStore: Common parent for custom report data stores.
  */
 class DataStore extends SqlQuery {
+	/**
+	 * Cacheable Traits.
+	 */
+	use CacheableTraits;
 
 	/**
 	 * Cache group for the reports.
@@ -117,69 +122,6 @@ class DataStore extends SqlQuery {
 		if ( static::$table_name && ! isset( $wpdb->{static::$table_name} ) ) {
 			$wpdb->{static::$table_name} = $wpdb->prefix . static::$table_name;
 		}
-	}
-
-	/**
-	 * Whether or not the report should use the caching layer.
-	 *
-	 * Provides an opportunity for plugins to prevent reports from using cache.
-	 *
-	 * @return boolean Whether or not to utilize caching.
-	 */
-	protected function should_use_cache() {
-		/**
-		 * Determines if a report will utilize caching.
-		 *
-		 * @param bool $use_cache Whether or not to use cache.
-		 * @param string $cache_key The report's cache key. Used to identify the report.
-		 */
-		return (bool) apply_filters( 'woocommerce_analytics_report_should_use_cache', true, $this->cache_key );
-	}
-
-	/**
-	 * Returns string to be used as cache key for the data.
-	 *
-	 * @param array $params Query parameters.
-	 * @return string
-	 */
-	protected function get_cache_key( $params ) {
-		return implode(
-			'_',
-			array(
-				'wc_report',
-				$this->cache_key,
-				md5( wp_json_encode( $params ) ),
-			)
-		);
-	}
-
-	/**
-	 * Wrapper around Cache::get().
-	 *
-	 * @param string $cache_key Cache key.
-	 * @return mixed
-	 */
-	protected function get_cached_data( $cache_key ) {
-		if ( $this->should_use_cache() ) {
-			return Cache::get( $cache_key );
-		}
-
-		return false;
-	}
-
-	/**
-	 * Wrapper around Cache::set().
-	 *
-	 * @param string $cache_key Cache key.
-	 * @param mixed  $value     New value.
-	 * @return bool
-	 */
-	protected function set_cached_data( $cache_key, $value ) {
-		if ( $this->should_use_cache() ) {
-			return Cache::set( $cache_key, $value );
-		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
This PR seeks to increase thespeed of the performance indicators endpoint by:
* Adding caching to the data retrieval
* Changing the request to use "end of the day" for the `before` param instead of "now" - giving caching a chance to work

### Detailed test instructions:

- Verify that performance indicators work as expected (change date ranges, etc)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Performance: add caching to dashboard performance indicator requests.