### PR TITLE
Fix sorting to push Storefront to the top of the theme list

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -272,7 +272,7 @@ class Onboarding {
 	/**
 	 * Sort themes returned from WooCommerce.com
 	 *
-	 * @param  array Array of themes from WooCommerce.com
+	 * @param  array $themes Array of themes from WooCommerce.com.
 	 * @return array
 	 */
 	public static function sort_woocommerce_themes( $themes ) {
@@ -300,9 +300,9 @@ class Onboarding {
 			$themes     = array();
 
 			if ( ! is_wp_error( $theme_data ) ) {
-				$theme_data = json_decode( $theme_data['body'] );
+				$theme_data           = json_decode( $theme_data['body'] );
 				$theme_data->products = self::sort_woocommerce_themes( $theme_data->products );
-				
+
 				foreach ( $theme_data->products as $theme ) {
 					$slug                                       = sanitize_title_with_dashes( $theme->slug );
 					$themes[ $slug ]                            = (array) $theme;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -270,6 +270,25 @@ class Onboarding {
 	}
 
 	/**
+	 * Sort themes returned from WooCommerce.com
+	 *
+	 * @param  array Array of themes from WooCommerce.com
+	 * @return array
+	 */
+	public static function sort_woocommerce_themes( $themes ) {
+		usort(
+			$themes,
+			function ( $product_1, $product_2 ) {
+				if ( in_array( 'Storefront', array( $product_1->slug, $product_2->slug ), true ) ) {
+					return 'Storefront' === $product_1->slug ? -1 : 1;
+				}
+				return $product_1->id < $product_2->id ? 1 : -1;
+			}
+		);
+		return $themes;
+	}
+
+	/**
 	 * Get a list of themes for the onboarding wizard.
 	 *
 	 * @return array
@@ -282,16 +301,8 @@ class Onboarding {
 
 			if ( ! is_wp_error( $theme_data ) ) {
 				$theme_data = json_decode( $theme_data['body'] );
-				usort(
-					$theme_data->products,
-					function ( $product_1, $product_2 ) {
-						if ( in_array( 'Storefront', array( $product_1->slug, $product_2->slug ), true ) ) {
-							return 'Storefront' === $product_1->slug ? -1 : 1;
-						}
-						return $product_1->id < $product_2->id ? 1 : -1;
-					}
-				);
-
+				$theme_data->products = self::sort_woocommerce_themes( $theme_data->products );
+				
 				foreach ( $theme_data->products as $theme ) {
 					$slug                                       = sanitize_title_with_dashes( $theme->slug );
 					$themes[ $slug ]                            = (array) $theme;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -279,6 +279,12 @@ class Onboarding {
 		usort(
 			$themes,
 			function ( $product_1, $product_2 ) {
+				if ( ! property_exists( $product_1, 'id' ) || ! property_exists( $product_1, 'slug' ) ) {
+					return 0;
+				}
+				if ( ! property_exists( $product_2, 'id' ) || ! property_exists( $product_2, 'slug' ) ) {
+					return 0;
+				}
 				if ( in_array( 'Storefront', array( $product_1->slug, $product_2->slug ), true ) ) {
 					return 'Storefront' === $product_1->slug ? -1 : 1;
 				}
@@ -300,10 +306,10 @@ class Onboarding {
 			$themes     = array();
 
 			if ( ! is_wp_error( $theme_data ) ) {
-				$theme_data           = json_decode( $theme_data['body'] );
-				$theme_data->products = self::sort_woocommerce_themes( $theme_data->products );
+				$theme_data    = json_decode( $theme_data['body'] );
+				$sorted_themes = self::sort_woocommerce_themes( $theme_data->products );
 
-				foreach ( $theme_data->products as $theme ) {
+				foreach ( $sorted_themes as $theme ) {
 					$slug                                       = sanitize_title_with_dashes( $theme->slug );
 					$themes[ $slug ]                            = (array) $theme;
 					$themes[ $slug ]['is_installed']            = false;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -280,10 +280,10 @@ class Onboarding {
 			$themes,
 			function ( $product_1, $product_2 ) {
 				if ( ! property_exists( $product_1, 'id' ) || ! property_exists( $product_1, 'slug' ) ) {
-					return 0;
+					return 1;
 				}
 				if ( ! property_exists( $product_2, 'id' ) || ! property_exists( $product_2, 'slug' ) ) {
-					return 0;
+					return 1;
 				}
 				if ( in_array( 'Storefront', array( $product_1->slug, $product_2->slug ), true ) ) {
 					return 'Storefront' === $product_1->slug ? -1 : 1;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -307,7 +307,8 @@ class Onboarding {
 
 			if ( ! is_wp_error( $theme_data ) ) {
 				$theme_data    = json_decode( $theme_data['body'] );
-				$sorted_themes = self::sort_woocommerce_themes( $theme_data->products );
+				$woo_themes    = property_exists( $theme_data, 'products' ) ? $theme_data->products : array();
+				$sorted_themes = self::sort_woocommerce_themes( $woo_themes );
 
 				foreach ( $sorted_themes as $theme ) {
 					$slug                                       = sanitize_title_with_dashes( $theme->slug );

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -285,8 +285,8 @@ class Onboarding {
 				usort(
 					$theme_data->products,
 					function ( $product_1, $product_2 ) {
-						if ( 'Storefront' === $product_1->slug ) {
-							return -1;
+						if ( in_array( 'Storefront', array( $product_1->slug, $product_2->slug ), true ) ) {
+							return 'Storefront' === $product_1->slug ? -1 : 1;
 						}
 						return $product_1->id < $product_2->id ? 1 : -1;
 					}

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -13,22 +13,28 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
 class WC_Tests_Onboarding extends WC_Unit_Test_Case {
 
 	/**
-	 * Tests that the themes returned from woocommerce.com are sorted properly.
-	 * - The first result should be the active theme.
-	 * - The second result should always be Storefront.
+	 * Verifies that given an array of theme objects, the object containing Storefront will be sorted to the first position.
 	 */
-	public function test_get_themes_storefront_first() {
-		// TODO: Perhaps we should mock the call to the remote in get_themes to speed things up.
-		$themes = \Automattic\WooCommerce\Admin\Features\Onboarding::get_themes();
-
-		// The default/installed theme should be first.
-		$first_theme  = $themes[0];
-		$active_theme = get_option( 'stylesheet' );
-		$this->assertEquals( $active_theme, $first_theme['slug'] );
-
-		// Storefront should be sorted to the second position in the array.
-		$second_theme = $themes[1];
-		$this->assertEquals( 'storefront', $second_theme['slug'] );
+	public function test_sort_woocommerce_themes() {
+		$theme1 = (object) [
+			'id' => 1,
+			'slug' => 'ribs'
+		];
+		$theme2 = (object) [
+			'id' => 2,
+			'slug' => 'chicken'
+		];
+		$theme3 = (object) [
+			'id' => 3,
+			'slug' => 'Storefront'
+		];
+		$theme4 = (object) [
+			'id' => 4,
+			'slug' => 'poutine'
+		];
+		$some_themes = array( $theme1, $theme2, $theme3, $theme4 );
+		$sorted_themes = \Automattic\WooCommerce\Admin\Features\Onboarding::sort_woocommerce_themes( $some_themes );
+		$this->assertEquals( 'Storefront', $sorted_themes[0]->slug );
 	}
 
 }

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -32,6 +32,10 @@ class WC_Tests_Onboarding extends WC_Unit_Test_Case {
 			'id'   => 4,
 			'slug' => 'poutine',
 		);
+		$theme4        = (object) array(
+			'noid'   => 5,
+			'noslug' => 'timbits',
+		);
 		$some_themes   = array( $theme1, $theme2, $theme3, $theme4 );
 		$sorted_themes = \Automattic\WooCommerce\Admin\Features\Onboarding::sort_woocommerce_themes( $some_themes );
 		$this->assertEquals( 'Storefront', $sorted_themes[0]->slug );

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -32,11 +32,11 @@ class WC_Tests_Onboarding extends WC_Unit_Test_Case {
 			'id'   => 4,
 			'slug' => 'poutine',
 		);
-		$theme4        = (object) array(
+		$theme5        = (object) array(
 			'noid'   => 5,
 			'noslug' => 'timbits',
 		);
-		$some_themes   = array( $theme1, $theme2, $theme3, $theme4 );
+		$some_themes   = array( $theme1, $theme2, $theme3, $theme4, $theme5 );
 		$sorted_themes = \Automattic\WooCommerce\Admin\Features\Onboarding::sort_woocommerce_themes( $some_themes );
 		$this->assertEquals( 'Storefront', $sorted_themes[0]->slug );
 	}

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -16,23 +16,23 @@ class WC_Tests_Onboarding extends WC_Unit_Test_Case {
 	 * Verifies that given an array of theme objects, the object containing Storefront will be sorted to the first position.
 	 */
 	public function test_sort_woocommerce_themes() {
-		$theme1 = (object) [
-			'id' => 1,
-			'slug' => 'ribs'
-		];
-		$theme2 = (object) [
-			'id' => 2,
-			'slug' => 'chicken'
-		];
-		$theme3 = (object) [
-			'id' => 3,
-			'slug' => 'Storefront'
-		];
-		$theme4 = (object) [
-			'id' => 4,
-			'slug' => 'poutine'
-		];
-		$some_themes = array( $theme1, $theme2, $theme3, $theme4 );
+		$theme1        = (object) array(
+			'id'   => 1,
+			'slug' => 'ribs',
+		);
+		$theme2        = (object) array(
+			'id'   => 2,
+			'slug' => 'chicken',
+		);
+		$theme3        = (object) array(
+			'id'   => 3,
+			'slug' => 'Storefront',
+		);
+		$theme4        = (object) array(
+			'id'   => 4,
+			'slug' => 'poutine',
+		);
+		$some_themes   = array( $theme1, $theme2, $theme3, $theme4 );
 		$sorted_themes = \Automattic\WooCommerce\Admin\Features\Onboarding::sort_woocommerce_themes( $some_themes );
 		$this->assertEquals( 'Storefront', $sorted_themes[0]->slug );
 	}

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Onboarding Themes Tests.
+ *
+ * @package WooCommerce\Tests\Onboarding-themes
+ */
+
+use \Automattic\WooCommerce\Admin\Features\Onboarding;
+
+/**
+ * Class WC_Tests_Shipping_Label_Banner_Display_Rules
+ */
+class WC_Tests_Onboarding extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests that the themes returned from woocommerce.com are sorted properly.
+	 * - The first result should be the active theme.
+	 * - The second result should always be Storefront.
+	 */
+	public function test_get_themes_storefront_first() {
+		// TODO: Perhaps we should mock the call to the remote in get_themes to speed things up.
+		$themes = \Automattic\WooCommerce\Admin\Features\Onboarding::get_themes();
+
+		// The default/installed theme should be first.
+		$first_theme  = $themes[0];
+		$active_theme = get_option( 'stylesheet' );
+		$this->assertEquals( $active_theme, $first_theme['slug'] );
+
+		// Storefront should be sorted to the second position in the array.
+		$second_theme = $themes[1];
+		$this->assertEquals( 'storefront', $second_theme['slug'] );
+	}
+
+}

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -32,11 +32,7 @@ class WC_Tests_Onboarding extends WC_Unit_Test_Case {
 			'id'   => 4,
 			'slug' => 'poutine',
 		);
-		$theme5        = (object) array(
-			'noid'   => 5,
-			'noslug' => 'timbits',
-		);
-		$some_themes   = array( $theme1, $theme2, $theme3, $theme4, $theme5 );
+		$some_themes   = array( $theme1, $theme2, $theme3, $theme4 );
 		$sorted_themes = \Automattic\WooCommerce\Admin\Features\Onboarding::sort_woocommerce_themes( $some_themes );
 		$this->assertEquals( 'Storefront', $sorted_themes[0]->slug );
 	}

--- a/tests/features/class-wc-tests-onboarding.php
+++ b/tests/features/class-wc-tests-onboarding.php
@@ -8,7 +8,7 @@
 use \Automattic\WooCommerce\Admin\Features\Onboarding;
 
 /**
- * Class WC_Tests_Shipping_Label_Banner_Display_Rules
+ * Class WC_Tests_Onboarding
  */
 class WC_Tests_Onboarding extends WC_Unit_Test_Case {
 


### PR DESCRIPTION
Fixes #4185 

Sorts themes so that Storefront is at the top again.

### Screenshots
<img width="769" alt="Screen Shot 2020-04-23 at 8 54 15 PM" src="https://user-images.githubusercontent.com/10561050/80132742-cf767880-85a4-11ea-8c05-b3458c5b2996.png">


### Detailed test instructions:

1. Delete the `wc_onboarding_themes` transient.
1. Enable the profiler and visit the theme step.
1. Make sure Storefront is shown directly next to your active theme (or as your active theme if you're using Storefront).