### PR TITLE
Task List: Small fixes and adjustments to WCPay task

### DIFF
--- a/client/dashboard/task-list/style.scss
+++ b/client/dashboard/task-list/style.scss
@@ -363,6 +363,10 @@
 		.text-style-strong {
 			font-weight: bold;
 		}
+
+		p {
+			font-size: 12px;
+		}
 	}
 
 	.woocommerce-task-payment__after {

--- a/client/dashboard/task-list/tasks/payments/methods.js
+++ b/client/dashboard/task-list/tasks/payments/methods.js
@@ -12,6 +12,7 @@ import interpolateComponents from 'interpolate-components';
  */
 import {
 	getSetting,
+	getAdminLink,
 	WC_ASSET_URL as wcAssetUrl,
 } from '@woocommerce/wc-admin-settings';
 import { Link } from '@woocommerce/components';
@@ -89,9 +90,10 @@ export function getPaymentMethods( {
 
 		const wcPaySettingsLink = (
 			<Link
-				href={
-					'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments'
-				}
+				href={ getAdminLink(
+					'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments'
+				) }
+				type="wp-admin"
 			>
 				{ __( 'Settings', 'woocommerce-admin' ) }
 			</Link>

--- a/client/dashboard/task-list/tasks/payments/wcpay.js
+++ b/client/dashboard/task-list/tasks/payments/wcpay.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
@@ -102,19 +102,14 @@ class WCPay extends Component {
 							'woocommerce-admin'
 						),
 						content: (
-							<Fragment>
-								<Button
-									isPrimary
-									isDefault
-									isBusy={ isPending }
-									onClick={ this.connect }
-								>
-									{ __(
-										'Verify details',
-										'woocommerce-admin'
-									) }
-								</Button>
-							</Fragment>
+							<Button
+								isPrimary
+								isDefault
+								isBusy={ isPending }
+								onClick={ this.connect }
+							>
+								{ __( 'Verify details', 'woocommerce-admin' ) }
+							</Button>
 						),
 					},
 				] }

--- a/client/dashboard/task-list/tasks/payments/wcpay.js
+++ b/client/dashboard/task-list/tasks/payments/wcpay.js
@@ -31,17 +31,15 @@ class WCPay extends Component {
 		const { createNotice, markConfigured } = this.props;
 		const query = getQuery();
 		// Handle redirect back from WCPay on-boarding
-		if ( query[ 'wcpay-connect' ] ) {
-			if ( query[ 'wcpay-connect' ] === '1' ) {
-				createNotice(
-					'success',
-					__(
-						'WooCommerce Payments connected successfully.',
-						'woocommerce-admin'
-					)
-				);
-				markConfigured( 'wcpay' );
-			}
+		if ( query[ 'wcpay-connection-success' ] ) {
+			createNotice(
+				'success',
+				__(
+					'WooCommerce Payments connected successfully.',
+					'woocommerce-admin'
+				)
+			);
+			markConfigured( 'wcpay' );
 		}
 	}
 

--- a/client/dashboard/task-list/tasks/payments/wcpay.js
+++ b/client/dashboard/task-list/tasks/payments/wcpay.js
@@ -6,14 +6,12 @@ import { Component } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
 
 /**
  * WooCommerce dependencies
  */
 import { getQuery } from '@woocommerce/navigation';
 import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
-import withSelect from 'wc-api/with-select';
 import { Stepper } from '@woocommerce/components';
 
 class WCPay extends Component {
@@ -44,15 +42,8 @@ class WCPay extends Component {
 	}
 
 	async connect() {
-		const { createNotice, options, updateOptions } = this.props;
+		const { createNotice } = this.props;
 		this.setState( { isPending: true } );
-
-		updateOptions( {
-			woocommerce_woocommerce_payments_settings: {
-				...options.woocommerce_woocommerce_payments_settings,
-				enabled: 'yes',
-			},
-		} );
 
 		const errorMessage = __(
 			'There was an error connecting to WooCommerce Payments. Please try again or skip to connect later in store settings.',
@@ -118,29 +109,9 @@ class WCPay extends Component {
 	}
 }
 
-export default compose(
-	withSelect( ( select ) => {
-		const { getOptions, isGetOptionsRequesting } = select( 'wc-api' );
-		const options = getOptions( [
-			'woocommerce_woocommerce_payments_settings',
-		] );
-		const optionsIsRequesting = Boolean(
-			isGetOptionsRequesting( [
-				'woocommerce_woocommerce_payments_settings',
-			] )
-		);
-
-		return {
-			options,
-			optionsIsRequesting,
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { createNotice } = dispatch( 'core/notices' );
-		const { updateOptions } = dispatch( 'wc-api' );
-		return {
-			createNotice,
-			updateOptions,
-		};
-	} )
-)( WCPay );
+export default withDispatch( ( dispatch ) => {
+	const { createNotice } = dispatch( 'core/notices' );
+	return {
+		createNotice,
+	};
+} )( WCPay );


### PR DESCRIPTION
A set of small fixes and tweaks to the WCPay task. In rough order of decreasing priority:
- https://github.com/woocommerce/woocommerce-admin/commit/09ac96f0db759e10c46d685363dbbaa559bd5c40: fixes https://github.com/woocommerce/woocommerce-admin/issues/4293 by changing the "Settings" link type
- https://github.com/woocommerce/woocommerce-admin/commit/ee6df5b7707d98e9408db952a0d8dc5865a54e75: modifies success query param check to match the redirect [[code](https://github.com/Automattic/woocommerce-payments/blob/65e92328f8cea9dc685feed3823a42e8f6baa3eb/includes/class-wc-payments-account.php#L415)]. (The error message won't actually be triggered until [this change](https://github.com/Automattic/woocommerce-payments/compare/update/task-list-return-url) is made.)
- https://github.com/woocommerce/woocommerce-admin/commit/9eecc39023cfda6175680cc6f3dd6e8cf41e4564: removes request to update "enabled" setting, as it can be interrupted by the redirect (leading to an occasional error notice after clicking "Verify details" [[screenshot](https://cloudup.com/cqk8keEsGI0)]), and it's set when the connection is finalized anyway [[code](https://github.com/Automattic/woocommerce-payments/blob/65e92328f8cea9dc685feed3823a42e8f6baa3eb/includes/class-wc-payments-account.php#L404)]
- https://github.com/woocommerce/woocommerce-admin/commit/898739a478866aa45e8f20ae30eed668f2dbecf0: 1px font size tweak to avoid "Terms of Service" widow [[before](https://user-images.githubusercontent.com/1867547/81899521-0aa70e80-9589-11ea-8cd7-1723c43783f8.png), [after](https://user-images.githubusercontent.com/1867547/81899526-0d096880-9589-11ea-8456-1fc0f5627d04.png)] – not sure whether it's the same on all devices/browsers
- https://github.com/woocommerce/woocommerce-admin/commit/aedd06f34802c4994f4c900c4934d7d14a620767: trivial refactor to remove an unnecessary Fragment

(Happy to drop some off the bottom in pursuit of a timely merge for the top ones.)

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Needs fresh Jetpack connection that hasn't had a WooCommerce Payments account (or "force onboarding" flag set), and dev mode: `define( 'WCPAY_DEV_MODE', true );`
- With WooCommerce Payments plugin deactivated, click "Set up payments" in the task list.
- Verify that the Terms of Service line in the payment method fits on one line. Click "Set up".
- Verify that no error notice shows up right before redirecting to stripe.com.
- To verify the success message on return from stripe.com, apply the change [here](https://github.com/Automattic/woocommerce-payments/compare/update/task-list-return-url).
- Verify that the Settings link takes you to the WooCommerce Payments settings screen, not the task list.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->