### PR TITLE
Increase selector specificity

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -49,7 +49,7 @@ if ( appRoot ) {
 
 	// Render notices just above the WP content div.
 	const wpBody = document.getElementById( 'wpbody-content' );
-	const wrap = wpBody.querySelector( '.wrap' );
+	const wrap = wpBody.querySelector( '[class="wrap"]' );
 	const noticeContainer = document.createElement( 'div' );
 
 	render(

--- a/client/index.js
+++ b/client/index.js
@@ -49,7 +49,7 @@ if ( appRoot ) {
 
 	// Render notices just above the WP content div.
 	const wpBody = document.getElementById( 'wpbody-content' );
-	const wrap = wpBody.querySelector( '[class="wrap"]' );
+	const wrap = wpBody.querySelector( '.wrap.woocommerce' ) || wpBody.querySelector( '[class="wrap"]' );
 	const noticeContainer = document.createElement( 'div' );
 
 	render(


### PR DESCRIPTION
Fixes #
`Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.`

The `.wrap` selector is too generic for the section. I work in a project hosted in VIP that has VaultPress as a MU Plugin and it injects a div containing the same _wrap_ class to the same parent div. However, it contains a few other classes on it while the selector we are applying here refers to the `<div class="wrap">` so increasing the specificity (elements with only the class wrap) we can solve this conflict and many others I don't realize.

### Accessibility

It doesn't apply.

### Detailed test instructions:

- Add another element using the wrap class
- Open Orders page
- Check if you still can see the page title