### PR TITLE
Use a Recommended pill (not a ribbon) for WooCommerce Payments

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -325,6 +325,18 @@
 		}
 	}
 
+	.woocommerce-task-payment__recommended-pill {
+		border: 1px solid $studio-gray-5;
+		border-radius: 28px;
+		font-size: 11px;
+		margin-left: 6px;
+		padding: 1px 9px;
+
+		span {
+			max-width: 70px;
+		}
+	}
+
 	.woocommerce-task-payment__before {
 		margin-right: $gap-larger;
 
@@ -366,6 +378,10 @@
 		}
 
 		.woocommerce-task-payment__recommended-ribbon {
+			display: none;
+		}
+
+		.woocommerce-task-payment__recommended-pill {
 			display: none;
 		}
 

--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -328,9 +328,10 @@
 	.woocommerce-task-payment__recommended-pill {
 		border: 1px solid $studio-gray-5;
 		border-radius: 28px;
-		font-size: 11px;
-		margin-left: 6px;
-		padding: 1px 9px;
+		display: inline-block;
+		font-size: 13px;
+		margin-left: 12px;
+		padding: 1px 10px;
 
 		span {
 			max-width: 70px;
@@ -454,7 +455,7 @@
 }
 
 .woocommerce-task-payment-wcpay.woocommerce-task-payment-not-configured {
-	background-color: $studio-woocommerce-purple-60;
+	background-color: $studio-woocommerce-purple-80;
 
 	.woocommerce-task-payment__title {
 		color: $studio-white;

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -248,25 +248,39 @@ class Payments extends Component {
 						'woocommerce-task-payment-' + key
 					);
 
+					const isRecommended =
+						key === this.recommendedMethod && ! isConfigured;
+					const showRecommendedRibbon =
+						isRecommended && this.recommendedMethod !== 'wcpay';
+					const showRecommendedPill =
+						isRecommended && this.recommendedMethod === 'wcpay';
+
 					return (
 						<Card key={ key } className={ classes }>
 							<div className="woocommerce-task-payment__before">
-								{ key === this.recommendedMethod &&
-									! isConfigured && (
-										<div className="woocommerce-task-payment__recommended-ribbon">
-											<span>
-												{ __(
-													'Recommended',
-													'woocommerce-admin'
-												) }
-											</span>
-										</div>
-									) }
+								{ showRecommendedRibbon && (
+									<div className="woocommerce-task-payment__recommended-ribbon">
+										<span>
+											{ __(
+												'Recommended',
+												'woocommerce-admin'
+											) }
+										</span>
+									</div>
+								) }
 								{ before }
 							</div>
 							<div className="woocommerce-task-payment__text">
 								<H className="woocommerce-task-payment__title">
 									{ title }
+									{ showRecommendedPill && (
+										<span className="woocommerce-task-payment__recommended-pill">
+											{ __(
+												'Recommended',
+												'woocommerce-admin'
+											) }
+										</span>
+									) }
 								</H>
 								<p className="woocommerce-task-payment__content">
 									{ content }


### PR DESCRIPTION
Fixes #4021 

Waiting on https://github.com/woocommerce/woocommerce-admin/pull/4022 to merge, then we need to rebase to pick up wcpay

Use a recommended pill (not the ribbon) for wcpay

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="1141" alt="Screen Shot 2020-03-27 at 4 40 34 PM" src="https://user-images.githubusercontent.com/1595739/77808731-de234b80-7049-11ea-98df-dd2707550769.png">

### Detailed test instructions:

- Navigate to the payments task for a US, non CBD store
- Ensure wcpay uses the recommended pill (not ribbon)
- Set up for non US store
- Ensure Stripe uses the recommended ribbon

**NOTE: If you are testing this using the plugin, don't forget to enable wcpay in config/plugin.json first**

### Changelog Note:

