### PR TITLE
Add profiler step view tracks

### DIFF
--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -65,14 +65,13 @@ class ProfileWizard extends Component {
 			window.document.documentElement.scrollTop = 0;
 
 			recordEvent( 'storeprofiler_step_view', {
-				step,
+				step: this.getCurrentStep().key,
 			} );
 		}
 	}
 
 	componentDidMount() {
-		const { profileItems, query, updateProfileItems } = this.props;
-		const { step } = query;
+		const { profileItems, updateProfileItems } = this.props;
 
 		document.documentElement.classList.remove( 'wp-toolbar' );
 		document.body.classList.add( 'woocommerce-onboarding' );
@@ -80,7 +79,7 @@ class ProfileWizard extends Component {
 		document.body.classList.add( 'woocommerce-admin-full-screen' );
 
 		recordEvent( 'storeprofiler_step_view', {
-			step,
+			step: this.getCurrentStep().key,
 		} );
 
 		// Track plugins if already installed.

--- a/client/dashboard/profile-wizard/index.js
+++ b/client/dashboard/profile-wizard/index.js
@@ -63,16 +63,25 @@ class ProfileWizard extends Component {
 
 		if ( prevStep !== step ) {
 			window.document.documentElement.scrollTop = 0;
+
+			recordEvent( 'storeprofiler_step_view', {
+				step,
+			} );
 		}
 	}
 
 	componentDidMount() {
-		const { profileItems, updateProfileItems } = this.props;
+		const { profileItems, query, updateProfileItems } = this.props;
+		const { step } = query;
 
 		document.documentElement.classList.remove( 'wp-toolbar' );
 		document.body.classList.add( 'woocommerce-onboarding' );
 		document.body.classList.add( 'woocommerce-profile-wizard__body' );
 		document.body.classList.add( 'woocommerce-admin-full-screen' );
+
+		recordEvent( 'storeprofiler_step_view', {
+			step,
+		} );
 
 		// Track plugins if already installed.
 		if (

--- a/client/dashboard/profile-wizard/steps/benefits/index.js
+++ b/client/dashboard/profile-wizard/steps/benefits/index.js
@@ -46,6 +46,10 @@ class Benefits extends Component {
 			this.pluginsToInstall.push( 'woocommerce-services' );
 		}
 
+		recordEvent( 'storeprofiler_plugins_to_install', {
+			plugins: this.pluginsToInstall,
+		} );
+
 		this.startPluginInstall = this.startPluginInstall.bind( this );
 		this.skipPluginInstall = this.skipPluginInstall.bind( this );
 	}
@@ -56,7 +60,8 @@ class Benefits extends Component {
 
 		if (
 			isPending &&
-			! isRequesting && ! isInstalling &&
+			! isRequesting &&
+			! isInstalling &&
 			( prevProps.isRequesting || prevState.isInstalling )
 		) {
 			goToNextStep();


### PR DESCRIPTION
Fixes #4136 

Adds a track for viewing each step in the profiler.

### Detailed test instructions:

1. Enter localStorage.setItem( 'debug', 'wc-admin:*' ); into your console. Leave your console open.
1. Enable the profiler.
1. Visit a profiler step and make sure the event is recorded `wcadmin_storeprofiler_step_view` with the correct step name in the console.
1. Change steps via the navigation or completing a step.
1. Make sure an event is fired for each step.