### PR TITLE
OBW: allow CBD only for US stores

### DIFF
--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -165,7 +165,7 @@ class Industry extends Component {
 		);
 		const industryKeys = Object.keys( industries );
 
-		const filteredIndustries =
+		const filteredIndustryKeys =
 			region === 'US'
 				? industryKeys
 				: industryKeys.filter(
@@ -185,7 +185,7 @@ class Industry extends Component {
 				</p>
 				<Card>
 					<div className="woocommerce-profile-wizard__checkbox-group">
-						{ filteredIndustries.map( ( slug ) => {
+						{ filteredIndustryKeys.map( ( slug ) => {
 							const selectedIndustry = find( selected, { slug } );
 
 							return (

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -38,7 +38,7 @@ class Industry extends Component {
 		 * Calls to `updateProfileItems` in the previous screen happen async
 		 * and won't be updated in wc-api's state when this component is initialized.
 		 * As such, we need to make sure cbd is not initialized as selected when a
-		 * user has changed location to non0-US based.
+		 * user has changed location to non-US based.
 		 */
 		const { locationSettings } = props;
 		const region = getCurrencyRegion(
@@ -163,18 +163,14 @@ class Industry extends Component {
 		const region = getCurrencyRegion(
 			locationSettings.woocommerce_default_country
 		);
+		const industryKeys = Object.keys( industries );
 
-		const filteredIndustries = Object.keys( industries ).filter(
-			( slug ) => {
-				if (
-					slug === 'cbd-other-hemp-derived-products' &&
-					region !== 'US'
-				) {
-					return false;
-				}
-				return true;
-			}
-		);
+		const filteredIndustries =
+			region === 'US'
+				? industryKeys
+				: industryKeys.filter(
+						( slug ) => slug !== 'cbd-other-hemp-derived-products'
+				  );
 
 		return (
 			<Fragment>

--- a/client/dashboard/profile-wizard/steps/industry.js
+++ b/client/dashboard/profile-wizard/steps/industry.js
@@ -27,11 +27,38 @@ const onboarding = getSetting( 'onboarding', {} );
 class Industry extends Component {
 	constructor( props ) {
 		const profileItems = get( props, 'profileItems', {} );
+		let selected = profileItems.industry || [];
+
+		/**
+		 * @todo Remove block on `updateProfileItems` refactor to wp.data dataStores.
+		 *
+		 * The following block is a side effect of wc-api not being truly async
+		 * and is a temporary fix until a refactor to wp.data can take place.
+		 *
+		 * Calls to `updateProfileItems` in the previous screen happen async
+		 * and won't be updated in wc-api's state when this component is initialized.
+		 * As such, we need to make sure cbd is not initialized as selected when a
+		 * user has changed location to non0-US based.
+		 */
+		const { locationSettings } = props;
+		const region = getCurrencyRegion(
+			locationSettings.woocommerce_default_country
+		);
+
+		if ( region !== 'US' ) {
+			const cbdSlug = 'cbd-other-hemp-derived-products';
+			selected = selected.filter( ( industry ) => {
+				return cbdSlug !== industry && cbdSlug !== industry.slug;
+			} );
+		}
+		/**
+		 * End block to be removed after refactor.
+		 */
 
 		super();
 		this.state = {
 			error: null,
-			selected: profileItems.industry || [],
+			selected,
 			textInputListContent: {},
 		};
 		this.onContinue = this.onContinue.bind( this );

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -119,13 +119,6 @@ class StoreDetails extends Component {
 		} );
 
 		const profileItemsToUpdate = { setup_client: values.isClient };
-		const cbdSlug = 'cbd-other-hemp-derived-products';
-		const hasCbdIndustry =
-			profileItems.industry &&
-			profileItems.industry.length &&
-			profileItems.industry.some( ( industry ) => {
-				return cbdSlug === industry || cbdSlug === industry.slug;
-			} );
 		const region = getCurrencyRegion( values.countryState );
 
 		/**
@@ -138,7 +131,8 @@ class StoreDetails extends Component {
 		 *
 		 * This comment may be removed when a refactor to wp.data datatores is complete.
 		 */
-		if ( region !== 'US' && hasCbdIndustry ) {
+		if ( region !== 'US' ) {
+			const cbdSlug = 'cbd-other-hemp-derived-products';
 			const trimmedIndustries = profileItems.industry.filter(
 				( industry ) => {
 					return cbdSlug !== industry && cbdSlug !== industry.slug;

--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -86,6 +86,7 @@ class StoreDetails extends Component {
 			updateProfileItems,
 			isProfileItemsError,
 			updateAndPersistSettingsForGroup,
+			profileItems,
 		} = this.props;
 
 		const currencySettings = this.deriveCurrencySettings(
@@ -117,7 +118,36 @@ class StoreDetails extends Component {
 			},
 		} );
 
-		await updateProfileItems( { setup_client: values.isClient } );
+		const profileItemsToUpdate = { setup_client: values.isClient };
+		const cbdSlug = 'cbd-other-hemp-derived-products';
+		const hasCbdIndustry =
+			profileItems.industry &&
+			profileItems.industry.length &&
+			profileItems.industry.some( ( industry ) => {
+				return cbdSlug === industry || cbdSlug === industry.slug;
+			} );
+		const region = getCurrencyRegion( values.countryState );
+
+		/**
+		 * If a user has already selected cdb industry and returns to change to a
+		 * non US store, remove cbd industry.
+		 *
+		 * NOTE: the following call to `updateProfileItems` does not respect the
+		 * `await` and performs an update aysnchronously. This means the following
+		 * screen may not be initialized with correct profile settings.
+		 *
+		 * This comment may be removed when a refactor to wp.data datatores is complete.
+		 */
+		if ( region !== 'US' && hasCbdIndustry ) {
+			const trimmedIndustries = profileItems.industry.filter(
+				( industry ) => {
+					return cbdSlug !== industry && cbdSlug !== industry.slug;
+				}
+			);
+			profileItemsToUpdate.industry = trimmedIndustries;
+		}
+
+		await updateProfileItems( profileItemsToUpdate );
 
 		if ( ! isSettingsError && ! isProfileItemsError ) {
 			goToNextStep();


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4106

Industry type CBD should only be displayed to US based stores. This PR filters the industry list based on store default location to remove the CBD option for non-US based stores.

See p1586527660260000-slack-proton for more info.

### Detailed test instructions:

1. Fire off the OBW.
2. Set a US store location.
3. Proceed to industry.
4. See the CBD option.
5. Go back to Store Details and enter a non-US location.
6. See the CBD industry option no longer available.
7. When clicking "Continue", see the Network request to `/onboarding/profile` and make sure the CBD option is not also sent.