### PR TITLE
Add setting to see if WcPay is configured

### DIFF
--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -40,9 +40,9 @@ export function getPaymentMethods( {
 } ) {
 	const settings = getSetting( 'onboarding', {
 		stripeSupportedCountries: [],
-		wcPayIsConfigured: false,
+		wcPayIsConnected: false,
 	} );
-	const { stripeSupportedCountries, wcPayIsConfigured } = settings;
+	const { stripeSupportedCountries, wcPayIsConnected } = settings;
 
 	const hasCbdIndustry =
 		some( profileItems.industry, {
@@ -112,8 +112,8 @@ export function getPaymentMethods( {
 							'on U.S. issued cards. ',
 						'woocommerce-admin'
 					) }
-					{ wcPayIsConfigured && wcPaySettingsLink }
-					{ ! wcPayIsConfigured && <p>{ tosPrompt }</p> }
+					{ wcPayIsConnected && wcPaySettingsLink }
+					{ ! wcPayIsConnected && <p>{ tosPrompt }</p> }
 					{ profileItems.setup_client && <p>{ wcPayDocPrompt }</p> }
 				</Fragment>
 			),
@@ -124,7 +124,7 @@ export function getPaymentMethods( {
 				isJetpackConnected,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
-			isConfigured: wcPayIsConfigured,
+			isConfigured: wcPayIsConnected,
 			isEnabled:
 				options.woocommerce_woocommerce_payments_settings &&
 				options.woocommerce_woocommerce_payments_settings.enabled ===

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -38,9 +38,11 @@ export function getPaymentMethods( {
 	options,
 	profileItems,
 } ) {
-	const stripeCountries = getSetting( 'onboarding', {
+	const settings = getSetting( 'onboarding', {
 		stripeSupportedCountries: [],
-	} ).stripeSupportedCountries;
+		wcPayIsConfigured: false,
+	} );
+	const { stripeSupportedCountries, wcPayIsConfigured } = settings;
 
 	const hasCbdIndustry =
 		some( profileItems.industry, {
@@ -99,11 +101,6 @@ export function getPaymentMethods( {
 			</Link>
 		);
 
-		// @todo This should check actual connection information.
-		const wcPayIsConfigured = activePlugins.includes(
-			'woocommerce-payments'
-		);
-
 		methods.push( {
 			key: 'wcpay',
 			title: __( 'WooCommerce Payments', 'woocommerce-admin' ),
@@ -154,7 +151,7 @@ export function getPaymentMethods( {
 			),
 			before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
 			visible:
-				stripeCountries.includes( countryCode ) && ! hasCbdIndustry,
+				stripeSupportedCountries.includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
 			isConfigured:

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -107,14 +107,7 @@ class OnboardingTasks {
 		$settings['onboarding']['stylesheet']                     = get_option( 'stylesheet' );
 		$settings['onboarding']['taxJarActivated']                = class_exists( 'WC_Taxjar' );
 		$settings['onboarding']['themeMods']                      = get_theme_mods();
-
-		if ( class_exists( 'WC_Payments' ) ) {
-			$api_client                                  = \WC_Payments::create_api_client();
-			$account                                     = new \WC_Payments_Account( $api_client );
-			$settings['onboarding']['wcPayIsConfigured'] = $account->is_stripe_connected();
-		} else {
-			$settings['onboarding']['wcPayIsConfigured'] = false;
-		}
+		$settings['onboarding']['wcPayIsConfigured']              = apply_filters( 'woocommerce_payments_is_configured', false );
 
 		return $settings;
 	}

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -108,6 +108,14 @@ class OnboardingTasks {
 		$settings['onboarding']['taxJarActivated']                = class_exists( 'WC_Taxjar' );
 		$settings['onboarding']['themeMods']                      = get_theme_mods();
 
+		if ( class_exists( 'WC_Payments' ) ) {
+			$api_client                                  = \WC_Payments::create_api_client();
+			$account                                     = new \WC_Payments_Account( $api_client );
+			$settings['onboarding']['wcPayIsConfigured'] = $account->is_stripe_connected();
+		} else {
+			$settings['onboarding']['wcPayIsConfigured'] = false;
+		}
+
 		return $settings;
 	}
 

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -88,6 +88,14 @@ class OnboardingTasks {
 			return $settings;
 		}
 
+		$wc_pay_is_connected = false;
+		if ( class_exists( '\WC_Payments' ) ) {
+			$wc_payments_gateway = \WC_Payments::get_gateway();
+			$wc_pay_is_connected = method_exists( $wc_payments_gateway, 'is_connected' )
+				? $wc_payments_gateway->is_connected()
+				: false;
+		}
+
 		// @todo We may want to consider caching some of these and use to check against
 		// task completion along with cache busting for active tasks.
 		$settings['onboarding']['automatedTaxSupportedCountries'] = self::get_automated_tax_supported_countries();
@@ -107,7 +115,7 @@ class OnboardingTasks {
 		$settings['onboarding']['stylesheet']                     = get_option( 'stylesheet' );
 		$settings['onboarding']['taxJarActivated']                = class_exists( 'WC_Taxjar' );
 		$settings['onboarding']['themeMods']                      = get_theme_mods();
-		$settings['onboarding']['wcPayIsConfigured']              = apply_filters( 'woocommerce_payments_is_configured', false );
+		$settings['onboarding']['wcPayIsConnected']               = $wc_pay_is_connected;
 
 		return $settings;
 	}


### PR DESCRIPTION
Fixes #4122 

Adds a setting to check if WcPay is configured. /cc @allendav Would be great to get your eyes on this to make sure this is the correct way to check configuration.

### Screenshots

<img width="705" alt="Screen Shot 2020-04-17 at 6 03 42 PM" src="https://user-images.githubusercontent.com/10561050/79583515-e06f4780-80d5-11ea-8407-2fa97dba4e56.png">


### Detailed test instructions:

1. Install, but don't configure WcPay and checkout this branch https://github.com/Automattic/woocommerce-payments/pull/629.
1. Navigate to the task list.
1. Make sure WcPay is still not yet configured and contains the "Set up" button.
1. Set up WcPay.
1. Navigate back to the task list after setup and note that WcPay is configured and now contains a toggle button instead of the previous style.