### PR TITLE
Adds Jetpack stats to performance indicator endpoints

### DIFF
--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -195,9 +195,10 @@ class Controller extends \WC_REST_Reports_Controller {
 				return;
 			}
 
-			$this->allowed_stats[]                         = 'jetpack/' . $module . '/all';
-			$this->labels[ 'jetpack/' . $module . '/all' ] = $data[ $module ]['name'];
-			$this->endpoints[ 'jetpack/' . $module ]       = '/jetpack/v4/module/' . $module . '/data';
+			$this->allowed_stats[]                          = 'jetpack/' . $module . '/all';
+			$this->labels[ 'jetpack/' . $module . '/all' ]  = $data[ $module ]['name'];
+			$this->endpoints[ 'jetpack/' . $module ]        = '/jetpack/v4/module/' . $module . '/data';
+			$this->formats[ 'jetpack/' . $module . '/all' ] = 'number';
 		}
 	}
 

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators;
 
+use \Automattic\WooCommerce\Admin\API\Reports\TimeInterval;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -530,10 +532,10 @@ class Controller extends \WC_REST_Reports_Controller {
 			// Loop over provided data and filter by the queried date.
 			// Note that this is currently limited to 30 days via the Jetpack API
 			// but the WordPress.com endpoint allows up to 90 days.
-			$total = 0;
+			$total  = 0;
+			$before = gmdate( 'Y-m-d', strtotime( isset( $query_args['before'] ) ? $query_args['before'] : TimeInterval::default_before() ) );
+			$after  = gmdate( 'Y-m-d', strtotime( isset( $query_args['after'] ) ? $query_args['after'] : TimeInterval::default_after() ) );
 			foreach ( $data['general']->visits->data as $datum ) {
-				$before = \DateTime::createFromFormat( 'Y-m-d H:i:s', $query_args['before'] )->format( 'Y-m-d' );
-				$after  = \DateTime::createFromFormat( 'Y-m-d H:i:s', $query_args['after'] )->format( 'Y-m-d' );
 				if ( $datum[0] >= $after && $datum[0] <= $before ) {
 					$total += $datum[ $index ];
 				}

--- a/src/API/Reports/PerformanceIndicators/Controller.php
+++ b/src/API/Reports/PerformanceIndicators/Controller.php
@@ -195,9 +195,9 @@ class Controller extends \WC_REST_Reports_Controller {
 				return;
 			}
 
-			$this->allowed_stats[]                      = 'jetpack/' . $module;
-			$this->labels[ 'jetpack/module' . $module ] = $data[ $module ]['name'];
-			$this->endpoint[ $module ]                  = '/jetpack/v4/module/' . $module . '/data';
+			$this->allowed_stats[]                         = 'jetpack/' . $module . '/all';
+			$this->labels[ 'jetpack/' . $module . '/all' ] = $data[ $module ]['name'];
+			$this->endpoints[ 'jetpack/' . $module ]       = '/jetpack/v4/module/' . $module . '/data';
 		}
 	}
 
@@ -449,14 +449,14 @@ class Controller extends \WC_REST_Reports_Controller {
 		$pieces   = $this->get_stats_parts( $object->stat );
 		$endpoint = $pieces[0];
 		$stat     = $pieces[1];
-		$url      = $this->urls[ $endpoint ];
+		$url      = isset( $this->urls[ $endpoint ] ) ? $this->urls[ $endpoint ] : '';
 
 		$links = array(
 			'api'    => array(
 				'href' => rest_url( $this->endpoints[ $endpoint ] ),
 			),
 			'report' => array(
-				'href' => ! empty( $url ) ? $url : '',
+				'href' => $url,
 			),
 		);
 

--- a/tests/api/reports-performance-indicators.php
+++ b/tests/api/reports-performance-indicators.php
@@ -120,7 +120,7 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 
 		$this->assertEquals( 'jetpack/stats/views', $reports[2]['stat'] );
 		$this->assertEquals( 'Views', $reports[2]['label'] );
-		$this->assertEquals( 0, $reports[2]['value'] );
+		$this->assertEquals( 10, $reports[2]['value'] );
 		$this->assertEquals( 'views', $reports[2]['chart'] );
 		$this->assertEquals( get_rest_url( null, '/jetpack/v4/module/stats/data' ), $response->data[2]['_links']['api'][0]['href'] );
 	}
@@ -239,6 +239,31 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 	}
 
 	/**
+	 * Test the ability to aggregate Jetpack stats based on default arguments.
+	 */
+	public function test_jetpack_stats_default_query_args() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'stats' => 'jetpack/stats/views',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $reports ) );
+
+		$this->assertEquals( 'jetpack/stats/views', $reports[0]['stat'] );
+		$this->assertEquals( 'Views', $reports[0]['label'] );
+		$this->assertEquals( 10, $reports[0]['value'] );
+		$this->assertEquals( 'views', $reports[0]['chart'] );
+		$this->assertEquals( get_rest_url( null, '/jetpack/v4/module/stats/data' ), $response->data[0]['_links']['api'][0]['href'] );
+	}
+
+	/**
 	 * Mock the Jetpack REST API responses since we're not really connected.
 	 *
 	 * @param WP_Rest_Response $response Response from the server.
@@ -291,6 +316,11 @@ class WC_Tests_API_Reports_Performance_Indicators extends WC_REST_Unit_Test_Case
 				array(
 					'2020-01-05',
 					5,
+					0,
+				),
+				array(
+					gmdate( 'Y-m-d' ),
+					10,
 					0,
 				),
 			);


### PR DESCRIPTION
Fixes #4139 

* Adds `jetpack/stats/views` and `jetpack/stats/visits` to the allowed endpoints.
* Adds data for each of those endpoints.
* Adds the ability to filter returned performance indicator data.

### Screenshots
<img width="625" alt="Screen Shot 2020-05-07 at 2 56 55 PM" src="https://user-images.githubusercontent.com/10561050/81291738-0784bd80-9073-11ea-92b6-c6f296e71b1a.png">

### Detailed test instructions:

1. Make sure you have Jetpack installed and connected.
1. Make a request to `/wp-json/wc-analytics/reports/performance-indicators/allowed`.
1. Note that the 2 new stats are included in the endpoint.
1. Make a request to `/wp-json/wc-analytics/reports/performance-indicators` with `jetpack/stats/views` and `jetpack/stats/visits` in the `stats` param.  (e.g., `stats=jetpack/stats/views,jetpack/stats/visits`).
1. Note the stats returned use the same default and before date params as other stats endpoints if not supplied.
1. Make another request including `before` and `after` params in `Y-m-d H:i:s` format.
1. Check that the stats data returned is correct if you have Jetpack data to analyze. (Note that the current Jetpack endpoint limits data to 30 days).
1. Make sure tests pass.