### PR TITLE
Remove auto connect functionality from Stripe payment task

### DIFF
--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -29,7 +29,7 @@ class Stripe extends Component {
 			connectURL: null,
 			errorTitle: null,
 			errorMessage: null,
-			isPending: true,
+			isPending: false,
 		};
 
 		this.updateSettings = this.updateSettings.bind( this );
@@ -294,7 +294,12 @@ class Stripe extends Component {
 	}
 
 	getConnectStep() {
-		const { oAuthConnectFailed, connectURL, errorMessage } = this.state;
+		const {
+			connectURL,
+			errorMessage,
+			isPending,
+			oAuthConnectFailed,
+		} = this.state;
 		const connectStep = {
 			key: 'connect',
 			label: __( 'Connect your Stripe account', 'woocommerce-admin' ),
@@ -307,12 +312,11 @@ class Stripe extends Component {
 			};
 		}
 
-		if ( ! this.requiresManualConfig() ) {
-			// We may still be fetching the connect URL.
-			if ( ! oAuthConnectFailed && ! connectURL ) {
-				return connectStep;
-			}
+		if ( isPending ) {
+			return connectStep;
+		}
 
+		if ( ! oAuthConnectFailed && connectURL ) {
 			return {
 				...connectStep,
 				description: __(
@@ -360,10 +364,7 @@ export default compose(
 		const { getActivePlugins, isJetpackConnected } = select(
 			PLUGINS_STORE_NAME
 		);
-		const options = getOptions( [
-			'woocommerce_stripe_settings',
-			'woocommerce_default_country',
-		] );
+		const options = getOptions( [ 'woocommerce_stripe_settings' ] );
 		const stripeSettings = get(
 			options,
 			[ 'woocommerce_stripe_settings' ],

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -7,7 +7,7 @@ import { compose } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
 import { withDispatch } from '@wordpress/data';
 import interpolateComponents from 'interpolate-components';
-import { Button, Modal } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { get } from 'lodash';
 
 /**
@@ -27,8 +27,6 @@ class Stripe extends Component {
 		this.state = {
 			oAuthConnectFailed: false,
 			connectURL: null,
-			errorTitle: null,
-			errorMessage: null,
 			isPending: false,
 		};
 
@@ -147,37 +145,6 @@ class Stripe extends Component {
 		}
 	}
 
-	renderErrorModal() {
-		const { errorTitle, errorMessage } = this.state;
-		return (
-			<Modal
-				title={ errorTitle }
-				onRequestClose={ () =>
-					this.setState( { errorMessage: null, errorTitle: null } )
-				}
-				className="woocommerce-task-payments__stripe-error-modal"
-			>
-				<div className="woocommerce-task-payments__stripe-error-wrapper">
-					<div className="woocommerce-task-payments__stripe-error-message">
-						{ errorMessage }
-					</div>
-					<Button
-						isPrimary
-						isDefault
-						onClick={ () =>
-							this.setState( {
-								errorMessage: null,
-								errorTitle: null,
-							} )
-						}
-					>
-						{ __( 'OK', 'woocommerce-admin' ) }
-					</Button>
-				</div>
-			</Modal>
-		);
-	}
-
 	renderConnectButton() {
 		const { connectURL } = this.state;
 		return (
@@ -294,23 +261,12 @@ class Stripe extends Component {
 	}
 
 	getConnectStep() {
-		const {
-			connectURL,
-			errorMessage,
-			isPending,
-			oAuthConnectFailed,
-		} = this.state;
+		const { connectURL, isPending, oAuthConnectFailed } = this.state;
+
 		const connectStep = {
 			key: 'connect',
 			label: __( 'Connect your Stripe account', 'woocommerce-admin' ),
 		};
-
-		if ( errorMessage ) {
-			return {
-				...connectStep,
-				content: this.renderErrorModal(),
-			};
-		}
 
 		if ( isPending ) {
 			return connectStep;

--- a/client/dashboard/task-list/tasks/payments/stripe.js
+++ b/client/dashboard/task-list/tasks/payments/stripe.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
@@ -20,24 +20,18 @@ import { WCS_NAMESPACE } from 'wc-api/constants';
 import withSelect from 'wc-api/with-select';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 
-/**
- * Internal dependencies
- */
-import { getCountryCode } from 'dashboard/utils';
-
 class Stripe extends Component {
 	constructor( props ) {
 		super( props );
 
 		this.state = {
-			autoConnectFailed: false,
+			oAuthConnectFailed: false,
 			connectURL: null,
 			errorTitle: null,
 			errorMessage: null,
 			isPending: true,
 		};
 
-		this.autoCreateAccount = this.autoCreateAccount.bind( this );
 		this.updateSettings = this.updateSettings.bind( this );
 	}
 
@@ -54,12 +48,6 @@ class Stripe extends Component {
 				this.completeMethod();
 				return;
 			}
-
-			/* eslint-disable react/no-did-mount-set-state */
-			this.setState( {
-				autoConnectFailed: true,
-			} );
-			/* eslint-enable react/no-did-mount-set-state */
 		}
 
 		if ( ! this.requiresManualConfig() ) {
@@ -101,12 +89,12 @@ class Stripe extends Component {
 
 	requiresManualConfig() {
 		const { activePlugins, isJetpackConnected } = this.props;
-		const { autoConnectFailed } = this.state;
+		const { oAuthConnectFailed } = this.state;
 
 		return (
 			! isJetpackConnected ||
 			! activePlugins.includes( 'woocommerce-services' ) ||
-			autoConnectFailed
+			oAuthConnectFailed
 		);
 	}
 
@@ -142,7 +130,7 @@ class Stripe extends Component {
 			} );
 			if ( ! result || ! result.oauthUrl ) {
 				this.setState( {
-					autoConnectFailed: true,
+					oAuthConnectFailed: true,
 					isPending: false,
 				} );
 				return;
@@ -153,59 +141,9 @@ class Stripe extends Component {
 			} );
 		} catch ( error ) {
 			this.setState( {
-				autoConnectFailed: true,
+				oAuthConnectFailed: true,
 				isPending: false,
 			} );
-		}
-	}
-
-	async autoCreateAccount( values ) {
-		const { countryCode } = this.props;
-		const { connectURL } = this.state;
-		const { email } = values;
-
-		try {
-			this.setState( { isPending: true } );
-
-			const result = await apiFetch( {
-				path: WCS_NAMESPACE + '/connect/stripe/account',
-				method: 'POST',
-				data: {
-					email,
-					country: countryCode,
-				},
-			} );
-
-			if ( result ) {
-				this.completeMethod();
-				return;
-			}
-		} catch {
-			if ( ! connectURL ) {
-				const errorTitle = __( 'Stripe', 'woocommerce-admin' );
-				const errorMessage = interpolateComponents( {
-					mixedString: sprintf(
-						__(
-							'We tried to create a Stripe account automatically for {{strong}}%s{{/strong}}, but an error occured. Please try connecting manually to continue.',
-							'woocommerce-admin'
-						),
-						email
-					),
-					components: {
-						strong: <strong />,
-					},
-				} );
-
-				this.setState( {
-					autoConnectFailed: true,
-					errorTitle,
-					errorMessage,
-					isPending: false,
-				} );
-			} else {
-				// An account with that email may exist so send them to Stripe to connect via oAuth.
-				window.location = connectURL;
-			}
 		}
 	}
 
@@ -240,39 +178,12 @@ class Stripe extends Component {
 		);
 	}
 
-	renderAutoConnect() {
-		const { isPending } = this.state;
-
+	renderConnectButton() {
+		const { connectURL } = this.state;
 		return (
-			<Form
-				initialValues={ {
-					email: '',
-				} }
-				onSubmitCallback={ this.autoCreateAccount }
-				validate={ this.validateAutoConnect }
-			>
-				{ ( { getInputProps, handleSubmit } ) => {
-					return (
-						<div className="woocommerce-task-payments__woocommerce-services-options">
-							<TextControl
-								label={ __(
-									'Email address',
-									'woocommerce-admin'
-								) }
-								{ ...getInputProps( 'email' ) }
-							/>
-							<Button
-								isPrimary
-								isDefault
-								isBusy={ isPending }
-								onClick={ handleSubmit }
-							>
-								{ __( 'Connect', 'woocommerce-admin' ) }
-							</Button>
-						</div>
-					);
-				} }
-			</Form>
+			<Button isPrimary isDefault href={ connectURL }>
+				{ __( 'Connect', 'woocommerce-admin' ) }
+			</Button>
 		);
 	}
 
@@ -310,16 +221,6 @@ class Stripe extends Component {
 				'Please enter a valid secret key. Valid keys start with "sk_live" or "rk_live".',
 				'woocommerce-admin'
 			);
-		}
-
-		return errors;
-	}
-
-	validateAutoConnect( values ) {
-		const errors = {};
-
-		if ( ! values.email ) {
-			errors.email = __( 'Please enter your email', 'woocommerce-admin' );
 		}
 
 		return errors;
@@ -393,7 +294,7 @@ class Stripe extends Component {
 	}
 
 	getConnectStep() {
-		const { autoConnectFailed, connectURL, errorMessage } = this.state;
+		const { oAuthConnectFailed, connectURL, errorMessage } = this.state;
 		const connectStep = {
 			key: 'connect',
 			label: __( 'Connect your Stripe account', 'woocommerce-admin' ),
@@ -408,17 +309,17 @@ class Stripe extends Component {
 
 		if ( ! this.requiresManualConfig() ) {
 			// We may still be fetching the connect URL.
-			if ( ! autoConnectFailed && ! connectURL ) {
+			if ( ! oAuthConnectFailed && ! connectURL ) {
 				return connectStep;
 			}
 
 			return {
 				...connectStep,
 				description: __(
-					'A Stripe account is required to process payments. We’ll create an account for you if you don’t have one already.',
+					'A Stripe account is required to process payments.',
 					'woocommerce-admin'
 				),
-				content: this.renderAutoConnect(),
+				content: this.renderConnectButton(),
 			};
 		}
 
@@ -463,9 +364,6 @@ export default compose(
 			'woocommerce_stripe_settings',
 			'woocommerce_default_country',
 		] );
-		const countryCode = getCountryCode(
-			options.woocommerce_default_country
-		);
 		const stripeSettings = get(
 			options,
 			[ 'woocommerce_stripe_settings' ],
@@ -480,7 +378,6 @@ export default compose(
 
 		return {
 			activePlugins: getActivePlugins(),
-			countryCode,
 			hasOptionsError,
 			isJetpackConnected: isJetpackConnected(),
 			isOptionsRequesting,


### PR DESCRIPTION
As of May 31 the API for stripe deferred account activation will no longer be
supported. As a result, the Stripe payment on-boarding step will no
longer be able to auto-create accounts for users.

See paJDYF-x4-p2

This PR removes all auto-connect functionality from the Stripe connect step, and instead
falls back to the oAuth setup flow.

### Screenshots

Before:
![stripe_onboarding_connect_before](https://user-images.githubusercontent.com/17905991/79816836-1acf3200-83bf-11ea-998b-6dfbd364ad1f.png)

After:
![stripe_onboarding_connect_after](https://user-images.githubusercontent.com/17905991/79816850-1f93e600-83bf-11ea-9454-9536a2136a39.png)

### Detailed test instructions:

- Kick off the onboarding task list by activating Woo from a fresh installation of WordPress (Be sure to install and activate Jetpack first)
- During the onboarding process, be sure to install WooCommerce Services per the prompt
- Once you make it to the Task List (Set up your store and start selling), select **Set up payments > Stripe Set up**
- If both Jetpack and WC Services are installed and connected, you will see a Connect button. Select the button.
- You should be directed to Stripes connect URL where you can sign in, sign up, or cancel and return
- Test all three, and ensure you are redirected back to the onboarding process, and stripe has been toggled on after successfully connecting

### Changelog Note:

Tweak: Remove Stripe deferred account activation, and revert to oAuth connection flow.
