### PR TITLE
Task list: Inject Jetpack fallback flow into WCPay task

### DIFF
--- a/client/dashboard/task-list/tasks/payments/index.js
+++ b/client/dashboard/task-list/tasks/payments/index.js
@@ -356,9 +356,7 @@ export default compose(
 			isUpdateOptionsRequesting,
 		} = select( 'wc-api' );
 
-		const { getActivePlugins, isJetpackConnected } = select(
-			PLUGINS_STORE_NAME
-		);
+		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 		const activePlugins = getActivePlugins();
 		const profileItems = getProfileItems();
 		const options = getOptions( [
@@ -382,7 +380,6 @@ export default compose(
 		const methods = getPaymentMethods( {
 			activePlugins,
 			countryCode,
-			isJetpackConnected: isJetpackConnected(),
 			options,
 			profileItems,
 		} );

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -33,7 +33,6 @@ import PayFast from './payfast';
 export function getPaymentMethods( {
 	activePlugins,
 	countryCode,
-	isJetpackConnected,
 	options,
 	profileItems,
 } ) {
@@ -119,10 +118,7 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <WCPayIcon />,
-			visible:
-				[ 'US' ].includes( countryCode ) &&
-				! hasCbdIndustry &&
-				isJetpackConnected,
+			visible: [ 'US' ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConfigured,

--- a/client/dashboard/task-list/tasks/payments/wcpay.js
+++ b/client/dashboard/task-list/tasks/payments/wcpay.js
@@ -91,6 +91,7 @@ class WCPay extends Component {
 		}
 	}
 
+	// TODO Call this when install completes to see if Jetpack steps need to be there.
 	async isJetpackRequired() {
 		const { createNotice } = this.props;
 		this.setState( { isPending: true } );
@@ -127,6 +128,7 @@ class WCPay extends Component {
 			<Stepper
 				isVertical
 				isPending={ ! installStep.isComplete || isPending }
+				// TODO Use component state to read and write current step.
 				currentStep={ installStep.isComplete ? 'connect' : 'install' }
 				steps={ [
 					installStep,

--- a/client/dashboard/task-list/tasks/payments/wcpay.js
+++ b/client/dashboard/task-list/tasks/payments/wcpay.js
@@ -7,6 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+import { addQueryArgs } from '@wordpress/url';
 import { includes, filter } from 'lodash';
 
 /**
@@ -31,7 +32,7 @@ class WCPay extends Component {
 		this.state = {
 			step: 'install',
 			isPending: ! props.installStep.isComplete,
-			isJetpackRequired: false,
+			isJetpackRequired: getQuery().from === 'jetpack',
 		};
 
 		this.connect = this.connect.bind( this );
@@ -113,7 +114,10 @@ class WCPay extends Component {
 	async isJetpackMissing() {
 		const { createNotice } = this.props;
 
-		if ( this.isJetpackActive && this.isJetpackConnected ) {
+		if (
+			this.state.isJetpackRequired ||
+			( this.isJetpackActive && this.isJetpackConnected )
+		) {
 			this.setState( { step: 'connect-wcpay' } );
 			return;
 		}
@@ -192,11 +196,13 @@ class WCPay extends Component {
 					<Connect
 						{ ...this.props }
 						setIsPending={ this.setIsPending }
+						redirectUrl={ addQueryArgs( window.location.href, {
+							from: 'jetpack',
+						} ) }
 						onConnect={ () => {
 							recordEvent( 'tasklist_wcpay_connect_jetpack', {
 								connect: true,
 							} );
-							this.setState( { step: 'connect-wcpay' } );
 						} }
 					/>
 				),

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -146,6 +146,19 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/wcpay-deps',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'wcpay_deps' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_connect_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/connect-wcpay',
 			array(
 				array(
@@ -602,6 +615,20 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		return( array(
 			'connectUrl' => $connect_url,
+		) );
+	}
+
+	/**
+	 * Returns plugin dependencies for WCPay.
+	 *
+	 * @return WP_Error|array Dependency flags.
+	 */
+	public function wcpay_deps() {
+		if ( ! defined( 'WCPAY_VERSION_NUMBER' ) ) {
+			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error communicating with the WooCommerce Payments plugin.', 'woocommerce-admin' ), 500 );
+		}
+		return( array(
+			'jetpack' => defined( 'WCPAY_MIN_JETPACK_VERSION' ) ? 'yes' : 'no'
 		) );
 	}
 

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -628,7 +628,7 @@ class Plugins extends \WC_REST_Data_Controller {
 			return new \WP_Error( 'woocommerce_rest_helper_connect', __( 'There was an error communicating with the WooCommerce Payments plugin.', 'woocommerce-admin' ), 500 );
 		}
 		return( array(
-			'jetpack' => defined( 'WCPAY_MIN_JETPACK_VERSION' ) ? 'yes' : 'no'
+			'jetpack' => defined( 'WCPAY_BUILTIN_JETPACK_CONNECTION' ) ? 'no' : 'yes',
 		) );
 	}
 


### PR DESCRIPTION
This is a proposed change for conditionally adding Jetpack installation/activation and connection steps into the middle of the WCPay task, adapting components and flow management approach from Shipping and Tax tasks.

Ultimately, WCPay will not require Jetpack (see https://github.com/Automattic/woocommerce-payments/pull/638) but there is uncertainly around when these changes will be released. This change allows the Jetpack dependency to be controlled by a `define` in the WCPay plugin, which is now checked after the task's install step with an AJAX request (if Jetpack is not already connected).

### Screenshots

https://cloudup.com/ciny8Oz1Sam

### Detailed test instructions:

With WooCommerce Payments not active, go to the task list » "Set up payments" » WooCommerce Payments "Set up". Verify that Jetpack is installed and connected if it needs to be.

WCPay **does** require Jetpack on `master` and in the newest `0.9.1` release. To test the case of WCPay not requiring Jetpack, either use the branch on https://github.com/Automattic/woocommerce-payments/pull/638 or add `define( 'WCPAY_BUILTIN_JETPACK_CONNECTION', true );` anywhere on your site.

### Testing combinations:
- [ ] Jetpack not installed, WCPay requires Jetpack.
- [ ] Jetpack not installed, WCPay doesn't require Jetpack.
- [ ] Jetpack installed but not active, WCPay requires Jetpack.
- [ ] Jetpack installed but not active, WCPay doesn't require Jetpack.
- [ ] Jetpack active but not connected, WCPay requires Jetpack.
- [ ] Jetpack active but not connected, WCPay doesn't require Jetpack.
- [ ] Jetpack connected, WCPay requires Jetpack.
- [ ] Jetpack connected, WCPay doesn't require Jetpack.

In all scenarios, the steps before redirect should match the steps after, and it should proceed to the _next_ step.