### PR TITLE
Add 'action after' date to admin notes and hourly task

### DIFF
--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -221,6 +221,11 @@ class Notes extends \WC_REST_CRUD_Controller {
 			$note_changed = true;
 		}
 
+		if ( ! is_null( $request->get_param( 'date_action_after' ) ) ) {
+			$note->set_date_action_after( $request->get_param( 'date_action_after' ) );
+			$note_changed = true;
+		}
+
 		if ( $note_changed ) {
 			$note->save();
 		}
@@ -271,15 +276,17 @@ class Notes extends \WC_REST_CRUD_Controller {
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $data, $request ) {
-		$context                   = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data                      = $this->add_additional_fields_to_object( $data, $request );
-		$data['date_created_gmt']  = wc_rest_prepare_date_response( $data['date_created'] );
-		$data['date_created']      = wc_rest_prepare_date_response( $data['date_created'], false );
-		$data['date_reminder_gmt'] = wc_rest_prepare_date_response( $data['date_reminder'] );
-		$data['date_reminder']     = wc_rest_prepare_date_response( $data['date_reminder'], false );
-		$data['title']             = stripslashes( $data['title'] );
-		$data['content']           = stripslashes( $data['content'] );
-		$data['is_snoozable']      = (bool) $data['is_snoozable'];
+		$context                       = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data                          = $this->add_additional_fields_to_object( $data, $request );
+		$data['date_created_gmt']      = wc_rest_prepare_date_response( $data['date_created'] );
+		$data['date_created']          = wc_rest_prepare_date_response( $data['date_created'], false );
+		$data['date_reminder_gmt']     = wc_rest_prepare_date_response( $data['date_reminder'] );
+		$data['date_reminder']         = wc_rest_prepare_date_response( $data['date_reminder'], false );
+		$data['title']                 = stripslashes( $data['title'] );
+		$data['content']               = stripslashes( $data['content'] );
+		$data['is_snoozable']          = (bool) $data['is_snoozable'];
+		$date['date_action_after']     = wc_rest_prepare_date_response( $data['date_action_after'], false );
+		$data['date_action_after_gmt'] = wc_rest_prepare_date_response( $data['date_action_after'] );
 		foreach ( (array) $data['actions'] as $key => $value ) {
 			$data['actions'][ $key ]->label  = stripslashes( $data['actions'][ $key ]->label );
 			$data['actions'][ $key ]->url    = $this->prepare_query_for_response( $data['actions'][ $key ]->query );
@@ -390,98 +397,110 @@ class Notes extends \WC_REST_CRUD_Controller {
 			'title'      => 'note',
 			'type'       => 'object',
 			'properties' => array(
-				'id'                => array(
+				'id'                    => array(
 					'description' => __( 'ID of the note record.', 'woocommerce-admin' ),
 					'type'        => 'integer',
 					'context'     => array( 'view' ),
 					'readonly'    => true,
 				),
-				'name'              => array(
+				'name'                  => array(
 					'description' => __( 'Name of the note.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'type'              => array(
+				'type'                  => array(
 					'description' => __( 'The type of the note (e.g. error, warning, etc.).', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'locale'            => array(
+				'locale'                => array(
 					'description' => __( 'Locale used for the note title and content.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'title'             => array(
+				'title'                 => array(
 					'description' => __( 'Title of the note.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'content'           => array(
+				'content'               => array(
 					'description' => __( 'Content of the note.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'icon'              => array(
+				'icon'                  => array(
 					'description' => __( 'Icon (gridicon) for the note.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'content_data'      => array(
+				'content_data'          => array(
 					'description' => __( 'Content data for the note. JSON string. Available for re-localization.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'status'            => array(
+				'status'                => array(
 					'description' => __( 'The status of the note (e.g. unactioned, actioned).', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
-				'source'            => array(
+				'source'                => array(
 					'description' => __( 'Source of the note.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'date_created'      => array(
+				'date_created'          => array(
 					'description' => __( 'Date the note was created.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'date_created_gmt'  => array(
+				'date_created_gmt'      => array(
 					'description' => __( 'Date the note was created (GMT).', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'date_reminder'     => array(
+				'date_reminder'         => array(
 					'description' => __( 'Date after which the user should be reminded of the note, if any.', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true, // @todo Allow date_reminder to be updated.
 				),
-				'date_reminder_gmt' => array(
+				'date_reminder_gmt'     => array(
 					'description' => __( 'Date after which the user should be reminded of the note, if any (GMT).', 'woocommerce-admin' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'is_snoozable'      => array(
+				'is_snoozable'          => array(
 					'description' => __( 'Whether or not a user can request to be reminded about the note.', 'woocommerce-admin' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'actions'           => array(
+				'actions'               => array(
 					'description' => __( 'An array of actions, if any, for the note.', 'woocommerce-admin' ),
 					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_action_after'     => array(
+					'description' => __( 'Date after which the note should be automatically actioned, if any.', 'woocommerce-admin' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true, // @todo Allow date_reminder to be updated.
+				),
+				'date_action_after_gmt' => array(
+					'description' => __( 'Date after which the note should be automatically actioned, if any (GMT).', 'woocommerce-admin' ),
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/src/Install.php
+++ b/src/Install.php
@@ -254,6 +254,7 @@ class Install {
 			date_created datetime NOT NULL default '0000-00-00 00:00:00',
 			date_reminder datetime NULL default null,
 			is_snoozable boolean DEFAULT 0 NOT NULL,
+			date_action_after datetime NULL default null,
 			PRIMARY KEY (note_id)
 		) $collate;
 		CREATE TABLE {$wpdb->prefix}wc_admin_note_actions (

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -49,19 +49,20 @@ class WC_Admin_Note extends \WC_Data {
 	public function __construct( $data = '' ) {
 		// Set default data here to allow `content_data` to be an object.
 		$this->data = array(
-			'name'          => '-',
-			'type'          => self::E_WC_ADMIN_NOTE_INFORMATIONAL,
-			'locale'        => 'en_US',
-			'title'         => '-',
-			'content'       => '-',
-			'icon'          => 'info',
-			'content_data'  => new \stdClass(),
-			'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED,
-			'source'        => 'woocommerce',
-			'date_created'  => '0000-00-00 00:00:00',
-			'date_reminder' => '',
-			'is_snoozable'  => false,
-			'actions'       => array(),
+			'name'              => '-',
+			'type'              => self::E_WC_ADMIN_NOTE_INFORMATIONAL,
+			'locale'            => 'en_US',
+			'title'             => '-',
+			'content'           => '-',
+			'icon'              => 'info',
+			'content_data'      => new \stdClass(),
+			'status'            => self::E_WC_ADMIN_NOTE_UNACTIONED,
+			'source'            => 'woocommerce',
+			'date_created'      => '0000-00-00 00:00:00',
+			'date_reminder'     => '',
+			'is_snoozable'      => false,
+			'date_action_after' => '',
+			'actions'           => array(),
 		);
 
 		parent::__construct( $data );
@@ -281,6 +282,16 @@ class WC_Admin_Note extends \WC_Data {
 		return $this->get_prop( 'actions', $context );
 	}
 
+	/**
+	 * Get the date the note should be automatically actioned.
+	 *
+	 * @param  string $context  What the value is for. Valid values are 'view' and 'edit'.
+	 * @return WC_DateTime|NULL object if the date is set or null if there is no date.
+	 */
+	public function get_date_action_after( $context = 'view' ) {
+		return $this->get_prop( 'date_action_after', $context );
+	}
+
 	/*
 	|--------------------------------------------------------------------------
 	| Setters
@@ -483,6 +494,15 @@ class WC_Admin_Note extends \WC_Data {
 	 */
 	public function set_is_snoozable( $is_snoozable ) {
 		return $this->set_prop( 'is_snoozable', $is_snoozable );
+	}
+
+	/**
+	 * Set date to automatically action the note.
+	 *
+	 * @param string|integer|null $date UTC timestamp, or ISO 8601 DateTime. If the DateTime string has no timezone or offset, WordPress site timezone will be assumed. Null if there is no date.
+	 */
+	public function set_date_action_after( $date ) {
+		$this->set_date_prop( 'date_action_after', $date );
 	}
 
 	/**

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -296,7 +296,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 16, count( $properties ) );
+		$this->assertEquals( 18, count( $properties ) );
 
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -80,6 +80,8 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'date_reminder', $note );
 		$this->assertArrayHasKey( 'date_reminder_gmt', $note );
 		$this->assertArrayHasKey( 'actions', $note );
+		$this->assertArrayHasKey( 'date_action_after', $note );
+		$this->assertArrayHasKey( 'date_action_after_gmt', $note );
 
 		$this->assertEquals( 'PHPUNIT_TEST_NOTE_1_ACTION_1_SLUG', $note['actions'][0]->name );
 		$this->assertEquals( 'http://example.org/wp-admin/admin.php?s=PHPUNIT_TEST_NOTE_1_ACTION_1_URL', $note['actions'][0]->url );
@@ -314,5 +316,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'date_reminder_gmt', $properties );
 		$this->assertArrayHasKey( 'actions', $properties );
 		$this->assertArrayHasKey( 'is_snoozable', $properties );
+		$this->assertArrayHasKey( 'date_action_after', $properties );
+		$this->assertArrayHasKey( 'date_action_after_gmt', $properties );
 	}
 }


### PR DESCRIPTION
Fixes #3973 

The reason for this is to end up resolving #3973. The first fix was rejected - I tried removing the nonce from the done admin note's action but this was rejected by the wc core team for security reasons. I then tried adding a callback function to the admin note's action, however the nonce seems to be processed before the callback so actioning the note in the callback still  happened too late - the error from the nonce still appeared first. So the idea here is to action the admin note before the nonce expires (24 hours), so it just disappears.

This PR is the first step toward that - it adds the `date_action_after` timestamp to admin notes, and sets up an hourly task to process those timestamps and action the matched admin notes.

The second step is back in the `woocommerce` plugin, setting the `date_action_after` to just less than 24 hours when the 'done' admin note is created.

### Detailed test instructions:

Check out the `master` branch.

Install the "WP Crontrol" plugin - needed to see cron events.

In phpMyAdmin delete any rows in `wp_wc_admin_notes` with the `name` of `wc-update-db-reminder`.

Check out this PR's branch.

Increment the version in `woocommerce_admin_version` option to trigger a db schema update.

In the woocommerce core repo, edit `includes/admin/notes/class-wc-notes-run-db-update.php` and at the end of the constructor add this:

```
$note_id = $this->update_needed_notice();
$this->update_done_notice($note_id);
$note = new WC_Admin_Note( $note_id );
$note->set_date_action_after( time() + 24*60*60 );
$note->save();
```

Refresh WordPress and the done notice should appear at the top of the page. **Remove the added code from the constructor before continuing.**

Go to Tools -> Cron Events. There should be an entry with a hook name of `wc_admin_action_admin_notes` and a recurrence of one hour.

In phpMyAdmin find the `wp_wc_admin_notes` row with the name of `wc-update-db-reminder` and a `status` of `unactioned`. Check that the `date_action_after` value for that row is roughly 24 hours after the current date/time (this was set when the note was created above). If there is a discrepancy check VVV for clock shift (`vagrant ssh`, `date`). Yes I'm serious.

Modify the row and set the `date_action_after` to some time just less than the current time.

Back in WordPress -> Tools -> Cron Events, find that `wc_admin_action_admin_notes` entry and click 'Run Now'. Wait a couple of seconds then go back to phpMyAdmin. The row `status` should now be `actioned`. Go back to WordPress and go back to a page that was showing the done notice - the notice should now be gone.

### Changelog Note:

Dev: add action after date/time to admin notes, along with an hourly task that automatically actions candidate admin notes