### PR TITLE
Homepage: Add stats numbers

### DIFF
--- a/client/dashboard/store-performance/utils.js
+++ b/client/dashboard/store-performance/utils.js
@@ -30,7 +30,7 @@ export const getIndictorValues = ( {
 	);
 
 	if ( ! primaryItem || ! secondaryItem ) {
-		return null;
+		return {};
 	}
 
 	const href =

--- a/client/dashboard/store-performance/utils.js
+++ b/client/dashboard/store-performance/utils.js
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import { find } from 'lodash';
+
+/**
+ * WooCommerce dependencies
+ */
+import { getCurrentDates, appendTimestamp } from '@woocommerce/date';
+import { SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { getNewPath } from '@woocommerce/navigation';
+import { calculateDelta, formatValue } from '@woocommerce/number';
+
+export const getIndictorValues = ( {
+	indicator,
+	primaryData,
+	secondaryData,
+	currency,
+	formatCurrency,
+	persistedQuery,
+} ) => {
+	const primaryItem = find(
+		primaryData.data,
+		( data ) => data.stat === indicator.stat
+	);
+	const secondaryItem = find(
+		secondaryData.data,
+		( data ) => data.stat === indicator.stat
+	);
+
+	if ( ! primaryItem || ! secondaryItem ) {
+		return null;
+	}
+
+	const href =
+		( primaryItem._links &&
+			primaryItem._links.report[ 0 ] &&
+			primaryItem._links.report[ 0 ].href ) ||
+		'';
+	const reportUrl =
+		( href &&
+			getNewPath( persistedQuery, href, {
+				chart: primaryItem.chart,
+			} ) ) ||
+		'';
+	const isCurrency = primaryItem.format === 'currency';
+
+	const delta = calculateDelta( primaryItem.value, secondaryItem.value );
+	const primaryValue = isCurrency
+		? formatCurrency( primaryItem.value )
+		: formatValue( currency, primaryItem.format, primaryItem.value );
+	const secondaryValue = isCurrency
+		? formatCurrency( secondaryItem.value )
+		: formatValue( currency, secondaryItem.format, secondaryItem.value );
+	return {
+		primaryValue,
+		secondaryValue,
+		delta,
+		reportUrl,
+	};
+};
+
+export const getIndicatorData = ( select, indicators, query ) => {
+	const {
+		getReportItems,
+		getReportItemsError,
+		isReportItemsRequesting,
+	} = select( 'wc-api' );
+	const { woocommerce_default_date_range: defaultDateRange } = select(
+		SETTINGS_STORE_NAME
+	).getSetting( 'wc_admin', 'wcAdminSettings' );
+	const datesFromQuery = getCurrentDates( query, defaultDateRange );
+	const endPrimary = datesFromQuery.primary.before;
+	const endSecondary = datesFromQuery.secondary.before;
+	const statKeys = indicators
+		.map( ( indicator ) => indicator.stat )
+		.join( ',' );
+	const primaryQuery = {
+		after: appendTimestamp( datesFromQuery.primary.after, 'start' ),
+		before: appendTimestamp(
+			endPrimary,
+			endPrimary.isSame( moment(), 'day' ) ? 'now' : 'end'
+		),
+		stats: statKeys,
+	};
+
+	const secondaryQuery = {
+		after: appendTimestamp( datesFromQuery.secondary.after, 'start' ),
+		before: appendTimestamp(
+			endSecondary,
+			endSecondary.isSame( moment(), 'day' ) ? 'now' : 'end'
+		),
+		stats: statKeys,
+	};
+
+	const primaryData = getReportItems(
+		'performance-indicators',
+		primaryQuery
+	);
+	const primaryError =
+		getReportItemsError( 'performance-indicators', primaryQuery ) || null;
+	const primaryRequesting = isReportItemsRequesting(
+		'performance-indicators',
+		primaryQuery
+	);
+
+	const secondaryData = getReportItems(
+		'performance-indicators',
+		secondaryQuery
+	);
+	const secondaryError =
+		getReportItemsError( 'performance-indicators', secondaryQuery ) || null;
+	const secondaryRequesting = isReportItemsRequesting(
+		'performance-indicators',
+		secondaryQuery
+	);
+
+	return {
+		primaryData,
+		primaryError,
+		primaryRequesting,
+		secondaryData,
+		secondaryError,
+		secondaryRequesting,
+		defaultDateRange,
+	};
+};

--- a/client/homepage/stats-overview/index.js
+++ b/client/homepage/stats-overview/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
-import { TabPanel, Button } from '@wordpress/components';
+import { TabPanel } from '@wordpress/components';
 import { xor } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 import PropTypes from 'prop-types';
@@ -18,8 +18,10 @@ import {
 	EllipsisMenu,
 	MenuItem,
 	MenuTitle,
+	Link,
 } from '@woocommerce/components';
 import { getSetting } from '@woocommerce/wc-admin-settings';
+import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -131,18 +133,18 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 					</ul>
 				) }
 			</TabPanel>
-			<Button
+			<Link
 				className="woocommerce-stats-overview__more-btn"
-				isLink
+				href={ getNewPath( {}, '/analytics/overview' ) }
+				type="wc-admin"
 				onClick={ () => {
 					recordEvent( 'statsoverview_indicators_click', {
-						key: 'overview',
+						key: 'view_detailed_stats',
 					} );
 				} }
-				href="www.example.com"
 			>
 				{ __( 'View detailed stats' ) }
-			</Button>
+			</Link>
 		</Card>
 	);
 };

--- a/client/homepage/stats-overview/index.js
+++ b/client/homepage/stats-overview/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
-import { TabPanel } from '@wordpress/components';
+import { TabPanel, Button } from '@wordpress/components';
 import { xor } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 import PropTypes from 'prop-types';
@@ -131,18 +131,18 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 					</ul>
 				) }
 			</TabPanel>
-			<div>
-				<a
-					onClick={ () => {
-						recordEvent( 'statsoverview_indicators_click', {
-							key: 'overview',
-						} );
-					} }
-					href="www.example.com"
-				>
-					{ __( 'View detailed stats' ) }
-				</a>
-			</div>
+			<Button
+				className="woocommerce-stats-overview__more-btn"
+				isLink
+				onClick={ () => {
+					recordEvent( 'statsoverview_indicators_click', {
+						key: 'overview',
+					} );
+				} }
+				href="www.example.com"
+			>
+				{ __( 'View detailed stats' ) }
+			</Button>
 		</Card>
 	);
 };

--- a/client/homepage/stats-overview/stats-list.js
+++ b/client/homepage/stats-overview/stats-list.js
@@ -24,7 +24,7 @@ import {
 	getIndictorValues,
 } from 'dashboard/store-performance/utils';
 
-const StatsList = ( {
+export const StatsList = ( {
 	stats,
 	primaryData,
 	secondaryData,

--- a/client/homepage/stats-overview/stats-list.js
+++ b/client/homepage/stats-overview/stats-list.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { Fragment, useContext } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * WooCommerce dependencies
+ */
+import {
+	SummaryNumber,
+	SummaryNumberPlaceholder,
+} from '@woocommerce/components';
+import { getPersistedQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import withSelect from 'wc-api/with-select';
+import { recordEvent } from 'lib/tracks';
+import { CurrencyContext } from 'lib/currency-context';
+import {
+	getIndicatorData,
+	getIndictorValues,
+} from 'dashboard/store-performance/utils';
+
+const StatsList = ( {
+	stats,
+	primaryData,
+	secondaryData,
+	primaryRequesting,
+	secondaryRequesting,
+	primaryError,
+	secondaryError,
+	query,
+} ) => {
+	const { formatCurrency, getCurrency } = useContext( CurrencyContext );
+	if ( primaryError || secondaryError ) {
+		return null;
+	}
+	const persistedQuery = getPersistedQuery( query );
+	const currency = getCurrency();
+
+	return (
+		<Fragment>
+			{ stats.map( ( item ) => {
+				if ( primaryRequesting || secondaryRequesting ) {
+					return <SummaryNumberPlaceholder key={ item.stat } />;
+				}
+				const {
+					primaryValue,
+					secondaryValue,
+					delta,
+					reportUrl,
+				} = getIndictorValues( {
+					indicator: item,
+					primaryData,
+					secondaryData,
+					currency,
+					formatCurrency,
+					persistedQuery,
+				} );
+
+				return (
+					<SummaryNumber
+						key={ item.stat }
+						href={ reportUrl }
+						label={ item.label }
+						value={ primaryValue }
+						prevLabel={ __(
+							'Previous Period:',
+							'woocommerce-admin'
+						) }
+						prevValue={ secondaryValue }
+						delta={ delta }
+						onLinkClickCallback={ () => {
+							recordEvent( 'statsoverview_indicators_click', {
+								key: item.stat,
+							} );
+						} }
+					/>
+				);
+			} ) }
+		</Fragment>
+	);
+};
+
+export default withSelect( ( select, { stats, query } ) => {
+	if ( stats.length === 0 ) {
+		return;
+	}
+	return getIndicatorData( select, stats, query );
+} )( StatsList );

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -24,6 +24,10 @@
 		width: 25%;
 		margin-bottom: 4px;
 
+		@include breakpoint( '<782px' ) {
+			width: 33.33%;
+		}
+
 		&:focus {
 			outline: none;
 			box-shadow: none;

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -7,6 +7,10 @@
 	}
 }
 
+.woocommerce-stats-overview__more-btn.components-button.is-link {
+	padding: $gap;
+}
+
 .woocommerce-stats-overview__tabs {
 	.components-tab-panel__tabs {
 		display: flex;
@@ -17,9 +21,17 @@
 		display: block;
 		padding: $gap;
 		width: 25%;
+		margin-bottom: 4px;
+
+		&:focus {
+			outline: none;
+			box-shadow: none;
+		}
 
 		&.is-active {
-			border-bottom: 4px solid #00f;
+			border-bottom: 4px solid $studio-blue-50;
+			// Avoid the text "jumping" when border-bottom applied.
+			margin-bottom: 0;
 		}
 
 		&:first-child {

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -8,7 +8,7 @@
 }
 
 .woocommerce-stats-overview__more-btn {
-	display: block;
+	display: inline-block;
 	padding: $gap;
 }
 

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -1,0 +1,33 @@
+.woocommerce-stats-overview {
+	.woocommerce-card__body {
+		padding: 0;
+	}
+	.woocommerce-summary {
+		margin: 0;
+	}
+}
+
+.woocommerce-stats-overview__tabs {
+	.components-tab-panel__tabs {
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.components-button {
+		display: block;
+		padding: $gap;
+		width: 25%;
+
+		&.is-active {
+			border-bottom: 4px solid #00f;
+		}
+
+		&:first-child {
+			text-align: left;
+		}
+
+		&:last-child {
+			text-align: right;
+		}
+	}
+}

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -7,7 +7,8 @@
 	}
 }
 
-.woocommerce-stats-overview__more-btn.components-button.is-link {
+.woocommerce-stats-overview__more-btn {
+	display: block;
 	padding: $gap;
 }
 

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { render, fireEvent, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { StatsOverview } from '../index';
+import StatsList from '../stats-list';
 import { recordEvent } from 'lib/tracks';
 
 jest.mock( 'lib/tracks' );
@@ -86,6 +91,55 @@ describe( 'StatsOverview rendering correct elements', () => {
 		expect( viewDetailedStatsLink ).toBeDefined();
 		expect( viewDetailedStatsLink.href ).toBe(
 			'http://localhost/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview'
+		);
+	} );
+} );
+
+describe( 'StatsOverview period selection', () => {
+	it( 'should have Today selected by default', () => {
+		render(
+			<StatsOverview
+				userPrefs={ {
+					hiddenStats: null,
+				} }
+				updateCurrentUserData={ () => {} }
+			/>
+		);
+
+		const todayBtn = screen.getByText( 'Today' );
+		expect( todayBtn.classList ).toContain( 'is-active' );
+	} );
+
+	it( 'should select a new period', () => {
+		render(
+			<StatsOverview
+				userPrefs={ {
+					hiddenStats: null,
+				} }
+				updateCurrentUserData={ () => {} }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Month to date' ) );
+
+		// Check props handed down to StatsList have the right period
+		expect( StatsList ).toHaveBeenLastCalledWith(
+			{
+				query: { compare: 'previous_period', period: 'month' },
+				stats: [
+					{
+						chart: 'total_sales',
+						label: 'Total Sales',
+						stat: 'revenue/total_sales',
+					},
+					{
+						chart: 'orders_count',
+						label: 'Orders',
+						stat: 'orders/orders_count',
+					},
+				],
+			},
+			{}
 		);
 	} );
 } );

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -27,11 +27,13 @@ describe( 'StatsOverview tracking', () => {
 			/>
 		);
 
-		const ellipsisBtn = screen.getByTitle(
-			'Choose which values to display'
-		);
+		const ellipsisBtn = screen.getByRole( 'button', {
+			name: 'Choose which values to display',
+		} );
 		fireEvent.click( ellipsisBtn );
-		const totalSalesBtn = screen.getByText( 'Total Sales' );
+		const totalSalesBtn = screen.getByRole( 'menuitemcheckbox', {
+			name: 'Total Sales',
+		} );
 		fireEvent.click( totalSalesBtn );
 
 		expect( recordEvent ).toHaveBeenCalledWith(
@@ -57,11 +59,13 @@ describe( 'StatsOverview toggle and persist stat preference', () => {
 			/>
 		);
 
-		const ellipsisBtn = screen.getByTitle(
-			'Choose which values to display'
-		);
+		const ellipsisBtn = screen.getByRole( 'button', {
+			name: 'Choose which values to display',
+		} );
 		fireEvent.click( ellipsisBtn );
-		const totalSalesBtn = screen.getByText( 'Total Sales' );
+		const totalSalesBtn = screen.getByRole( 'menuitemcheckbox', {
+			name: 'Total Sales',
+		} );
 		fireEvent.click( totalSalesBtn );
 
 		expect( updateCurrentUserData ).toHaveBeenCalledWith( {
@@ -106,7 +110,7 @@ describe( 'StatsOverview period selection', () => {
 			/>
 		);
 
-		const todayBtn = screen.getByText( 'Today' );
+		const todayBtn = screen.getByRole( 'tab', { name: 'Today' } );
 		expect( todayBtn.classList ).toContain( 'is-active' );
 	} );
 
@@ -120,7 +124,7 @@ describe( 'StatsOverview period selection', () => {
 			/>
 		);
 
-		fireEvent.click( screen.getByText( 'Month to date' ) );
+		fireEvent.click( screen.getByRole( 'tab', { name: 'Month to date' } ) );
 
 		// Check props handed down to StatsList have the right period
 		expect( StatsList ).toHaveBeenLastCalledWith(

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -6,6 +6,10 @@ import { StatsOverview } from '../index';
 import { recordEvent } from 'lib/tracks';
 
 jest.mock( 'lib/tracks' );
+// Mock the stats list so that it can be tested separately.
+jest.mock( '../stats-list', () =>
+	jest.fn().mockImplementation( () => <div>mocked stats list</div> )
+);
 
 describe( 'StatsOverview tracking', () => {
 	it( 'should record an event when a stat is toggled', () => {
@@ -64,5 +68,24 @@ describe( 'StatsOverview toggle and persist stat preference', () => {
 				],
 			},
 		} );
+	} );
+} );
+
+describe( 'StatsOverview rendering correct elements', () => {
+	it( 'should include a link to all the overview page', () => {
+		render(
+			<StatsOverview
+				userPrefs={ {
+					hiddenStats: null,
+				} }
+				updateCurrentUserData={ () => {} }
+			/>
+		);
+
+		const viewDetailedStatsLink = screen.getByText( 'View detailed stats' );
+		expect( viewDetailedStatsLink ).toBeDefined();
+		expect( viewDetailedStatsLink.href ).toBe(
+			'http://localhost/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview'
+		);
 	} );
 } );

--- a/client/homepage/stats-overview/test/stats-list.js
+++ b/client/homepage/stats-overview/test/stats-list.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { StatsList } from '../stats-list';
+import { recordEvent } from 'lib/tracks';
+
+jest.mock( 'lib/tracks' );
+
+const stats = [
+	{ stat: 'revenue/net_revenue', label: 'Net Sales' },
+	{ stat: 'orders/orders_count', label: 'Orders' },
+];
+
+const data = {
+	data: [
+		{
+			stat: 'revenue/net_revenue',
+			chart: 'net_revenue',
+			label: 'Net Sales',
+			format: 'currency',
+			value: 100,
+			_links: {
+				api: [
+					{
+						href:
+							'http://tangaroa.test/wp-json/wc-analytics/reports/revenue/stats',
+					},
+				],
+				report: [ { href: '/analytics/revenue' } ],
+			},
+		},
+		{
+			stat: 'orders/orders_count',
+			chart: 'orders_count',
+			label: 'Orders',
+			format: 'number',
+			value: 100,
+			_links: {
+				api: [
+					{
+						href:
+							'http://tangaroa.test/wp-json/wc-analytics/reports/orders/stats',
+					},
+				],
+				report: [ { href: '/analytics/orders' } ],
+			},
+		},
+	],
+};
+
+describe( 'StatsList', () => {
+	it( 'should render SummaryNumbers', () => {
+		render(
+			<StatsList
+				stats={ stats }
+				primaryData={ data }
+				secondaryData={ data }
+				query={ {
+					period: 'today',
+					compare: 'previous_period',
+				} }
+			/>
+		);
+
+		// Check that there should be two.
+		expect( screen.getAllByText( 'Previous Period:' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( '0%' ) ).toHaveLength( 2 );
+		expect( screen.getByText( 'Net Sales' ) ).toBeDefined();
+		expect( screen.getByText( 'Orders' ) ).toBeDefined();
+	} );
+
+	it( 'should render placeholders when data is fetching', () => {
+		render( <StatsList stats={ stats } primaryRequesting={ true } /> );
+
+		// Check that there should be two.
+		expect( screen.getAllByTestId( 'summary-placeholder' ) ).toHaveLength(
+			2
+		);
+	} );
+
+	it( 'should record an event on click of SummaryNumbers', () => {
+		render(
+			<StatsList
+				stats={ stats }
+				primaryData={ data }
+				secondaryData={ data }
+				query={ {
+					period: 'today',
+					compare: 'previous_period',
+				} }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Net Sales' ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'statsoverview_indicators_click',
+			{
+				key: 'revenue/net_revenue',
+			}
+		);
+	} );
+} );

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -245,7 +245,10 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
-		const path = query.path || 'homepage';
+		const defaultPath = window.wcAdminFeatures.homepage
+			? 'homepage'
+			: 'dashboard';
+		const path = query.path || defaultPath;
 		const screen = path.replace( '/analytics', '' ).replace( '/', '' );
 
 		const isExcludedScreen = excludedScreens.includes( screen );

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -245,7 +245,7 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
-		const path = query.path || 'dashboard';
+		const path = query.path || 'homepage';
 		const screen = path.replace( '/analytics', '' ).replace( '/', '' );
 
 		const isExcludedScreen = excludedScreens.includes( screen );
@@ -273,6 +273,7 @@ window.wpNavMenuUrlUpdate = function( query ) {
 		'stock',
 		'settings',
 		'customers',
+		'homepage',
 	] );
 	const nextQuery = getPersistedQuery( query );
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -48,6 +48,7 @@ export { default as Spinner } from './spinner';
 export { default as Stepper } from './stepper';
 export { default as SummaryList } from './summary';
 export { default as SummaryListPlaceholder } from './summary/placeholder';
+export { SummaryNumberPlaceholder } from './summary/placeholder';
 export { default as SummaryNumber } from './summary/number';
 export { default as Table } from './table/table';
 export { default as TableCard } from './table';

--- a/packages/components/src/summary/placeholder.js
+++ b/packages/components/src/summary/placeholder.js
@@ -12,6 +12,22 @@ import { withViewportMatch } from '@wordpress/viewport';
  */
 import { getHasItemsClass } from './utils';
 
+export const SummaryNumberPlaceholder = () => (
+	<li className="woocommerce-summary__item-container is-placeholder">
+		<span className="woocommerce-summary__item">
+			<span className="woocommerce-summary__item-label" />
+			<span className="woocommerce-summary__item-data">
+				<span className="woocommerce-summary__item-value" />
+				<div className="woocommerce-summary__item-delta">
+					<span className="woocommerce-summary__item-delta-value" />
+				</div>
+			</span>
+			<span className="woocommerce-summary__item-prev-label" />
+			<span className="woocommerce-summary__item-prev-value" />
+		</span>
+	</li>
+);
+
 /**
  * `SummaryListPlaceholder` behaves like `SummaryList` but displays placeholder summary items instead of data.
  * This can be used while loading data.
@@ -29,30 +45,11 @@ class SummaryListPlaceholder extends Component {
 			'is-placeholder': true,
 		} );
 
-		const rows = range( numberOfItems ).map( ( i ) => {
-			return (
-				<li
-					className="woocommerce-summary__item-container is-placeholder"
-					key={ i }
-				>
-					<span className="woocommerce-summary__item">
-						<span className="woocommerce-summary__item-label" />
-						<span className="woocommerce-summary__item-data">
-							<span className="woocommerce-summary__item-value" />
-							<div className="woocommerce-summary__item-delta">
-								<span className="woocommerce-summary__item-delta-value" />
-							</div>
-						</span>
-						<span className="woocommerce-summary__item-prev-label" />
-						<span className="woocommerce-summary__item-prev-value" />
-					</span>
-				</li>
-			);
-		} );
-
 		return (
 			<ul className={ classes } aria-hidden="true">
-				{ rows }
+				{ range( numberOfItems ).map( ( i ) => {
+					return <SummaryNumberPlaceholder key={ i } />;
+				} ) }
 			</ul>
 		);
 	}

--- a/packages/components/src/summary/placeholder.js
+++ b/packages/components/src/summary/placeholder.js
@@ -13,7 +13,10 @@ import { withViewportMatch } from '@wordpress/viewport';
 import { getHasItemsClass } from './utils';
 
 export const SummaryNumberPlaceholder = () => (
-	<li className="woocommerce-summary__item-container is-placeholder">
+	<li
+		data-testid="summary-placeholder"
+		className="woocommerce-summary__item-container is-placeholder"
+	>
 		<span className="woocommerce-summary__item">
 			<span className="woocommerce-summary__item-label" />
 			<span className="woocommerce-summary__item-data">


### PR DESCRIPTION
Partially solves #4084

Adds the SummaryNumbers used in the dashboard to show data. The SummaryNumber component is added without any styling, including small viewports. I'll handle that in the next PR.

### Screenshots

![Screen Shot 2020-05-05 at 1 33 37 PM](https://user-images.githubusercontent.com/1922453/81028356-16ce0480-8ed5-11ea-866f-e3c4b4735a7d.png)

### Other Changes

* Update `persistedQueries` such that the navigating to the Home Screen doesn't bring any extra query parameters along.
* Created `store-performance/utils.js` to house some functions for data handling that are re-used.

### Detailed test instructions:

1. Go to homescreen.
2. Check that the selected overview stats are showing correct data for various periods.

### Changelog Note:

None: this is part of an ongoing feature