### PR TITLE
Enable tracking on the fly during onboarding

### DIFF
--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -18,7 +18,11 @@ const tracksDebug = debug( 'wc-admin:tracks' );
 export function recordEvent( eventName, eventProperties ) {
 	tracksDebug( 'recordevent %s %o', 'wcadmin_' + eventName, eventProperties, {
 		_tqk: window._tkq,
-		shouldRecord: window._tkq && process.env.NODE_ENV !== 'development',
+		shouldRecord:
+			process.env.NODE_ENV !== 'development' &&
+			!! window._tkq &&
+			!! window.wcTracks &&
+			!! window.wcTracks.isEnabled,
 	} );
 
 	if (

--- a/client/lib/tracks.js
+++ b/client/lib/tracks.js
@@ -16,7 +16,10 @@ const tracksDebug = debug( 'wc-admin:tracks' );
  */
 
 export function recordEvent( eventName, eventProperties ) {
-	tracksDebug( 'recordevent %s %o', 'wcadmin_' + eventName, eventProperties );
+	tracksDebug( 'recordevent %s %o', 'wcadmin_' + eventName, eventProperties, {
+		_tqk: window._tkq,
+		shouldRecord: window._tkq && process.env.NODE_ENV !== 'development',
+	} );
 
 	if (
 		! window.wcTracks ||

--- a/client/profile-wizard/steps/usage-modal.js
+++ b/client/profile-wizard/steps/usage-modal.js
@@ -25,6 +25,7 @@ class UsageModal extends Component {
 		super( props );
 		this.state = {
 			allowTracking: props.allowTracking,
+			isLoadingScripts: false,
 		};
 
 		this.onTrackingChange = this.onTrackingChange.bind( this );
@@ -36,7 +37,7 @@ class UsageModal extends Component {
 		} );
 	}
 
-	async componentDidUpdate( prevProps ) {
+	async componentDidUpdate( prevProps, prevState ) {
 		const {
 			hasErrors,
 			isRequesting,
@@ -44,8 +45,12 @@ class UsageModal extends Component {
 			onContinue,
 			createNotice,
 		} = this.props;
+		const { isLoadingScripts } = this.state;
 		const isRequestSuccessful =
-			! isRequesting && prevProps.isRequesting && ! hasErrors;
+			! isRequesting &&
+			! isLoadingScripts &&
+			( prevProps.isRequesting || prevState.isLoadingScripts ) &&
+			! hasErrors;
 		const isRequestError =
 			! isRequesting && prevProps.isRequesting && hasErrors;
 
@@ -67,10 +72,19 @@ class UsageModal extends Component {
 	}
 
 	updateTracking() {
+		const { allowTracking } = this.state;
 		const { updateOptions } = this.props;
-		const allowTracking = this.state.allowTracking ? 'yes' : 'no';
+
+		if ( allowTracking && typeof window.wcTracks.enable === 'function' ) {
+			this.setState( { isLoadingScripts: true } );
+			window.wcTracks.enable( () => {
+				this.setState( { isLoadingScripts: false } );
+			} );
+		}
+
+		const trackingValue = allowTracking ? 'yes' : 'no';
 		updateOptions( {
-			woocommerce_allow_tracking: allowTracking,
+			woocommerce_allow_tracking: trackingValue,
 		} );
 	}
 

--- a/client/profile-wizard/steps/usage-modal.js
+++ b/client/profile-wizard/steps/usage-modal.js
@@ -80,6 +80,8 @@ class UsageModal extends Component {
 			window.wcTracks.enable( () => {
 				this.setState( { isLoadingScripts: false } );
 			} );
+		} else if ( ! allowTracking ) {
+			window.wcTracks.isEnabled = false;
 		}
 
 		const trackingValue = allowTracking ? 'yes' : 'no';


### PR DESCRIPTION
Fixes #4365 

This PR attempts to immediately load tracking scripts when a user opts in without the need to refresh the page.

### Screenshots
<img width="389" alt="Screen Shot 2020-05-13 at 9 16 46 PM" src="https://user-images.githubusercontent.com/10561050/81849352-15e54480-955f-11ea-8797-be55e2ed31a1.png">

### Detailed test instructions:

1. Check out this branch of WC - https://github.com/woocommerce/woocommerce/pull/26493
1. Set `woocommerce_allow_tracking` to `no`.
1. Open your console and enter `localStorage.setItem( 'debug', 'wc-admin:*' )`.
1. Visit the profiler first step and opt in to tracking at the modal.
1. Note the console debug messages shows the events and `_tqk` is defined if opted in.
1. Note that `shouldRecord` is `true` if opted in and not under development mode.