### PR TITLE
Change "Demo" to "Sample" products

### DIFF
--- a/client/dashboard/profile-wizard/steps/usage-modal.js
+++ b/client/dashboard/profile-wizard/steps/usage-modal.js
@@ -97,7 +97,7 @@ class UsageModal extends Component {
 		return (
 			<Modal
 				title={ __(
-					'Build a Better WooCommerce',
+					'Build a better WooCommerce',
 					'woocommerce-admin'
 				) }
 				onRequestClose={ () => this.props.onClose() }

--- a/client/dashboard/task-list/tasks/appearance.js
+++ b/client/dashboard/task-list/tasks/appearance.js
@@ -153,7 +153,7 @@ class Appearance extends Component {
 					createNotice(
 						'error',
 						__(
-							'There was an error importing some of the demo products.',
+							'There was an error importing some of the sample products.',
 							'woocommerce-admin'
 						)
 					);
@@ -161,7 +161,7 @@ class Appearance extends Component {
 					createNotice(
 						'success',
 						__(
-							'All demo products have been imported.',
+							'All sample products have been imported.',
 							'woocommerce-admin'
 						)
 					);
@@ -266,7 +266,7 @@ class Appearance extends Component {
 		const steps = [
 			{
 				key: 'import',
-				label: __( 'Import demo products', 'woocommerce-admin' ),
+				label: __( 'Import sample products', 'woocommerce-admin' ),
 				description: __(
 					'We’ll add some products that will make it easier to see what your store looks like',
 					'woocommerce-admin'


### PR DESCRIPTION
A few years ago we had a discussion on the name of the files for test products and we choose "sample" data over "dummy" data. I think we should likely stick to that naming (which is also the name of the folder and the files in WC core: https://github.com/woocommerce/woocommerce/tree/master/sample-data)

**First commit changes that wording**

**Second commit:** All titles and questions in the new onboarding wizards only capitalise names and the first letter of the sentence. This seemed a tiny bit off. 

Suggestion after reviewing new onboarding doc by @pmcpinto 