### PR TITLE
Use PAGE_ROOT constant to reduce redundancy

### DIFF
--- a/src/PageController.php
+++ b/src/PageController.php
@@ -176,7 +176,7 @@ class PageController {
 			}
 		}
 
-		$woocommerce_breadcrumb = array( 'admin.php?page=wc-admin', __( 'WooCommerce', 'woocommerce-admin' ) );
+		$woocommerce_breadcrumb = array( 'admin.php?page=' . self::PAGE_ROOT, __( 'WooCommerce', 'woocommerce-admin' ) );
 
 		array_unshift( $breadcrumbs, $woocommerce_breadcrumb );
 


### PR DESCRIPTION
I think we can use `PAGE_ROOT` constant to represent `wc-admin` the whole class. This way we can respect DRY principle as well as reduce redundancy.