### PR TITLE
Enable wcpay feature flag in plugin and core

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -9,6 +9,6 @@
 		"onboarding": true,
 	  	"shipping-label-banner": true,
 		"store-alerts": true,
-		"wcpay": false
+		"wcpay": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -9,6 +9,6 @@
 		"onboarding": true,
 		"shipping-label-banner": true,
 		"store-alerts": true,
-		"wcpay": false
+		"wcpay": true
 	}
 }


### PR DESCRIPTION
Fixes #4023 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

N/A

### Detailed test instructions:

- Build the plugin and install on a site. Ensure the WooCommerce Payments task appears in the new OBW and that you can use it to install, activate and initiate the KYC flow
- Remove both plugins and then build WooCommerce core from master. Install on a site and repeat the above test

### Changelog Note:

