### PR TITLE
Bugfix on payments step in CBD flow

### DIFF
--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -218,6 +218,7 @@ class Payments extends Component {
 						query,
 						installStep: this.getInstallStep(),
 						markConfigured: this.markConfigured,
+						hasCbdIndustry: currentMethod.hasCbdIndustry,
 					} ) }
 				</Card>
 			);

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -283,9 +283,9 @@ class Payments extends Component {
 										</span>
 									) }
 								</H>
-								<p className="woocommerce-task-payment__content">
+								<div className="woocommerce-task-payment__content">
 									{ content }
-								</p>
+								</div>
 							</div>
 							<div className="woocommerce-task-payment__after">
 								{ container && ! isConfigured ? (

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -68,7 +68,9 @@ export function getPaymentMethods( {
 
 		const wcPayDocLink = (
 			<Link
-				href={ 'https://docs.woocommerce.com/document/payments/testing/dev-mode/' }
+				href={
+					'https://docs.woocommerce.com/document/payments/testing/dev-mode/'
+				}
 				target="_blank"
 				type="external"
 			/>
@@ -269,6 +271,7 @@ export function getPaymentMethods( {
 				options.woocommerce_square_credit_card_settings.enabled ===
 					'yes',
 			optionName: 'woocommerce_square_credit_card_settings',
+			hasCbdIndustry,
 		},
 		{
 			key: 'payfast',

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -44,7 +44,12 @@ class Square extends Component {
 	}
 
 	async connect() {
-		const { createNotice, options, updateOptions } = this.props;
+		const {
+			createNotice,
+			hasCbdIndustry,
+			options,
+			updateOptions,
+		} = this.props;
 		this.setState( { isPending: true } );
 
 		updateOptions( {
@@ -60,9 +65,12 @@ class Square extends Component {
 		);
 
 		try {
-			// It's necessary to declare the new tab before the async call,
-			// otherwise, it won't be possible to open it.
-			const newWindow = window.open( '/', '_blank' );
+			let newWindow = null;
+			if ( hasCbdIndustry ) {
+				// It's necessary to declare the new tab before the async call,
+				// otherwise, it won't be possible to open it.
+				newWindow = window.open( '/', '_blank' );
+			}
 
 			const result = await apiFetch( {
 				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square',
@@ -72,16 +80,26 @@ class Square extends Component {
 			if ( ! result || ! result.connectUrl ) {
 				this.setState( { isPending: false } );
 				createNotice( 'error', errorMessage );
-				newWindow.close();
+				if ( hasCbdIndustry ) {
+					newWindow.close();
+				}
 				return;
 			}
 
 			this.setState( { isPending: true } );
-			newWindow.location.href = result.connectUrl;
-			window.location = getAdminLink( 'admin.php?page=wc-admin' );
+			this.redirect( result.connectUrl, newWindow );
 		} catch ( error ) {
 			this.setState( { isPending: false } );
 			createNotice( 'error', errorMessage );
+		}
+	}
+
+	redirect( connectUrl, newWindow ) {
+		if ( newWindow ) {
+			newWindow.location.href = connectUrl;
+			window.location = getAdminLink( 'admin.php?page=wc-admin' );
+		} else {
+			window.location = connectUrl;
 		}
 	}
 

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -15,6 +15,7 @@ import { getQuery } from '@woocommerce/navigation';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { Stepper } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 class Square extends Component {
 	constructor( props ) {
@@ -59,6 +60,10 @@ class Square extends Component {
 		);
 
 		try {
+			// It's necessary to declare the new tab before the async call,
+			// otherwise, it won't be possible to open it.
+			const newWindow = window.open( '/', '_blank' );
+
 			const result = await apiFetch( {
 				path: WC_ADMIN_NAMESPACE + '/onboarding/plugins/connect-square',
 				method: 'POST',
@@ -67,11 +72,13 @@ class Square extends Component {
 			if ( ! result || ! result.connectUrl ) {
 				this.setState( { isPending: false } );
 				createNotice( 'error', errorMessage );
+				newWindow.close();
 				return;
 			}
 
 			this.setState( { isPending: true } );
-			window.location = result.connectUrl;
+			newWindow.location.href = result.connectUrl;
+			window.location = getAdminLink( 'admin.php?page=wc-admin' );
 		} catch ( error ) {
 			this.setState( { isPending: false } );
 			createNotice( 'error', errorMessage );

--- a/client/dashboard/task-list/tasks/payments/square.js
+++ b/client/dashboard/task-list/tasks/payments/square.js
@@ -53,8 +53,8 @@ class Square extends Component {
 		this.setState( { isPending: true } );
 
 		updateOptions( {
-			woocommerce_stripe_settings: {
-				...options.woocommerce_stripe_settings,
+			woocommerce_square_credit_card_settings: {
+				...options.woocommerce_square_credit_card_settings,
 				enabled: 'yes',
 			},
 		} );
@@ -146,9 +146,13 @@ class Square extends Component {
 export default compose(
 	withSelect( ( select ) => {
 		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
-		const options = getOptions( [ 'woocommerce_stripe_settings' ] );
+		const options = getOptions( [
+			'woocommerce_square_credit_card_settings',
+		] );
 		const optionsIsRequesting = Boolean(
-			isGetOptionsRequesting( [ 'woocommerce_stripe_settings' ] )
+			isGetOptionsRequesting( [
+				'woocommerce_square_credit_card_settings',
+			] )
 		);
 
 		return {

--- a/src/API/OnboardingPlugins.php
+++ b/src/API/OnboardingPlugins.php
@@ -505,7 +505,7 @@ class OnboardingPlugins extends \WC_REST_Data_Controller {
 		if ( 'US' === WC()->countries->get_base_country() ) {
 			$profile = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 			if ( ! empty( $profile['industry'] ) ) {
-				$has_cbd_industry = array_search( 'cbd-other-hemp-derived-products', array_column( $profile['industry'], 'slug' ) );
+				$has_cbd_industry = in_array( 'cbd-other-hemp-derived-products', array_column( $profile['industry'], 'slug' ), true );
 			}
 		}
 


### PR DESCRIPTION
Fixes #4053

There is a bugfix and a new feature in this PR:

**In the Square flow for CBD stores**
- `Bugfix` - The `Connect` button should redirect the user to Square's attestation [page](https://squareup.com/t/f_partnerships/d_referrals/p_woocommerce/c_general/o_none/l_us/dt_alldevice/pr_payments/?route=/solutions/cbd).
- `New feature` - After pressing `Connect` a new tab opens with the Square webpage.


_In the file: `/src/API/OnboardingPlugins.php`, the `array_search` method was changed to `in_array`.
We used the method `array_search` that returns the position of the found element in the array. When the element was in the first position, the result was `0` and didn't execute the conditional statement. Now we use `in_array` instead. This method returns a boolean value._


### Detailed test instructions:
- On the 2nd step of the `Onboarding Wizard` (_Industry_) choose `CBD and other hemp-derived products`.
- The `countryCode` must be `US`
- Go to:
      `WooCommerce`|`Dashboard`|`Set up payments` (or use this URL `/wp-admin/admin.php?page=wc-admin&task=payments`)
- **Only** the `Square` payment method should be visible. The text: `Selling CBD products is only supported by Square.` should be visible in the card.
![screenshot-square](https://user-images.githubusercontent.com/1314156/77069938-167eb600-69c8-11ea-9155-7dd3e0a4d0f7.png)

- After finishing the process a new tab should be opened with the URL: 
`https://squareup.com/t/f_partnerships/d_referrals/p_woocommerce/c_general/o_none/l_us/dt_alldevice/pr_payments/?route=/solutions/cbd`. And the current tab should redirect the user to the dashboard.

_If the industry `CBD and other hemp-derived products` is not selected, the `Set up payments` should 
 have a normal behavior._
