### PR TITLE
Add order count rule

### DIFF
--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -40,6 +40,10 @@ class GetRuleProcessor {
 				return new PluginVersionRuleProcessor();
 			case 'stored_state':
 				return new StoredStateRuleProcessor();
+			case 'order_count':
+				return new OrderCountRuleProcessor(
+					new OrdersProvider()
+				);
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -41,9 +41,7 @@ class GetRuleProcessor {
 			case 'stored_state':
 				return new StoredStateRuleProcessor();
 			case 'order_count':
-				return new OrderCountRuleProcessor(
-					new OrdersProvider()
-				);
+				return new OrderCountRuleProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/OrderCountRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OrderCountRuleProcessor.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Rule processor for publishing based on the number of orders.
+ *
+ * @package WooCommerce Admin/Classes;
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rule processor for publishing based on the number of orders.
+ */
+class OrderCountRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Constructor.
+	 *
+	 * @param object $orders_provider The orders provider.
+	 */
+	public function __construct( $orders_provider = null ) {
+		$this->orders_provider = null === $orders_provider
+			? new OrdersProvider()
+			: $orders_provider;
+	}
+
+	/**
+	 * Process the rule.
+	 *
+	 * @param object $rule         The rule to process.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool Whether the rule passes or not.
+	 */
+	public function process( $rule, $stored_state ) {
+		$count = $this->orders_provider->get_order_count();
+
+		return ComparisonOperation::compare(
+			$count,
+			$rule->value,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->value ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/RemoteInboxNotifications/OrdersProvider.php
+++ b/src/RemoteInboxNotifications/OrdersProvider.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Provider for order-related queries and operations.
+ *
+ * @package WooCommerce Admin/Classes
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provider for order-related queries and operations.
+ */
+class OrdersProvider {
+	/**
+	 * Allowed order statuses for calculating milestones.
+	 *
+	 * @var array
+	 */
+	protected $allowed_statuses = array(
+		'pending',
+		'processing',
+		'completed',
+	);
+
+	/**
+	 * Returns the number of orders.
+	 *
+	 * @return integer The number of orders.
+	 */
+	public function get_order_count() {
+		$status_counts = array_map( 'wc_orders_count', $this->allowed_statuses );
+		$orders_count  = array_sum( $status_counts );
+
+		return $orders_count;
+	}
+}


### PR DESCRIPTION
Note that this is branched off #4260 and shouldn't be merged until that PR is merged.

This adds a rule that triggers if the given condition matches the number of orders (for example, "> 10", or "<= 1000").

### Detailed test instructions:

The test file used in earlier PRs contains a rule that triggers publishing an admin note when more than 10 orders are present. To test, go through the procedure in #4143.

### Additional spec rules added by this PR

Order count:

```
{
    "type": "order_count",
    "operation": ">",
    "value": 10
}
```

### Changelog Note:

Enhancement: Add order count rule

