### PR TITLE
Changed email marketing note and the old filter was removed

### DIFF
--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -16,11 +16,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Admin_Notes_Onboarding_Email_Marketing {
 	/**
-	 * Note traits.
-	 */
-	use NoteTraits;
-
-	/**
 	 * Name of the note for use in the database.
 	 */
 	const NOTE_NAME = 'wc-admin-onboarding-email-marketing';

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -11,8 +11,6 @@ namespace Automattic\WooCommerce\Admin\Notes;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Admin\Features\Onboarding;
-
 /**
  * WC_Admin_Notes_Onboarding_Email_Marketing
  */
@@ -31,14 +29,6 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 	 * Possibly add email marketing note.
 	 */
 	public static function possibly_add_onboarding_email_marketing_note() {
-		// We want to show the email marketing note after day 2 if the profiler is complete.
-		$onboarding_data     = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
-		$is_completed        = isset( $onboarding_data['completed'] ) && true === $onboarding_data['completed'];
-		$two_days_in_seconds = 2 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $two_days_in_seconds ) || ! $is_completed ) {
-			return;
-		}
-
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// We already have this note? Then exit, we're done.
@@ -47,7 +37,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 			return;
 		}
 
-		$content = __( 'We\'re here for you — get tips, product updates, and inspiration straight to your mailbox.', 'woocommerce-admin' );
+		$content = __( 'We\'re here for you - get tips, product updates and inspiration straight to your email box', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Tips, product updates, and inspiration', 'woocommerce-admin' ) );


### PR DESCRIPTION
Fixes #4156

In this PR the email marketing note was modified and the old filter was removed.

### Detailed test instructions:

1. Go to the database and delete the registry with name `wc-admin-onboarding-email-marketing` in the table `wp_wc_admin_notes`.
>Sentese: DELETE FROM \`wp_wc_admin_notes\` WHERE \`name\` = 'wc-admin-onboarding-email-marketing'

2. Be sure you have `WooCommerce` installed.
3. Run the `cron`. If you have trouble doing it, install the plugin `WP Control`.
4. Verify that a registry with the name `wc-admin-onboarding-email-marketing` was added to the table `wp_wc_admin_notes` with the content: `We're here for you - get tips, product updates and inspiration straight to your email box` in.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: the email marketing note was modified and the old filter was removed
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
