### PR TITLE
OBW: Get utils plugins data from wp.data

### DIFF
--- a/client/dashboard/components/cart-modal.js
+++ b/client/dashboard/components/cart-modal.js
@@ -173,12 +173,12 @@ export default compose(
 		const { getProfileItems } = select( 'wc-api' );
 		const { getInstalledPlugins } = select( PLUGINS_STORE_NAME );
 		const profileItems = getProfileItems();
+		const installedPlugins = getInstalledPlugins();
 		const productIds = getProductIdsForCart(
 			profileItems,
 			false,
 			installedPlugins
 		);
-		const installedPlugins = getInstalledPlugins();
 
 		return { profileItems, productIds };
 	} )

--- a/client/dashboard/components/cart-modal.js
+++ b/client/dashboard/components/cart-modal.js
@@ -13,6 +13,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { getSetting } from '@woocommerce/wc-admin-settings';
 import { List } from '@woocommerce/components';
+import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -170,8 +171,14 @@ class CartModal extends Component {
 export default compose(
 	withSelect( ( select ) => {
 		const { getProfileItems } = select( 'wc-api' );
+		const { getInstalledPlugins } = select( PLUGINS_STORE_NAME );
 		const profileItems = getProfileItems();
-		const productIds = getProductIdsForCart( profileItems );
+		const productIds = getProductIdsForCart(
+			profileItems,
+			false,
+			installedPlugins
+		);
+		const installedPlugins = getInstalledPlugins();
 
 		return { profileItems, productIds };
 	} )

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -46,7 +46,8 @@ export function getCurrencyRegion( countryState ) {
  */
 export function getProductIdsForCart(
 	profileItems,
-	includeInstalledItems = false
+	includeInstalledItems = false,
+	installedPlugins
 ) {
 	const onboarding = getSetting( 'onboarding', {} );
 
@@ -57,7 +58,6 @@ export function getProductIdsForCart(
 	}
 
 	const productIds = [];
-	const plugins = getSetting( 'plugins', {} );
 	const productTypes = profileItems.product_types || [];
 
 	productTypes.forEach( ( productType ) => {
@@ -65,7 +65,7 @@ export function getProductIdsForCart(
 			onboarding.productTypes[ productType ] &&
 			onboarding.productTypes[ productType ].product &&
 			( includeInstalledItems ||
-				! plugins.installedPlugins.includes(
+				! installedPlugins.includes(
 					onboarding.productTypes[ productType ].slug
 				) )
 		) {

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -42,6 +42,7 @@ export function getCurrencyRegion( countryState ) {
  *
  * @param {Object} profileItems Onboarding profile.
  * @param {boolean} includeInstalledItems Include installed items in returned product IDs.
+ * @param {Array} installedPlugins Installed plugins.
  * @return {Array} Product Ids.
  */
 export function getProductIdsForCart(

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -102,13 +102,19 @@ class TaskDashboard extends Component {
 	}
 
 	getTasks() {
-		const { profileItems, query, taskListPayments } = this.props;
+		const {
+			profileItems,
+			query,
+			taskListPayments,
+			installedPlugins,
+		} = this.props;
 
 		return getAllTasks( {
 			profileItems,
 			options: taskListPayments,
 			query,
 			toggleCartModal: this.toggleCartModal.bind( this ),
+			installedPlugins,
 		} ).filter( ( task ) => task.visible );
 	}
 

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -442,10 +442,12 @@ export default compose(
 			[ 'woocommerce_task_list_tracked_completed_tasks' ],
 			[]
 		);
+		const installedPlugins = getInstalledPlugins();
 		const tasks = getAllTasks( {
 			profileItems,
 			options: getOptions( [ 'woocommerce_task_list_payments' ] ),
 			query: props.query,
+			installedPlugins,
 		} );
 		const completedTaskKeys = tasks
 			.filter( ( task ) => task.completed )
@@ -454,7 +456,6 @@ export default compose(
 			( task ) => task.visible && ! task.completed
 		);
 		const activePlugins = getActivePlugins();
-		const installedPlugins = getInstalledPlugins();
 
 		return {
 			modalDismissed,

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -28,6 +28,7 @@ export function getAllTasks( {
 	options,
 	query,
 	toggleCartModal,
+	installedPlugins,
 } ) {
 	const {
 		hasPhysicalProducts,
@@ -43,8 +44,16 @@ export function getAllTasks( {
 		shippingZonesCount: 0,
 	} );
 
-	const productIds = getProductIdsForCart( profileItems, true );
-	const remainingProductIds = getProductIdsForCart( profileItems );
+	const productIds = getProductIdsForCart(
+		profileItems,
+		true,
+		installedPlugins
+	);
+	const remainingProductIds = getProductIdsForCart(
+		profileItems,
+		false,
+		installedPlugins
+	);
 
 	const paymentsCompleted = get(
 		options,


### PR DESCRIPTION
Follow up to https://github.com/woocommerce/woocommerce-admin/pull/4357 which pulled plugin data from wcSettings. A problem may occur if plugins are added during the OBW, then the wcSettings global will be outdated. By gathering plugin data from the Plugins DataStore, we can be sure the data is fresh.

### Detailed test instructions:

* Run through the OBW - select an extension for purchase
* Open the Dashboard (ensure the task list is shown)
* Verify no fatal errors are encountered
* Verify the "purchase" step is shown

