### PR TITLE
Update marketing hub recommended plugins API url.

### DIFF
--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -123,7 +123,7 @@ class Marketing {
 
 		if ( false === $plugins ) {
 			// TODO update placeholder URL.
-			$request = wp_remote_get( 'https://ephemeral-findingsimple-20200320.atomicsites.blog/wp-json/wccom/marketing-tab/1.0/recommendations.json' );
+			$request = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.0/recommendations.json' );
 			$plugins = [];
 
 			if ( ! is_wp_error( $request ) && 200 === $request['response']['code'] ) {

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -122,7 +122,6 @@ class Marketing {
 		$plugins = get_transient( self::RECOMMENDED_PLUGINS_TRANSIENT );
 
 		if ( false === $plugins ) {
-			// TODO update placeholder URL.
 			$request = wp_remote_get( 'https://woocommerce.com/wp-json/wccom/marketing-tab/1.0/recommendations.json' );
 			$plugins = [];
 


### PR DESCRIPTION
Simple one - Replaces the placeholder recommendation URL with live url from WCCOM.

### Detailed test instructions:

- Delete `_transient_wc_marketing_recommended_plugins` option if you have already viewed the marketing hub previously.
- Reload/view the marketing hub - you should see recommendations are still available/loaded.
- Double check the src location of the images to confirm they are coming from WCCOM
