### PR TITLE
Add WCS to allowed plugins list for order page prompt.

### DIFF
--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -26,10 +26,26 @@ class ShippingLabelBanner {
 	 * Constructor
 	 */
 	public function __construct() {
+		add_filter( 'woocommerce_admin_plugins_whitelist', array( $this, 'get_shipping_banner_allowed_plugins' ), 10, 2 );
+
 		if ( ! is_admin() ) {
 			return;
 		}
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 6, 2 );
+	}
+
+	/**
+	 * Gets an array of plugins that can be installed & activated via shipping label prompt.
+	 *
+	 * @param array $plugins Array of plugin slugs to be allowed.
+	 *
+	 * @return array
+	 */
+	public static function get_shipping_banner_allowed_plugins( $plugins ) {
+		$shipping_banner_plugins = array(
+			'woocommerce-services' => 'woocommerce-services/woocommerce-services.php',
+		);
+		return array_merge( $plugins, $shipping_banner_plugins );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4232

Utilizes `woocommerce_admin_plugins_whitelist` filter to make sure WooCommerce Services is allowed to be installed even if new onboarding experience is disabled

### Detailed test instructions:
1. Set up store for prompt (WCS is not installed, US address, US dollars)
1. Go to "Help" dropdown in top right of admin
1. Click on 'Setup Wizard'
1. Click on 'Disable' under "New onboarding experience'
1. Go to order page for a shippable product.
1. Click "Create shipping label" on prompt
1. Install should complete successfully and shipping modal should open.
