### PR TITLE
Refactor notes and conditions for adding notes

### DIFF
--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -192,7 +192,12 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * @param string $slug The slug of the plugin being installed.
 	 */
 	private function create_install_plugin_error_inbox_notification_for_jetpack_installs( $slug ) {
-		WC_Admin_Notes_Install_JP_And_WCS_Plugins::possibly_add_install_jp_and_wcs_note( $slug );
+		// Exit early if we're not installing the Jetpack or the WooCommerce Services plugins.
+		if ( 'jetpack' !== $slug && 'woocommerce-services' !== $slug ) {
+			return;
+		}
+
+		WC_Admin_Notes_Install_JP_And_WCS_Plugins::possibly_add_note();
 	}
 
 	/**

--- a/src/Events.php
+++ b/src/Events.php
@@ -63,14 +63,14 @@ class Events {
 	 * Note: WC_Admin_Notes_Order_Milestones::other_milestones is hooked to this as well.
 	 */
 	public function do_wc_admin_daily() {
-		WC_Admin_Notes_New_Sales_Record::possibly_add_sales_record_note();
-		WC_Admin_Notes_Mobile_App::possibly_add_mobile_app_note();
-		WC_Admin_Notes_Tracking_Opt_In::possibly_add_tracking_opt_in_note();
-		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_onboarding_email_marketing_note();
-		WC_Admin_Notes_Onboarding_Payments::possibly_add_onboarding_payments_note();
-		WC_Admin_Notes_Personalize_Store::possibly_add_personalize_store_note();
+		WC_Admin_Notes_New_Sales_Record::possibly_add_note();
+		WC_Admin_Notes_Mobile_App::possibly_add_note();
+		WC_Admin_Notes_Tracking_Opt_In::possibly_add_note();
+		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_note();
+		WC_Admin_Notes_Onboarding_Payments::possibly_add_note();
+		WC_Admin_Notes_Personalize_Store::possibly_add_note();
 		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
-		WC_Admin_Notes_Marketing::possibly_add_note_intro();
-		WC_Admin_Notes_Giving_Feedback_Notes::add_notes_for_admin_giving_feedback();
+		WC_Admin_Notes_Marketing::possibly_add_note();
+		WC_Admin_Notes_Giving_Feedback_Notes::possibly_add_note();
 	}
 }

--- a/src/Install.php
+++ b/src/Install.php
@@ -468,7 +468,7 @@ class Install {
 	 * Create notes.
 	 */
 	protected static function create_notes() {
-		WC_Admin_Notes_Historical_Data::add_note();
+		WC_Admin_Notes_Historical_Data::possibly_add_note();
 	}
 
 	/**

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -44,23 +44,38 @@ trait NoteTraits {
 	}
 
 	/**
-	 * Add the note if it passes predefined conditions.
+	 * Checks if a note can and should be added.
+	 *
+	 * @return bool
 	 */
-	public static function possibly_add_note() {
-		if ( self::note_exists() ) {
-			return;
-		}
-
+	public static function can_be_added() {
 		$note = self::get_note();
 
 		if ( ! $note instanceof WC_Admin_Note ) {
 			return;
 		}
 
+		if ( self::note_exists() ) {
+			return false;
+		}
+
 		if (
 			'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) &&
 			WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING === $note->get_type()
 		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 */
+	public static function possibly_add_note() {
+		$note = self::get_note();
+
+		if ( ! self::can_be_added() ) {
 			return;
 		}
 

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -33,4 +33,13 @@ trait NoteTraits {
 
 		return ( ( time() - $wc_admin_installed ) >= $seconds );
 	}
+
+	/**
+	 * Check if the note has been previously added.
+	 */
+	public static function note_exists() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		return ! empty( $note_ids );
+	}
 }

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -51,6 +51,19 @@ trait NoteTraits {
 			return;
 		}
 
-		self::add_note();
+		$note = self::get_note();
+
+		if ( ! $note instanceof WC_Admin_Note ) {
+			return;
+		}
+
+		if (
+			'no' === get_option( 'woocommerce_show_marketplace_suggestions', 'yes' ) &&
+			WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING === $note->get_type()
+		) {
+			return;
+		}
+
+		$note->save();
 	}
 }

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -42,4 +42,15 @@ trait NoteTraits {
 		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 		return ! empty( $note_ids );
 	}
+
+	/**
+	 * Add the note if it passes predefined conditions.
+	 */
+	public static function possibly_add_note() {
+		if ( self::note_exists() ) {
+			return;
+		}
+
+		self::add_note();
+	}
 }

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -66,4 +66,11 @@ trait NoteTraits {
 
 		$note->save();
 	}
+
+	/**
+	 * Alias this method for backwards compatibility.
+	 */
+	public static function add_note() {
+		self::possibly_add_note();
+	}
 }

--- a/src/Notes/WC_Admin_Note.php
+++ b/src/Notes/WC_Admin_Note.php
@@ -17,10 +17,11 @@ defined( 'ABSPATH' ) || exit;
 class WC_Admin_Note extends \WC_Data {
 
 	// Note types.
-	const E_WC_ADMIN_NOTE_ERROR         = 'error';   // used for presenting error conditions.
-	const E_WC_ADMIN_NOTE_WARNING       = 'warning'; // used for presenting warning conditions.
-	const E_WC_ADMIN_NOTE_UPDATE        = 'update';  // i.e. used when a new version is available.
-	const E_WC_ADMIN_NOTE_INFORMATIONAL = 'info';    // used for presenting informational messages.
+	const E_WC_ADMIN_NOTE_ERROR         = 'error';     // used for presenting error conditions.
+	const E_WC_ADMIN_NOTE_WARNING       = 'warning';   // used for presenting warning conditions.
+	const E_WC_ADMIN_NOTE_UPDATE        = 'update';    // i.e. used when a new version is available.
+	const E_WC_ADMIN_NOTE_INFORMATIONAL = 'info';      // used for presenting informational messages.
+	const E_WC_ADMIN_NOTE_MARKETING     = 'marketing'; // used for adding marketing messages.
 
 	// Note status codes.
 	const E_WC_ADMIN_NOTE_UNACTIONED = 'unactioned'; // the note has not yet been actioned by a user.
@@ -121,6 +122,7 @@ class WC_Admin_Note extends \WC_Data {
 			self::E_WC_ADMIN_NOTE_WARNING,
 			self::E_WC_ADMIN_NOTE_UPDATE,
 			self::E_WC_ADMIN_NOTE_INFORMATIONAL,
+			self::E_WC_ADMIN_NOTE_MARKETING,
 		);
 
 		return apply_filters( 'woocommerce_note_types', $allowed_types );

--- a/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
+++ b/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
@@ -15,6 +15,14 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_Deactivate_Plugin.
  */
 class WC_Admin_Notes_Deactivate_Plugin {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
 	const NOTE_NAME = 'wc-admin-deactivate-plugin';
 
 	/**
@@ -28,9 +36,7 @@ class WC_Admin_Notes_Deactivate_Plugin {
 	 * Creates the note to deactivate the older version.
 	 */
 	public static function add_note() {
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
+++ b/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
@@ -33,9 +33,9 @@ class WC_Admin_Notes_Deactivate_Plugin {
 	}
 
 	/**
-	 * Creates the note to deactivate the older version.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce-admin' ) );
@@ -51,7 +51,7 @@ class WC_Admin_Notes_Deactivate_Plugin {
 			'unactioned',
 			true
 		);
-		$note->save();
+		return $note;
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
+++ b/src/Notes/WC_Admin_Notes_Deactivate_Plugin.php
@@ -36,10 +36,6 @@ class WC_Admin_Notes_Deactivate_Plugin {
 	 * Creates the note to deactivate the older version.
 	 */
 	public static function add_note() {
-		if ( self::note_exists() ) {
-			return;
-		}
-
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Deactivate old WooCommerce Admin version', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Your current version of WooCommerce Admin is outdated and a newer version is included with WooCommerce.  We recommend deactivating the plugin and using the stable version included with WooCommerce.', 'woocommerce-admin' ) );

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -62,9 +62,9 @@ class WC_Admin_Notes_Draw_Attention {
 	}
 
 	/**
-	 * Add the note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'How to draw attention to your online store', 'woocommerce-admin' ) );
 		$note->set_content( __( 'To get you started, here are seven ways to boost your sales and avoid getting drowned out by similar, mass-produced products competing for the same buyers.', 'woocommerce-admin' ) );
@@ -80,7 +80,6 @@ class WC_Admin_Notes_Draw_Attention {
 			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true
 		);
-
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -69,7 +69,7 @@ class WC_Admin_Notes_Draw_Attention {
 		$note->set_title( __( 'How to draw attention to your online store', 'woocommerce-admin' ) );
 		$note->set_content( __( 'To get you started, here are seven ways to boost your sales and avoid getting drowned out by similar, mass-produced products competing for the same buyers.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
-		$note->set_type( WC_ADMIN_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_type( WC_ADMIN_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -69,7 +69,7 @@ class WC_Admin_Notes_Draw_Attention {
 		$note->set_title( __( 'How to draw attention to your online store', 'woocommerce-admin' ) );
 		$note->set_content( __( 'To get you started, here are seven ways to boost your sales and avoid getting drowned out by similar, mass-produced products competing for the same buyers.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
-		$note->set_type( WC_ADMIN_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( WC_ADMIN_Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\WooCommerce\Admin\Notes;
 
+use \Automattic\WooCommerce\Admin\Features\Onboarding;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,8 +25,7 @@ class WC_Admin_Notes_Draw_Attention {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME   = 'wc-admin-draw-attention';
-	const OPTION_NAME = 'woocommerce_onboarding_profile';
+	const NOTE_NAME = 'wc-admin-draw-attention';
 
 	/**
 	 * Constructor.
@@ -32,21 +33,21 @@ class WC_Admin_Notes_Draw_Attention {
 	public function __construct() {
 		// Trigger this when the onboarding options are updated.
 		add_filter(
-			'update_option_' . self::OPTION_NAME,
-			array( $this, 'possibly_add_draw_attention_note' ),
+			'update_option_' . Onboarding::PROFILE_DATA_OPTION,
+			array( $this, 'check_onboarding_profile' ),
 			10,
 			3
 		);
 	}
 
 	/**
-	 * Possibly add a draw attention note.
+	 * Check to see if profiler options match before possibly adding note.
 	 *
 	 * @param object $old_value The old option value.
 	 * @param object $value     The new option value.
 	 * @param string $option    The name of the option.
 	 */
-	public static function possibly_add_draw_attention_note( $old_value, $value, $option ) {
+	public static function check_onboarding_profile( $old_value, $value, $option ) {
 		// Skip adding if this store is being set up for a client.
 		if ( ! isset( $value['setup_client'] ) || $value['setup_client'] ) {
 			return;
@@ -57,14 +58,14 @@ class WC_Admin_Notes_Draw_Attention {
 			return;
 		}
 
-		// Exit early if there is already a note.
-		if ( self::note_exists() ) {
-			return;
-		}
+		self::possibly_add_note();
+	}
 
-		// Create the note.
+	/**
+	 * Add the note.
+	 */
+	public static function add_note() {
 		$note = new WC_Admin_Note();
-
 		$note->set_title( __( 'How to draw attention to your online store', 'woocommerce-admin' ) );
 		$note->set_content( __( 'To get you started, here are seven ways to boost your sales and avoid getting drowned out by similar, mass-produced products competing for the same buyers.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );

--- a/src/Notes/WC_Admin_Notes_Draw_Attention.php
+++ b/src/Notes/WC_Admin_Notes_Draw_Attention.php
@@ -15,6 +15,14 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_Draw_Attention
  */
 class WC_Admin_Notes_Draw_Attention {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
 	const NOTE_NAME   = 'wc-admin-draw-attention';
 	const OPTION_NAME = 'woocommerce_onboarding_profile';
 
@@ -50,9 +58,7 @@ class WC_Admin_Notes_Draw_Attention {
 		}
 
 		// Exit early if there is already a note.
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -26,9 +26,9 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 	const NOTE_NAME = 'wc-admin-store-notice-giving-feedback-2';
 
 	/**
-	 * Possibly add a notice setting moved note.
+	 * Get the note.
 	 */
-	protected static function add_note() {
+	protected static function get_note() {
 		// We need to show Admin Giving feeback notification after 8 days of install.
 		$eight_days_in_seconds = 8 * DAY_IN_SECONDS;
 		if ( ! self::wc_admin_active_for( $eight_days_in_seconds ) ) {
@@ -49,6 +49,6 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 			__( 'Share feedback', 'woocommerce-admin' ),
 			'https://automattic.survey.fm/new-onboarding-survey'
 		);
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -26,21 +26,9 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 	const NOTE_NAME = 'wc-admin-store-notice-giving-feedback-2';
 
 	/**
-	 * Add notes for admin giving feedback.
-	 */
-	public static function add_notes_for_admin_giving_feedback() {
-		self::possibly_add_admin_giving_feedback_note();
-	}
-
-	/**
 	 * Possibly add a notice setting moved note.
 	 */
-	protected static function possibly_add_admin_giving_feedback_note() {
-		// We already have this note? Then exit, we're done.
-		if ( self::note_exists() ) {
-			return;
-		}
-
+	protected static function add_note() {
 		// We need to show Admin Giving feeback notification after 8 days of install.
 		$eight_days_in_seconds = 8 * DAY_IN_SECONDS;
 		if ( ! self::wc_admin_active_for( $eight_days_in_seconds ) ) {

--- a/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
+++ b/src/Notes/WC_Admin_Notes_Giving_Feedback_Notes.php
@@ -21,6 +21,11 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 	use NoteTraits;
 
 	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-store-notice-giving-feedback-2';
+
+	/**
 	 * Add notes for admin giving feedback.
 	 */
 	public static function add_notes_for_admin_giving_feedback() {
@@ -31,12 +36,8 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 	 * Possibly add a notice setting moved note.
 	 */
 	protected static function possibly_add_admin_giving_feedback_note() {
-		$name       = 'wc-admin-store-notice-giving-feedback-2';
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
 		// We already have this note? Then exit, we're done.
-		$note_ids = $data_store->get_notes_with_name( $name );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 
@@ -53,7 +54,7 @@ class WC_Admin_Notes_Giving_Feedback_Notes {
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'info' );
-		$note->set_name( $name );
+		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'share-feedback',

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -17,6 +17,14 @@ use \Automattic\WooCommerce\Admin\Install;
  * WC_Admin_Notes_Historical_Data.
  */
 class WC_Admin_Notes_Historical_Data {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
 	const NOTE_NAME = 'wc-admin-historical-data';
 
 	/**
@@ -30,9 +38,7 @@ class WC_Admin_Notes_Historical_Data {
 	 * Update status of note to actioned on data import trigger.
 	 */
 	public static function update_status_to_actioned() {
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -48,9 +48,9 @@ class WC_Admin_Notes_Historical_Data {
 	}
 
 	/**
-	 * Creates a note for regenerating historical data.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$is_upgrading = get_option( Install::VERSION_OPTION );
 		if ( $is_upgrading ) {
 			return;
@@ -82,7 +82,6 @@ class WC_Admin_Notes_Historical_Data {
 			'actioned',
 			true
 		);
-
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -38,7 +38,9 @@ class WC_Admin_Notes_Historical_Data {
 	 * Update status of note to actioned on data import trigger.
 	 */
 	public static function update_status_to_actioned() {
-		if ( self::note_exists() ) {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( empty( $note_ids ) ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Historical_Data.php
+++ b/src/Notes/WC_Admin_Notes_Historical_Data.php
@@ -56,15 +56,13 @@ class WC_Admin_Notes_Historical_Data {
 			return;
 		}
 
-		// First, see if orders exist and if we've already created this kind of note so we don't do it again.
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-		$orders     = wc_get_orders(
+		// Only add this note if we don't have any orders.
+		$orders = wc_get_orders(
 			array(
 				'limit' => 1,
 			)
 		);
-		if ( ! empty( $note_ids ) || count( $orders ) < 1 ) {
+		if ( count( $orders ) < 1 ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
+++ b/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
@@ -19,6 +19,14 @@ use \Automattic\WooCommerce\Admin\PluginsHelper;
  * WC_Admin_Notes_Install_JP_And_WCS_Plugins
  */
 class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
 	const NOTE_NAME = 'wc-admin-install-jp-and-wcs-plugins';
 
 	/**
@@ -43,8 +51,7 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// Exit early if there is already a note to install Jetpack.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
+++ b/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
@@ -38,9 +38,9 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
 	}
 
 	/**
-	 * Add the note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$content = __( 'We noticed that there was a problem during the Jetpack and WooCommerce Services install. Please try again and enjoy all the advantages of having the plugins connected to your store! Sorry for the inconvenience. The "Jetpack" and "WooCommerce Services" plugins will be installed & activated for free.', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();
@@ -58,8 +58,7 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
 			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
 			true
 		);
-
-		$note->save();
+		return $note;
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
+++ b/src/Notes/WC_Admin_Notes_Install_JP_And_WCS_Plugins.php
@@ -38,23 +38,9 @@ class WC_Admin_Notes_Install_JP_And_WCS_Plugins {
 	}
 
 	/**
-	 * Possibly add the Install Jetpack and WooCommerceServices plugins note.
-	 *
-	 * @param string $slug The slug of the plugin being installed.
+	 * Add the note.
 	 */
-	public static function possibly_add_install_jp_and_wcs_note( $slug ) {
-		// Exit early if we're not installing the Jetpack or the WooCommerce Services plugins.
-		if ( 'jetpack' !== $slug && 'woocommerce-services' !== $slug ) {
-			return;
-		}
-
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
-		// Exit early if there is already a note to install Jetpack.
-		if ( self::note_exists() ) {
-			return;
-		}
-
+	public static function add_note() {
 		$content = __( 'We noticed that there was a problem during the Jetpack and WooCommerce Services install. Please try again and enjoy all the advantages of having the plugins connected to your store! Sorry for the inconvenience. The "Jetpack" and "WooCommerce Services" plugins will be installed & activated for free.', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();

--- a/src/Notes/WC_Admin_Notes_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Marketing.php
@@ -33,7 +33,7 @@ class WC_Admin_Notes_Marketing {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Connect with your audience', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'woocommerce-admin' ) );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_icon( 'speaker' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );

--- a/src/Notes/WC_Admin_Notes_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Marketing.php
@@ -33,7 +33,7 @@ class WC_Admin_Notes_Marketing {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Connect with your audience', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'woocommerce-admin' ) );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'speaker' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );

--- a/src/Notes/WC_Admin_Notes_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Marketing.php
@@ -27,13 +27,9 @@ class WC_Admin_Notes_Marketing {
 	const NOTE_NAME = 'wc-admin-marketing-intro';
 
 	/**
-	 * Maybe add a note introducing the marketing hub.
+	 * Add the note.
 	 */
-	public static function possibly_add_note_intro() {
-		if ( self::note_exists() ) {
-			return;
-		}
-
+	public static function add_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Connect with your audience', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'woocommerce-admin' ) );

--- a/src/Notes/WC_Admin_Notes_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Marketing.php
@@ -27,9 +27,9 @@ class WC_Admin_Notes_Marketing {
 	const NOTE_NAME = 'wc-admin-marketing-intro';
 
 	/**
-	 * Add the note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Connect with your audience', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'woocommerce-admin' ) );
@@ -44,7 +44,6 @@ class WC_Admin_Notes_Marketing {
 			admin_url( 'admin.php?page=wc-admin&path=/marketing' ),
 			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
-
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Marketing.php
@@ -24,19 +24,13 @@ class WC_Admin_Notes_Marketing {
 	/**
 	 * Name of the note for use in the database.
 	 */
-	const NOTE_NAME_INTRO = 'wc-admin-marketing-intro';
+	const NOTE_NAME = 'wc-admin-marketing-intro';
 
 	/**
 	 * Maybe add a note introducing the marketing hub.
 	 */
 	public static function possibly_add_note_intro() {
-
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
-		// See if we've already created this kind of note so we don't do it again.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME_INTRO );
-
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 
@@ -45,7 +39,7 @@ class WC_Admin_Notes_Marketing {
 		$note->set_content( __( 'Grow your customer base and increase your sales with marketing tools built for WooCommerce.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'speaker' );
-		$note->set_name( self::NOTE_NAME_INTRO );
+		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(

--- a/src/Notes/WC_Admin_Notes_Mobile_App.php
+++ b/src/Notes/WC_Admin_Notes_Mobile_App.php
@@ -28,17 +28,10 @@ class WC_Admin_Notes_Mobile_App {
 	/**
 	 * Possibly add mobile app note.
 	 */
-	public static function possibly_add_mobile_app_note() {
+	public static function add_note() {
 		// We want to show the mobile app note after day 2.
 		$two_days_in_seconds = 2 * DAY_IN_SECONDS;
 		if ( ! self::wc_admin_active_for( $two_days_in_seconds ) ) {
-			return;
-		}
-
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
-		// We already have this note? Then exit, we're done.
-		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Mobile_App.php
+++ b/src/Notes/WC_Admin_Notes_Mobile_App.php
@@ -26,9 +26,9 @@ class WC_Admin_Notes_Mobile_App {
 	const NOTE_NAME = 'wc-admin-mobile-app';
 
 	/**
-	 * Possibly add mobile app note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		// We want to show the mobile app note after day 2.
 		$two_days_in_seconds = 2 * DAY_IN_SECONDS;
 		if ( ! self::wc_admin_active_for( $two_days_in_seconds ) ) {
@@ -46,6 +46,6 @@ class WC_Admin_Notes_Mobile_App {
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/mobile/' );
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Mobile_App.php
+++ b/src/Notes/WC_Admin_Notes_Mobile_App.php
@@ -38,8 +38,7 @@ class WC_Admin_Notes_Mobile_App {
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 
 		// We already have this note? Then exit, we're done.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_New_Sales_Record.php
+++ b/src/Notes/WC_Admin_Notes_New_Sales_Record.php
@@ -15,8 +15,24 @@ defined( 'ABSPATH' ) || exit;
  * WC_Admin_Notes_New_Sales_Record
  */
 class WC_Admin_Notes_New_Sales_Record {
-	const NOTE_NAME                = 'wc-admin-new-sales-record';
-	const RECORD_DATE_OPTION_KEY   = 'woocommerce_sales_record_date'; // ISO 8601 (YYYY-MM-DD) date.
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-new-sales-record';
+
+	/**
+	 * Option name for the sales record date in ISO 8601 (YYYY-MM-DD) date.
+	 */
+	const RECORD_DATE_OPTION_KEY = 'woocommerce_sales_record_date';
+
+	/**
+	 * Option name for the sales record amount.
+	 */
 	const RECORD_AMOUNT_OPTION_KEY = 'woocommerce_sales_record_amount';
 
 	/**

--- a/src/Notes/WC_Admin_Notes_New_Sales_Record.php
+++ b/src/Notes/WC_Admin_Notes_New_Sales_Record.php
@@ -56,7 +56,7 @@ class WC_Admin_Notes_New_Sales_Record {
 	/**
 	 * Possibly add a sales record note.
 	 */
-	public static function possibly_add_sales_record_note() {
+	public static function possibly_add_note() {
 		/**
 		 * Filter to allow for disabling sales record milestones.
 		 *

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -28,12 +28,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 	/**
 	 * Possibly add email marketing note.
 	 */
-	public static function possibly_add_onboarding_email_marketing_note() {
-		// We already have this note? Then exit, we're done.
-		if ( self::note_exists() ) {
-			return;
-		}
-
+	public static function add_note() {
 		$content = __( 'We\'re here for you - get tips, product updates and inspiration straight to your email box', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -16,6 +16,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Admin_Notes_Onboarding_Email_Marketing {
 	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
 	 * Name of the note for use in the database.
 	 */
 	const NOTE_NAME = 'wc-admin-onboarding-email-marketing';
@@ -24,11 +29,8 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 	 * Possibly add email marketing note.
 	 */
 	public static function possibly_add_onboarding_email_marketing_note() {
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
 		// We already have this note? Then exit, we're done.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -35,7 +35,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 		$note->set_title( __( 'Tips, product updates, and inspiration', 'woocommerce-admin' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_icon( 'mail' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -35,7 +35,7 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 		$note->set_title( __( 'Tips, product updates, and inspiration', 'woocommerce-admin' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'mail' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Email_Marketing.php
@@ -26,9 +26,9 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 	const NOTE_NAME = 'wc-admin-onboarding-email-marketing';
 
 	/**
-	 * Possibly add email marketing note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$content = __( 'We\'re here for you - get tips, product updates and inspiration straight to your email box', 'woocommerce-admin' );
 
 		$note = new WC_Admin_Note();
@@ -40,6 +40,6 @@ class WC_Admin_Notes_Onboarding_Email_Marketing {
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'yes-please', __( 'Yes please!', 'woocommerce-admin' ), 'https://woocommerce.us8.list-manage.com/subscribe/post?u=2c1434dc56f9506bf3c3ecd21&amp;id=13860df971&amp;SIGNUPPAGE=plugin' );
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -28,9 +28,9 @@ class WC_Admin_Notes_Onboarding_Payments {
 	const NOTE_NAME = 'wc-admin-onboarding-payments-reminder';
 
 	/**
-	 * Creates a note to remind store owners to set up payments.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		// This note should only be added if the task list is still shown.
 		if ( ! Onboarding::should_show_tasks() ) {
 			return;
@@ -74,7 +74,6 @@ class WC_Admin_Notes_Onboarding_Payments {
 			'actioned',
 			true
 		);
-
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -17,6 +17,14 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
  * WC_Admin_Notes_Onboarding_Payments.
  */
 class WC_Admin_Notes_Onboarding_Payments {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
 	const NOTE_NAME = 'wc-admin-onboarding-payments-reminder';
 
 	/**
@@ -52,9 +60,7 @@ class WC_Admin_Notes_Onboarding_Payments {
 		}
 
 		// Don't add this note if previously added.
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Payments.php
@@ -30,7 +30,7 @@ class WC_Admin_Notes_Onboarding_Payments {
 	/**
 	 * Creates a note to remind store owners to set up payments.
 	 */
-	public static function possibly_add_onboarding_payments_note() {
+	public static function add_note() {
 		// This note should only be added if the task list is still shown.
 		if ( ! Onboarding::should_show_tasks() ) {
 			return;
@@ -56,11 +56,6 @@ class WC_Admin_Notes_Onboarding_Payments {
 			}
 		);
 		if ( ! empty( $enabled_gateways ) ) {
-			return;
-		}
-
-		// Don't add this note if previously added.
-		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -36,9 +36,9 @@ class WC_Admin_Notes_Onboarding_Profiler {
 	}
 
 	/**
-	 * Creates a note to remind store owners to complete the profiler.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		if ( ! Onboarding::should_show_profiler() ) {
 			return;
 		}
@@ -65,8 +65,7 @@ class WC_Admin_Notes_Onboarding_Profiler {
 			'actioned',
 			false
 		);
-
-		$note->save();
+		return $note;
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -31,19 +31,15 @@ class WC_Admin_Notes_Onboarding_Profiler {
 	 * Attach hooks.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'add_reminder' ) );
+		add_action( 'admin_init', array( $this, 'possibly_add_note' ) );
 		add_action( 'update_option_' . Onboarding::PROFILE_DATA_OPTION, array( $this, 'update_status_on_complete' ), 10, 2 );
 	}
 
 	/**
 	 * Creates a note to remind store owners to complete the profiler.
 	 */
-	public static function add_reminder() {
+	public static function add_note() {
 		if ( ! Onboarding::should_show_profiler() ) {
-			return;
-		}
-
-		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
+++ b/src/Notes/WC_Admin_Notes_Onboarding_Profiler.php
@@ -17,6 +17,14 @@ use \Automattic\WooCommerce\Admin\Features\Onboarding;
  * WC_Admin_Notes_Onboarding_Profiler.
  */
 class WC_Admin_Notes_Onboarding_Profiler {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
 	const NOTE_NAME = 'wc-admin-onboarding-profiler-reminder';
 
 	/**
@@ -35,9 +43,7 @@ class WC_Admin_Notes_Onboarding_Profiler {
 			return;
 		}
 
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Order_Milestones.php
+++ b/src/Notes/WC_Admin_Notes_Order_Milestones.php
@@ -18,7 +18,7 @@ class WC_Admin_Notes_Order_Milestones {
 	/**
 	 * Name of the "other milestones" note.
 	 */
-	const ORDERS_MILESTONE_NOTE_NAME = 'wc-admin-orders-milestone';
+	const NOTE_NAME = 'wc-admin-orders-milestone';
 
 	/**
 	 * Option key name to store last order milestone.
@@ -306,7 +306,7 @@ class WC_Admin_Notes_Order_Milestones {
 		$this->set_last_milestone( $current_milestone );
 
 		// We only want one milestone note at any time.
-		WC_Admin_Notes::delete_notes_with_name( self::ORDERS_MILESTONE_NOTE_NAME );
+		WC_Admin_Notes::delete_notes_with_name( self::NOTE_NAME );
 
 		// Add the milestone note.
 		$note = new WC_Admin_Note();
@@ -316,7 +316,7 @@ class WC_Admin_Notes_Order_Milestones {
 		$note->add_action( $note_action['name'], $note_action['label'], $note_action['query'] );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_icon( 'trophy' );
-		$note->set_name( self::ORDERS_MILESTONE_NOTE_NAME );
+		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->save();
 	}

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -28,7 +28,7 @@ class WC_Admin_Notes_Personalize_Store {
 	/**
 	 * Possibly add the note.
 	 */
-	public static function possibly_add_personalize_store_note() {
+	public static function add_note() {
 		// Only show the note to stores with homepage.
 		$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
 		if ( ! $homepage_id ) {
@@ -42,11 +42,6 @@ class WC_Admin_Notes_Personalize_Store {
 		$five_days_in_seconds = 5 * DAY_IN_SECONDS;
 
 		if ( ! self::wc_admin_active_for( $five_days_in_seconds ) && ! $is_task_list_complete ) {
-			return;
-		}
-
-		// We already have this note? Then exit, we're done.
-		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -26,9 +26,9 @@ class WC_Admin_Notes_Personalize_Store {
 	const NOTE_NAME = 'wc-admin-personalize-store';
 
 	/**
-	 * Possibly add the note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		// Only show the note to stores with homepage.
 		$homepage_id = get_option( 'woocommerce_onboarding_homepage_post_id', false );
 		if ( ! $homepage_id ) {
@@ -56,7 +56,6 @@ class WC_Admin_Notes_Personalize_Store {
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce-admin' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
-
-		$note->save();
+		return $note;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Personalize_Store.php
+++ b/src/Notes/WC_Admin_Notes_Personalize_Store.php
@@ -45,11 +45,8 @@ class WC_Admin_Notes_Personalize_Store {
 			return;
 		}
 
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
 		// We already have this note? Then exit, we're done.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Admin Usage Tracking Opt In Note Provider.
  *
- * Adds a note to the merchant's inbox showing the benefits of the Facebook extension.
+ * Adds a Usage Tracking Opt In extension note.
  *
  * @package WooCommerce Admin
  */
@@ -33,9 +33,9 @@ class WC_Admin_Notes_Tracking_Opt_In {
 	}
 
 	/**
-	 * Possibly add Usage Tracking Opt In extension note.
+	 * Get the note.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		// Only show this note to stores that are opted out.
 		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
 			return;
@@ -69,8 +69,7 @@ class WC_Admin_Notes_Tracking_Opt_In {
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'tracking-dismiss', __( 'Dismiss', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, false );
 		$note->add_action( 'tracking-opt-in', __( 'Activate usage tracking', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
-
-		$note->save();
+		return $note;
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -35,7 +35,7 @@ class WC_Admin_Notes_Tracking_Opt_In {
 	/**
 	 * Possibly add Usage Tracking Opt In extension note.
 	 */
-	public static function possibly_add_tracking_opt_in_note() {
+	public static function add_note() {
 		// Only show this note to stores that are opted out.
 		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
 			return;
@@ -43,11 +43,6 @@ class WC_Admin_Notes_Tracking_Opt_In {
 
 		// We want to show the note after one week.
 		if ( ! self::wc_admin_active_for( WEEK_IN_SECONDS ) ) {
-			return;
-		}
-
-		// We already have this note? Then exit, we're done.
-		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
+++ b/src/Notes/WC_Admin_Notes_Tracking_Opt_In.php
@@ -46,11 +46,8 @@ class WC_Admin_Notes_Tracking_Opt_In {
 			return;
 		}
 
-		$data_store = \WC_Data_Store::load( 'admin-note' );
-
 		// We already have this note? Then exit, we're done.
-		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
-		if ( ! empty( $note_ids ) ) {
+		if ( self::note_exists() ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -94,7 +94,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 		$note->set_title( __( 'Try the new way to get paid', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.', 'woocommerce-admin' ) );
 		$note->set_content_data( (object) array() );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_icon( 'credit-card' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -39,9 +39,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 * Attach hooks.
 	 */
 	public function __construct() {
-
 		add_action( 'woocommerce_note_action_install-now', array( $this, 'install' ) );
-
 		add_action( 'wc-admin-woocommerce-payments_add_note', array( $this, 'add_note' ) );
 	}
 
@@ -49,7 +47,6 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 * Maybe add a note on WooCommerce Payments for US based sites older than a week without the plugin installed.
 	 */
 	public static function possibly_add_note() {
-
 		if ( ! self::wc_admin_active_for( WEEK_IN_SECONDS ) || 'US' !== WC()->countries->get_base_country() ) {
 			return;
 		}
@@ -93,7 +90,6 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 * Add a note about WooCommerce Payments.
 	 */
 	public static function add_note() {
-
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Try the new way to get paid', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.', 'woocommerce-admin' ) );
@@ -131,7 +127,6 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 * @param WC_Admin_Note $note Note being acted upon.
 	 */
 	public function install( $note ) {
-
 		if ( self::NOTE_NAME === $note->get_name() ) {
 			$install_request = array( 'plugin' => self::PLUGIN_SLUG );
 			$installer       = new \Automattic\WooCommerce\Admin\API\Plugins();

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -74,7 +74,12 @@ class WC_Admin_Notes_WooCommerce_Payments {
 
 		if ( $current_date >= $publish_date ) {
 
-			self::add_note();
+			$note = self::get_note();
+			if ( self::can_be_added() ) {
+				$note->save();
+			}
+
+			return;
 
 		} else {
 

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -89,7 +89,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	/**
 	 * Add a note about WooCommerce Payments.
 	 */
-	public static function add_note() {
+	public static function get_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Try the new way to get paid', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.', 'woocommerce-admin' ) );
@@ -105,8 +105,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 		if ( self::is_installed() ) {
 			$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
 		}
-
-		$note->save();
+		return $note;
 	}
 
 

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -56,7 +56,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 
-		// We already have this note? Then exit, we're done.
+		// We already have this note? Then mark the note as actioned.
 		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
 		if ( ! empty( $note_ids ) ) {
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -53,7 +53,7 @@ class Package {
 			self::$active_version = WC_ADMIN_VERSION_NUMBER;
 			$update_version       = new WC_Admin_Notes_Deactivate_Plugin();
 			if ( version_compare( WC_ADMIN_VERSION_NUMBER, self::VERSION, '<' ) ) {
-				$update_version::add_note();
+				$update_version::possibly_add_note();
 			} else {
 				$update_version::delete_note();
 			}

--- a/tests/notes/class-wc-tests-marketing-notes.php
+++ b/tests/notes/class-wc-tests-marketing-notes.php
@@ -56,9 +56,13 @@ class WC_Tests_Marketing_Notes extends WC_Unit_Test_Case {
 	 * Tests to see if marketing notes are prevented when marketing is opted out.
 	 */
 	public function test_prevent_add_marketing_note() {
+		// Update settings so that note should be added.
+		update_option( 'woocommerce_default_country', 'US:GA' );
+		update_option( 'woocommerce_admin_install_timestamp', time() - WEEK_IN_SECONDS );
+		// Set user preferences to disallow marketing suggestions.
 		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
 
-		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_note();
+		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
 
 		// Load all marketing notes and check that the note was not added.
 		$data_store = \WC_Data_Store::load( 'admin-note' );

--- a/tests/notes/class-wc-tests-marketing-notes.php
+++ b/tests/notes/class-wc-tests-marketing-notes.php
@@ -7,7 +7,7 @@
 
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
-use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 
 /**
  * Class WC_Tests_Marketing_Notes

--- a/tests/notes/class-wc-tests-marketing-notes.php
+++ b/tests/notes/class-wc-tests-marketing-notes.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Marketing notes tests
+ *
+ * @package WooCommerce\Tests\Notes
+ */
+
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
+
+/**
+ * Class WC_Tests_Marketing_Notes
+ */
+class WC_Tests_Marketing_Notes extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests that a marketing note can be added.
+	 */
+	public function test_add_remove_marketing_note() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( 'PHPUNIT_TEST_MARKETING_NOTE' );
+		$note->set_content( 'PHPUNIT_TEST_MARKETING_NOTE_CONTENT' );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_icon( 'info' );
+		$note->set_name( 'PHPUNIT_TEST_MARKETING_NOTE_NAME' );
+		$note->set_source( 'PHPUNIT_TEST' );
+		$note->set_is_snoozable( false );
+		$note->save();
+
+		// Load all marketing notes and check that the note was successfully saved.
+		$notes = $data_store->get_notes(
+			array(
+				'type' => array( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING ),
+			)
+		);
+
+		$this->assertEquals( 1, count( $notes ) );
+
+		// Opt out of WooCommerce marketing.
+		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
+
+		// Reload all marketing notes to verify they have been removed.
+		$notes = $data_store->get_notes(
+			array(
+				'type' => array( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING ),
+			)
+		);
+
+		$this->assertEquals( 0, count( $notes ) );
+	}
+
+	/**
+	 * Tests to see if marketing notes are prevented when marketing is opted out.
+	 */
+	public function test_prevent_add_marketing_note() {
+		update_option( 'woocommerce_show_marketplace_suggestions', 'no' );
+
+		WC_Admin_Notes_Onboarding_Email_Marketing::possibly_add_note();
+
+		// Load all marketing notes and check that the note was not added.
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$notes      = $data_store->get_notes(
+			array(
+				'type' => array( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING ),
+			)
+		);
+
+		$this->assertEquals( 0, count( $notes ) );
+	}
+}


### PR DESCRIPTION
Fixes #4283 

This PR:
* Refactors the admin notes and attempts to standardize the methods used between notes.  
* Adds conditions and filters to prevent or remove marketing notes if opted out.
* Adds tests for marketing notes.

It also adds the marketing type to the following notes.  Any others we want to add or remove from this list? /cc @pmcpinto :
* `WC_Admin_Notes_WooCommerce_Payments`
* `WC_Admin_Notes_Onboarding_Email_Marketing`
* `WC_Admin_Notes_Marketing`
* `WC_Admin_Notes_Draw_Attention`

Note that there are a couple of note classes that will probably require a follow-up since they contain multiple notes or break the pattern we traditionally use to add notes.

I've also kept the newly added filters and checks in `NoteTraits` as I think they may be useful as a trait to the RINDS system instead of moving these to an abstract class.

### Detailed test instructions:

1. Under wccom settings `?page=wc-settings&tab=advanced&section=woocommerce_com` toggle off "Show Suggestions."
1. Note that any of the above notes were removed from your notes.
1. Attempt to add any of the above notes again by matching conditions and triggering the cron event `wc_admin_daily`.  `WC_Admin_Notes_Onboarding_Email_Marketing` does not have any extra conditions that need to be met and is easy to test.
1. Make sure all notes can still be added due to refactoring and that no errors occur.
1. Make sure all tests pass.