### PR TITLE
OBW: respect Store Location async

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -111,12 +111,8 @@ class Shipping extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { countryCode, isCompleteAddress } = this.props;
+		const { countryCode } = this.props;
 		const { step } = this.state;
-
-		if ( step === 'store_location' && isCompleteAddress ) {
-			this.completeStep();
-		}
 
 		if (
 			step === 'rates' &&
@@ -185,6 +181,7 @@ class Shipping extends Component {
 							recordEvent( 'tasklist_shipping_set_location', {
 								country,
 							} );
+							this.completeStep();
 						} }
 					/>
 				),
@@ -334,15 +331,6 @@ export default compose(
 		const countryName = country ? country.name : null;
 		const activePlugins = getActivePlugins();
 
-		const {
-			woocommerce_store_address: storeAddress,
-			woocommerce_default_country: defaultCountry,
-			woocommerce_store_postcode: storePostcode,
-		} = settings;
-		const isCompleteAddress = Boolean(
-			storeAddress && defaultCountry && storePostcode
-		);
-
 		return {
 			countryCode,
 			countryName,
@@ -351,7 +339,6 @@ export default compose(
 			settings,
 			activePlugins,
 			isJetpackConnected: isJetpackConnected(),
-			isCompleteAddress,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -111,8 +111,12 @@ class Shipping extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { countryCode } = this.props;
+		const { countryCode, isCompleteAddress } = this.props;
 		const { step } = this.state;
+
+		if ( step === 'store_location' && isCompleteAddress ) {
+			this.completeStep();
+		}
 
 		if (
 			step === 'rates' &&
@@ -181,7 +185,6 @@ class Shipping extends Component {
 							recordEvent( 'tasklist_shipping_set_location', {
 								country,
 							} );
-							this.completeStep();
 						} }
 					/>
 				),
@@ -331,6 +334,15 @@ export default compose(
 		const countryName = country ? country.name : null;
 		const activePlugins = getActivePlugins();
 
+		const {
+			woocommerce_store_address: storeAddress,
+			woocommerce_default_country: defaultCountry,
+			woocommerce_store_postcode: storePostcode,
+		} = settings;
+		const isCompleteAddress = Boolean(
+			storeAddress && defaultCountry && storePostcode
+		);
+
 		return {
 			countryCode,
 			countryName,
@@ -339,6 +351,7 @@ export default compose(
 			settings,
 			activePlugins,
 			isJetpackConnected: isJetpackConnected(),
+			isCompleteAddress,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -111,22 +111,8 @@ class Shipping extends Component {
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { countryCode, settings } = this.props;
-		const {
-			woocommerce_store_address: storeAddress,
-			woocommerce_default_country: defaultCountry,
-			woocommerce_store_postcode: storePostcode,
-		} = settings;
+		const { countryCode } = this.props;
 		const { step } = this.state;
-
-		if (
-			step === 'store_location' &&
-			storeAddress &&
-			defaultCountry &&
-			storePostcode
-		) {
-			this.completeStep();
-		}
 
 		if (
 			step === 'rates' &&
@@ -187,6 +173,7 @@ class Shipping extends Component {
 				),
 				content: (
 					<StoreLocation
+						{ ...this.props }
 						onComplete={ ( values ) => {
 							const country = getCountryCode(
 								values.countryState
@@ -196,7 +183,6 @@ class Shipping extends Component {
 							} );
 							this.completeStep();
 						} }
-						{ ...this.props }
 					/>
 				),
 				visible: true,
@@ -357,9 +343,13 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
+		const { updateAndPersistSettingsForGroup } = dispatch(
+			SETTINGS_STORE_NAME
+		);
 
 		return {
 			createNotice,
+			updateAndPersistSettingsForGroup,
 		};
 	} )
 )( Shipping );

--- a/client/dashboard/task-list/tasks/steps/location.js
+++ b/client/dashboard/task-list/tasks/steps/location.js
@@ -29,10 +29,10 @@ export default class StoreLocation extends Component {
 			onComplete,
 			createNotice,
 			isSettingsError,
-			updateSettings,
+			updateAndPersistSettingsForGroup,
 		} = this.props;
 
-		await updateSettings( {
+		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
 				woocommerce_store_address: values.addressLine1,
 				woocommerce_store_address_2: values.addressLine2,

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -266,7 +266,8 @@ class Tax extends Component {
 							} );
 							if ( this.shouldShowSuccessScreen() ) {
 								this.setState( { stepIndex: null } );
-							} else {
+								// Only complete step if another update hasn't already shown succes screen.
+							} else if ( this.state.stepIndex !== null ) {
 								this.completeStep();
 							}
 						} }

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -165,7 +165,7 @@ class Tax extends Component {
 		}
 	}
 
-	configureTaxRates() {
+	async configureTaxRates() {
 		const {
 			generalSettings,
 			updateAndPersistSettingsForGroup,
@@ -173,16 +173,16 @@ class Tax extends Component {
 
 		if ( generalSettings.woocommerce_calc_taxes !== 'yes' ) {
 			this.setState( { isPending: true } );
-			updateAndPersistSettingsForGroup( 'general', {
+			await updateAndPersistSettingsForGroup( 'general', {
 				general: {
 					woocommerce_calc_taxes: 'yes',
 				},
 			} );
-		} else {
-			window.location = getAdminLink(
-				'admin.php?page=wc-settings&tab=tax&section=standard&wc_onboarding_active_task=tax'
-			);
 		}
+
+		window.location = getAdminLink(
+			'admin.php?page=wc-settings&tab=tax&section=standard&wc_onboarding_active_task=tax'
+		);
 	}
 
 	updateAutomatedTax() {

--- a/client/dashboard/task-list/tasks/tax.js
+++ b/client/dashboard/task-list/tasks/tax.js
@@ -185,28 +185,26 @@ class Tax extends Component {
 		);
 	}
 
-	updateAutomatedTax() {
-		const {
-			createNotice,
-			isGeneralSettingsError,
-			isTaxSettingsError,
-			updateAndPersistSettingsForGroup,
-		} = this.props;
+	async updateAutomatedTax() {
+		const { createNotice, updateAndPersistSettingsForGroup } = this.props;
 		const { automatedTaxEnabled } = this.state;
 
-		updateAndPersistSettingsForGroup( 'tax', {
+		await updateAndPersistSettingsForGroup( 'tax', {
 			tax: {
 				wc_connect_taxes_enabled: automatedTaxEnabled ? 'yes' : 'no',
 			},
 		} );
 
-		updateAndPersistSettingsForGroup( 'general', {
+		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
 				woocommerce_calc_taxes: 'yes',
 			},
 		} );
 
-		if ( ! isTaxSettingsError && ! isGeneralSettingsError ) {
+		if (
+			! this.props.isTaxSettingsError &&
+			! this.props.isGeneralSettingsError
+		) {
 			// @todo This is a workaround to force the task to mark as complete.
 			// This should probably be updated to use wc-api so we can fetch tax rates.
 			setSetting( 'onboarding', {


### PR DESCRIPTION
Fixes #4031

1. `<StoreLocation />` had the wrong props for updating locations in the shipping task.
2. Async methods in the shipping and tax tasks called actual async actions after the settings refactor. This caused duplicate logic to be called:

>Functions of the OBW were written using async/await pattern even though data actions weren't actually async functions. This was a known problem #2959. Async functions called by StoreLocation's onComplete called duplicate logic also found in its parent component's componentDidUpdate. But, since the async logic was called synchronously, one or the other wasn't actually firing.

>Settings data stores were refactored and did export async action creators. So that duplicate logic ended up being fired twice.

### Detailed test instructions:

1. Go through both “Set up shipping” and “Set up tax” tasks on the Dashboard.
2. Delete the `woocommerce_store_address` option and go through each again.
3. Try a variety of jetpack connected and not installed on each.
4. Make sure no steps are skipped and the tasks operate as they should.