### PR TITLE
New notification: How to draw attention to your online store

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -16,6 +16,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Woo_Subscriptions_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Install_JP_And_WCS_Plugins;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Draw_Attention;
 
 /**
  * Feature plugin main class.
@@ -186,6 +187,7 @@ class FeaturePlugin {
 		new WC_Admin_Notes_Tracking_Opt_In();
 		new WC_Admin_Notes_WooCommerce_Payments();
 		new WC_Admin_Notes_Install_JP_And_WCS_Plugins();
+		new WC_Admin_Notes_Draw_Attention();
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * WooCommerce Admin Draw Attention note provider
+ *
+ * Adds a note to the merchant's inbox
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Draw_Attention
+ */
+class WC_Admin_Notes_Draw_Attention {
+	const NOTE_NAME   = 'wc-admin-draw-attention';
+	const OPTION_NAME = 'woocommerce_onboarding_profile';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Trigger this when the onboarding options are updated.
+		add_filter(
+			'update_option_' . self::OPTION_NAME,
+			array( $this, 'possibly_add_draw_attention_note' )
+		);
+	}
+
+	/**
+	 * Possibly add a draw attention note.
+	 */
+	public static function possibly_add_draw_attention_note() {
+		$onboarding_profile = get_option( self::OPTION_NAME );
+
+		// Skip adding if this store is being set up for a client.
+		if ( ! isset( $onboarding_profile['setup_client'] ) || $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
+		// Skip adding if the merchant has no products.
+		if ( ! isset( $onboarding_profile['product_count'] ) || '0' === $onboarding_profile['product_count'] ) {
+			return;
+		}
+
+		// Exit early if there is already a note.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			return;
+		}
+
+		// Create the note.
+		$note = new WC_Admin_Note();
+
+		$note->set_title( __( 'How to draw attention to your online store', 'woocommerce-admin' ) );
+		$note->set_content( __( 'To get you started, here are seven ways to boost your sales and avoid getting drowned out by similar, mass-produced products competing for the same buyers.', 'woocommerce-admin' ) );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_ADMIN_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/how-to-make-your-online-store-stand-out/?utm_source=inbox',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+
+		$note->save();
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -25,23 +25,27 @@ class WC_Admin_Notes_Draw_Attention {
 		// Trigger this when the onboarding options are updated.
 		add_filter(
 			'update_option_' . self::OPTION_NAME,
-			array( $this, 'possibly_add_draw_attention_note' )
+			array( $this, 'possibly_add_draw_attention_note' ),
+			10,
+			3
 		);
 	}
 
 	/**
 	 * Possibly add a draw attention note.
+	 *
+	 * @param object $old_value The old option value.
+	 * @param object $value     The new option value.
+	 * @param string $option    The name of the option.
 	 */
-	public static function possibly_add_draw_attention_note() {
-		$onboarding_profile = get_option( self::OPTION_NAME );
-
+	public static function possibly_add_draw_attention_note( $old_value, $value, $option ) {
 		// Skip adding if this store is being set up for a client.
-		if ( ! isset( $onboarding_profile['setup_client'] ) || $onboarding_profile['setup_client'] ) {
+		if ( ! isset( $value['setup_client'] ) || $value['setup_client'] ) {
 			return;
 		}
 
 		// Skip adding if the merchant has no products.
-		if ( ! isset( $onboarding_profile['product_count'] ) || '0' === $onboarding_profile['product_count'] ) {
+		if ( ! isset( $value['product_count'] ) || '0' === $value['product_count'] ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #4195

This adds a new admin note while the OBW is being completed. The note is added with two conditions:

- "I'm setting up a store for a client" must be _unchecked_
- "How many products do you plan to display?" must be >= 1

### Screenshots

![image](https://user-images.githubusercontent.com/224531/81376073-24d68c00-9146-11ea-98c7-7e1c3ff77979.png)

### Detailed test instructions:

- delete all notes from the db: `DELETE FROM wp_wc_admin_notes`
- delete the onboarding profile option: `DELETE FROM wp_options WHERE option_name = 'woocommerce_onboarding_profile'`
- start the OBW via Coupons -> Help -> Setup Wizard -> Profile Setup Wizard -> Enable
- work through the wizard, don't select setting up a store for a client, and select >= 1 for the number of products
- once completed, you should see the new message in the inbox

### Changelog Note:

Enhancement: New notification: How to draw attention to your online store