### PR TITLE
Update wcadmin db version after db callback

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -84,3 +84,10 @@ function wc_admin_update_0251_db_version() {
 function wc_admin_update_110_remove_facebook_note() {
 	WC_Admin_Notes::delete_notes_with_name( 'wc-admin-facebook-extension' );
 }
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_110_db_version() {
+	Installer::update_db_version( '1.1.0' );
+}

--- a/src/Install.php
+++ b/src/Install.php
@@ -42,6 +42,7 @@ class Install {
 		),
 		'1.1.0'  => array(
 			'wc_admin_update_110_remove_facebook_note',
+			'wc_admin_update_110_db_version',
 		),
 	);
 


### PR DESCRIPTION
Fixes #4321 

Adds a missing version update after async db upgrades take place to prevent infinite install loop.

### Detailed test instructions:

1. Set `woocommerce_admin_version` in `wp_options` to  a version between `0.25.1` and `1.1.0`.
1. Delete `wc_admin_installing` to speed things up.
1. Wait for action scheduler events to take place.
1. Note that the version was updated to the latest.