### PR TITLE
Inbox notification: add event recording

### DIFF
--- a/client/header/activity-panel/panels/inbox/action.js
+++ b/client/header/activity-panel/panels/inbox/action.js
@@ -50,7 +50,7 @@ class InboxNoteAction extends Component {
 			} else {
 				removeAllNotes();
 			}
-			actionCallback();
+			actionCallback( true );
 		} else {
 			this.setState( { inAction }, () =>
 				triggerNoteAction( noteId, action.id )

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -94,17 +94,17 @@ class InboxNoteCard extends Component {
 		onToggle();
 	}
 
-	closeDismissModal( acepted ) {
+	closeDismissModal( noteNameDismissConfirmation ) {
 		const { dismissType } = this.state;
 		const { note, screen } = this.props;
 		const noteNameDismissAll = dismissType === 'all' ? true : false;
-		const noteNameDismissAllConfirmation = acepted ? true : false;
 
 		recordEvent( 'inbox_action_dismiss', {
 			note_name: note.name,
 			note_title: note.title,
 			note_name_dismiss_all: noteNameDismissAll,
-			note_name_dismiss_all_confirmation: noteNameDismissAllConfirmation,
+			note_name_dismiss_confirmation:
+				noteNameDismissConfirmation || false,
 			screen,
 		} );
 

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -38,16 +38,21 @@ class InboxNoteCard extends Component {
 	}
 
 	componentDidMount() {
-		this.bodyNotificationRef.current.addEventListener( 'click', ( event ) =>
-			this.handleBodyClick( event, this.props )
-		);
+		if ( this.bodyNotificationRef.current ) {
+			this.bodyNotificationRef.current.addEventListener(
+				'click',
+				( event ) => this.handleBodyClick( event, this.props )
+			);
+		}
 	}
 
 	componentWillUnmount() {
-		this.bodyNotificationRef.current.removeEventListener(
-			'click',
-			( event ) => this.handleBodyClick( event, this.props )
-		);
+		if ( this.bodyNotificationRef.current ) {
+			this.bodyNotificationRef.current.removeEventListener(
+				'click',
+				( event ) => this.handleBodyClick( event, this.props )
+			);
+		}
 	}
 
 	handleBodyClick( event, props ) {

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -31,11 +31,11 @@ class InboxNoteCard extends Component {
 		this.state = {
 			isDismissModalOpen: false,
 			dismissType: null,
-			screen: this.getScreenName(),
 		};
 		this.openDismissModal = this.openDismissModal.bind( this );
 		this.closeDismissModal = this.closeDismissModal.bind( this );
 		this.bodyNotificationRef = createRef();
+		this.screen = this.getScreenName();
 	}
 
 	componentDidMount() {
@@ -60,13 +60,12 @@ class InboxNoteCard extends Component {
 		const innerLink = event.target.href;
 		if ( innerLink ) {
 			const { note } = props;
-			const { screen } = this.state;
 
 			recordEvent( 'wcadmin_inbox_action_click', {
 				note_name: note.name,
 				note_title: note.title,
 				note_content_inner_link: innerLink,
-				screen,
+				screen: this.screen,
 			} );
 		}
 	}
@@ -96,14 +95,13 @@ class InboxNoteCard extends Component {
 	onVisible( isVisible ) {
 		if ( isVisible && ! this.hasBeenSeen ) {
 			const { note } = this.props;
-			const { screen } = this.state;
 
 			recordEvent( 'inbox_note_view', {
 				note_content: note.content,
 				note_name: note.name,
 				note_title: note.title,
 				note_type: note.type,
-				screen,
+				screen: this.screen,
 			} );
 
 			this.hasBeenSeen = true;
@@ -119,7 +117,7 @@ class InboxNoteCard extends Component {
 	}
 
 	closeDismissModal( noteNameDismissConfirmation ) {
-		const { dismissType, screen } = this.state;
+		const { dismissType } = this.state;
 		const { note } = this.props;
 		const noteNameDismissAll = dismissType === 'all' ? true : false;
 
@@ -129,7 +127,7 @@ class InboxNoteCard extends Component {
 			note_name_dismiss_all: noteNameDismissAll,
 			note_name_dismiss_confirmation:
 				noteNameDismissConfirmation || false,
-			screen,
+			screen: this.screen,
 		} );
 
 		this.setState( {

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { cloneElement, Component, Fragment } from '@wordpress/element';
+import {
+	cloneElement,
+	Component,
+	createRef,
+	Fragment,
+} from '@wordpress/element';
 import { Button, Dropdown, Modal } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import VisibilitySensor from 'react-visibility-sensor';
@@ -29,18 +34,46 @@ class InboxNoteCard extends Component {
 		};
 		this.openDismissModal = this.openDismissModal.bind( this );
 		this.closeDismissModal = this.closeDismissModal.bind( this );
+		this.bodyNotificationRef = createRef();
+	}
+
+	componentDidMount() {
+		this.bodyNotificationRef.current.addEventListener( 'click', ( event ) =>
+			this.handleBodyClick( event, this.props )
+		);
+	}
+
+	componentWillUnmount() {
+		this.bodyNotificationRef.current.removeEventListener(
+			'click',
+			( event ) => this.handleBodyClick( event, this.props )
+		);
+	}
+
+	handleBodyClick( event, props ) {
+		const innerLink = event.target.href;
+		if ( innerLink ) {
+			const { note, screen } = props;
+
+			recordEvent( 'wcadmin_inbox_note_view', {
+				note_name: note.name,
+				note_content_inner_link: innerLink,
+				screen,
+			} );
+		}
 	}
 
 	// Trigger a view Tracks event when the note is seen.
 	onVisible( isVisible ) {
 		if ( isVisible && ! this.hasBeenSeen ) {
-			const { note } = this.props;
+			const { note, screen } = this.props;
 
 			recordEvent( 'inbox_note_view', {
 				note_content: note.content,
 				note_name: note.name,
 				note_title: note.title,
 				note_type: note.type,
+				screen,
 			} );
 
 			this.hasBeenSeen = true;
@@ -55,7 +88,20 @@ class InboxNoteCard extends Component {
 		onToggle();
 	}
 
-	closeDismissModal() {
+	closeDismissModal( acepted ) {
+		const { dismissType } = this.state;
+		const { note, screen } = this.props;
+		const noteNameDismissAll = dismissType === 'all' ? true : false;
+		const noteNameDismissAllConfirmation = acepted ? true : false;
+
+		recordEvent( 'wcadmin_inbox_note_view', {
+			note_name: note.name,
+			note_name_dismiss: note.name,
+			note_name_dismiss_all: noteNameDismissAll,
+			note_name_dismiss_all_confirmation: noteNameDismissAllConfirmation,
+			screen,
+		} );
+
 		this.setState( {
 			isDismissModalOpen: false,
 		} );
@@ -241,6 +287,7 @@ class InboxNoteCard extends Component {
 									dangerouslySetInnerHTML={ sanitizeHTML(
 										content
 									) }
+									ref={ this.bodyNotificationRef }
 								/>
 							</Section>
 						</div>
@@ -264,6 +311,7 @@ class InboxNoteCard extends Component {
 }
 
 InboxNoteCard.propTypes = {
+	screen: PropTypes.string,
 	note: PropTypes.shape( {
 		id: PropTypes.number,
 		status: PropTypes.string,

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -31,6 +31,7 @@ class InboxNoteCard extends Component {
 		this.state = {
 			isDismissModalOpen: false,
 			dismissType: null,
+			screen: this.getScreenName(),
 		};
 		this.openDismissModal = this.openDismissModal.bind( this );
 		this.closeDismissModal = this.closeDismissModal.bind( this );
@@ -58,7 +59,8 @@ class InboxNoteCard extends Component {
 	handleBodyClick( event, props ) {
 		const innerLink = event.target.href;
 		if ( innerLink ) {
-			const { note, screen } = props;
+			const { note } = props;
+			const { screen } = this.state;
 
 			recordEvent( 'wcadmin_inbox_action_click', {
 				note_name: note.name,
@@ -69,10 +71,32 @@ class InboxNoteCard extends Component {
 		}
 	}
 
+	getScreenName() {
+		let screenName = '';
+		const urlParams = new URLSearchParams( window.location.search );
+
+		if ( urlParams.has( 'page' ) ) {
+			const currentPage =
+				urlParams.get( 'page' ) === 'wc-admin'
+					? 'home_screen'
+					: urlParams.get( 'page' );
+			screenName = urlParams.has( 'path' )
+				? urlParams
+						.get( 'path' )
+						.replace( /\//g, '_' )
+						.substring( 1 )
+				: currentPage;
+		} else if ( urlParams.has( 'post_type' ) ) {
+			screenName = urlParams.get( 'post_type' );
+		}
+		return screenName;
+	}
+
 	// Trigger a view Tracks event when the note is seen.
 	onVisible( isVisible ) {
 		if ( isVisible && ! this.hasBeenSeen ) {
-			const { note, screen } = this.props;
+			const { note } = this.props;
+			const { screen } = this.state;
 
 			recordEvent( 'inbox_note_view', {
 				note_content: note.content,
@@ -95,8 +119,8 @@ class InboxNoteCard extends Component {
 	}
 
 	closeDismissModal( noteNameDismissConfirmation ) {
-		const { dismissType } = this.state;
-		const { note, screen } = this.props;
+		const { dismissType, screen } = this.state;
+		const { note } = this.props;
 		const noteNameDismissAll = dismissType === 'all' ? true : false;
 
 		recordEvent( 'inbox_action_dismiss', {
@@ -317,7 +341,6 @@ class InboxNoteCard extends Component {
 }
 
 InboxNoteCard.propTypes = {
-	screen: PropTypes.string,
 	note: PropTypes.shape( {
 		id: PropTypes.number,
 		status: PropTypes.string,

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -55,8 +55,9 @@ class InboxNoteCard extends Component {
 		if ( innerLink ) {
 			const { note, screen } = props;
 
-			recordEvent( 'wcadmin_inbox_note_view', {
+			recordEvent( 'wcadmin_inbox_action_click', {
 				note_name: note.name,
+				note_title: note.title,
 				note_content_inner_link: innerLink,
 				screen,
 			} );
@@ -94,9 +95,9 @@ class InboxNoteCard extends Component {
 		const noteNameDismissAll = dismissType === 'all' ? true : false;
 		const noteNameDismissAllConfirmation = acepted ? true : false;
 
-		recordEvent( 'wcadmin_inbox_note_view', {
+		recordEvent( 'inbox_action_dismiss', {
 			note_name: note.name,
-			note_name_dismiss: note.name,
+			note_title: note.title,
 			note_name_dismiss_all: noteNameDismissAll,
 			note_name_dismiss_all_confirmation: noteNameDismissAllConfirmation,
 			screen,

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -57,9 +57,11 @@ class InboxPanel extends Component {
 		);
 
 		if ( URLparams.page ) {
+			const currentPage =
+				URLparams.page === 'wc-admin' ? 'home_screen' : URLparams.page;
 			screenName = URLparams.path
 				? URLparams.path.replace( /\//g, '_' ).substring( 1 )
-				: URLparams.page;
+				: currentPage;
 		} else if ( URLparams.post_type ) {
 			screenName = URLparams.post_type;
 		}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -50,24 +50,6 @@ class InboxPanel extends Component {
 		return unreadNotes.length;
 	}
 
-	getScreenName() {
-		let screenName = '';
-		const urlParams = Object.fromEntries(
-			new URLSearchParams( window.location.search )
-		);
-
-		if ( urlParams.page ) {
-			const currentPage =
-				urlParams.page === 'wc-admin' ? 'home_screen' : urlParams.page;
-			screenName = urlParams.path
-				? urlParams.path.replace( /\//g, '_' ).substring( 1 )
-				: currentPage;
-		} else if ( urlParams.post_type ) {
-			screenName = urlParams.post_type;
-		}
-		return screenName;
-	}
-
 	renderEmptyCard() {
 		return (
 			<ActivityCard
@@ -97,7 +79,6 @@ class InboxPanel extends Component {
 			return this.renderEmptyCard();
 		}
 
-		const screen = this.getScreenName();
 		const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
 		return notesArray.map( ( note ) => (
@@ -105,7 +86,6 @@ class InboxPanel extends Component {
 				key={ note.id }
 				note={ note }
 				lastRead={ lastRead }
-				screen={ screen }
 			/>
 		) );
 	}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -52,18 +52,18 @@ class InboxPanel extends Component {
 
 	getScreenName() {
 		let screenName = '';
-		const URLparams = Object.fromEntries(
+		const urlParams = Object.fromEntries(
 			new URLSearchParams( window.location.search )
 		);
 
-		if ( URLparams.page ) {
+		if ( urlParams.page ) {
 			const currentPage =
-				URLparams.page === 'wc-admin' ? 'home_screen' : URLparams.page;
-			screenName = URLparams.path
-				? URLparams.path.replace( /\//g, '_' ).substring( 1 )
+				urlParams.page === 'wc-admin' ? 'home_screen' : urlParams.page;
+			screenName = urlParams.path
+				? urlParams.path.replace( /\//g, '_' ).substring( 1 )
 				: currentPage;
-		} else if ( URLparams.post_type ) {
-			screenName = URLparams.post_type;
+		} else if ( urlParams.post_type ) {
+			screenName = urlParams.post_type;
 		}
 		return screenName;
 	}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -50,6 +50,22 @@ class InboxPanel extends Component {
 		return unreadNotes.length;
 	}
 
+	getScreenName() {
+		let screenName = '';
+		const URLparams = Object.fromEntries(
+			new URLSearchParams( window.location.search )
+		);
+
+		if ( URLparams.page ) {
+			screenName = URLparams.path
+				? URLparams.path.replace( /\//g, '_' ).substring( 1 )
+				: URLparams.page;
+		} else if ( URLparams.post_type ) {
+			screenName = URLparams.post_type;
+		}
+		return screenName;
+	}
+
 	renderEmptyCard() {
 		return (
 			<ActivityCard
@@ -69,16 +85,17 @@ class InboxPanel extends Component {
 	renderNotes() {
 		const { lastRead, notes } = this.props;
 
-		const validNotes = filter( notes, ( note )=> {
-				const { is_deleted: isDeleted } = note;
-				const noteActive = has( note, 'is_deleted' ) ? ! isDeleted : true;
-				return noteActive;
-			} );
+		const validNotes = filter( notes, ( note ) => {
+			const { is_deleted: isDeleted } = note;
+			const noteActive = has( note, 'is_deleted' ) ? ! isDeleted : true;
+			return noteActive;
+		} );
 
 		if ( validNotes.length === 0 ) {
 			return this.renderEmptyCard();
 		}
 
+		const screen = this.getScreenName();
 		const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
 		return notesArray.map( ( note ) => (
@@ -86,6 +103,7 @@ class InboxPanel extends Component {
 				key={ note.id }
 				note={ note }
 				lastRead={ lastRead }
+				screen={ screen }
 			/>
 		) );
 	}

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -341,6 +341,16 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test deleting a single note without permission. It should fail.
+	 */
+	public function test_delete_single_note_without_permission() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'DELETE', $this->endpoint . '/delete/3' ) );
+		$note     = $response->get_data();
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * Test undiong a single note delete.
 	 */
 	public function test_undo_single_notes_delete() {
@@ -382,6 +392,16 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $notes ) );
+	}
+
+	/**
+	 * Test deleting all the notes without permission. It should fail.
+	 */
+	public function test_delete_all_notes_without_permission() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'DELETE', $this->endpoint . '/delete/all' ) );
+		$notes    = $response->get_data();
+
+		$this->assertEquals( 401, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
> **_NOTE:_**  A rebase will be necessary. Only the last four commits should be considered in this PR.

Fixes #partially-4099

This PR adds some event recording to the inbox notifications.

Events:
`wcadmin_inbox_note_view`
New event prop: `screen` (value: home screen, analytics_revenue, customers, etc)

`wcadmin_wcadmin_inbox_action_click`
New event prop: `screen` (value: home screen, analytics_revenue, customers, etc)
New event prop: `note_name` (name of the note that received a click in the main cta. eg: wc-admin-wc-helper).
New event prop: `note_name_dismiss` (name of the note that was dismissed. eg: wc-admin-wc-helper).
New event prop: `note_name_dismiss_all` (`true` for dismiss all messages and `false` for dismiss this messages ).
New event prop: `note_name_dismiss_all_confirmation` (`true` for yes I'm sure and `false` for cancel).


_Please be sure the [PR 4281](https://github.com/woocommerce/woocommerce-admin/pull/4281) has been approved before approving this one_


> **_NOTE 2:_**  As this is a part of a big functionality this branch will be merged with the branch `add/4099`, and it will be that branch that will be merged with `master`.
To make the code reviewing easier, this PR only has the code referring to the functionality described in the title.
If you want to test everything together, all the changes are merged in the branch: `add/4099_test_branch`.

### Detailed test instructions:
#### Verify `screen` prop for `wcadmin_wcadmin_inbox_action_click` and `wcadmin_inbox_action_dismiss `
1. Go to any page (e.g. the `Analytics / Revenue`).
2. Press the `Inbox` button in the navbar, to open the inbox notifications
3. Press the `Dismiss` button of any notification.
4. Select one of the two options in the dropdown.
5. Press the `Cancel` option in the modal.
6. It should send the value `analytics_revenue`

1. Go to another page (e.g. the `Home`)

2-5. Follow the same steps that are done for `Analytics / Revenue`

6. Verify that the sent value now is `home_screen`

#### Only for `wcadmin_wcadmin_inbox_action_click`

**_Verify link clicks in the body's message_**

1-2. Follow the first 2 steps.

3. Press a link inside of the body of an inbox message
4. It should set the prop `note_content_inner_link` with the link's URL, and record the event.
 
#### Only for `wcadmin_inbox_action_dismiss`

**_Verify `note_name` prop_**

1-3. Follow the first 3 steps.

4. Select the option `Dismiss this message` from the dropdown.
5. Confirm or cancel the action in the modal (both should trigger the event).
6. Verify that the `note_name` value is correctly set with the note name.
7. Do the same with the option `Dismiss all messages`.

**_Verify `note_name_dismiss` prop_**

1-5. Follow the first 5 steps.

6. Verify that the `note_name_dismiss` value is correctly set with the note name.
7. Do the same with the option `Dismiss all messages`.

**_Verify `note_name_dismiss_all` prop_**

1-5. Follow the first 5 steps.

6. The prop `note_name_dismiss_all` should be `false`.
7. Do the same with the option `Dismiss all messages`.
6. Now the prop `note_name_dismiss_all` should be `true`.

**_Verify `note_name_dismiss_confirmation` prop_**

1-4. Follow the first 4 steps.

5. Press `Cancel`
6. The prop `note_name_dismiss_confirmation` should be `false`.
7. Follow the first 4 steps again but now choose: `Yes, I'm sure`. 
6. Now the prop `note_name_dismiss_confirmation` should be `true`.
7. Do the same choosing the option `Dismiss all messages` in step 4.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: added event recording to the inbox notifications.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
