### PR TITLE
POC: how slotfill would work for Homepage

### DIFF
--- a/client/homepage/index.js
+++ b/client/homepage/index.js
@@ -26,7 +26,14 @@ const MyPlugin = () => {
 		</HomepageContent>
 	);
 };
-registerPlugin( 'my-plugin', { render: MyPlugin } );
+registerPlugin(
+	'my-plugin-homepage',
+	{ render: MyPlugin },
+	'wc-admin-homepage'
+);
+// Register an unrelated plugin which should not be rendered.
+// Depends on https://github.com/psealock/gutenberg/tree/update/plugins-area-scoping
+registerPlugin( 'my-plugin-unrelated', { render: MyPlugin }, 'something-else' );
 
 // Homepage.js
 const Homepage = () => {
@@ -37,7 +44,7 @@ const Homepage = () => {
 					<span>I am INTERNAL content body</span>
 				</HomepageContent>
 				<HomepageContent.Slot />
-				<PluginArea />
+				<PluginArea scope="wc-admin-homepage" />
 			</SlotFillProvider>
 		</div>
 	);

--- a/client/homepage/index.js
+++ b/client/homepage/index.js
@@ -1,5 +1,46 @@
+import {
+	SlotFillProvider,
+	Panel,
+	PanelBody,
+	createSlotFill,
+} from '@wordpress/components';
+import { registerPlugin, PluginArea } from '@wordpress/plugins';
+
+// exported component available to plugins maybe '@woocommerce/slotfills`
+const { Fill, Slot } = createSlotFill( 'MyPanelSlot' );
+const HomepageContent = ( { children } ) => (
+	<Fill>
+		<Panel header="Content wrapper">
+			<PanelBody>{ children }</PanelBody>
+		</Panel>
+	</Fill>
+);
+HomepageContent.Slot = () => <Slot />;
+
+// my-plugion.js
+// import { HomepageContent } from '@woocommerce/slotfills`;
+const MyPlugin = () => {
+	return (
+		<HomepageContent>
+			<span>I am EXTERNAL content body</span>
+		</HomepageContent>
+	);
+};
+registerPlugin( 'my-plugin', { render: MyPlugin } );
+
+// Homepage.js
 const Homepage = () => {
-	return <div>Hello World</div>;
+	return (
+		<div>
+			<SlotFillProvider>
+				<HomepageContent>
+					<span>I am INTERNAL content body</span>
+				</HomepageContent>
+				<HomepageContent.Slot />
+				<PluginArea />
+			</SlotFillProvider>
+		</div>
+	);
 };
 
 export default Homepage;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -358,6 +358,7 @@ class Loader {
 				'wp-html-entities',
 				'wp-i18n',
 				'wp-keycodes',
+				'wp-plugins',
 				'wc-csv',
 				'wc-currency',
 				'wc-date',

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -15,7 +15,7 @@ global.wp = {
 
 global.wc = {};
 
-const wordPressPackages = [ 'element', 'date', 'data' ];
+const wordPressPackages = [ 'element', 'date', 'data', 'plugins' ];
 
 const wooCommercePackages = [
 	'components',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,6 +42,7 @@ const externals = {
 	'@wordpress/html-entities': { this: [ 'wp', 'htmlEntities' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
 	'@wordpress/data-controls': { this: [ 'wp', 'dataControls' ] },
+	'@wordpress/plugins': { this: [ 'wp', 'plugins' ] },
 	tinymce: 'tinymce',
 	moment: 'moment',
 	react: 'React',


### PR DESCRIPTION
This is a POC that is not meant to be merged. I made it to solidify my own understanding of slotFill and it turns out to be a good starting point for some questions around how we'll use it.

This is a distillation of https://github.com/woocommerce/woocommerce-admin/pull/3203 into its most basic elements. 

### Questions

1. Are the patterns proposed in https://github.com/woocommerce/woocommerce-admin/pull/3203 how we envision for the homepage and potentially the rest of the app? What were the drawbacks leading to that PR not getting merged?
2. Instead of exporting content components, ie `<HomepageContent />`, to `@woocommerce/components`, what about a new package such as `@woocommerce/slotfills`?
3. We spoke previously about using the slotFill approach ourselves. I think this is a great idea, but it still requires rendering content anywhere within `<SlotFillProvider />`. Is it worth the added misdirection instead of rendering directly in the `<Homepage />` component's output? 
4. What is the scope of `<SlotFillProvider />`? Should it encompass the entire app? Or limit it to the Homepage?

cc @jeffstieler 