### PR TITLE
Fix aria-label attribute.

### DIFF
--- a/client/dashboard/profile-wizard/steps/benefits/logo.js
+++ b/client/dashboard/profile-wizard/steps/benefits/logo.js
@@ -13,7 +13,7 @@ class Logo extends Component {
 				viewBox="0 0 161 46"
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
-				ariaLabel={ __( 'WooCommerce + Jetpack', 'woocommerce-admin' ) }
+				aria-label={ __( 'WooCommerce + Jetpack', 'woocommerce-admin' ) }
 				className="woocommerce-profile-wizard__benefits-logo"
 			>
 				<path


### PR DESCRIPTION
This PR seeks to fix an errantly named `ariaLabel` attribute ([React supports all `aria-*` attributes](https://reactjs.org/docs/accessibility.html#wai-aria)).

### Detailed test instructions:

- Go through the OBW and get to the Woo+Jetpack step
- Verify there are no console errors from the `ariaLabel` attribute
- ???
- Profit