### PR TITLE
Guard against null themes

### DIFF
--- a/client/profile-wizard/steps/theme/index.js
+++ b/client/profile-wizard/steps/theme/index.js
@@ -313,7 +313,9 @@ class Theme extends Component {
 		const allThemes = [
 			...themes.filter(
 				( theme ) =>
-					theme.has_woocommerce_support || theme.slug === activeTheme
+					theme &&
+					( theme.has_woocommerce_support ||
+						theme.slug === activeTheme )
 			),
 			...uploadedThemes,
 		];


### PR DESCRIPTION
There was an error where nulls were in the themes array:

```
Uncaught TypeError: Cannot read property 'has_woocommerce_support' of null
```

Reloading the server made the error go away and I couldn't reproduce it, however this PR addresses the array.filter predicate that caused the error.