### PR TITLE
Add time after wcadmin activation rule

### DIFF
--- a/src/RemoteInboxNotifications/GetRuleProcessor.php
+++ b/src/RemoteInboxNotifications/GetRuleProcessor.php
@@ -40,6 +40,8 @@ class GetRuleProcessor {
 				return new PluginVersionRuleProcessor();
 			case 'stored_state':
 				return new StoredStateRuleProcessor();
+			case 'wcadmin_active_for':
+				return new WCAdminActiveForRuleProcessor();
 		}
 
 		return new FailRuleProcessor();

--- a/src/RemoteInboxNotifications/WCAdminActiveForProvider.php
+++ b/src/RemoteInboxNotifications/WCAdminActiveForProvider.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * WCAdmin active for provider.
+ *
+ * @package WooCommerce Admin/Classes;
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WCAdminActiveForProvider class
+ */
+class WCAdminActiveForProvider {
+	/**
+	 * Get the number of seconds that the store has been active.
+	 *
+	 * @return number Number of seconds.
+	 */
+	public function get_wcadmin_active_for_in_seconds() {
+		$install_timestamp = get_option( 'woocommerce_admin_install_timestamp' );
+
+		return time() - $install_timestamp;
+	}
+}

--- a/src/RemoteInboxNotifications/WCAdminActiveForRuleProcessor.php
+++ b/src/RemoteInboxNotifications/WCAdminActiveForRuleProcessor.php
@@ -37,11 +37,11 @@ class WCAdminActiveForRuleProcessor implements RuleProcessorInterface {
 	 */
 	public function process( $rule, $stored_state ) {
 		$active_for_seconds = $this->wcadmin_active_for_provider->get_wcadmin_active_for_in_seconds();
-		$rule_seconds       = $rule->days * 24 * 60 * 60;
+		$rule_seconds       = $rule->days * DAY_IN_SECONDS;
 
 		return ComparisonOperation::compare(
-			$rule_seconds,
 			$active_for_seconds,
+			$rule_seconds,
 			$rule->operation
 		);
 	}

--- a/src/RemoteInboxNotifications/WCAdminActiveForRuleProcessor.php
+++ b/src/RemoteInboxNotifications/WCAdminActiveForRuleProcessor.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Rule processor for publishing if wc-admin has been active for at least the
+ * given number of seconds.
+ *
+ * @package WooCommerce Admin/Classes;
+ */
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Rule processor for publishing if wc-admin has been active for at least the
+ * given number of seconds.
+ */
+class WCAdminActiveForRuleProcessor implements RuleProcessorInterface {
+	/**
+	 * Constructor
+	 *
+	 * @param object $wcadmin_active_for_provider Provides the amount of time wcadmin has been active for.
+	 */
+	public function __construct( $wcadmin_active_for_provider = null ) {
+		$this->wcadmin_active_for_provider = null === $wcadmin_active_for_provider
+			? new WCAdminActiveForProvider()
+			: $wcadmin_active_for_provider;
+	}
+
+	/**
+	 * Performs a comparison operation against the amount of time wc-admin has
+	 * been active for in days.
+	 *
+	 * @param object $rule         The rule being processed.
+	 * @param object $stored_state Stored state.
+	 *
+	 * @return bool The result of the operation.
+	 */
+	public function process( $rule, $stored_state ) {
+		$active_for_seconds = $this->wcadmin_active_for_provider->get_wcadmin_active_for_in_seconds();
+		$rule_seconds       = $rule->days * 24 * 60 * 60;
+
+		return ComparisonOperation::compare(
+			$rule_seconds,
+			$active_for_seconds,
+			$rule->operation
+		);
+	}
+
+	/**
+	 * Validates the rule.
+	 *
+	 * @param object $rule The rule to validate.
+	 *
+	 * @return bool Pass/fail.
+	 */
+	public function validate( $rule ) {
+		if ( ! isset( $rule->days ) ) {
+			return false;
+		}
+
+		if ( ! isset( $rule->operation ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/tests/remote-inbox-notifications/mock-wc-admin-active-for-provider.php
+++ b/tests/remote-inbox-notifications/mock-wc-admin-active-for-provider.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Mock WCAdminActiveForProvider
+ *
+ * @package WooCommerce\Tests\RemoteInboxNotifications
+ */
+
+/**
+ * Mock WCAdminActiveForProvider
+ */
+class MockWCAdminActiveForProvider {
+	/**
+	 * Get the number of seconds that the store has been active.
+	 *
+	 * @return number Number of seconds.
+	 */
+	public function get_wcadmin_active_for_in_seconds() {
+		// Return 8 days in seconds.
+		return 8 * 24 * 60 * 60;
+	}
+}

--- a/tests/remote-inbox-notifications/mock-wc-admin-active-for-provider.php
+++ b/tests/remote-inbox-notifications/mock-wc-admin-active-for-provider.php
@@ -15,7 +15,6 @@ class MockWCAdminActiveForProvider {
 	 * @return number Number of seconds.
 	 */
 	public function get_wcadmin_active_for_in_seconds() {
-		// Return 8 days in seconds.
-		return 8 * 24 * 60 * 60;
+		return 8 * DAY_IN_SECONDS;
 	}
 }

--- a/tests/remote-inbox-notifications/wcadmin-active-for-rule-processor.php
+++ b/tests/remote-inbox-notifications/wcadmin-active-for-rule-processor.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * WCAdmin active for rule processor tests.
+ *
+ * @package WooCommerce\Tests\RemoteInboxNotification
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\WCAdminActiveForRuleProcessor;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor
+ */
+class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor extends WC_Unit_Test_Case {
+	/**
+	 * Less than 8 days evaluates to false
+	 *
+	 * @group fast
+	 */
+	public function test_less_than_8_days_evaluates_to_false() {
+		$processor = new WCAdminActiveForRuleProcessor(
+			new MockWCAdminActiveForProvider()
+		);
+		$rule      = json_decode(
+			'{
+				"type": "wcadmin_active_for",
+				"operation": ">",
+				"days": 7
+			}'
+		);
+
+		$result = $processor->process( $rule, new stdClass() );
+
+		$this->assertEquals( false, $result );
+	}
+
+	/**
+	 * Greater than 8 days evaluates to true
+	 *
+	 * @group fast
+	 */
+	public function test_greater_than_8_days_evaluates_to_true() {
+		$processor = new WCAdminActiveForRuleProcessor(
+			new MockWCAdminActiveForProvider()
+		);
+		$rule      = json_decode(
+			'{
+				"type": "wcadmin_active_for",
+				"operation": ">",
+				"days": 12
+			}'
+		);
+
+		$result = $processor->process( $rule, new stdClass() );
+
+		$this->assertEquals( true, $result );
+	}
+}

--- a/tests/remote-inbox-notifications/wcadmin-active-for-rule-processor.php
+++ b/tests/remote-inbox-notifications/wcadmin-active-for-rule-processor.php
@@ -12,11 +12,11 @@ use Automattic\WooCommerce\Admin\RemoteInboxNotifications\WCAdminActiveForRulePr
  */
 class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor extends WC_Unit_Test_Case {
 	/**
-	 * Less than 8 days evaluates to false
+	 * Less than 8 days evaluates to true
 	 *
 	 * @group fast
 	 */
-	public function test_less_than_8_days_evaluates_to_false() {
+	public function test_less_than_8_days_evaluates_to_true() {
 		$processor = new WCAdminActiveForRuleProcessor(
 			new MockWCAdminActiveForProvider()
 		);
@@ -30,15 +30,15 @@ class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor extends WC
 
 		$result = $processor->process( $rule, new stdClass() );
 
-		$this->assertEquals( false, $result );
+		$this->assertEquals( true, $result );
 	}
 
 	/**
-	 * Greater than 8 days evaluates to true
+	 * Greater than 8 days evaluates to false
 	 *
 	 * @group fast
 	 */
-	public function test_greater_than_8_days_evaluates_to_true() {
+	public function test_greater_than_8_days_evaluates_to_false() {
 		$processor = new WCAdminActiveForRuleProcessor(
 			new MockWCAdminActiveForProvider()
 		);
@@ -52,6 +52,6 @@ class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor extends WC
 
 		$result = $processor->process( $rule, new stdClass() );
 
-		$this->assertEquals( true, $result );
+		$this->assertEquals( false, $result );
 	}
 }

--- a/tests/remote-inbox-notifications/wcadmin-active-for-rule-processor.php
+++ b/tests/remote-inbox-notifications/wcadmin-active-for-rule-processor.php
@@ -12,11 +12,11 @@ use Automattic\WooCommerce\Admin\RemoteInboxNotifications\WCAdminActiveForRulePr
  */
 class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor extends WC_Unit_Test_Case {
 	/**
-	 * Less than 8 days evaluates to true
+	 * Greater than 7 days evaluates to true
 	 *
 	 * @group fast
 	 */
-	public function test_less_than_8_days_evaluates_to_true() {
+	public function test_greater_than_7_days_evaluates_to_true() {
 		$processor = new WCAdminActiveForRuleProcessor(
 			new MockWCAdminActiveForProvider()
 		);
@@ -34,11 +34,11 @@ class WC_Tests_RemoteInboxNotifications_WCAdminActiveForRuleProcessor extends WC
 	}
 
 	/**
-	 * Greater than 8 days evaluates to false
+	 * Greater than 12 days evaluates to false
 	 *
 	 * @group fast
 	 */
-	public function test_greater_than_8_days_evaluates_to_false() {
+	public function test_greater_than_12_days_evaluates_to_false() {
 		$processor = new WCAdminActiveForRuleProcessor(
 			new MockWCAdminActiveForProvider()
 		);


### PR DESCRIPTION
Note that this is branched off #4260 and shouldn't be merged until that PR is merged.

This adds a rule that triggers if the given condition matches the time since wcadmin activation (in days).

### Detailed test instructions:

The test file used in earlier PRs contains a rule that triggers publishing an admin note when wcadmin was activated more than 8 days ago. To test, go through the procedure in #4143.

### Additional spec rules added by this PR

WCAdmin active for:

```
{
    "type": "wcadmin_active_for",
    "operation": ">",
    "days": 8
}
```

### Changelog Note:

Enhancement: Add wcadmin active for rule

