### PR TITLE
Homepage: Style summary numbers

### DIFF
--- a/client/homepage/stats-overview/index.js
+++ b/client/homepage/stats-overview/index.js
@@ -8,7 +8,6 @@ import { TabPanel } from '@wordpress/components';
 import { xor } from 'lodash';
 import { withDispatch } from '@wordpress/data';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 /**
  * WooCommerce dependencies
@@ -58,11 +57,6 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 
 	const activeStats = stats.filter(
 		( item ) => ! hiddenStats.includes( item.stat )
-	);
-
-	const listClasses = classnames(
-		'woocommerce-summary',
-		`has-${ activeStats.length }-items`
 	);
 
 	return (
@@ -122,29 +116,29 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 				] }
 			>
 				{ ( tab ) => (
-					<ul className={ listClasses }>
-						<StatsList
-							query={ {
-								period: tab.name,
-								compare: 'previous_period',
-							} }
-							stats={ activeStats }
-						/>
-					</ul>
+					<StatsList
+						query={ {
+							period: tab.name,
+							compare: 'previous_period',
+						} }
+						stats={ activeStats }
+					/>
 				) }
 			</TabPanel>
-			<Link
-				className="woocommerce-stats-overview__more-btn"
-				href={ getNewPath( {}, '/analytics/overview' ) }
-				type="wc-admin"
-				onClick={ () => {
-					recordEvent( 'statsoverview_indicators_click', {
-						key: 'view_detailed_stats',
-					} );
-				} }
-			>
-				{ __( 'View detailed stats' ) }
-			</Link>
+			<div className="woocommerce-stats-overview__footer">
+				<Link
+					className="woocommerce-stats-overview__more-btn"
+					href={ getNewPath( {}, '/analytics/overview' ) }
+					type="wc-admin"
+					onClick={ () => {
+						recordEvent( 'statsoverview_indicators_click', {
+							key: 'view_detailed_stats',
+						} );
+					} }
+				>
+					{ __( 'View detailed stats' ) }
+				</Link>
+			</div>
 		</Card>
 	);
 };

--- a/client/homepage/stats-overview/stats-list.js
+++ b/client/homepage/stats-overview/stats-list.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { Fragment, useContext } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 
 /**
  * WooCommerce dependencies
@@ -42,10 +43,19 @@ export const StatsList = ( {
 	const currency = getCurrency();
 
 	return (
-		<Fragment>
+		<ul
+			className={ classnames( 'woocommerce-stats-overview__stats', {
+				'is-even': stats.length % 2 === 0,
+			} ) }
+		>
 			{ stats.map( ( item ) => {
 				if ( primaryRequesting || secondaryRequesting ) {
-					return <SummaryNumberPlaceholder key={ item.stat } />;
+					return (
+						<SummaryNumberPlaceholder
+							className="is-homepage"
+							key={ item.stat }
+						/>
+					);
 				}
 				const {
 					primaryValue,
@@ -63,6 +73,7 @@ export const StatsList = ( {
 
 				return (
 					<SummaryNumber
+						isHomepage
 						key={ item.stat }
 						href={ reportUrl }
 						label={ item.label }
@@ -81,7 +92,7 @@ export const StatsList = ( {
 					/>
 				);
 			} ) }
-		</Fragment>
+		</ul>
 	);
 };
 

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -29,7 +29,7 @@ $outer-border: $core-grey-light-700;
 	.components-button {
 		display: block;
 		padding: $gap;
-		width: 25%;
+		width: 33.33%;
 		margin-bottom: 4px;
 
 		&:focus {
@@ -45,10 +45,12 @@ $outer-border: $core-grey-light-700;
 
 		&:first-child {
 			text-align: left;
+			padding-right: 0;
 		}
 
 		&:last-child {
 			text-align: right;
+			padding-left: 0;
 		}
 	}
 }

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -1,3 +1,6 @@
+// Set up some local color variables to make the CSS more clear
+$outer-border: $core-grey-light-700;
+
 .woocommerce-stats-overview {
 	.woocommerce-card__body {
 		padding: 0;
@@ -5,6 +8,10 @@
 	.woocommerce-summary {
 		margin: 0;
 	}
+}
+
+.woocommerce-stats-overview__footer {
+	border-top: 1px solid $outer-border;
 }
 
 .woocommerce-stats-overview__more-btn {
@@ -16,6 +23,7 @@
 	.components-tab-panel__tabs {
 		display: flex;
 		justify-content: space-between;
+		border-bottom: 1px solid $outer-border;
 	}
 
 	.components-button {
@@ -23,10 +31,6 @@
 		padding: $gap;
 		width: 25%;
 		margin-bottom: 4px;
-
-		@include breakpoint( '<782px' ) {
-			width: 33.33%;
-		}
 
 		&:focus {
 			outline: none;
@@ -46,5 +50,22 @@
 		&:last-child {
 			text-align: right;
 		}
+	}
+}
+
+.woocommerce-stats-overview__stats {
+	margin: 0;
+
+	// Perhaps these should be moved to the component itself?
+	.woocommerce-summary__item-container:nth-last-of-type(1) .woocommerce-summary__item {
+		border-bottom: none;
+	}
+
+	&.is-even .woocommerce-summary__item-container:nth-last-of-type(2) .woocommerce-summary__item {
+		border-bottom: none;
+	}
+
+	.woocommerce-summary__item-container:nth-of-type(even) .woocommerce-summary__item {
+		border-right: none;
 	}
 }

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -58,7 +58,11 @@ $outer-border: $core-grey-light-700;
 .woocommerce-stats-overview__stats {
 	margin: 0;
 
-	// Perhaps these should be moved to the component itself?
+	.woocommerce-summary__item-container {
+		width: 50%;
+		display: inline-block;
+	}
+
 	.woocommerce-summary__item-container:nth-last-of-type(1) .woocommerce-summary__item {
 		border-bottom: none;
 	}

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -30,8 +30,10 @@ const SummaryNumber = ( {
 	selected,
 	value,
 	onLinkClickCallback,
+	isHomepage,
 } ) => {
 	const liClasses = classnames( 'woocommerce-summary__item-container', {
+		'is-homepage': isHomepage,
 		'is-dropdown-button': onToggle,
 		'is-dropdown-expanded': isOpen,
 	} );

--- a/packages/components/src/summary/placeholder.js
+++ b/packages/components/src/summary/placeholder.js
@@ -12,10 +12,13 @@ import { withViewportMatch } from '@wordpress/viewport';
  */
 import { getHasItemsClass } from './utils';
 
-export const SummaryNumberPlaceholder = () => (
+export const SummaryNumberPlaceholder = ( { className } ) => (
 	<li
 		data-testid="summary-placeholder"
-		className="woocommerce-summary__item-container is-placeholder"
+		className={ classnames(
+			'woocommerce-summary__item-container is-placeholder',
+			className
+		) }
 	>
 		<span className="woocommerce-summary__item">
 			<span className="woocommerce-summary__item-label" />

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -214,7 +214,13 @@ $inner-border: $core-grey-light-500;
 .woocommerce-summary__item-container {
 	margin-bottom: 0;
 
-	&:last-of-type .woocommerce-summary__item {
+	// Perhaps these should be moved to StatsList? This way layout logic can be CSS?
+	&.is-homepage {
+		width: 50%;
+		display: inline-block;
+	}
+
+	&:not(.is-homepage):last-of-type .woocommerce-summary__item {
 		// Make sure the last item always uses the outer-border color.
 		border-bottom-color: $outer-border !important;
 	}

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -214,12 +214,6 @@ $inner-border: $core-grey-light-500;
 .woocommerce-summary__item-container {
 	margin-bottom: 0;
 
-	// Perhaps these should be moved to StatsList? This way layout logic can be CSS?
-	&.is-homepage {
-		width: 50%;
-		display: inline-block;
-	}
-
 	&:not(.is-homepage):last-of-type .woocommerce-summary__item {
 		// Make sure the last item always uses the outer-border color.
 		border-bottom-color: $outer-border !important;


### PR DESCRIPTION
Adds styling to Homepage stats overview containers of summary numbers.

This PR styles the layout of the individual SummayNumbers but not the SummayNumbers themselves. For reference, here is the final goal:

![Screen Shot 2020-05-20 at 1 39 10 PM](https://user-images.githubusercontent.com/1922453/82395298-56811880-9a9f-11ea-9a93-badf7dfdb05f.png)

### Screenshots

Loading state

![Screen Shot 2020-05-20 at 1 36 18 PM](https://user-images.githubusercontent.com/1922453/82395153-03a76100-9a9f-11ea-8e06-ad3bc0825155.png)

With data

![Screen Shot 2020-05-20 at 1 36 24 PM](https://user-images.githubusercontent.com/1922453/82395157-04d88e00-9a9f-11ea-9b33-187e45e87319.png)

### Testing instructions

* Go to the homepage.
* See the stats in loading state and once data has arrived.
* Confirm the layout is as it should be: 2 columns, borders looking correct, and placeholders rendered nicely.
* Add or remove some stats and see that the layout should respond accordingly (keep in mind the delay of the toggles is a known issue).

