### PR TITLE
Advanced Filters: fix currency initialization

### DIFF
--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -122,7 +122,7 @@ class ReportFilters extends Component {
 			<Filters
 				query={ query }
 				siteLocale={ LOCALE.siteLocale }
-				currency={ Currency }
+				currency={ Currency.getCurrency() }
 				path={ path }
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/client/lib/currency-context.js
+++ b/client/lib/currency-context.js
@@ -23,7 +23,7 @@ export const getFilteredCurrencyInstance = ( query ) => {
 		config,
 		query
 	);
-	return new Currency( filteredConfig );
+	return Currency( filteredConfig );
 };
 
 export const CurrencyContext = createContext(

--- a/docs/examples/extensions/dashboard-section/js/global-prices.js
+++ b/docs/examples/extensions/dashboard-section/js/global-prices.js
@@ -9,9 +9,7 @@ import moment from 'moment';
 import { Card, Chart } from '@woocommerce/components';
 import Currency from '@woocommerce/currency';
 
-const storeCurrency = new Currency(); // give this store settings.
-const formatCurrency = storeCurrency.formatCurrency.bind( storeCurrency );
-
+const storeCurrency = Currency();
 const data = [];
 
 for ( let i = 1; i <= 20; i++ ) {
@@ -43,7 +41,7 @@ const GlobalPrices = () => {
 				legendTotals={ { primary: average } }
 				showHeaderControls={ false }
 				valueType={ 'currency' }
-				tooltipValueFormat={ formatCurrency }
+				tooltipValueFormat={ storeCurrency.formatCurrency }
 			/>
 		</Card>
 	);

--- a/packages/components/src/advanced-filters/docs/example.js
+++ b/packages/components/src/advanced-filters/docs/example.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { AdvancedFilters } from '@woocommerce/components';
-import Currency from '@woocommerce/currency';
+import { CURRENCY } from '@woocommerce/wc-admin-settings';
 
 const ORDER_STATUSES = {
 	cancelled: 'Cancelled',
@@ -15,7 +15,6 @@ const ORDER_STATUSES = {
 };
 
 const siteLocale = 'en_US';
-const siteCurrency = new Currency(); // pass site currency settings.
 
 const path =
 	new URL( document.location ).searchParams.get( 'path' ) || '/devdocs';
@@ -157,6 +156,6 @@ export default () => (
 		query={ query }
 		filterTitle="Orders"
 		config={ advancedFilters }
-		currency={ siteCurrency }
+		currency={ CURRENCY }
 	/>
 );

--- a/packages/components/src/advanced-filters/number-filter.js
+++ b/packages/components/src/advanced-filters/number-filter.js
@@ -9,6 +9,11 @@ import classnames from 'classnames';
 import { sprintf, __, _x } from '@wordpress/i18n';
 
 /**
+ * WooCommerce dependencies
+ */
+import Currency from '@woocommerce/currency';
+
+/**
  * Internal dependencies
  */
 import TextControlWithAffixes from '../text-control-with-affixes';
@@ -37,8 +42,9 @@ class NumberFilter extends Component {
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 
 		if ( inputType === 'currency' ) {
-			rangeStart = currency.formatCurrency( rangeStart );
-			rangeEnd = currency.formatCurrency( rangeEnd );
+			const { formatCurrency } = Currency( currency );
+			rangeStart = formatCurrency( rangeStart );
+			rangeEnd = formatCurrency( rangeEnd );
 		}
 
 		let filterStr = rangeStart;

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -94,8 +94,13 @@ class ReportFilters extends Component {
 	}
 
 	getDateQuery( query ) {
-		const { period, compare, before, after } = getDateParamsFromQuery( query );
-		const { primary: primaryDate, secondary: secondaryDate } = getCurrentDates( query );
+		const { period, compare, before, after } = getDateParamsFromQuery(
+			query
+		);
+		const {
+			primary: primaryDate,
+			secondary: secondaryDate,
+		} = getCurrentDates( query );
 		return {
 			period,
 			compare,
@@ -126,7 +131,9 @@ class ReportFilters extends Component {
 						{ showDatePicker && (
 							<DateRangeFilterPicker
 								key={ JSON.stringify( query ) }
-								dateQuery={ dateQuery || this.getDateQuery( query ) }
+								dateQuery={
+									dateQuery || this.getDateQuery( query )
+								}
 								onRangeSelect={ this.onRangeSelect }
 								isoDateFormat={ isoDateFormat }
 							/>
@@ -224,15 +231,7 @@ ReportFilters.defaultProps = {
 	query: {},
 	showDatePicker: true,
 	onDateSelect: () => {},
-	currency: new Currency( {
-		code: 'USD',
-		precision: 2,
-		symbol: '$',
-		symbolPosition: 'left',
-		decimalSeparator: '.',
-		thousandSeparator: ',',
-		priceFormat: '%1$s%2$s',
-	} ),
+	currency: Currency().getCurrency(),
 };
 
 export default ReportFilters;

--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -17,7 +17,15 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```JS
 import Currency from '@woocommerce/currency';
 
-const storeCurrency = new Currency(); // pass store settings into constructor.
+const storeCurrency = Currency( {
+		code: 'USD',
+		precision: 2,
+		symbol: '$',
+		symbolPosition: 'left',
+		decimalSeparator: '.',
+		thousandSeparator: ',',
+		priceFormat: '%1$s%2$s',
+	} ); // pass store settings into constructor.
 
 // Formats money with a given currency symbol. Uses site's currency settings for formatting,
 // from the settings api. Defaults to symbol=`$`, precision=2, decimalSeparator=`.`, thousandSeparator=`,`

--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -17,15 +17,7 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ```JS
 import Currency from '@woocommerce/currency';
 
-const storeCurrency = Currency( {
-		code: 'USD',
-		precision: 2,
-		symbol: '$',
-		symbolPosition: 'left',
-		decimalSeparator: '.',
-		thousandSeparator: ',',
-		priceFormat: '%1$s%2$s',
-	} ); // pass store settings into constructor.
+const storeCurrency = Currency(); // pass store settings into constructor.
 
 // Formats money with a given currency symbol. Uses site's currency settings for formatting,
 // from the settings api. Defaults to symbol=`$`, precision=2, decimalSeparator=`.`, thousandSeparator=`,`

--- a/packages/currency/test/index.js
+++ b/packages/currency/test/index.js
@@ -5,13 +5,13 @@ import Currency from '../src';
 
 describe( 'formatCurrency', () => {
 	it( 'should use defaults (USD) when currency not passed in', () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatCurrency( 9.99 ) ).toBe( '$9.99' );
 		expect( currency.formatCurrency( 30 ) ).toBe( '$30.00' );
 	} );
 
 	it( 'should uses store currency settings, not locale-based', () => {
-		const currency = new Currency( {
+		const currency = Currency( {
 			code: 'JPY',
 			symbol: '¥',
 			precision: 3,
@@ -25,7 +25,7 @@ describe( 'formatCurrency', () => {
 	} );
 
 	it( "should return empty string when given an input that isn't a number", () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatCurrency( 'abc' ) ).toBe( '' );
 		expect( currency.formatCurrency( false ) ).toBe( '' );
 		expect( currency.formatCurrency( null ) ).toBe( '' );
@@ -34,26 +34,26 @@ describe( 'formatCurrency', () => {
 
 describe( 'currency.formatDecimal', () => {
 	it( 'should round a number to 2 decimal places in USD', () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatDecimal( 9.49258 ) ).toBe( 9.49 );
 		expect( currency.formatDecimal( 30 ) ).toBe( 30 );
 		expect( currency.formatDecimal( 3.0002 ) ).toBe( 3 );
 	} );
 
 	it( 'should round a number to 0 decimal places in JPY', () => {
-		const currency = new Currency( { precision: 0 } );
+		const currency = Currency( { precision: 0 } );
 		expect( currency.formatDecimal( 1239.88 ) ).toBe( 1240 );
 		expect( currency.formatDecimal( 1500 ) ).toBe( 1500 );
 		expect( currency.formatDecimal( 33715.02 ) ).toBe( 33715 );
 	} );
 
 	it( 'should correctly convert and round a string', () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatDecimal( '19.80' ) ).toBe( 19.8 );
 	} );
 
 	it( "should return 0 when given an input that isn't a number", () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatDecimal( 'abc' ) ).toBe( 0 );
 		expect( currency.formatDecimal( false ) ).toBe( 0 );
 		expect( currency.formatDecimal( null ) ).toBe( 0 );
@@ -62,26 +62,26 @@ describe( 'currency.formatDecimal', () => {
 
 describe( 'currency.formatDecimalString', () => {
 	it( 'should round a number to 2 decimal places in USD', () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatDecimalString( 9.49258 ) ).toBe( '9.49' );
 		expect( currency.formatDecimalString( 30 ) ).toBe( '30.00' );
 		expect( currency.formatDecimalString( 3.0002 ) ).toBe( '3.00' );
 	} );
 
 	it( 'should round a number to 0 decimal places in JPY', () => {
-		const currency = new Currency( { precision: 0 } );
+		const currency = Currency( { precision: 0 } );
 		expect( currency.formatDecimalString( 1239.88 ) ).toBe( '1240' );
 		expect( currency.formatDecimalString( 1500 ) ).toBe( '1500' );
 		expect( currency.formatDecimalString( 33715.02 ) ).toBe( '33715' );
 	} );
 
 	it( 'should correctly convert and round a string', () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatDecimalString( '19.80' ) ).toBe( '19.80' );
 	} );
 
 	it( "should return empty string when given an input that isn't a number", () => {
-		const currency = new Currency();
+		const currency = Currency();
 		expect( currency.formatDecimalString( 'abc' ) ).toBe( '' );
 		expect( currency.formatDecimalString( false ) ).toBe( '' );
 		expect( currency.formatDecimalString( null ) ).toBe( '' );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4346

In https://github.com/woocommerce/woocommerce-admin/pull/4027 changes were made to Currency package such that a `Currency()` was a factory function returning a bunch of methods. This is a distinction from a currency object with properties that some components expect.

In `client/analytics/components/report-filters/index.js` the fix was to pass in the property object directly.

```diff
- currency={ Currency }
+ currency={ Currency.getCurrency() }
```

Other changes included are removal of `new Currency()` because Currency is no longer a class with a constructor, but now a regular function. I'm not sure how this didn't throw an error before.

### Detailed test instructions:

1. Go to WooCommerce > Customers.
2. Click on the dropdown menu under Show:
3. Select to add an Advanced Filter.
4. Choose `Total Spend` or `AOV`.
5. The filters work as intended.

### Changelog Note:

Fix: Monetary Advanced Filters in Customers Report with correct currency object prop.
