### PR TITLE
Remove A/B testing from order page shipping prompt.

### DIFF
--- a/src/Features/ShippingLabelBannerDisplayRules.php
+++ b/src/Features/ShippingLabelBannerDisplayRules.php
@@ -96,28 +96,9 @@ class ShippingLabelBannerDisplayRules {
 	}
 
 	/**
-	 * Determines whether or not the banner should be displayed.
-	 */
-	public function should_display_banner() {
-		if ( ! $this->should_allow_banner() ) {
-			return false;
-		}
-		$ab_test = get_option( 'woocommerce_shipping_prompt_ab' );
-
-		// If it doesn't exist yet, generate it for later use and save it, so we always show the same to this user.
-		if ( ! $ab_test ) {
-			$ab_test = 1 !== wp_rand( 1, 4 ) ? 'a' : 'b'; // 25% of users. b gets the prompt.
-			update_option( 'woocommerce_shipping_prompt_ab', $ab_test, false );
-		}
-
-		return 'b' === $ab_test;
-	}
-
-
-	/**
 	 * Determines whether banner is eligible for display (does not include a/b logic).
 	 */
-	public function should_allow_banner() {
+	public function should_display_banner() {
 		return $this->banner_not_dismissed() &&
 			$this->jetpack_installed_and_active() &&
 			$this->jetpack_up_to_date() &&

--- a/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
+++ b/tests/features/class-wc-tests-shipping-label-banner-display-rules.php
@@ -84,7 +84,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), true );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
 			}
 		);
 	}
@@ -95,7 +95,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	public function test_if_banner_hidden_when_jetpack_disconnected() {
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( null, null, null, null, null );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
 
 	/**
@@ -105,7 +105,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_shipping_dismissed_timestamp', -1 );
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
 
 	/**
@@ -131,7 +131,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), true );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
 			}
 		);
 	}
@@ -142,7 +142,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 	public function test_if_banner_hidden_when_no_shippable_product() {
 		$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-		$this->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+		$this->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 	}
 
 	/**
@@ -154,7 +154,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
 		);
 	}
@@ -168,7 +168,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
 		);
 	}
@@ -181,7 +181,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, true );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
 		);
 	}
@@ -194,7 +194,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.3', true, '1.22.5', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
 		);
 	}
@@ -207,7 +207,7 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', true, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
+				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
 		);
 	}
@@ -220,34 +220,6 @@ class WC_Tests_Shipping_Label_Banner_Display_Rules extends WC_Unit_Test_Case {
 			function( $that ) {
 				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.4', false, false );
 
-				$that->assertEquals( $shipping_label_banner_display_rules->should_allow_banner(), false );
-			}
-		);
-	}
-
-	/**
-	 * Test if the banner is displayed when site is in 'b' group.
-	 */
-	public function test_display_banner_if_b_flag() {
-		$this->with_order(
-			function( $that ) {
-				update_option( 'woocommerce_shipping_prompt_ab', 'b' );
-
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
-				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), true );
-			}
-		);
-	}
-
-	/**
-	 * Test if the banner is displayed when site is in 'a' group.
-	 */
-	public function test_no_display_banner_if_a_flag() {
-		$this->with_order(
-			function( $that ) {
-				update_option( 'woocommerce_shipping_prompt_ab', 'a' );
-
-				$shipping_label_banner_display_rules = new ShippingLabelBannerDisplayRules( '4.4', true, '1.22.5', false, false );
 				$that->assertEquals( $shipping_label_banner_display_rules->should_display_banner(), false );
 			}
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/67

Removes the A/B testing from the order page shipping label prompt. After some discussions, we want to show the prompt to all users instead of 25%.