### PR TITLE
OBW: "activated" success message upon continuing with existing theme

### DIFF
--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -92,7 +92,7 @@ class Theme extends Component {
 			location,
 		} );
 
-		if ( theme !== activeTheme && getPriceValue( price ) <= 0 ) {
+		if ( slug !== activeTheme && getPriceValue( price ) <= 0 ) {
 			this.installTheme( slug );
 		} else {
 			updateProfileItems( { theme: slug } );
@@ -169,7 +169,13 @@ class Theme extends Component {
 	}
 
 	renderTheme( theme ) {
-		const { demo_url: demoUrl, has_woocommerce_support: hasSupport, image, slug, title } = theme;
+		const {
+			demo_url: demoUrl,
+			has_woocommerce_support: hasSupport,
+			image,
+			slug,
+			title,
+		} = theme;
 		const { chosen } = this.state;
 		const { activeTheme = '' } = getSetting( 'onboarding', {} );
 

--- a/client/dashboard/profile-wizard/steps/theme/index.js
+++ b/client/dashboard/profile-wizard/steps/theme/index.js
@@ -83,7 +83,7 @@ class Theme extends Component {
 
 	onChoose( theme, location = '' ) {
 		const { updateProfileItems } = this.props;
-		const { price, slug } = theme;
+		const { is_installed: isInstalled, price, slug } = theme;
 		const { activeTheme = '' } = getSetting( 'onboarding', {} );
 
 		this.setState( { chosen: slug } );
@@ -93,7 +93,11 @@ class Theme extends Component {
 		} );
 
 		if ( slug !== activeTheme && getPriceValue( price ) <= 0 ) {
-			this.installTheme( slug );
+			if ( isInstalled ) {
+				this.activateTheme( slug );
+			} else {
+				this.installTheme( slug );
+			}
 		} else {
 			updateProfileItems( { theme: slug } );
 		}
@@ -106,7 +110,17 @@ class Theme extends Component {
 			path: '/wc-admin/onboarding/themes/install?theme=' + slug,
 			method: 'POST',
 		} )
-			.then( () => {
+			.then( ( response ) => {
+				createNotice(
+					'success',
+					sprintf(
+						__(
+							'%s was installed on your site.',
+							'woocommerce-admin'
+						),
+						response.name
+					)
+				);
 				this.activateTheme( slug );
 			} )
 			.catch( ( response ) => {
@@ -127,7 +141,7 @@ class Theme extends Component {
 					'success',
 					sprintf(
 						__(
-							'%s was installed and activated on your site.',
+							'%s was activated on your site.',
 							'woocommerce-admin'
 						),
 						response.name


### PR DESCRIPTION
Fixes #4109

This PR solves a problem at the end of the profiler. There was a conditional that always was sending the user to the theme installation flow.

### Screenshots
**Test 1**
In the last step of the new onboarding, when the user presses `Continue with my active theme`, it should finish the process without reinstalling the installed theme.
![Screen Capture on 2020-04-19 at 19-05-16](https://user-images.githubusercontent.com/1314156/79701338-a38c8780-8272-11ea-9196-a1a518e0bb11.gif)

**Test 2**
When the user chooses a new theme, it should be installed and show a message confirming that the process was successful
![Screen Capture on 2020-04-19 at 22-46-22](https://user-images.githubusercontent.com/1314156/79706535-f7599980-828f-11ea-867d-67f1777ba3ba.gif)


### Detailed test instructions:

- Go to the last step of the new onboarding (URL: `/wp-admin/admin.php?page=wc-admin&step=theme`).

**Test 1**
- Press `Continue with my active theme`.
- It shouldn't reinstall the selected theme. 
- Verify that the message: `[theme name] was installed and activated on your site` is not shown.

**Test 2**
- Press `Choose` to select one of the available themes.
- It should install the new theme and show a message like: `[theme name] was installed and activated on your site`.
<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fixed the conditional that always was sending the user to the theme installation flow.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
