### PR TITLE
Only migrate options on version change

### DIFF
--- a/src/Install.php
+++ b/src/Install.php
@@ -70,41 +70,25 @@ class Install {
 
 		// Add wc-admin report tables to list of WooCommerce tables.
 		add_filter( 'woocommerce_install_get_tables', array( __CLASS__, 'add_tables' ) );
-
-		// Migrate option names by filtering their default values.
-		// This attaches a targeted filter for each migrated option name that will retreive
-		// the old value and use it as the default for the new option. This default
-		// will be used in the first retreival of the new option.
-		foreach ( self::$migrated_options as $new_option => $old_option ) {
-			add_filter( "default_option_{$new_option}", array( __CLASS__, 'handle_option_migration' ), 10, 2 );
-		}
 	}
 
 	/**
 	 * Migrate option values to their new keys/names.
-	 *
-	 * @param mixed  $default Default value for the option.
-	 * @param string $new_option Option name.
-	 * @return mixed Migrated option value.
 	 */
-	public static function handle_option_migration( $default, $new_option ) {
-		if ( isset( self::$migrated_options[ $new_option ] ) ) {
-			wc_maybe_define_constant( 'WC_ADMIN_MIGRATING_OPTIONS', true );
+	public static function migrate_options() {
+		wc_maybe_define_constant( 'WC_ADMIN_MIGRATING_OPTIONS', true );
 
-			// Avoid infinite loops - this filter is applied in add_option(), update_option(), and get_option().
-			remove_filter( "default_option_{$new_option}", array( __CLASS__, 'handle_option_migration' ), 10, 2 );
+		foreach ( self::$migrated_options as $new_option => $old_option ) {
+			$old_option_value = get_option( $old_option, false );
 
-			// Migrate the old option value.
-			$old_option_name  = self::$migrated_options[ $new_option ];
-			$old_option_value = get_option( $old_option_name, $default );
+			// Continue if no option value was previously set.
+			if ( false === $old_option_value ) {
+				continue;
+			}
 
 			update_option( $new_option, $old_option_value );
-			delete_option( $old_option_name );
-
-			return $old_option_value;
+			delete_option( $old_option );
 		}
-
-		return $default;
 	}
 
 	/**
@@ -156,6 +140,7 @@ class Install {
 		set_transient( 'wc_admin_installing', 'yes', MINUTE_IN_SECONDS * 10 );
 		wc_maybe_define_constant( 'WC_ADMIN_INSTALLING', true );
 
+		self::migrate_options();
 		self::create_tables();
 		self::create_events();
 		self::delete_obsolete_notes();


### PR DESCRIPTION
Fixes #4322 

Migrates options only on version change/install instead of every option retrieval.
Fixes the issue where `woocommerce_admin_install_timestamp` was being reset on every page load.

/cc @jeffstieler in case I'm missing any reasoning or benefits to using the `default_option_{$option}` hook.

### Detailed test instructions:

1. Check out the commit hash `a8506601b9bfe5fbed366b5b438b80fc8d9899cf` on `master` to mimic a version prior to the merge of #4323 .
1. Set `woocommerce_admin_version` in wp_options to a version between 0.25.1 and 1.1.0.
1. Add an old option name to `wp_options`, such as `wc_onboarding_opt_in`.
1. Set the option `woocommerce_admin_version` to an older version to force an install/version update.
1. Make sure the old option name is updated to the new name with its previous value.  E.g., `woocommerce_onboarding_opt_in` in the example above.
1. Make sure that old options that were not in the database are not added as new options.