### PR TITLE
Store details: check if industries exist before trimming

### DIFF
--- a/client/dashboard/profile-wizard/steps/store-details.js
+++ b/client/dashboard/profile-wizard/steps/store-details.js
@@ -131,7 +131,11 @@ class StoreDetails extends Component {
 		 *
 		 * This comment may be removed when a refactor to wp.data datatores is complete.
 		 */
-		if ( region !== 'US' ) {
+		if (
+			region !== 'US' &&
+			profileItems.industry &&
+			profileItems.industry.length
+		) {
 			const cbdSlug = 'cbd-other-hemp-derived-products';
 			const trimmedIndustries = profileItems.industry.filter(
 				( industry ) => {


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/4117 Adds a check in Store Details to see if CBD has been selected when a store location is changed to non US stores. This failed on fresh install with no industries present.

This PR adds checks to see if industries are present in profile items and only trims them if they are set.

## Testing Instructions

1. On a fresh install, complete Store Details of the OBW
2. Continue to the next step and see no errors.