### PR TITLE
Fix/shipping banner dismiss

### DIFF
--- a/src/Features/ShippingLabelBannerDisplayRules.php
+++ b/src/Features/ShippingLabelBannerDisplayRules.php
@@ -136,14 +136,17 @@ class ShippingLabelBannerDisplayRules {
 	 * @return bool
 	 */
 	private function banner_not_dismissed() {
-		$dismissed_timestamp = get_option( 'woocommerce_shipping_dismissed_timestamp' );
-		if ( ! is_numeric( $dismissed_timestamp ) ) {
+		$dismissed_timestamp_ms = get_option( 'woocommerce_shipping_dismissed_timestamp' );
+
+		if ( ! is_numeric( $dismissed_timestamp_ms ) ) {
 			return true;
 		}
-		$dismissed_timestamp_ms = intval( $dismissed_timestamp );
+		$dismissed_timestamp_ms = intval( $dismissed_timestamp_ms );
+		$dismissed_timestamp    = intval( round( $dismissed_timestamp_ms / 1000 ) );
+		$expired_timestamp      = $dismissed_timestamp + 24 * 60 * 60; // 24 hours from click time
 
-		$dismissed_for_good = -1 === $dismissed_timestamp;
-		$dismissed_24h      = time() < ( ( $dismissed_timestamp_ms / 1000 ) + ( 24 * 60 * 60 ) );
+		$dismissed_for_good = -1 === $dismissed_timestamp_ms;
+		$dismissed_24h      = time() < $expired_timestamp;
 
 		return ! $dismissed_for_good && ! $dismissed_24h;
 	}

--- a/src/Features/ShippingLabelBannerDisplayRules.php
+++ b/src/Features/ShippingLabelBannerDisplayRules.php
@@ -137,9 +137,13 @@ class ShippingLabelBannerDisplayRules {
 	 */
 	private function banner_not_dismissed() {
 		$dismissed_timestamp = get_option( 'woocommerce_shipping_dismissed_timestamp' );
+		if ( ! is_numeric( $dismissed_timestamp ) ) {
+			return true;
+		}
+		$dismissed_timestamp_ms = intval( $dismissed_timestamp );
 
 		$dismissed_for_good = -1 === $dismissed_timestamp;
-		$dismissed_24h      = time() < $dismissed_timestamp;
+		$dismissed_24h      = time() < ( ( $dismissed_timestamp_ms / 1000 ) + ( 24 * 60 * 60 ) );
 
 		return ! $dismissed_for_good && ! $dismissed_24h;
 	}

--- a/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -109,11 +109,11 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test if the banner is hidden when a dismiss banner option is checked for 24 hours.
+	 * Banner should not show if it was dismissed 2 hours ago.
 	 */
-	public function test_if_banner_hidden_when_dismiss_after_24h_option_enabled() {
-		$two_hours_from_now = time() + ( 2 * 60 * 60 * 1000 );
-		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_now );
+	public function test_if_banner_hidden_when_dismiss_was_clicked_2_hrs_ago() {
+		$two_hours_from_ago = ( time() - 2 * 60 * 60 ) * 1000;
+		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_ago );
 
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
@@ -121,11 +121,11 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test if the banner is hidden when a dismiss banner option is checked for 24 hours.
+	 * Banner should show if it was dismissed 24 hours and 1 second ago.
 	 */
-	public function test_show_banner_if_dismiss_after_24h_option_enabled_has_expired() {
-		$two_hours_from_now = time() - ( 2 * 60 * 60 * 1000 );
-		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_now );
+	public function test_if_banner_hidden_when_dismiss_was_clicked_24_hrs_1s_ago() {
+		$twenty_four_hours_one_sec_ago = ( time() - 24 * 60 * 60 - 1 ) * 1000;
+		update_option( 'woocommerce_shipping_dismissed_timestamp', $twenty_four_hours_one_sec_ago );
 
 		$this->with_order(
 			function( $that ) {

--- a/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -112,7 +112,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	 * Test if the banner is hidden when a dismiss banner option is checked for 24 hours.
 	 */
 	public function test_if_banner_hidden_when_dismiss_after_24h_option_enabled() {
-		$two_hours_from_now = time() + ( 2 * 60 * 60 );
+		$two_hours_from_now = time() + ( 2 * 60 * 60 * 1000 );
 		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_now );
 
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
@@ -124,7 +124,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	 * Test if the banner is hidden when a dismiss banner option is checked for 24 hours.
 	 */
 	public function test_show_banner_if_dismiss_after_24h_option_enabled_has_expired() {
-		$two_hours_from_now = time() - ( 2 * 60 * 60 );
+		$two_hours_from_now = time() - ( 2 * 60 * 60 * 1000 );
 		update_option( 'woocommerce_shipping_dismissed_timestamp', $two_hours_from_now );
 
 		$this->with_order(


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/61

Frontend passes milliseconds and PHP use `time()` (seconds) to compare the value.  Now fixed. Updated test.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Open order page
- Click "Remind me later". Check database `SELECT * FROM wordpress.wp_options where option_name = 'woocommerce_shipping_dismissed_timestamp';`. Confirm 13 digit `ms` value
- Click "I don't need this". Confirm DB value is set to `-1`.
- Run unit test and it should cover test cases

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
