### PR TITLE
Fix JS error when opening dashboard after selecting n extension to purchase.

### DIFF
--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -48,9 +48,7 @@ export function getProductIdsForCart(
 	profileItems,
 	includeInstalledItems = false
 ) {
-	const productIds = [];
 	const onboarding = getSetting( 'onboarding', {} );
-	const productTypes = profileItems.product_types || [];
 
 	// The population of onboarding.productTypes only happens if the task list should be shown
 	// so bail early if it isn't present.
@@ -58,12 +56,16 @@ export function getProductIdsForCart(
 		return productIds;
 	}
 
+	const productIds = [];
+	const plugins = getSetting( 'plugins', {} );
+	const productTypes = profileItems.product_types || [];
+
 	productTypes.forEach( ( productType ) => {
 		if (
 			onboarding.productTypes[ productType ] &&
 			onboarding.productTypes[ productType ].product &&
 			( includeInstalledItems ||
-				! onboarding.installedPlugins.includes(
+				! plugins.installedPlugins.includes(
 					onboarding.productTypes[ productType ].slug
 				) )
 		) {


### PR DESCRIPTION
Get installed plugins from new plugin settings object. (Missed in https://github.com/woocommerce/woocommerce-admin/pull/4093)

### Detailed test instructions:

- Run through the OBW - select an extension for purchase
- Open the Dashboard (ensure the task list is shown)
- Verify no fatal errors are encountered
- Verify the "purchase" step is shown

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

