### PR TITLE
Fix double prefixed wcadmin events

### DIFF
--- a/client/dashboard/task-list/index.js
+++ b/client/dashboard/task-list/index.js
@@ -309,7 +309,7 @@ class TaskDashboard extends Component {
 			.filter( ( x ) => x.completed )
 			.map( ( x ) => x.key );
 
-		recordEvent( 'wcadmin_tasklist_skip', {
+		recordEvent( 'tasklist_skip', {
 			completed_tasks_count: completedTaskKeys.length,
 			completed_tasks: completedTaskKeys,
 			reason: 'skip',
@@ -325,7 +325,7 @@ class TaskDashboard extends Component {
 			.filter( ( x ) => x.completed )
 			.map( ( x ) => x.key );
 
-		recordEvent( 'wcadmin_tasklist_skip', {
+		recordEvent( 'tasklist_skip', {
 			completed_tasks_count: completedTaskKeys.length,
 			completed_tasks: completedTaskKeys,
 			reason: 'later',

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -946,7 +946,7 @@ class Onboarding {
 		$new_value = ! $previous;
 
 		wc_admin_record_tracks_event(
-			'wcadmin_storeprofiler_toggled',
+			'storeprofiler_toggled',
 			array(
 				'previous'  => $previous,
 				'new_value' => $new_value,


### PR DESCRIPTION
Fixes #4064 

Removes double prefix from events.

### Detailed test instructions:

1. Enable the task list if not enabled.
1. Toggle the store profiler.
1. Skip the task list using the skip button.
1. Note the tracked events in MC tracks `wcadmin_storeprofiler_toggled`, `wcadmin_tasklist_skip`