### PR TITLE
Inbox notification: Remove icons

### DIFF
--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -3,7 +3,6 @@
  */
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
 import VisibilitySensor from 'react-visibility-sensor';
 
 /**
@@ -32,7 +31,6 @@ class InboxNoteCard extends Component {
 				note_name: note.name,
 				note_title: note.title,
 				note_type: note.type,
-				note_icon: note.icon,
 			} );
 
 			this.hasBeenSeen = true;
@@ -82,7 +80,6 @@ InboxNoteCard.propTypes = {
 		id: PropTypes.number,
 		status: PropTypes.string,
 		title: PropTypes.string,
-		icon: PropTypes.string,
 		content: PropTypes.string,
 		date_created: PropTypes.string,
 		date_created_gmt: PropTypes.string,

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -132,7 +132,6 @@ export default compose(
 				'title',
 				'content',
 				'type',
-				'icon',
 				'status',
 				'actions',
 				'date_created',

--- a/docs/examples/activity-panel-inbox.md
+++ b/docs/examples/activity-panel-inbox.md
@@ -110,6 +110,8 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_One {
 		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'wapi-example-plugin-one' );
+		$note->set_layout('plain');
+		$note->set_image('');
 		// This example has two actions. A note can have 0 or 1 as well.
 		$note->add_action(
 			'settings',
@@ -206,6 +208,8 @@ class WooCommerce_Activity_Panel_Inbox_Example_Plugin_Two {
 		// Don't include the gridicons- part of the name.
 		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
+		$note->set_layout('plain');
+		$note->set_image('');
 		$note->set_source( 'wapi-example-plugin-two' );
 		// This example has no actions. A note can have 1 or 2 as well.
 		$note->save();

--- a/src/API/NoteActions.php
+++ b/src/API/NoteActions.php
@@ -122,7 +122,6 @@ class NoteActions extends Notes {
 				'note_type'    => $note->get_type(),
 				'note_title'   => $note->get_title(),
 				'note_content' => $note->get_content(),
-				'note_icon'    => $note->get_icon(),
 				'action_name'  => $triggered_action->name,
 				'action_label' => $triggered_action->label,
 			)

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -426,12 +426,6 @@ class Notes extends \WC_REST_CRUD_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'icon'              => array(
-					'description' => __( 'Icon (gridicon) for the note.', 'woocommerce-admin' ),
-					'type'        => 'string',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
 				'content_data'      => array(
 					'description' => __( 'Content data for the note. JSON string. Available for re-localization.', 'woocommerce-admin' ),
 					'type'        => 'string',

--- a/src/Install.php
+++ b/src/Install.php
@@ -40,7 +40,7 @@ class Install {
 			'wc_admin_update_0251_remove_unsnooze_action',
 			'wc_admin_update_0251_db_version',
 		),
-		'1.1.0' => array(
+		'1.1.0'  => array(
 			'wc_admin_update_110_remove_facebook_note',
 		),
 	);
@@ -250,7 +250,6 @@ class Install {
 			locale varchar(20) NOT NULL,
 			title longtext NOT NULL,
 			content longtext NOT NULL,
-			icon varchar(200) NOT NULL,
 			content_data longtext NULL default null,
 			status varchar(200) NOT NULL,
 			source varchar(200) NOT NULL,

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -30,7 +30,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			'locale'       => $note->get_locale(),
 			'title'        => $note->get_title(),
 			'content'      => $note->get_content(),
-			'icon'         => $note->get_icon(),
 			'status'       => $note->get_status(),
 			'source'       => $note->get_source(),
 			'is_snoozable' => (int) $note->get_is_snoozable(),
@@ -71,7 +70,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		if ( 0 !== $note_id || '0' !== $note_id ) {
 			$note_row = $wpdb->get_row(
 				$wpdb->prepare(
-					"SELECT name, type, locale, title, content, icon, content_data, status, source, date_created, date_reminder, is_snoozable FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
+					"SELECT name, type, locale, title, content, content_data, status, source, date_created, date_reminder, is_snoozable, layout, image FROM {$wpdb->prefix}wc_admin_notes WHERE note_id = %d LIMIT 1",
 					$note->get_id()
 				)
 			);
@@ -94,7 +93,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_locale( $note_row->locale );
 			$note->set_title( $note_row->title );
 			$note->set_content( $note_row->content );
-			$note->set_icon( $note_row->icon );
 
 			// The default for 'content_value' used to be an array, so there might be rows with invalid data!
 			$content_data = json_decode( $note_row->content_data );
@@ -154,7 +152,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 					'locale'        => $note->get_locale(),
 					'title'         => $note->get_title(),
 					'content'       => $note->get_content(),
-					'icon'          => $note->get_icon(),
 					'content_data'  => wp_json_encode( $note->get_content_data() ),
 					'status'        => $note->get_status(),
 					'source'        => $note->get_source(),

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -54,7 +54,6 @@ class WC_Admin_Note extends \WC_Data {
 			'locale'        => 'en_US',
 			'title'         => '-',
 			'content'       => '-',
-			'icon'          => 'info',
 			'content_data'  => new \stdClass(),
 			'status'        => self::E_WC_ADMIN_NOTE_UNACTIONED,
 			'source'        => 'woocommerce',
@@ -211,16 +210,6 @@ class WC_Admin_Note extends \WC_Data {
 	 */
 	public function get_content( $context = 'view' ) {
 		return $this->get_prop( 'content', $context );
-	}
-
-	/**
-	 * Get note icon (Gridicon).
-	 *
-	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
-	 * @return string
-	 */
-	public function get_icon( $context = 'view' ) {
-		return $this->get_prop( 'icon', $context );
 	}
 
 	/**
@@ -397,19 +386,6 @@ class WC_Admin_Note extends \WC_Data {
 		}
 
 		$this->set_prop( 'content', $content );
-	}
-
-	/**
-	 * Set note icon (Gridicon).
-	 *
-	 * @param string $icon Note icon.
-	 */
-	public function set_icon( $icon ) {
-		if ( empty( $icon ) ) {
-			$this->error( 'admin_note_invalid_data', __( 'The admin note icon prop cannot be empty.', 'woocommerce-admin' ) );
-		}
-
-		$this->set_prop( 'icon', $icon );
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes.php
+++ b/src/Notes/WC_Admin_Notes.php
@@ -46,7 +46,6 @@ class WC_Admin_Notes {
 			$notes[ $note_id ]['locale']        = $note->get_locale( $context );
 			$notes[ $note_id ]['title']         = $note->get_title( $context );
 			$notes[ $note_id ]['content']       = $note->get_content( $context );
-			$notes[ $note_id ]['icon']          = $note->get_icon( $context );
 			$notes[ $note_id ]['content_data']  = $note->get_content_data( $context );
 			$notes[ $note_id ]['status']        = $note->get_status( $context );
 			$notes[ $note_id ]['source']        = $note->get_source( $context );

--- a/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
+++ b/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
@@ -38,7 +38,6 @@ class WC_Admin_Notes_Deactivate_Plugin {
 		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
-		$note->set_icon( 'warning' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -53,7 +53,6 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 		$note->set_content( __( 'If you like WooCommerce Admin please leave us a 5 star rating. A huge thanks in advance!', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( $name );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -66,7 +66,6 @@ class WC_Admin_Notes_Historical_Data {
 		$note->set_title( __( 'WooCommerce Admin: Historical Analytics Data', 'woocommerce-admin' ) );
 		$note->set_content( __( 'To view your historical analytics data, you must process your existing orders and customers.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
+++ b/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
@@ -55,7 +55,6 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_ADMIN_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'plugins' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(

--- a/src/Notes/WC_Admin_Notes_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Marketing.php
@@ -44,7 +44,6 @@ class WC_Admin_Notes_Marketing {
 		$note->set_title( __( 'Connect with your audience', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'speaker' );
 		$note->set_name( self::NOTE_NAME_INTRO );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Mobile_App.php
+++ b/src/Notes/WC_Admin_Notes_Mobile_App.php
@@ -50,7 +50,6 @@ class WC_Admin_Notes_Mobile_App {
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'phone' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/mobile/' );

--- a/src/Notes/WC_Admin_Notes_New_Sales_Record.php
+++ b/src/Notes/WC_Admin_Notes_New_Sales_Record.php
@@ -109,7 +109,6 @@ class WC_Admin_Notes_New_Sales_Record {
 			$note->set_content( $content );
 			$note->set_content_data( $content_data );
 			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-			$note->set_icon( 'trophy' );
 			$note->set_name( self::NOTE_NAME );
 			$note->set_source( 'woocommerce-admin' );
 			$note->add_action( 'view-report', __( 'View report', 'woocommerce-admin' ), $report_url );

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -39,7 +39,6 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'mail' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'yes-please', __( 'Yes please!', 'woocommerce-admin' ), 'https://woocommerce.us8.list-manage.com/subscribe/post?u=2c1434dc56f9506bf3c3ecd21&amp;id=13860df971&amp;SIGNUPPAGE=plugin' );

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -45,7 +45,6 @@ class WC_Admin_Notes_Onboarding_Profiler {
 		$note->set_title( __( 'Welcome to WooCommerce! Set up your store and start selling', 'woocommerce-admin' ) );
 		$note->set_content( __( "We're here to help you going through the most important steps to get your store up and running.", 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Order_Milestones.php
+++ b/src/Notes/WC_Admin_Notes_Order_Milestones.php
@@ -315,7 +315,6 @@ class WC_Admin_Notes_Order_Milestones {
 		$note_action = $this->get_note_action_for_milestone( $current_milestone );
 		$note->add_action( $note_action['name'], $note_action['label'], $note_action['query'] );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'trophy' );
 		$note->set_name( self::ORDERS_MILESTONE_NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->save();

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -60,7 +60,6 @@ class WC_Admin_Notes_Personalize_Store {
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'notice' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce-admin' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );

--- a/src/Notes/WC_Admin_Notes_Settings_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Settings_Notes.php
@@ -42,7 +42,6 @@ class WC_Admin_Notes_Settings_Notes {
 		$note->set_content( __( 'It can now be found in the Customizer.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( $name );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -72,7 +72,6 @@ class WC_Admin_Notes_Tracking_Opt_In {
 		$note->set_content( $note_content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'tracking-dismiss', __( 'Dismiss', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, false );

--- a/src/Notes/WC_Admin_Notes_Welcome_Message.php
+++ b/src/Notes/WC_Admin_Notes_Welcome_Message.php
@@ -40,7 +40,6 @@ class WC_Admin_Notes_Welcome_Message {
 		$note->set_title( __( 'New feature(s)', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Welcome to the new WooCommerce experience! In this new release you\'ll be able to have a glimpse of how your store is doing in the Dashboard, manage important aspects of your business (such as managing orders, stock, reviews) from anywhere in the interface, dive into your store data with a completely new Analytics section and more!', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -99,7 +99,6 @@ class WC_Admin_Notes_WooCommerce_Payments {
 		$note->set_content( __( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'credit-card' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/payments/', WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );

--- a/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Woo_Subscriptions_Notes.php
@@ -185,7 +185,6 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 		$note->set_content( __( 'Connect to get important product notifications and updates.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( self::CONNECTION_NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
@@ -335,7 +334,6 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 		// Reset everything in case we are repurposing an expired note as an expiring note.
 		$note->set_title( $note_title );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_WARNING );
-		$note->set_icon( 'notice' );
 		$note->set_name( self::SUBSCRIPTION_NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->clear_actions();
@@ -399,7 +397,6 @@ class WC_Admin_Notes_Woo_Subscriptions_Notes {
 		$note->set_content( $note_content );
 		$note->set_content_data( $note_content_data );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_WARNING );
-		$note->set_icon( 'notice' );
 		$note->set_name( self::SUBSCRIPTION_NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->clear_actions();

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -69,7 +69,6 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'PHPUNIT_TEST_NOTE_1_TITLE', $note['title'] );
 
 		$this->assertEquals( 'PHPUNIT_TEST_NOTE_1_CONTENT', $note['content'] );
-		$this->assertEquals( 'info', $note['icon'] );
 		$this->assertArrayHasKey( 'content_data', $note );
 		$this->assertEquals( 1.23, $note['content_data']->amount );
 		$this->assertEquals( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED, $note['status'] );
@@ -294,7 +293,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 16, count( $properties ) );
+		$this->assertEquals( 17, count( $properties ) );
 
 		$this->assertArrayHasKey( 'id', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
@@ -303,7 +302,6 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'title', $properties );
 
 		$this->assertArrayHasKey( 'content', $properties );
-		$this->assertArrayHasKey( 'icon', $properties );
 		$this->assertArrayHasKey( 'content_data', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'source', $properties );

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -34,10 +34,11 @@ class WC_Helper_Admin_Notes {
 		$note_1->set_content( 'PHPUNIT_TEST_NOTE_1_CONTENT' );
 		$note_1->set_content_data( (object) array( 'amount' => 1.23 ) );
 		$note_1->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note_1->set_icon( 'info' );
 		$note_1->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_1->set_source( 'PHPUNIT_TEST' );
 		$note_1->set_is_snoozable( false );
+		$note_1->set_layout( 'plain' );
+		$note_1->set_image( '' );
 		$note_1->add_action(
 			'PHPUNIT_TEST_NOTE_1_ACTION_1_SLUG',
 			'PHPUNIT_TEST_NOTE_1_ACTION_1_LABEL',
@@ -55,11 +56,12 @@ class WC_Helper_Admin_Notes {
 		$note_2->set_content( 'PHPUNIT_TEST_NOTE_2_CONTENT' );
 		$note_2->set_content_data( (object) array( 'amount' => 4.56 ) );
 		$note_2->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_WARNING );
-		$note_2->set_icon( 'info' );
 		$note_2->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_2->set_source( 'PHPUNIT_TEST' );
 		$note_2->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
 		$note_2->set_is_snoozable( true );
+		$note_2->set_layout( 'banner' );
+		$note_2->set_image( 'https://an-image.jpg' );
 		// This note has no actions.
 		$note_2->save();
 
@@ -68,11 +70,12 @@ class WC_Helper_Admin_Notes {
 		$note_3->set_content( 'PHPUNIT_TEST_NOTE_3_CONTENT' );
 		$note_3->set_content_data( (object) array( 'amount' => 7.89 ) );
 		$note_3->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note_3->set_icon( 'info' );
 		$note_3->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_3->set_source( 'PHPUNIT_TEST' );
 		$note_3->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED );
 		$note_3->set_date_reminder( time() - HOUR_IN_SECONDS );
+		$note_3->set_layout( 'thumbnail' );
+		$note_3->set_image( 'https://an-image.jpg' );
 		// This note has no actions.
 		$note_3->save();
 

--- a/tests/notes/class-wc-tests-notes-data-store.php
+++ b/tests/notes/class-wc-tests-notes-data-store.php
@@ -20,10 +20,11 @@ class WC_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		$note->set_title( 'PHPUNIT_TEST_NOTE' );
 		$note->set_content( 'PHPUNIT_TEST_NOTE_CONTENT' );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_icon( 'info' );
 		$note->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note->set_source( 'PHPUNIT_TEST' );
 		$note->set_is_snoozable( false );
+		$note->set_layout( 'plain' );
+		$note->set_image( '' );
 		$note->add_action(
 			'PHPUNIT_TEST_ACTION_SLUG',
 			'PHPUNIT_TEST_ACTION_LABEL',
@@ -39,10 +40,11 @@ class WC_Tests_Notes_Data_Store extends WC_Unit_Test_Case {
 		$this->assertEquals( $note->get_title(), $read_note->get_title() );
 		$this->assertEquals( $note->get_content(), $read_note->get_content() );
 		$this->assertEquals( $note->get_type(), $read_note->get_type() );
-		$this->assertEquals( $note->get_icon(), $read_note->get_icon() );
 		$this->assertEquals( $note->get_name(), $read_note->get_name() );
 		$this->assertEquals( $note->get_source(), $read_note->get_source() );
 		$this->assertEquals( $note->get_is_snoozable(), '0' !== $read_note->get_is_snoozable() );
+		$this->assertEquals( $note->get_layout(), $read_note->get_layout() );
+		$this->assertEquals( $note->get_image(), $read_note->get_image() );
 		$this->assertEquals( $note->get_actions(), $read_note->get_actions() );
 	}
 


### PR DESCRIPTION
Fixes #partially-4099

In this PR the `icon` is removed from all the inbox notifications.

_Please be sure the [PR 4256](https://github.com/woocommerce/woocommerce-admin/pull/4256) has been approved before approving this one_

> **_NOTE:_**  As this is a part of a big functionality this branch will be merged with the branch `add/4099`, and it will be that branch that will be merged with `master`.
To make the code reviewing easier, this PR only has the code referring to the functionality described in the title.
If you want to test everything together, all the changes are merged in the branch: `add/4099_test_branch`.


### Screenshots
![screenshot-one wordpress test-2020 04 29-17_52_02](https://user-images.githubusercontent.com/1314156/80646073-74c89b00-8a42-11ea-9503-017097920da0.png)


### Detailed test instructions:

- dbDelta should remove the `icon` column from the table `wp_wc_admin_notes`.
- Verify that the inbox notifications `icons` are not present anymore in the frontend.
- The same with the backend.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Dev: Removed from all the inbox notifications
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
