### PR TITLE
Overwrite button overflow css from Wordpress 5.4 defaults

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -39,6 +39,7 @@
 		line-height: 25px;
 		text-decoration: none;
 		text-shadow: none;
+		overflow: visible;
 	}
 
 	.notice-dismiss {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/63

Wordpress 5.4 button component CSS has overflow set to hidden. This causes the button to shrink itself and hides the text. Overwrite this back to `visible` so the text remain the same width.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/572862/78949169-0c604c80-7a88-11ea-9e42-b4d77ce10f5d.png)

After:
![image](https://user-images.githubusercontent.com/572862/78949174-108c6a00-7a88-11ea-9d96-8d86dced485f.png)


### Detailed test instructions:
1. Open up an order page
2. Make sure you meet the conditions to open the banner. ie. this function should return `true`: https://github.com/woocommerce/woocommerce-admin/blob/master/src/Features/ShippingLabelBannerDisplayRules.php#L120
3. Resize window, make sure the shipping banner button doesn't hide the text. It should match the 2nd screenshot.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
