### PR TITLE
Improve layout of Installed Extensions marketing card for tablet and mobile screens

### DIFF
--- a/client/marketing/overview/installed-extensions/row.js
+++ b/client/marketing/overview/installed-extensions/row.js
@@ -138,14 +138,16 @@ class InstalledExtensionRow extends Component {
 		return (
 			<div className="woocommerce-marketing-installed-extensions-card__item">
 				<ProductIcon src={ icon } />
-				<div className="woocommerce-marketing-installed-extensions-card__item-text">
-					<h4>{ name }</h4>
-					{ status === 'configured' || (
-						<p className="woocommerce-marketing-installed-extensions-card__item-description">{ description }</p>
-					) }
-				</div>
-				<div className="woocommerce-marketing-installed-extensions-card__item-actions">
-					{ actions }
+				<div className="woocommerce-marketing-installed-extensions-card__item-text-and-actions">
+					<div className="woocommerce-marketing-installed-extensions-card__item-text">
+						<h4>{ name }</h4>
+						{ status === 'configured' || (
+							<p className="woocommerce-marketing-installed-extensions-card__item-description">{ description }</p>
+						) }
+					</div>
+					<div className="woocommerce-marketing-installed-extensions-card__item-actions">
+						{ actions }
+					</div>
 				</div>
 			</div>
 		)

--- a/client/marketing/overview/installed-extensions/style.scss
+++ b/client/marketing/overview/installed-extensions/style.scss
@@ -4,9 +4,9 @@
 	}
 
 	&__item {
-		padding: 18px 24px;
 		display: flex;
 		align-items: center;
+		padding: 18px 24px;
 
 		h4 {
 			font-weight: 400;
@@ -25,15 +25,32 @@
 		border-bottom: 1px solid $core-grey-light-500;
 	}
 
+	&__item-text-and-actions {
+		display: flex;
+		flex-wrap: wrap;
+		flex-grow: 2;
+		min-width: 0; // Flexbox truncated text fix
+
+		@include breakpoint( '>600px' ) {
+			flex-wrap: nowrap;
+		}
+	}
+
 	&__item-actions {
-		float: right;
+		@include breakpoint( '>600px' ) {
+			text-align: right;
+			white-space: nowrap;
+			padding-left: 25px;
+		}
 	}
 
 	&__item-description {
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		max-width: 550px;
+		@include breakpoint( '>960px' ) {
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			max-width: 550px;
+		}
 	}
 
 	&__item-links {
@@ -42,7 +59,11 @@
 
 		li {
 			display: inline-block;
-			margin: 0 0 0 30px;
+			margin: 0 25px 0 0;
+
+			@include breakpoint( '>600px' ) {
+				margin: 0 0 0 30px;
+			}
 		}
 
 		a {
@@ -58,6 +79,14 @@
 	}
 
 	&__item-text {
+		min-width: 0; // Flexbox truncated text fix
 		flex-grow: 2;
+		margin: 0 0 10px;
+		width: 100%;
+
+		@include breakpoint( '>600px' ) {
+			margin: 0;
+			width: auto;
+		}
 	}
 }

--- a/client/marketing/overview/installed-extensions/style.scss
+++ b/client/marketing/overview/installed-extensions/style.scss
@@ -5,7 +5,7 @@
 
 	&__item {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		padding: 18px 24px;
 
 		h4 {
@@ -28,6 +28,7 @@
 	&__item-text-and-actions {
 		display: flex;
 		flex-wrap: wrap;
+		align-items: center;
 		flex-grow: 2;
 		min-width: 0; // Flexbox truncated text fix
 
@@ -75,6 +76,7 @@
 	}
 
 	.woocommere-admin-marketing-product-icon {
+		align-self: flex-start;
 		margin-right: 14px;
 		margin-top: 2px; // Align top of image with text
 	}

--- a/client/marketing/overview/installed-extensions/style.scss
+++ b/client/marketing/overview/installed-extensions/style.scss
@@ -5,7 +5,7 @@
 
 	&__item {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		padding: 18px 24px;
 
 		h4 {
@@ -76,6 +76,7 @@
 
 	.woocommere-admin-marketing-product-icon {
 		margin-right: 14px;
+		margin-top: 2px; // Align top of image with text
 	}
 
 	&__item-text {

--- a/client/marketing/overview/welcome-card/style.scss
+++ b/client/marketing/overview/welcome-card/style.scss
@@ -60,7 +60,7 @@
 
 		@include breakpoint( '>600px' ) {
 			text-align: left;
-			margin-left: 20px;
+			margin: 0 0 0 20px;
 		}
 
 		@include breakpoint( '>960px' ) {

--- a/client/marketing/overview/welcome-card/style.scss
+++ b/client/marketing/overview/welcome-card/style.scss
@@ -5,6 +5,12 @@
 		display: flex;
 		justify-content: center;
 		align-items: center;
+		flex-wrap: wrap;
+		padding: 22px;
+
+		@include breakpoint( '>600px' ) {
+			flex-wrap: nowrap;
+		}
 
 		@include breakpoint( '>960px' ) {
 			padding: 32px 108px;
@@ -46,14 +52,20 @@
 	}
 
 	h3 {
-		font-size: 24px;
-		line-height: 32px;
+		font-size: 20px;
+		line-height: 26px;
 		font-weight: normal;
-		margin-left: 20px;
+		text-align: center;
+		margin: 1em 0 0;
 
-		@include breakpoint( '<960px' ) {
-			font-size: 20px;
-			line-height: 26px;
+		@include breakpoint( '>600px' ) {
+			text-align: left;
+			margin-left: 20px;
+		}
+
+		@include breakpoint( '>960px' ) {
+			font-size: 24px;
+			line-height: 32px;
 		}
 	}
 

--- a/src/Marketing/InstalledExtensions.php
+++ b/src/Marketing/InstalledExtensions.php
@@ -266,7 +266,7 @@ class InstalledExtensions {
 			'slug'        => $slug,
 			'status'      => $status,
 			'name'        => $plugin_data['Name'],
-			'description' => $plugin_data['Description'],
+			'description' => html_entity_decode( wp_trim_words( $plugin_data['Description'], 20 ) ),
 			'supportUrl'  => 'https://woocommerce.com/my-account/create-a-ticket/',
 		];
 	}


### PR DESCRIPTION
Fix lack of responsiveness of the "Installed Extensions" card on from the Marketing Tab MVP #3953

### Accessibility
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
Current: https://d.pr/v/dwIzFY
Updated by this PR: https://d.pr/v/urc6Si 

### Testing
- Check out branch
- `npm run build`
- Go to the marketing tab.
- You must have at least one marketing extension installed
- Resize the browser