### PR TITLE
SQL example: update to dynamic currencies

### DIFF
--- a/docs/examples/extensions/sql-modification/js/index.js
+++ b/docs/examples/extensions/sql-modification/js/index.js
@@ -91,10 +91,14 @@ const addTableColumn = ( reportTableData ) => {
 	];
 	const newRows = reportTableData.rows.map( ( row, index ) => {
 		const item = reportTableData.items.data[ index ];
+		const currency =
+			reportTableData.endpoint === 'revenue'
+				? item.subtotals.currency
+				: item.currency;
 		const newRow = [
 			{
-				display: item.currency,
-				value: item.currency,
+				display: currency,
+				value: currency,
 			},
 			...row,
 		];
@@ -125,4 +129,36 @@ addFilter(
 	'woocommerce_admin_persisted_queries',
 	'plugin-domain',
 	persistQueries
+);
+
+const currencies = {
+	ZAR: {
+		code: 'ZAR',
+		symbol: 'R',
+		symbolPosition: 'left',
+		thousandSeparator: ' ',
+		decimalSeparator: ',',
+		precision: 2,
+	},
+	NZD: {
+		code: 'NZD',
+		symbol: '$NZ',
+		symbolPosition: 'left',
+		thousandSeparator: ',',
+		decimalSeparator: '.',
+		precision: 2,
+	},
+};
+
+const updateReportCurrencies = ( config, { currency } ) => {
+	if ( currency && currencies[ currency ] ) {
+		return currencies[ currency ];
+	}
+	return config;
+};
+
+addFilter(
+	'woocommerce_admin_report_currency',
+	'plugin-domain',
+	updateReportCurrencies
 );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/3742
Depends on https://github.com/woocommerce/woocommerce-admin/pull/4027

Updates the SQL modification example to use the dynamic report currency filter so that reports numbers in the chart and table reflect selected currencies.

### Screenshots

<img width="839" alt="Screen Shot 2020-04-01 at 9 09 55 AM" src="https://user-images.githubusercontent.com/1922453/78070617-98bf9f00-73f8-11ea-92c7-e07c444a403f.png">


### Detailed test instructions:

1. Create two or more orders for today.
1. On the last order, change the postmeta value for key `_order_currency` to `NZD` or `ZAR`. If you are using vvv, you can go to the last page of the `wp_postmeta` table and edit the key value pair directly in phpmyadmin.
1. You may need to clear your cache `wp transient delete woocommerce_reports-transient-version`.
1. `npm run example -- --ext=sql-modification`
2. Activate WooCommerce Admin SQL modification Example
3. Go to any report and change the time to "today"
4. Manipulate the currency dropdown to see the results update accordingly.
5. Ensure the report chart and table now reflect the selected currency.