### PR TITLE
Hide Marketing Tab Recomended Extensions card if marketing suggestions are disabled

### DIFF
--- a/client/marketing/overview/index.js
+++ b/client/marketing/overview/index.js
@@ -1,4 +1,9 @@
 /**
+ * WooCommerce dependencies
+ */
+import { getSetting } from '@woocommerce/wc-admin-settings';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
@@ -9,11 +14,13 @@ import WelcomeCard from './welcome-card';
 import '../data';
 
 const MarketingOverview = () => {
+	const allowMarketplaceSuggestions = getSetting( 'allowMarketplaceSuggestions', false );
+
 	return (
 		<div className="woocommerce-marketing-overview">
 			<WelcomeCard />
 			<InstalledExtensions />
-			<RecommendedExtensions />
+			{ allowMarketplaceSuggestions && <RecommendedExtensions /> }
 			<KnowledgeBase />
 		</div>
 	);

--- a/client/marketing/overview/index.js
+++ b/client/marketing/overview/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { Component } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
@@ -13,17 +8,15 @@ import KnowledgeBase from './knowledge-base';
 import WelcomeCard from './welcome-card';
 import '../data';
 
-class MarketingOverview extends Component {
-	render() {
-		return (
-			<div className="woocommerce-marketing-overview">
-				<WelcomeCard />
-				<InstalledExtensions />
-				<RecommendedExtensions />
-				<KnowledgeBase />
-			</div>
-		);
-	}
-}
+const MarketingOverview = () => {
+	return (
+		<div className="woocommerce-marketing-overview">
+			<WelcomeCard />
+			<InstalledExtensions />
+			<RecommendedExtensions />
+			<KnowledgeBase />
+		</div>
+	);
+};
 
 export default MarketingOverview;

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -12,6 +12,7 @@ use \_WP_Dependency;
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\API\Reports\Orders\DataStore as OrdersDataStore;
 use Automattic\WooCommerce\Admin\API\Plugins;
+use WC_Marketplace_Suggestions;
 
 /**
  * Loader Class.
@@ -755,6 +756,9 @@ class Loader {
 		if ( self::is_embed_page() ) {
 			$settings['embedBreadcrumbs'] = self::get_embed_breadcrumbs();
 		}
+
+		$settings['allowMarketplaceSuggestions'] = WC_Marketplace_Suggestions::allow_suggestions();
+
 		return $settings;
 	}
 


### PR DESCRIPTION
Hide the Recomended Extensions card in the Marketing Tab if the site has not opted-in to marketing suggestions.

### Detailed test instructions:

- Checkout this branch
- Run `npm start`
- Enable/Disable Marketplace Suggestions in WooCommerce > Settings > Advanced > WooCommerce.com
- View the Marketing tab

### Changelog Note:

N/A

cc: @jconroy 