### PR TITLE
Onboarding - business details step: increase max-height on competitors listbox

### DIFF
--- a/client/dashboard/profile-wizard/steps/business-details.js
+++ b/client/dashboard/profile-wizard/steps/business-details.js
@@ -626,30 +626,34 @@ class BusinessDetails extends Component {
 										'brick-mortar-other',
 									].includes( values.selling_venues ) && (
 										<Fragment>
-											<SelectControl
-												label={ __(
-													'Which platform is the store using?',
-													'woocommerce-admin'
-												) }
-												options={ otherPlatformOptions }
-												required
-												{ ...getInputProps(
-													'other_platform'
-												) }
-											/>
-											{ values.other_platform ===
-												'other' && (
-												<TextControl
+											<div className="business-competitors">
+												<SelectControl
 													label={ __(
-														'What is the platform name?',
+														'Which platform is the store using?',
 														'woocommerce-admin'
 													) }
+													options={
+														otherPlatformOptions
+													}
 													required
 													{ ...getInputProps(
-														'other_platform_name'
+														'other_platform'
 													) }
 												/>
-											) }
+												{ values.other_platform ===
+													'other' && (
+													<TextControl
+														label={ __(
+															'What is the platform name?',
+															'woocommerce-admin'
+														) }
+														required
+														{ ...getInputProps(
+															'other_platform_name'
+														) }
+													/>
+												) }
+											</div>
 										</Fragment>
 									) }
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -29,7 +29,7 @@
 		}
 
 		.business-competitors .woocommerce-select-control__listbox {
-			max-height: 504px;
+			max-height: unset;
 		}
 	}
 

--- a/client/dashboard/profile-wizard/style.scss
+++ b/client/dashboard/profile-wizard/style.scss
@@ -27,6 +27,10 @@
 			max-width: 100%;
 			justify-content: center;
 		}
+
+		.business-competitors .woocommerce-select-control__listbox {
+			max-height: 504px;
+		}
 	}
 
 	.woocommerce-profile-wizard__card-actions {


### PR DESCRIPTION
Fixes #4095

In this PR the competitors' Listbox in the Business Details step in the Onboarding process has been enlarged. 

### Screenshots
![competitors-listbox](https://user-images.githubusercontent.com/1314156/79005150-a7126700-7b2c-11ea-8d6e-c5b30a31d5f3.png)


### Detailed test instructions:

- Go to the `Business Details` step in the Onboarding (URL: `/wp-admin/admin.php?page=wc-admin&step=business-details`).
- In the `Currently selling elsewhere?` listbox, choose the option `Yes, on another platform`.
- Verify that all the competitors are visible at once after clicking the `Which platform is the store using?` listbox.

### Notes
It looks like the [GH diff](https://github.com/woocommerce/woocommerce-admin/pull/4111/files) is acting a little funny since the only change that I made to the file `client/dashboard/profile-wizard/steps/business-details.js` was to add a `div` with `className='business-competitors'` and an extra `tab` to the lines inside the `div`.
