### PR TITLE
Homepage: layout sections

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -110,7 +110,11 @@ class Header extends Component {
 		} );
 
 		return (
-			<div className={ className } ref={ this.headerRef }>
+			<div
+				id="woocommerce-layout__header"
+				className={ className }
+				ref={ this.headerRef }
+			>
 				<h1 className="woocommerce-layout__header-breadcrumbs">
 					{ _sections.map( ( section, i ) => {
 						const sectionPiece = Array.isArray( section ) ? (

--- a/client/homepage/index.js
+++ b/client/homepage/index.js
@@ -9,13 +9,14 @@ import { compose } from '@wordpress/compose';
 import ProfileWizard from '../profile-wizard';
 import withSelect from 'wc-api/with-select';
 import { isOnboardingEnabled } from 'dashboard/utils';
+import Layout from './layout';
 
 const Homepage = ( { profileItems, query } ) => {
 	if ( isOnboardingEnabled() && ! profileItems.completed ) {
 		return <ProfileWizard query={ query } />;
 	}
 
-	return <div>Hello World</div>;
+	return <Layout />;
 };
 
 export default compose(

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -39,12 +39,15 @@ class Layout extends Component {
 
 	componentWillUnmount() {
 		window.removeEventListener( 'scroll', this.handleScroll );
+		window.cancelAnimationFrame( this.handle );
 	}
 
 	handleScroll( e ) {
 		if ( e.target === window.document ) {
-			this.setState( {
-				inboxHeight: this.getInboxHeight(),
+			this.handle = window.requestAnimationFrame( () => {
+				this.setState( {
+					inboxHeight: this.getInboxHeight(),
+				} );
 			} );
 		}
 	}

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -15,7 +15,7 @@ class Layout extends Component {
 		super( props );
 
 		this.state = {
-			//inboxHeight: this.getInboxHeight(),
+			inboxHeight: this.getInboxHeight(),
 			showInbox: true,
 		};
 
@@ -34,25 +34,25 @@ class Layout extends Component {
 	}
 
 	componentDidMount() {
-		//window.addEventListener( 'scroll', this.handleScroll );
+		window.addEventListener( 'scroll', this.handleScroll );
 	}
 
 	componentWillUnmount() {
-		//window.removeEventListener( 'scroll', this.handleScroll );
+		window.removeEventListener( 'scroll', this.handleScroll );
 	}
 
 	handleScroll( e ) {
 		if ( e.target === window.document ) {
 			this.setState( {
-				//inboxHeight: this.getInboxHeight(),
+				inboxHeight: this.getInboxHeight(),
 			} );
 		}
 	}
 
 	render() {
-		const { showInbox } = this.state;
+		const { inboxHeight, showInbox } = this.state;
 		const inboxStyles = {
-			//maxHeight: inboxHeight,
+			maxHeight: inboxHeight,
 		};
 		return (
 			<div

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,6 +16,7 @@ class Layout extends Component {
 
 		this.state = {
 			inboxHeight: this.getInboxHeight(),
+			showInbox: true,
 		};
 
 		this.handleScroll = this.handleScroll.bind( this );
@@ -44,24 +47,39 @@ class Layout extends Component {
 	}
 
 	render() {
-		const { inboxHeight } = this.state;
+		const { inboxHeight, showInbox } = this.state;
 		const inboxStyles = {
 			maxHeight: inboxHeight,
 		};
 		return (
-			<div className="woocommerce-homepage">
-				<div
-					className="woocommerce-homepage-column is-inbox"
-					style={ inboxStyles }
-				>
-					<div className="temp-content" />
-					<div className="temp-content" />
-					<div className="temp-content" />
-					<div className="temp-content" />
-					<div className="temp-content" />
-					<div className="temp-content" />
-					<div className="temp-content" />
-				</div>
+			<div
+				className={ classnames( 'woocommerce-homepage', {
+					hasInbox: showInbox,
+				} ) }
+			>
+				{ showInbox && (
+					<div
+						className="woocommerce-homepage-column is-inbox"
+						style={ inboxStyles }
+					>
+						<div className="temp-content">
+							<Button
+								isPrimary
+								onClick={ () => {
+									this.setState( { showInbox: false } );
+								} }
+							>
+								Dismiss All
+							</Button>
+						</div>
+						<div className="temp-content" />
+						<div className="temp-content" />
+						<div className="temp-content" />
+						<div className="temp-content" />
+						<div className="temp-content" />
+						<div className="temp-content" />
+					</div>
+				) }
 				<div className="woocommerce-homepage-column">
 					<div className="temp-content" />
 					<div className="temp-content" />

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+// import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Layout = () => {
+	return (
+		<div className="woocommerce-homepage">
+			<div className="woocommerce-homepage-column is-inbox">
+				<div className="temp-content" />
+				<div className="temp-content" />
+				<div className="temp-content" />
+				<div className="temp-content" />
+				<div className="temp-content" />
+				<div className="temp-content" />
+				<div className="temp-content" />
+			</div>
+			<div className="woocommerce-homepage-column">
+				<div className="temp-content" />
+				<div className="temp-content" />
+				<div className="temp-content" />
+			</div>
+		</div>
+	);
+};
+
+export default Layout;

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -23,6 +23,9 @@ class Layout extends Component {
 	}
 
 	getInboxHeight() {
+		if ( window.innerWidth <= 782 ) {
+			return 'auto';
+		}
 		const scroll = window.scrollY;
 		const base = 90;
 		return `calc(100vh ${ base - scroll < 0 ? '+' : '-' } ${ Math.abs(

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -1,32 +1,75 @@
 /**
  * External dependencies
  */
-// import { Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-const Layout = () => {
-	return (
-		<div className="woocommerce-homepage">
-			<div className="woocommerce-homepage-column is-inbox">
-				<div className="temp-content" />
-				<div className="temp-content" />
-				<div className="temp-content" />
-				<div className="temp-content" />
-				<div className="temp-content" />
-				<div className="temp-content" />
-				<div className="temp-content" />
+class Layout extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			inboxHeight: this.getInboxHeight(),
+		};
+
+		this.handleScroll = this.handleScroll.bind( this );
+	}
+
+	getInboxHeight() {
+		const scroll = window.scrollY;
+		const base = 90;
+		return `calc(100vh ${ base - scroll < 0 ? '+' : '-' } ${ Math.abs(
+			base - scroll
+		) }px)`;
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'scroll', this.handleScroll );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'scroll', this.handleScroll );
+	}
+
+	handleScroll( e ) {
+		if ( e.target === window.document ) {
+			this.setState( {
+				inboxHeight: this.getInboxHeight(),
+			} );
+		}
+	}
+
+	render() {
+		const { inboxHeight } = this.state;
+		const inboxStyles = {
+			maxHeight: inboxHeight,
+		};
+		return (
+			<div className="woocommerce-homepage">
+				<div
+					className="woocommerce-homepage-column is-inbox"
+					style={ inboxStyles }
+				>
+					<div className="temp-content" />
+					<div className="temp-content" />
+					<div className="temp-content" />
+					<div className="temp-content" />
+					<div className="temp-content" />
+					<div className="temp-content" />
+					<div className="temp-content" />
+				</div>
+				<div className="woocommerce-homepage-column">
+					<div className="temp-content" />
+					<div className="temp-content" />
+					<div className="temp-content" />
+				</div>
 			</div>
-			<div className="woocommerce-homepage-column">
-				<div className="temp-content" />
-				<div className="temp-content" />
-				<div className="temp-content" />
-			</div>
-		</div>
-	);
-};
+		);
+	}
+}
 
 export default Layout;

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -15,7 +15,7 @@ class Layout extends Component {
 		super( props );
 
 		this.state = {
-			inboxHeight: this.getInboxHeight(),
+			//inboxHeight: this.getInboxHeight(),
 			showInbox: true,
 		};
 
@@ -34,25 +34,25 @@ class Layout extends Component {
 	}
 
 	componentDidMount() {
-		window.addEventListener( 'scroll', this.handleScroll );
+		//window.addEventListener( 'scroll', this.handleScroll );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'scroll', this.handleScroll );
+		//window.removeEventListener( 'scroll', this.handleScroll );
 	}
 
 	handleScroll( e ) {
 		if ( e.target === window.document ) {
 			this.setState( {
-				inboxHeight: this.getInboxHeight(),
+				//inboxHeight: this.getInboxHeight(),
 			} );
 		}
 	}
 
 	render() {
-		const { inboxHeight, showInbox } = this.state;
+		const { showInbox } = this.state;
 		const inboxStyles = {
-			maxHeight: inboxHeight,
+			//maxHeight: inboxHeight,
 		};
 		return (
 			<div

--- a/client/homepage/layout.js
+++ b/client/homepage/layout.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
 
@@ -18,6 +18,7 @@ class Layout extends Component {
 			inboxHeight: this.getInboxHeight(),
 			showInbox: true,
 		};
+		this.inbox = createRef();
 
 		this.handleScroll = this.handleScroll.bind( this );
 	}
@@ -35,9 +36,14 @@ class Layout extends Component {
 
 	componentDidMount() {
 		window.addEventListener( 'scroll', this.handleScroll );
+		this.inbox.current.addEventListener( 'scroll', this.handleInboxScroll );
 	}
 
 	componentWillUnmount() {
+		this.inbox.current.removeEventListener(
+			'scroll',
+			this.handleInboxScroll
+		);
 		window.removeEventListener( 'scroll', this.handleScroll );
 		window.cancelAnimationFrame( this.handle );
 	}
@@ -51,6 +57,26 @@ class Layout extends Component {
 			} );
 		}
 	}
+
+	handleInboxScroll( event ) {
+		const limit = 20;
+		const header = window.document.getElementById(
+			'woocommerce-layout__header'
+		);
+		const threshold = header.offsetTop;
+		const isInboxScrolled = event.target.scrollTop > limit;
+		if ( isInboxScrolled ) {
+			if ( header ) {
+				header.classList.add( 'is-scrolled' );
+			}
+		} else if (
+			! isInboxScrolled &&
+			window.pageYOffset < threshold - limit
+		) {
+			header.classList.remove( 'is-scrolled' );
+		}
+	}
+	s;
 
 	render() {
 		const { inboxHeight, showInbox } = this.state;
@@ -67,6 +93,7 @@ class Layout extends Component {
 					<div
 						className="woocommerce-homepage-column is-inbox"
 						style={ inboxStyles }
+						ref={ this.inbox }
 					>
 						<div className="temp-content">
 							<Button

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -1,8 +1,3 @@
-.woocommerce-page #wpcontent,
-.woocommerce-page.woocommerce_page_wc-admin #wpbody-content {
-	overflow-x: inherit !important; // Overwriting wc-admin css from elsewhere. Necessary to make the right-hand column 'stick'
-}
-
 .woocommerce-homepage {
 	display: flex;
 	max-width: 1032px;
@@ -12,14 +7,12 @@
 	&.hasInbox .woocommerce-homepage-column {
 		width: calc(50% - 12px);
 
-		@include breakpoint('<782px') {
+		@include breakpoint( '<782px' ) {
 			width: 100%;
-			position: inherit;
-			top: auto;
 		}
 	}
 
-	@include breakpoint('<782px') {
+	@include breakpoint( '<782px' ) {
 		margin-left: -16px;
 		margin-right: -16px;
 		flex-direction: column-reverse;
@@ -27,12 +20,11 @@
 }
 .woocommerce-homepage-column {
 	width: 100%;
-	position: sticky;
-	top: 130px;
-	align-self: flex-start;
 
 	&.is-inbox {
-		position: static;
+		overflow-y: scroll;
+		margin-top: -45px;
+		padding-top: 45px;
 	}
 }
 .temp-content {

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -8,7 +8,6 @@
 	width: calc( 50% - 12px );
 
 	&.is-inbox {
-        max-height: calc(100vh - 90px);
         overflow-y: scroll;
 		margin-top: -45px;
 		padding-top: 45px;

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -3,24 +3,28 @@
 	max-width: 1032px;
 	margin: 0 auto;
 	justify-content: space-between;
+
+	&.hasInbox .woocommerce-homepage-column {
+		width: calc(50% - 12px);
+	}
 }
 .woocommerce-homepage-column {
-	width: calc( 50% - 12px );
+	width: 100%;
 
 	&.is-inbox {
-        overflow-y: scroll;
+		overflow-y: scroll;
 		margin-top: -45px;
 		padding-top: 45px;
 	}
 }
 .temp-content {
-    width: 100%;
-    height: 300px;
-    margin-bottom: 24px;
-    background-color: yellowgreen;
+	width: 100%;
+	height: 300px;
+	margin-bottom: 24px;
+	background-color: #9acd32;
 }
 
 .is-inbox .temp-content {
-    height: 225px;
-    background-color: cornflowerblue;
+	height: 225px;
+	background-color: #6495ed;
 }

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -6,6 +6,16 @@
 
 	&.hasInbox .woocommerce-homepage-column {
 		width: calc(50% - 12px);
+
+		@include breakpoint( '<782px' ) {
+			width: 100%;
+		}
+	}
+
+	@include breakpoint( '<782px' ) {
+		margin-left: -16px;
+		margin-right: -16px;
+		flex-direction: column-reverse;
 	}
 }
 .woocommerce-homepage-column {

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -23,8 +23,17 @@
 
 	&.is-inbox {
 		overflow-y: scroll;
+		/* Hid the scrollbar in Firefox, Safari, IE 11 */
+		scrollbar-width: none;
+		overflow: -moz-scrollbars-none;
+		-ms-overflow-style: none;
 		margin-top: -45px;
 		padding-top: 45px;
+
+		/* Hid the scrollbar in Chrome */
+		&::-webkit-scrollbar {
+			width: 0 !important;
+		}
 	}
 }
 .temp-content {

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -1,3 +1,8 @@
+.woocommerce-page #wpcontent,
+.woocommerce-page.woocommerce_page_wc-admin #wpbody-content {
+	overflow-x: inherit !important; // Overwriting wc-admin css from elsewhere. Necessary to make the right-hand column 'stick'
+}
+
 .woocommerce-homepage {
 	display: flex;
 	max-width: 1032px;
@@ -7,12 +12,14 @@
 	&.hasInbox .woocommerce-homepage-column {
 		width: calc(50% - 12px);
 
-		@include breakpoint( '<782px' ) {
+		@include breakpoint('<782px') {
 			width: 100%;
+			position: inherit;
+			top: auto;
 		}
 	}
 
-	@include breakpoint( '<782px' ) {
+	@include breakpoint('<782px') {
 		margin-left: -16px;
 		margin-right: -16px;
 		flex-direction: column-reverse;
@@ -20,11 +27,12 @@
 }
 .woocommerce-homepage-column {
 	width: 100%;
+	position: sticky;
+	top: 130px;
+	align-self: flex-start;
 
 	&.is-inbox {
-		overflow-y: scroll;
-		margin-top: -45px;
-		padding-top: 45px;
+		position: static;
 	}
 }
 .temp-content {

--- a/client/homepage/style.scss
+++ b/client/homepage/style.scss
@@ -1,0 +1,27 @@
+.woocommerce-homepage {
+	display: flex;
+	max-width: 1032px;
+	margin: 0 auto;
+	justify-content: space-between;
+}
+.woocommerce-homepage-column {
+	width: calc( 50% - 12px );
+
+	&.is-inbox {
+        max-height: calc(100vh - 90px);
+        overflow-y: scroll;
+		margin-top: -45px;
+		padding-top: 45px;
+	}
+}
+.temp-content {
+    width: 100%;
+    height: 300px;
+    margin-bottom: 24px;
+    background-color: yellowgreen;
+}
+
+.is-inbox .temp-content {
+    height: 225px;
+    background-color: cornflowerblue;
+}

--- a/client/homepage/test/index.js
+++ b/client/homepage/test/index.js
@@ -4,12 +4,7 @@ import Homepage from '../index';
 describe( 'homepage', () => {
 	it( 'should render', () => {
 		const { container } = render( <Homepage /> );
-		expect( container ).toMatchInlineSnapshot( `
-		<div>
-		  <div>
-		    Hello World
-		  </div>
-		</div>
-	` );
+		// For now
+		expect( container ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4231

This PR adds the layout interaction. I placed some nice pastel blocks to see how it behaves as well as a faux dismiss button.

This PR includes a fair amount of temporary code and markup which can be removed as those pieces come into play.

### Screenshots

<img width="1200" alt="Screen Shot 2020-04-28 at 3 20 19 PM" src="https://user-images.githubusercontent.com/1922453/80443726-ff869880-8963-11ea-8edf-c6b030ef351c.png">

### Detailed test instructions:

1. Scroll around the page. The left side will be an "infinite scroll" and the right will remain like normally displayed blocks.
2. Try smaller screen sizes.
3. Click "Dismiss All" to simulate clearing the inbox. The right panel will occupy the entire space.

@jameskoster Would you be able to take this for a spin to make sure the interaction is as intended?