### PR TITLE
Add scrollable styling to left side of Table, and keep updated

### DIFF
--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -93,8 +93,8 @@
 		background: linear-gradient(90deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0));
 	}
 
-	&.is-scrollable::after,
-	&.is-scrollable-back::before {
+	&.is-scrollable-right::after,
+	&.is-scrollable-left::before {
 		opacity: 1;
 	}
 

--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -81,6 +81,7 @@
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 0.3s;
+		z-index: 1;
 	}
 
 	&::after {

--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -76,7 +76,7 @@
 		content: '';
 		position: absolute;
 		top: 0;
-		width: 41px;
+		width: 60px;
 		height: 100%;
 		opacity: 0;
 		pointer-events: none;
@@ -85,12 +85,12 @@
 
 	&::after {
 		right: 0;
-		background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
+		background: linear-gradient(90deg, rgba($white, 0), $white);
 	}
 
 	&::before {
 		left: 0;
-		background: linear-gradient(90deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0));
+		background: linear-gradient(90deg, $white, rgba($white, 0));
 	}
 
 	&.is-scrollable-right::after,

--- a/packages/components/src/table/style.scss
+++ b/packages/components/src/table/style.scss
@@ -71,20 +71,30 @@
 .woocommerce-table__table {
 	overflow-x: auto;
 
-	&::after {
+	&::after,
+	&::before {
 		content: '';
 		position: absolute;
-		right: 0;
 		top: 0;
 		width: 41px;
 		height: 100%;
-		background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 0.3s;
 	}
 
-	&.is-scrollable::after {
+	&::after {
+		right: 0;
+		background: linear-gradient(90deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.2));
+	}
+
+	&::before {
+		left: 0;
+		background: linear-gradient(90deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0));
+	}
+
+	&.is-scrollable::after,
+	&.is-scrollable-back::before {
 		opacity: 1;
 	}
 

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -54,8 +54,8 @@ class Table extends Component {
 		super( props );
 		this.state = {
 			tabIndex: null,
-			isScrollable: false,
-			isScrollableBack: false,
+			isScrollableRight: false,
+			isScrollableLeft: false,
 		};
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
@@ -105,20 +105,21 @@ class Table extends Component {
 
 	updateTableShadow() {
 		const table = this.container.current;
+		const { isScrollableRight, isScrollableLeft } = this.state;
 
 		const scrolledToEnd =
 			table.scrollWidth - table.scrollLeft <= table.offsetWidth;
-		if ( scrolledToEnd && this.state.isScrollable ) {
-			this.setState( { isScrollable: false } );
-		} else if ( ! scrolledToEnd && ! this.state.isScrollable ) {
-			this.setState( { isScrollable: true } );
+		if ( scrolledToEnd && isScrollableRight ) {
+			this.setState( { isScrollableRight: false } );
+		} else if ( ! scrolledToEnd && ! this.state.isScrollableRight ) {
+			this.setState( { isScrollableRight: true } );
 		}
 
 		const scrolledToStart = table.scrollLeft <= 0;
-		if ( scrolledToStart && this.state.isScrollableBack ) {
-			this.setState( { isScrollableBack: false } );
-		} else if ( ! scrolledToStart && ! this.state.isScrollableBack ) {
-			this.setState( { isScrollableBack: true } );
+		if ( scrolledToStart && isScrollableLeft ) {
+			this.setState( { isScrollableLeft: false } );
+		} else if ( ! scrolledToStart && ! isScrollableLeft ) {
+			this.setState( { isScrollableLeft: true } );
 		}
 	}
 
@@ -133,10 +134,10 @@ class Table extends Component {
 			rowHeader,
 			rows,
 		} = this.props;
-		const { isScrollable, isScrollableBack, tabIndex } = this.state;
+		const { isScrollableRight, isScrollableLeft, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames, {
-			'is-scrollable': isScrollable,
-			'is-scrollable-back': isScrollableBack,
+			'is-scrollable-right': isScrollableRight,
+			'is-scrollable-left': isScrollableLeft,
 		} );
 		const sortedBy =
 			query.orderby ||

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -55,6 +55,7 @@ class Table extends Component {
 		this.state = {
 			tabIndex: null,
 			isScrollable: false,
+			isScrollableBack: false,
 		};
 		this.container = createRef();
 		this.sortBy = this.sortBy.bind( this );
@@ -102,8 +103,10 @@ class Table extends Component {
 		const table = this.container.current;
 		const scrolledToEnd =
 			table.scrollWidth - table.scrollLeft <= table.offsetWidth;
+		const scrolledToStart = table.scrollLeft <= 0;
 		this.setState( {
 			isScrollable: ! scrolledToEnd,
+			isScrollableBack: ! scrolledToStart,
 		} );
 	}
 
@@ -118,9 +121,10 @@ class Table extends Component {
 			rowHeader,
 			rows,
 		} = this.props;
-		const { isScrollable, tabIndex } = this.state;
+		const { isScrollable, isScrollableBack, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames, {
 			'is-scrollable': isScrollable,
+			'is-scrollable-back': isScrollableBack,
 		} );
 		const sortedBy =
 			query.orderby ||

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -74,6 +74,10 @@ class Table extends Component {
 		window.addEventListener( 'resize', this.updateTableShadow );
 	}
 
+	componentDidUpdate() {
+		this.updateTableShadow();
+	}
+
 	componentWillUnmount() {
 		window.removeEventListener( 'resize', this.updateTableShadow );
 	}
@@ -101,13 +105,21 @@ class Table extends Component {
 
 	updateTableShadow() {
 		const table = this.container.current;
+
 		const scrolledToEnd =
 			table.scrollWidth - table.scrollLeft <= table.offsetWidth;
+		if ( scrolledToEnd && this.state.isScrollable ) {
+			this.setState( { isScrollable: false } );
+		} else if ( ! scrolledToEnd && ! this.state.isScrollable ) {
+			this.setState( { isScrollable: true } );
+		}
+
 		const scrolledToStart = table.scrollLeft <= 0;
-		this.setState( {
-			isScrollable: ! scrolledToEnd,
-			isScrollableBack: ! scrolledToStart,
-		} );
+		if ( scrolledToStart && this.state.isScrollableBack ) {
+			this.setState( { isScrollableBack: false } );
+		} else if ( ! scrolledToStart && ! this.state.isScrollableBack ) {
+			this.setState( { isScrollableBack: true } );
+		}
 	}
 
 	render() {


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/commit/2b21dba372330c60bca9ae9f2fb5fac15da46ba0 adds to `<Table>` a visible indication of being scrollable to the left, after table has been scrolled to the right – by analogy with the existing right-side indicator.

https://github.com/woocommerce/woocommerce-admin/commit/ac3203954f2408a9e3b75316c9e13b914efc3b0a makes sure that the indicators adapt to changes in column visibility and other updates that could impact the width of the table rows.

Note that latter change would cause an infinite render loop if `setState` is not called conditionally – open to ideas for avoiding this in a more robust way if possible.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

(Copied interaction from existing, so not anticipating any _new_ accessibility concerns.)

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

Starting with a table without horizontal scrolling: <img width="350" src="https://user-images.githubusercontent.com/1867547/80016339-fc416780-84a0-11ea-9683-6aedeb67bfef.png">

<table>
<tr><th></th><th><code>master</code></th><th>this branch</th></tr>
<tr><td>Toggle columns on</td><td><img width="350" src="https://user-images.githubusercontent.com/1867547/80016001-83421000-84a0-11ea-9986-3458f0647979.png"></td><td><img width="350" src="https://user-images.githubusercontent.com/1867547/80016003-84733d00-84a0-11ea-9b6e-7c8d78ed546a.png"></td></tr>
<tr><td>Scrolled right</td><td><img width="350" src="https://user-images.githubusercontent.com/1867547/80015834-4d049080-84a0-11ea-815f-1acd16625410.png"></td><td><img width="350" src="https://user-images.githubusercontent.com/1867547/80015871-5c83d980-84a0-11ea-87ce-19c9c94093f4.png"></td></tr>
</table>

### Detailed test instructions:

- Navigate to a screen with a table
- Set few enough columns visible to avoid horizontal scrolling
- Add columns to necessitate horizontal scrolling
- **Verify that a shadow appears on the right side**
- Scroll to the right and **verify that a shadow appears on the left side**

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
