### PR TITLE
Homepage: Add Hello World, routing, and feature flag

### DIFF
--- a/client/homepage/index.js
+++ b/client/homepage/index.js
@@ -1,0 +1,5 @@
+const Homepage = () => {
+	return <div>Hello World</div>;
+};
+
+export default Homepage;

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -22,6 +22,7 @@ import {
 import AnalyticsReport, { getReports } from 'analytics/report';
 import AnalyticsSettings from 'analytics/settings';
 import Dashboard from 'dashboard';
+import Homepage from 'homepage';
 import DevDocs from 'devdocs';
 import MarketingOverview from 'marketing/overview';
 
@@ -69,10 +70,6 @@ export const getPages = () => {
 			wpOpenMenu: 'toplevel_page_woocommerce',
 		} );
 	}
-
-	const Homepage = () => {
-		return <div>Hello World</div>;
-	};
 
 	if ( window.wcAdminFeatures.homepage ) {
 		pages.push( {

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -55,7 +55,7 @@ export const getPages = () => {
 		} );
 	}
 
-	if ( window.wcAdminFeatures[ 'analytics-dashboard' ] ) {
+	if ( window.wcAdminFeatures[ 'analytics-dashboard' ] && ! window.wcAdminFeatures.homepage ) {
 		pages.push( {
 			container: Dashboard,
 			path: '/',
@@ -67,7 +67,40 @@ export const getPages = () => {
 		} );
 	}
 
+	const Homepage = () => {
+		return (
+			<div>Hello World</div>
+		);
+	};
+
+	if ( window.wcAdminFeatures.homepage ) {
+		pages.push( {
+			container: Homepage,
+			path: '/',
+			breadcrumbs: [
+				...initialBreadcrumbs,
+				__( 'Home', 'woocommerce-admin' ),
+			],
+			wpOpenMenu: 'toplevel_page_woocommerce',
+		} );
+	}
+
 	if ( window.wcAdminFeatures.analytics ) {
+		if ( window.wcAdminFeatures.homepage ) {
+			pages.push( {
+				container: Dashboard,
+				path: '/analytics/overview',
+				breadcrumbs: [
+					...initialBreadcrumbs,
+					[
+						'/analytics/overview',
+						__( 'Analytics', 'woocommerce-admin' ),
+					],
+					__( 'Overview', 'woocommerce-admin' ),
+				],
+				wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
+			} );
+		}
 		pages.push( {
 			container: AnalyticsSettings,
 			path: '/analytics/settings',
@@ -79,7 +112,7 @@ export const getPages = () => {
 				],
 				__( 'Settings', 'woocommerce-admin' ),
 			],
-			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-revenue',
+			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -109,7 +142,7 @@ export const getPages = () => {
 					report.title,
 				];
 			},
-			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-revenue',
+			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 		} );
 	}
 

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -55,7 +55,10 @@ export const getPages = () => {
 		} );
 	}
 
-	if ( window.wcAdminFeatures[ 'analytics-dashboard' ] && ! window.wcAdminFeatures.homepage ) {
+	if (
+		window.wcAdminFeatures[ 'analytics-dashboard' ] &&
+		! window.wcAdminFeatures.homepage
+	) {
 		pages.push( {
 			container: Dashboard,
 			path: '/',
@@ -68,9 +71,7 @@ export const getPages = () => {
 	}
 
 	const Homepage = () => {
-		return (
-			<div>Hello World</div>
-		);
+		return <div>Hello World</div>;
 	};
 
 	if ( window.wcAdminFeatures.homepage ) {
@@ -101,6 +102,10 @@ export const getPages = () => {
 				wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
 			} );
 		}
+		const ReportWpOpenMenu = `toplevel_page_wc-admin-path--analytics-${
+			window.wcAdminFeatures.homepage ? 'overview' : 'revenue'
+		}`;
+
 		pages.push( {
 			container: AnalyticsSettings,
 			path: '/analytics/settings',
@@ -112,7 +117,7 @@ export const getPages = () => {
 				],
 				__( 'Settings', 'woocommerce-admin' ),
 			],
-			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
+			wpOpenMenu: ReportWpOpenMenu,
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -142,7 +147,7 @@ export const getPages = () => {
 					report.title,
 				];
 			},
-			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
+			wpOpenMenu: ReportWpOpenMenu,
 		} );
 	}
 

--- a/config/core.json
+++ b/config/core.json
@@ -9,6 +9,7 @@
 		"onboarding": true,
 	  	"shipping-label-banner": true,
 		"store-alerts": true,
-		"wcpay": true
+		"wcpay": true,
+		"homepage": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -9,6 +9,7 @@
 		"onboarding": true,
 		"shipping-label-banner": true,
 		"store-alerts": true,
-		"wcpay": true
+		"wcpay": true,
+		"homepage": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -9,6 +9,7 @@
 		"onboarding": true,
 		"shipping-label-banner": true,
 		"store-alerts": true,
-		"wcpay": true
+		"wcpay": true,
+		"homepage": false
 	}
 }

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -75,20 +75,23 @@ class Analytics {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
+		$features = wc_admin_get_feature_config();
+		
 		$report_pages = array(
 			array(
 				'id'       => 'woocommerce-analytics',
 				'title'    => __( 'Analytics', 'woocommerce-admin' ),
 				'path'     => '/analytics/overview',
+				'path'     => $features['homepage'] ? '/analytics/overview' : '/analytics/revenue',
 				'icon'     => 'dashicons-chart-bar',
 				'position' => 56, // After WooCommerce & Product menu items.
 			),
-			array(
+			$features['homepage'] ? array(
 				'id'       => 'woocommerce-analytics-overview',
 				'title'    => __( 'Overview', 'woocommerce-admin' ),
 				'parent' => 'woocommerce-analytics',
 				'path'     => '/analytics/overview',
-			),
+			) : null,
 			array(
 				'id'     => 'woocommerce-analytics-revenue',
 				'title'  => __( 'Revenue', 'woocommerce-admin' ),

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -79,9 +79,15 @@ class Analytics {
 			array(
 				'id'       => 'woocommerce-analytics',
 				'title'    => __( 'Analytics', 'woocommerce-admin' ),
-				'path'     => '/analytics/revenue',
+				'path'     => '/analytics/overview',
 				'icon'     => 'dashicons-chart-bar',
 				'position' => 56, // After WooCommerce & Product menu items.
+			),
+			array(
+				'id'       => 'woocommerce-analytics-overview',
+				'title'    => __( 'Overview', 'woocommerce-admin' ),
+				'parent' => 'woocommerce-analytics',
+				'path'     => '/analytics/overview',
 			),
 			array(
 				'id'     => 'woocommerce-analytics-revenue',

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -76,7 +76,7 @@ class Analytics {
 	 */
 	public function register_pages() {
 		$features = wc_admin_get_feature_config();
-		
+
 		$report_pages = array(
 			array(
 				'id'       => 'woocommerce-analytics',

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -81,8 +81,8 @@ class AnalyticsDashboard {
 	public function register_page() {
 		wc_admin_register_page(
 			array(
-				'id'     => 'woocommerce-dashboard',
-				'title'  => __( 'Dashboard', 'woocommerce-admin' ),
+				'id'     => 'woocommerce-home',
+				'title'  => __( 'Home', 'woocommerce-admin' ),
 				'parent' => 'woocommerce',
 				'path'   => self::MENU_SLUG,
 			)

--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -79,10 +79,14 @@ class AnalyticsDashboard {
 	 * Registers dashboard page.
 	 */
 	public function register_page() {
+		$features = wc_admin_get_feature_config();
+		$id = $features['homepage'] ? 'woocommerce-home' : 'woocommerce-dashboard';
+		$title = $features['homepage'] ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
+
 		wc_admin_register_page(
 			array(
-				'id'     => 'woocommerce-home',
-				'title'  => __( 'Home', 'woocommerce-admin' ),
+				'id'     => $id,
+				'title'  => $title,
 				'parent' => 'woocommerce',
 				'path'   => self::MENU_SLUG,
 			)

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -244,7 +244,7 @@ class Loader {
 	public static function register_page_handler() {
 		wc_admin_register_page(
 			array(
-				'id'         => 'woocommerce-dashboard', // Expected to be overridden if dashboard is enabled.
+				'id'         => 'woocommerce-home', // Expected to be overridden if dashboard is enabled.
 				'parent'     => 'woocommerce',
 				'title'      => null,
 				'path'       => self::APP_ENTRY_POINT,

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -244,7 +244,7 @@ class Loader {
 	public static function register_page_handler() {
 		$features = wc_admin_get_feature_config();
 		$id = $features['homepage'] ? 'woocommerce-home' : 'woocommerce-dashboard';
-		
+
 		wc_admin_register_page(
 			array(
 				'id'         => $id, // Expected to be overridden if dashboard is enabled.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -242,9 +242,12 @@ class Loader {
 	 * @todo The entry point for the embed needs moved to this class as well.
 	 */
 	public static function register_page_handler() {
+		$features = wc_admin_get_feature_config();
+		$id = $features['homepage'] ? 'woocommerce-home' : 'woocommerce-dashboard';
+		
 		wc_admin_register_page(
 			array(
-				'id'         => 'woocommerce-home', // Expected to be overridden if dashboard is enabled.
+				'id'         => $id, // Expected to be overridden if dashboard is enabled.
 				'parent'     => 'woocommerce',
 				'title'      => null,
 				'path'       => self::APP_ENTRY_POINT,


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4138
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4081

Adds a Hello World homepage component with updated routing. Its wrapped in a feature flag so that when turned off, changes should revert to the Dashboard and routing well all know and love.

### Screenshots

![Screen Shot 2020-04-22 at 12 42 36 PM](https://user-images.githubusercontent.com/1922453/79928340-cbf4cb80-8496-11ea-958b-14572687184b.png)

### Detailed test instructions:

1. See the new Homepage screen with "Hello World".
2. Falsify the new feature flag in `config/development.json`.
3. Propagate that change by re-running `npm start`.
4. Make sure there is no difference in navigation from the current setup.

