### PR TITLE
Fix the WCPay method not appearing as recommended sometimes

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -44,13 +44,6 @@ class Payments extends Component {
 			enabledMethods,
 		};
 
-		this.recommendedMethod = 'stripe';
-		methods.forEach( ( method ) => {
-			if ( method.key === 'wcpay' && method.visible ) {
-				this.recommendedMethod = 'wcpay';
-			}
-		} );
-
 		this.completeTask = this.completeTask.bind( this );
 		this.markConfigured = this.markConfigured.bind( this );
 		this.skipTask = this.skipTask.bind( this );
@@ -229,6 +222,13 @@ class Payments extends Component {
 			);
 		}
 
+		let recommendedMethod = 'stripe';
+		methods.forEach( ( method ) => {
+			if ( method.key === 'wcpay' && method.visible ) {
+				recommendedMethod = 'wcpay';
+			}
+		} );
+
 		return (
 			<div className="woocommerce-task-payments">
 				{ methods.map( ( method ) => {
@@ -254,12 +254,9 @@ class Payments extends Component {
 						'woocommerce-task-payment-' + key
 					);
 
-					const isRecommended =
-						key === this.recommendedMethod && ! isConfigured;
-					const showRecommendedRibbon =
-						isRecommended && this.recommendedMethod !== 'wcpay';
-					const showRecommendedPill =
-						isRecommended && this.recommendedMethod === 'wcpay';
+					const isRecommended = key === recommendedMethod && ! isConfigured;
+					const showRecommendedRibbon = isRecommended && key !== 'wcpay';
+					const showRecommendedPill = isRecommended && key === 'wcpay';
 
 					return (
 						<Card key={ key } className={ classes }>
@@ -296,10 +293,10 @@ class Payments extends Component {
 								{ container && ! isConfigured ? (
 									<Button
 										isPrimary={
-											key === this.recommendedMethod
+											key === recommendedMethod
 										}
 										isDefault={
-											key !== this.recommendedMethod
+											key !== recommendedMethod
 										}
 										onClick={ () => {
 											recordEvent(


### PR DESCRIPTION
Fixes #4249 (discussion and steps to reproduce there)

**The problem:** sometimes, on the Payments task of the onboarding task list, the WCPay card takes a bit to appear, and when it does, it doesn't get the "Recommended" pill. Instead, Stripe keeps being the recommended method, which is visually jarring since the WCPay card is heavily emphasized by its background color.

**The cause:** As discussed in #4249, I don't have the slightlest idea about how to reproduce this issue. Maybe @LevinMedia with his cursed laptop can try and see if this branch fixes the problem.

**The solution:** Instead of assign what payment method is the `recommendedMethod` immutably in the component constructor, recalculate it on `render`. The logic is exactly the same, the only change is that it's recalculated every time the component is rendered, so if WCPay is displayed 2 seconds after the page loads, when it's displayed it will get the `recommended` pill, and Stripe will lose its ribbon.