### PR TITLE
update unit test bootstrap for WC 4.2

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,6 +52,9 @@ function wc_admin_install() {
  */
 function wc_test_includes() {
 	$wc_tests_framework_base_dir = wc_dir() . '/tests';
+	if ( ! is_dir( $wc_tests_framework_base_dir . '/framework' ) ) {
+		$wc_tests_framework_base_dir .= '/legacy';
+	}
 
 	// WooCommerce test classes.
 	// Framework.


### PR DESCRIPTION
This PR updates the unit test bootstrap to account for [test folder organization changes in WooCommerce 4.2](https://github.com/woocommerce/woocommerce/pull/26345).

### Testing

- Run `phpunit` against both WC 4.1 and `master`