### PR TITLE
Fix/amazon plugin slug

### DIFF
--- a/src/Marketing/InstalledExtensions.php
+++ b/src/Marketing/InstalledExtensions.php
@@ -179,7 +179,6 @@ class InstalledExtensions {
 
 			$data['settingsUrl'] = admin_url( 'admin.php?page=wc-settings&tab=integration&section=kk_wcintegration' );
 			$data['docsUrl']     = 'https://docs.woocommerce.com/document/google-ads/';
-			$data['supportUrl']  = 'https://www.kliken.com/support.html';
 		}
 
 		return $data;
@@ -240,7 +239,6 @@ class InstalledExtensions {
 
 			$data['settingsUrl'] = admin_url( 'admin.php?page=codisto-settings' );
 			$data['docsUrl']     = 'https://docs.woocommerce.com/document/getting-started-with-woocommerce-amazon-ebay-integration/';
-			$data['supportUrl']  = 'https://get.codisto.help/hc/en-us/categories/204467528';
 		}
 
 		return $data;

--- a/src/Marketing/InstalledExtensions.php
+++ b/src/Marketing/InstalledExtensions.php
@@ -69,7 +69,7 @@ class InstalledExtensions {
 			'facebook-for-woocommerce',
 			'kliken-marketing-for-google',
 			'hubwoo-integration',
-			'codistoconnect',
+			'woocommerce-amazon-ebay-integration',
 		];
 	}
 
@@ -220,7 +220,7 @@ class InstalledExtensions {
 	 * @return array|bool
 	 */
 	protected static function get_amazon_ebay_extension_data() {
-		$slug = 'codistoconnect';
+		$slug = 'woocommerce-amazon-ebay-integration';
 
 		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
 			return false;


### PR DESCRIPTION
Fixes #4267

The Codisto Amazon & Ebay integration plugin is named different between woocommerce.com and wordpress.org

wp.org = codistoconnect/connect.php "Codisto LINQ by Codisto"
wc.com = woocommerce-amazon-ebay-integration/woocommerce-amazon-ebay-integration.php "WooCommerce Amazon and eBay Integration"

We'd like to make sure we support the version from WCCOM until we can add a proper API for plugins to use themselves.

### Detailed test instructions:

- Download plugin from WCCOM (it should be a plugin folder called woocommerce-amazon-ebay-integration)
- Install and activate
- Notice that the Installed Extensions Tab now recognizes the plugin.
