### PR TITLE
Update WooCommerce Payments Dev Mode doc link

### DIFF
--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -68,7 +68,7 @@ export function getPaymentMethods( {
 
 		const wcPayDocLink = (
 			<Link
-				href={ 'https://docs.woocommerce.com/document/payments/' }
+				href={ 'https://docs.woocommerce.com/document/payments/testing/dev-mode/' }
 				target="_blank"
 				type="external"
 			/>


### PR DESCRIPTION
This patch updates the WooCommerce Payments Dev Mode doc link added in #3978. See https://github.com/woocommerce/woocommerce-admin/pull/3978#issuecomment-605098644 for prior discussion about a placeholder link being used.

The document linked to with this patch will be published in a couple of days (it will 404 right now).

Part of #3948.

/cc @allendav @LevinMedia 