### PR TITLE
Added check to show WC Pay option only when Jetpack is connected

### DIFF
--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -352,6 +352,7 @@ export default compose(
 			getActivePlugins,
 			getOptions,
 			getUpdateOptionsError,
+			isJetpackConnected,
 			isUpdateOptionsRequesting,
 		} = select( 'wc-api' );
 
@@ -378,6 +379,7 @@ export default compose(
 		const methods = getPaymentMethods( {
 			activePlugins,
 			countryCode,
+			isJetpackConnected: isJetpackConnected(),
 			options,
 			profileItems,
 		} );

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -33,6 +33,7 @@ import PayFast from './payfast';
 export function getPaymentMethods( {
 	activePlugins,
 	countryCode,
+	isJetpackConnected,
 	options,
 	profileItems,
 } ) {
@@ -121,7 +122,7 @@ export function getPaymentMethods( {
 			visible:
 				[ 'US' ].includes( countryCode ) &&
 				! hasCbdIndustry &&
-				profileItems.jetpack_connected,
+				isJetpackConnected,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConfigured,

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -118,7 +118,10 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <WCPayIcon />,
-			visible: [ 'US' ].includes( countryCode ) && ! hasCbdIndustry,
+			visible:
+				[ 'US' ].includes( countryCode ) &&
+				! hasCbdIndustry &&
+				profileItems.jetpack_connected,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConfigured,

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -113,13 +113,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		$wccom_auth               = \WC_Helper_Options::get( 'auth' );
 		$items['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
-		$jetpack_connected = false;
-		if ( class_exists( '\Jetpack_Data' ) ) {
-			$user_token        = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-			$jetpack_connected = isset( $user_token->external_user_id );
-		}
-		$items['jetpack_connected'] = $jetpack_connected;
-
 		$item = $this->prepare_item_for_response( $items, $request );
 		$data = $this->prepare_response_for_collection( $item );
 
@@ -373,13 +366,6 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			'wccom_connected'     => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce-admin' ),
-				'context'           => array( 'view' ),
-				'readonly'          => true,
-				'validate_callback' => 'rest_validate_request_arg',
-			),
-			'jetpack_connected'   => array(
-				'type'              => 'boolean',
-				'description'       => __( 'Whether or not the site was connected to Jetpack.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -113,6 +113,13 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 		$wccom_auth               = \WC_Helper_Options::get( 'auth' );
 		$items['wccom_connected'] = empty( $wccom_auth['access_token'] ) ? false : true;
 
+		$jetpack_connected = false;
+		if ( class_exists( '\Jetpack_Data' ) ) {
+			$user_token        = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+			$jetpack_connected = isset( $user_token->external_user_id );
+		}
+		$items['jetpack_connected'] = $jetpack_connected;
+
 		$item = $this->prepare_item_for_response( $items, $request );
 		$data = $this->prepare_response_for_collection( $item );
 
@@ -366,6 +373,13 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 			'wccom_connected'     => array(
 				'type'              => 'boolean',
 				'description'       => __( 'Whether or not the store was connected to WooCommerce.com during the extension flow.', 'woocommerce-admin' ),
+				'context'           => array( 'view' ),
+				'readonly'          => true,
+				'validate_callback' => 'rest_validate_request_arg',
+			),
+			'jetpack_connected'   => array(
+				'type'              => 'boolean',
+				'description'       => __( 'Whether or not the site was connected to Jetpack.', 'woocommerce-admin' ),
 				'context'           => array( 'view' ),
 				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',


### PR DESCRIPTION
Fixes #4092

In this PR a verification was added to the Setup Checklist payment step, to show WC Pay option only when Jetpack is connected.

### Screenshots
If the site is not connected to Jetpack the WC Pay option shouldn't be visible on the setup checklist payment step:
<img width="1674" alt="Dashboard ‹ WooCommerce ‹ Extraordinary Winter — WooCommerce 2020-04-08 17-01-38" src="https://user-images.githubusercontent.com/22080/78845075-6f84ad00-79bc-11ea-9d30-213dc3f396d3.png">

### Detailed test instructions:

- The solution won't work with a site with Jetpack in `Development mode`, so it would be a good idea to use an ephemeral instance to test.
- Install Jetpack but don't connect it.
- Install and activate `WooCommerce` and a `test release` with this code.
- Go to the setup checklist payment step (URL: `/wp-admin/admin.php?page=wc-admin&task=payments`).
- The WC Pay option shouldn't be visible.
- Go to the Jetpack dashboard and connect it (URL: `/wp-admin/admin.php?page=jetpack#/dashboard`).
- Go back to the setup checklist payment step.
- The WC Pay option should be visible now.
