### PR TITLE
Add back giving feedback note with some changes

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Giving_Feedback_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Mobile_App;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_New_Sales_Record;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
@@ -70,5 +71,6 @@ class Events {
 		WC_Admin_Notes_Personalize_Store::possibly_add_personalize_store_note();
 		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
 		WC_Admin_Notes_Marketing::possibly_add_note_intro();
+		WC_Admin_Notes_Giving_Feedback_Notes::add_notes_for_admin_giving_feedback();
 	}
 }

--- a/src/Install.php
+++ b/src/Install.php
@@ -460,6 +460,7 @@ class Install {
 		$obsolete_notes_names = array(
 			'wc-admin-welcome-note',
 			'wc-admin-store-notice-setting-moved',
+			'wc-admin-store-notice-giving-feedback',
 		);
 
 		$additional_obsolete_notes_names = apply_filters(

--- a/src/Install.php
+++ b/src/Install.php
@@ -460,7 +460,6 @@ class Install {
 		$obsolete_notes_names = array(
 			'wc-admin-welcome-note',
 			'wc-admin-store-notice-setting-moved',
-			'wc-admin-store-notice-giving-feedback',
 		);
 
 		$additional_obsolete_notes_names = apply_filters(

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -31,7 +31,7 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 	 * Possibly add a notice setting moved note.
 	 */
 	protected static function possibly_add_admin_giving_feedback_note() {
-		$name       = 'wc-admin-store-notice-giving-feedback';
+		$name       = 'wc-admin-store-notice-giving-feedback-2';
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// We already have this note? Then exit, we're done.

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WooCommerce Admin (Dashboard) Giving feedback notes provider
+ *
+ * Adds notes to the merchant's inbox about giving feedback.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Giving_Feedback_Notes
+ */
+class WC_Admin_Notes_Giving_Feedback_Notes {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Add notes for admin giving feedback.
+	 */
+	public static function add_notes_for_admin_giving_feedback() {
+		self::possibly_add_admin_giving_feedback_note();
+	}
+
+	/**
+	 * Possibly add a notice setting moved note.
+	 */
+	protected static function possibly_add_admin_giving_feedback_note() {
+		$name       = 'wc-admin-store-notice-giving-feedback';
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		// We already have this note? Then exit, we're done.
+		$note_ids = $data_store->get_notes_with_name( $name );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		// We need to show Admin Giving feeback notification after 8 days of install.
+		$eight_days_in_seconds = 8 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $eight_days_in_seconds ) ) {
+			return;
+		}
+
+		// Otherwise, create our new note.
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Give feedback', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Now that you’ve chosen us as a partner, our goal is to make sure we\'re providing the right tools to meet your needs. We\'re looking forward to having your feedback on the store setup experience so we can improve it in the future.', 'woocommerce-admin' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'info' );
+		$note->set_name( $name );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'share-feedback',
+			__( 'Share feedback', 'woocommerce-admin' ),
+			'https://automattic.survey.fm/new-onboarding-survey'
+		);
+		$note->save();
+	}
+}


### PR DESCRIPTION
Fixes #

This adds back the giving feedback note (removed in #4182) with new copy, per #4178.

### Screenshots

![image](https://user-images.githubusercontent.com/224531/81355362-a95ae780-9111-11ea-9138-e23c02ba2146.png)

### Detailed test instructions:

- Edit `src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php` and change the 8 to 0 on line 44
- Run the `wc_admin_daily` cron event
- Check that the giving feedback event is displayed

### Changelog Note:

Enhancement: Add back giving feedback note with new copy
