### PR TITLE
Fix confusing UX when knowledge base card fails to retreive posts

### DIFF
--- a/client/marketing/overview/knowledge-base/index.js
+++ b/client/marketing/overview/knowledge-base/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
@@ -143,15 +143,20 @@ class KnowledgeBase extends Component {
 			)
 		};
 
+		const renderCardBody = () => {
+			if ( isLoading ) {
+				return <Spinner />;
+			}
+			return posts.length === 0 ? renderEmpty() : renderPosts();
+		};
+
 		return (
 			<Card
 				title={ __( 'WooCommerce knowledge base', 'woocommerce-admin' ) }
 				description={ __( 'Learn the ins and outs of successful marketing from the experts at WooCommerce.', 'woocommerce-admin' ) }
 				className="woocommerce-marketing-knowledgebase-card"
 			>
-				<Fragment>
-					{ isLoading ? <Spinner /> : ( posts.length === 0 ? renderEmpty() : renderPosts() ) }
-				</Fragment>
+				{ renderCardBody() }
 			</Card>
 		)
 	}

--- a/client/marketing/overview/knowledge-base/index.js
+++ b/client/marketing/overview/knowledge-base/index.js
@@ -11,7 +11,7 @@ import { withDispatch, withSelect } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { Card, Pagination } from '@woocommerce/components';
+import { Card, Pagination, EmptyContent } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -109,6 +109,40 @@ class KnowledgeBase extends Component {
 		const { posts, isLoading } = this.props;
 		const { page, animate } = this.state;
 
+		const renderEmpty = () => {
+			const title = __(
+				'There was an error loading knowledge base posts. Please check again later.',
+				'woocommerce-admin'
+			);
+
+			return (
+				<EmptyContent
+					title={ title }
+					illustrationWidth={ 250 }
+					actionLabel=""
+				/>
+			);
+		};
+
+		const renderPosts = () => {
+			return (
+				<div className="woocommerce-marketing-knowledgebase-card__posts">
+					<Slider animationKey={ page } animate={ animate }>
+						{ this.getCurrentSlide() }
+					</Slider>
+					<Pagination
+						page={ page }
+						perPage={ 2 }
+						total={ posts.length }
+						onPageChange={ this.onPaginationPageChange }
+						showPagePicker={ false }
+						showPerPagePicker={ false }
+						showPageArrowsLabel={ false }
+					/>
+				</div>
+			)
+		};
+
 		return (
 			<Card
 				title={ __( 'WooCommerce knowledge base', 'woocommerce-admin' ) }
@@ -116,22 +150,7 @@ class KnowledgeBase extends Component {
 				className="woocommerce-marketing-knowledgebase-card"
 			>
 				<Fragment>
-					{ isLoading ? <Spinner /> : (
-						<div className="woocommerce-marketing-knowledgebase-card__posts">
-							<Slider animationKey={ page } animate={ animate }>
-								{ this.getCurrentSlide() }
-							</Slider>
-							<Pagination
-								page={ page }
-								perPage={ 2 }
-								total={ posts.length }
-								onPageChange={ this.onPaginationPageChange }
-								showPagePicker={ false }
-								showPerPagePicker={ false }
-								showPageArrowsLabel={ false }
-							/>
-						</div>
-					) }
+					{ isLoading ? <Spinner /> : ( posts.length === 0 ? renderEmpty() : renderPosts() ) }
 				</Fragment>
 			</Card>
 		)

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -132,8 +132,8 @@ class Marketing {
 			set_transient(
 				self::RECOMMENDED_PLUGINS_TRANSIENT,
 				$plugins,
-				// Expire transient in 15 minutes if remote get failed
-				// Cache an empty result to avoid repeated failed requests
+				// Expire transient in 15 minutes if remote get failed.
+				// Cache an empty result to avoid repeated failed requests.
 				empty( $plugins ) ? 900 : 3 * DAY_IN_SECONDS
 			);
 		}
@@ -194,7 +194,7 @@ class Marketing {
 			set_transient(
 				self::KNOWLEDGE_BASE_TRANSIENT,
 				$posts,
-				// Expire transient in 15 minutes if remote get failed
+				// Expire transient in 15 minutes if remote get failed.
 				empty( $posts ) ? 900 : DAY_IN_SECONDS
 			);
 		}

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -129,8 +129,13 @@ class Marketing {
 				$plugins = json_decode( $request['body'], true );
 			}
 
-			// Cache an empty result to avoid repeated failed requests.
-			set_transient( self::RECOMMENDED_PLUGINS_TRANSIENT, $plugins, 3 * DAY_IN_SECONDS );
+			set_transient(
+				self::RECOMMENDED_PLUGINS_TRANSIENT,
+				$plugins,
+				// Expire transient in 15 minutes if remote get failed
+				// Cache an empty result to avoid repeated failed requests
+				empty( $plugins ) ? 900 : 3 * DAY_IN_SECONDS
+			);
 		}
 
 		return array_values( $plugins );
@@ -186,7 +191,12 @@ class Marketing {
 				}
 			}
 
-			set_transient( self::KNOWLEDGE_BASE_TRANSIENT, $posts, DAY_IN_SECONDS );
+			set_transient(
+				self::KNOWLEDGE_BASE_TRANSIENT,
+				$posts,
+				// Expire transient in 15 minutes if remote get failed
+				empty( $posts ) ? 900 : DAY_IN_SECONDS
+			);
 		}
 
 		return $posts;


### PR DESCRIPTION
If the Marketing Tab knowledge base posts can't be retrieved for whatever reason the card is kind of broken. See screenshots below.

This PR:
- Uses the `EmptyContent` component to display feedback to the user (see screenshot)
- Reduces the cache timeout when no posts are found from **24 hours** to **15 minutes**. This means users aren't unnecessarily shown an EmptyContent message for 24 hours. Posts will be retrieved sooner when their internet or WC.com is back online.

### Accessibility
- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

Before: 
![Screenshot](https://d.pr/i/PhuT1s+)
Screenshot: https://d.pr/i/PhuT1s 

After: 
![Screenshot](https://d.pr/i/dsX2vV+)
Screenshot: https://d.pr/i/dsX2vV 


### Detailed test instructions:

- Check out this branch locally
- Go offline, turn off your internet
- Delete the transient `wc_marketing_knowledge_base`
- Load the Marketing Tab
- You should see the EmptyContent state shown above