### PR TITLE
Adds the onboarding payments note

### DIFF
--- a/client/dashboard/task-list/tasks.js
+++ b/client/dashboard/task-list/tasks.js
@@ -51,6 +51,11 @@ export function getAllTasks( {
 		[ 'woocommerce_task_list_payments', 'completed' ],
 		false
 	);
+	const paymentsSkipped = get(
+		options,
+		[ 'woocommerce_task_list_payments', 'skipped' ],
+		false
+	);
 
 	const tasks = [
 		{
@@ -143,9 +148,9 @@ export function getAllTasks( {
 			),
 			icon: 'payment',
 			container: <Payments />,
-			completed: paymentsCompleted,
+			completed: paymentsCompleted || paymentsSkipped,
 			onClick: () => {
-				if ( paymentsCompleted ) {
+				if ( paymentsCompleted || paymentsSkipped ) {
 					window.location = getAdminLink(
 						'admin.php?page=wc-settings&tab=checkout'
 					);

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -83,7 +83,7 @@ class Payments extends Component {
 		updateOptions( {
 			woocommerce_task_list_payments: {
 				completed: 1,
-				timestamp: Date.now(),
+				timestamp: Math.floor( Date.now() / 1000 ),
 			},
 		} );
 
@@ -110,7 +110,7 @@ class Payments extends Component {
 		updateOptions( {
 			woocommerce_task_list_payments: {
 				skipped: 1,
-				timestamp: Date.now(),
+				timestamp: Math.floor( Date.now() / 1000 ),
 			},
 		} );
 

--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -83,6 +83,7 @@ class Payments extends Component {
 		updateOptions( {
 			woocommerce_task_list_payments: {
 				completed: 1,
+				timestamp: Date.now(),
 			},
 		} );
 
@@ -108,7 +109,8 @@ class Payments extends Component {
 
 		updateOptions( {
 			woocommerce_task_list_payments: {
-				completed: 1,
+				skipped: 1,
+				timestamp: Date.now(),
 			},
 		} );
 

--- a/src/Events.php
+++ b/src/Events.php
@@ -15,6 +15,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Personalize_Store;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Marketing;
@@ -67,6 +68,7 @@ class Events {
 		WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();
 		WC_Admin_Notes_Tracking_Opt_In::possibly_add_tracking_opt_in_note();
 		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_onboarding_email_marketing_note();
+		WC_Admin_Notes_Onboarding_Payments::possibly_add_onboarding_payments_note();
 		WC_Admin_Notes_Personalize_Store::possibly_add_personalize_store_note();
 		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
 		WC_Admin_Notes_Marketing::possibly_add_note_intro();

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * WooCommerce Admin: Payments reminder note.
+ *
+ * Adds a notes to complete the payment methods.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+use \Automattic\WooCommerce\Admin\Features\Onboarding;
+
+/**
+ * WC_Admin_Notes_Onboarding_Payments.
+ */
+class WC_Admin_Notes_Onboarding_Payments {
+	const NOTE_NAME = 'wc-admin-onboarding-payments-reminder';
+
+	/**
+	 * Creates a note to remind store owners to set up payments.
+	 */
+	public static function possibly_add_onboarding_payments_note() {
+		// This note should only be added if the task list is still shown.
+		if ( ! Onboarding::should_show_tasks() ) {
+			return;
+		}
+
+		// Make sure payments task was skipped at least 3 days ago.
+		$three_days = 3 * DAY_IN_SECONDS;
+		( ( time() - $wc_admin_installed ) >= $seconds );
+		$payments_task = get_option( 'woocommerce_task_list_payments', array() );
+		if (
+			! isset( $payments_task['skipped'] ) ||
+			( time() - $payments_task['timestamp'] ) < $three_days
+		) {
+			return;
+		}
+
+		// Check to see if any gateways have been added.
+		$gateways         = WC()->payment_gateways->get_available_payment_gateways();
+		$enabled_gateways = array_filter(
+			$gateways,
+			function( $gateway ) {
+				return 'yes' === $gateway->enabled;
+			}
+		);
+		if ( ! empty( $enabled_gateways ) ) {
+			return;
+		}
+
+		// Don't add this note if previously added.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Start accepting payments on your store!', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Take payments with the provider that’s right for you - choose from 100+ payment gateways for WooCommerce.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'credit-card' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'view-payment-gateways',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/product-category/woocommerce-extensions/payment-gateways/',
+			'actioned',
+			true
+		);
+
+		$note->save();
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -29,12 +29,11 @@ class WC_Admin_Notes_Onboarding_Payments {
 		}
 
 		// Make sure payments task was skipped at least 3 days ago.
-		$three_days = 3 * DAY_IN_SECONDS;
-		( ( time() - $wc_admin_installed ) >= $seconds );
-		$payments_task = get_option( 'woocommerce_task_list_payments', array() );
+		$three_days_in_seconds = 3 * DAY_IN_SECONDS;
+		$payments_task         = get_option( 'woocommerce_task_list_payments', array() );
 		if (
 			! isset( $payments_task['skipped'] ) ||
-			( time() - $payments_task['timestamp'] ) < $three_days
+			( time() - $payments_task['timestamp'] ) < $three_days_in_seconds
 		) {
 			return;
 		}

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -33,6 +33,7 @@ class WC_Admin_Notes_Onboarding_Payments {
 		$payments_task         = get_option( 'woocommerce_task_list_payments', array() );
 		if (
 			! isset( $payments_task['skipped'] ) ||
+			! isset( $payments_task['timestamp'] ) ||
 			( time() - $payments_task['timestamp'] ) < $three_days_in_seconds
 		) {
 			return;


### PR DESCRIPTION
Fixes #3791 

If payments are skipped in the task list, a note is added 3 days after to reminder store owners to set up payments.

Note that this note is added if the following conditions are met:
* The user skipped the payments task more than 3 days ago.
* The user does not have any enabled payment gateways.

### Screenshots
<img width="517" alt="Screen Shot 2020-04-20 at 6 53 04 PM" src="https://user-images.githubusercontent.com/10561050/79772513-d600b800-8338-11ea-80cf-e51c66918cc4.png">

### Detailed test instructions:

1. Delete `woocommerce_task_list_payments` in your options table if it exists.
1. Disable all payment methods.
1. Enable the task list and visit the payments task.
1. Choose the "skip" option.
1. Wait 3 days ... or update the timestamp in `woocommerce_task_list_payments` to speed things up.
1. Check that a note is added.
1.  Click on the "Learn more" button in the note and make sure the note is actioned and you are taken to the wc payment extensions page.