### PR TITLE
Make button hover color match WCS modal button hover color.

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -40,6 +40,10 @@
 		text-decoration: none;
 		text-shadow: none;
 		overflow: visible;
+		&:hover {
+			background-color: #ff3997;
+			border-color: #ff3997;
+		}
 	}
 
 	.notice-dismiss {


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-shipping-issues/issues/68

Changes hover color of button in WCS order page onboarding prompt so it matches the hover color used for the buttons in the WCS modal.


### Screenshots

non-hover background color (unchanged):
<img width="348" alt="image" src="https://user-images.githubusercontent.com/6209518/80427986-b79d3e00-889d-11ea-875d-3ec0afba297f.png">

Old hover color:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/6209518/80428051-d7ccfd00-889d-11ea-9c1a-07fbd9a4755b.png">


New hover color:
<img width="332" alt="image" src="https://user-images.githubusercontent.com/6209518/80428014-c4219680-889d-11ea-8ccc-7290a3f083f5.png">


### Detailed test instructions:
- Set up store with US dollars and US-based address and WooCommerce Services **not** installed
- Create product/order for shippable product.
- Go to order page to see prompt
- Try hover

