### PR TITLE
Reset profiler when visiting old obw URL

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -149,7 +149,7 @@ class Onboarding {
 
 		if ( 'wc-setup' === $current_page ) {
 			delete_transient( '_wc_activation_redirect' );
-			wp_safe_redirect( wc_admin_url() );
+			wp_safe_redirect( wc_admin_url( '&reset_profiler=1' ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #3695 

Resets the new onboarding profiler when visitng the old OBW path (i.e., `wp-admin/admin.php?page=wc-setup`).

### Detailed test instructions:

1. Complete the profiler so that the task list is shown.
1. Visit `wp-admin/admin.php?page=wc-setup`.
1. Make sure the profiler is reset.