### PR TITLE
Add method to send WC profile data after profiler completion

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -147,7 +147,7 @@ class Onboarding {
 	 * Send profile data to WooCommerce.com.
 	 */
 	public static function send_profile_data() {
-		if ( ! class_exists( '\WC_Helper_API' ) ) {
+		if ( ! class_exists( '\WC_Helper_API' ) && method_exists( '\WC_Helper_API', 'put' ) ) {
 			return;
 		}
 

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -147,6 +147,10 @@ class Onboarding {
 	 * Send profile data to WooCommerce.com.
 	 */
 	public static function send_profile_data() {
+		if ( 'yes' !== get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			return;
+		}
+
 		if ( ! class_exists( '\WC_Helper_API' ) && method_exists( '\WC_Helper_API', 'put' ) ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #1893 

~~**Blocked:** The current helper API does not let us send the proper request type so this won't work until core is updated.~~

This PR sends the profiler data to wccom after the profiler is completed.

### Detailed test instructions:

1. Connect/authorize your store with WCCOM.
1.  Log the result of the newly added `WC_Helper_API::put()` response.
1. Enable the profiler and fill out all the data, completing the profiler.
1. Note the response is successful.
1. Delete `woocommerce_onboarding_profile` and revisit the profiler.
1. Skip steps by directly appending `step=theme` to the URL.
1. Note the defaults are added and profile data is still accepted.
1. Repeat these steps while disconnected from WCCOM and connect to make sure data is sent after connecting.