### PR TITLE
Add Jetpack connection to plugin benefits step

### DIFF
--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -21,8 +21,16 @@ class Connect extends Component {
 		props.setIsPending( true );
 	}
 
+	componentDidMount() {
+		const { autoConnect, jetpackConnectUrl } = this.props;
+
+		if ( autoConnect && jetpackConnectUrl ) {
+			this.connectJetpack();
+		}
+	}
+
 	componentDidUpdate( prevProps ) {
-		const { createNotice, error, isRequesting, setIsPending } = this.props;
+		const { autoConnect, createNotice, error, isRequesting, jetpackConnectUrl, setIsPending } = this.props;
 
 		if ( prevProps.isRequesting && ! isRequesting ) {
 			setIsPending( false );
@@ -31,10 +39,15 @@ class Connect extends Component {
 		if ( error && error !== prevProps.error ) {
 			createNotice( 'error', error );
 		}
+
+		if ( autoConnect && jetpackConnectUrl ) {
+			this.connectJetpack();
+		}
 	}
 
 	async connectJetpack() {
 		const { jetpackConnectUrl, onConnect } = this.props;
+
 		if ( onConnect ) {
 			onConnect();
 		}
@@ -42,7 +55,11 @@ class Connect extends Component {
 	}
 
 	render() {
-		const { hasErrors, isRequesting, onSkip, skipText } = this.props;
+		const { autoConnect, hasErrors, isRequesting, onSkip, skipText } = this.props;
+
+		if ( autoConnect ) {
+			return null;
+		}
 
 		return (
 			<Fragment>
@@ -73,6 +90,10 @@ class Connect extends Component {
 }
 
 Connect.propTypes = {
+	/**
+	 * If connection should happen automatically, or requires user confirmation.
+	 */
+	autoConnect: PropTypes.bool,
 	/**
 	 * Method to create a displayed notice.
 	 */
@@ -112,6 +133,7 @@ Connect.propTypes = {
 };
 
 Connect.defaultProps = {
+	autoConnect: false,
 	setIsPending: () => {},
 };
 

--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -30,13 +30,24 @@ class Connect extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { autoConnect, createNotice, error, isRequesting, jetpackConnectUrl, setIsPending } = this.props;
+		const {
+			autoConnect,
+			createNotice,
+			error,
+			isRequesting,
+			jetpackConnectUrl,
+			onError,
+			setIsPending,
+		} = this.props;
 
 		if ( prevProps.isRequesting && ! isRequesting ) {
 			setIsPending( false );
 		}
 
 		if ( error && error !== prevProps.error ) {
+			if ( onError ) {
+				onError();
+			}
 			createNotice( 'error', error );
 		}
 
@@ -55,7 +66,13 @@ class Connect extends Component {
 	}
 
 	render() {
-		const { autoConnect, hasErrors, isRequesting, onSkip, skipText } = this.props;
+		const {
+			autoConnect,
+			hasErrors,
+			isRequesting,
+			onSkip,
+			skipText,
+		} = this.props;
 
 		if ( autoConnect ) {
 			return null;
@@ -114,6 +131,14 @@ Connect.propTypes = {
 	 * Generated Jetpack connection URL.
 	 */
 	jetpackConnectUrl: PropTypes.string,
+	/**
+	 * Called before the redirect to Jetpack.
+	 */
+	onConnect: PropTypes.func,
+	/**
+	 * Called when the plugin has an error retrieving the jetpackConnectUrl.
+	 */
+	onError: PropTypes.func,
 	/**
 	 * Called when the plugin connection is skipped.
 	 */

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -258,7 +258,10 @@ class Benefits extends Component {
 								this.setState( { isInstalling: false } )
 							}
 							onError={ () =>
-								this.setState( { isPending: false } )
+								this.setState( {
+									isInstalling: true,
+									isPending: false,
+								} )
 							}
 							pluginSlugs={ this.pluginsToInstall }
 						/>

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -12,6 +12,7 @@ import { filter } from 'lodash';
  * WooCommerce dependencies
  */
 import { Card, H, Plugins } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
 
 /**
@@ -65,10 +66,11 @@ class Benefits extends Component {
 		} = this.props;
 		const { isInstalling, isPending } = this.state;
 
-		// Installation is complete, begin Jetpack connection.
+		// Installation and requests are complete, begin Jetpack connection.
 		if (
 			! isInstalling &&
-			prevState.isInstalling &&
+			! isRequesting &&
+			( prevState.isInstalling || prevState.isRequesting ) &&
 			activePlugins.includes( 'jetpack' )
 		) {
 			if ( ! isJetpackConnected ) {
@@ -273,6 +275,9 @@ class Benefits extends Component {
 							onError={ () =>
 								this.setState( { isPending: false } )
 							}
+							redirectUrl={ getAdminLink(
+								'admin.php?page=wc-admin&reset_profiler=0'
+							) }
 						/>
 					) }
 				</div>

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -270,6 +270,9 @@ class Benefits extends Component {
 									'storeprofiler_jetpack_connect_redirect'
 								);
 							} }
+							onError={ () =>
+								this.setState( { isPending: false } )
+							}
 						/>
 					) }
 				</div>

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -12,10 +12,11 @@ import TYPES from './action-types';
 import { WC_ADMIN_NAMESPACE } from '../constants';
 import { pluginNames } from './constants';
 
-export function updateActivePlugins( active ) {
+export function updateActivePlugins( active, added ) {
 	return {
 		type: TYPES.UPDATE_ACTIVE_PLUGINS,
 		active,
+		added,
 	};
 }
 
@@ -123,7 +124,7 @@ export function* activatePlugins( plugins ) {
 		} );
 
 		if ( results && results.status === 'success' ) {
-			yield updateActivePlugins( results.activatedPlugins );
+			yield updateActivePlugins( null, results.activatedPlugins );
 			return results;
 		}
 

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -12,19 +12,19 @@ import TYPES from './action-types';
 import { WC_ADMIN_NAMESPACE } from '../constants';
 import { pluginNames } from './constants';
 
-export function updateActivePlugins( active, added ) {
+export function updateActivePlugins( active, replace = false ) {
 	return {
 		type: TYPES.UPDATE_ACTIVE_PLUGINS,
 		active,
-		added,
+		replace,
 	};
 }
 
-export function updateInstalledPlugins( installed, added ) {
+export function updateInstalledPlugins( installed, replace = false ) {
 	return {
 		type: TYPES.UPDATE_INSTALLED_PLUGINS,
 		installed,
-		added,
+		replace,
 	};
 }
 
@@ -124,7 +124,7 @@ export function* activatePlugins( plugins ) {
 		} );
 
 		if ( results && results.status === 'success' ) {
-			yield updateActivePlugins( null, results.activatedPlugins );
+			yield updateActivePlugins( results.activatedPlugins );
 			return results;
 		}
 

--- a/packages/data/src/plugins/reducer.js
+++ b/packages/data/src/plugins/reducer.js
@@ -34,7 +34,7 @@ const plugins = (
 		case TYPES.UPDATE_ACTIVE_PLUGINS:
 			state = {
 				...state,
-				active,
+				active: added ? concat( state.active, added ) : active,
 				requesting: {
 					...state.requesting,
 					getActivePlugins: false,

--- a/packages/data/src/plugins/reducer.js
+++ b/packages/data/src/plugins/reducer.js
@@ -21,20 +21,20 @@ const plugins = (
 		type,
 		active,
 		installed,
-		added,
 		selector,
 		isRequesting,
 		error,
 		jetpackConnection,
 		redirectUrl,
 		jetpackConnectUrl,
+		replace,
 	}
 ) => {
 	switch ( type ) {
 		case TYPES.UPDATE_ACTIVE_PLUGINS:
 			state = {
 				...state,
-				active: added ? concat( state.active, added ) : active,
+				active: replace ? active : concat( state.active, active ),
 				requesting: {
 					...state.requesting,
 					getActivePlugins: false,
@@ -50,7 +50,9 @@ const plugins = (
 		case TYPES.UPDATE_INSTALLED_PLUGINS:
 			state = {
 				...state,
-				installed: added ? concat( state.installed, added ) : installed,
+				installed: replace
+					? installed
+					: concat( state.installed, installed ),
 				requesting: {
 					...state.requesting,
 					getInstalledPlugins: false,

--- a/packages/data/src/plugins/resolvers.js
+++ b/packages/data/src/plugins/resolvers.js
@@ -27,7 +27,7 @@ export function* getActivePlugins() {
 			method: 'GET',
 		} );
 
-		yield updateActivePlugins( results.plugins );
+		yield updateActivePlugins( results.plugins, true );
 	} catch ( error ) {
 		yield setError( 'getActivePlugins', error );
 	}
@@ -43,7 +43,7 @@ export function* getInstalledPlugins() {
 			method: 'GET',
 		} );
 
-		yield updateInstalledPlugins( results );
+		yield updateInstalledPlugins( results, true );
 	} catch ( error ) {
 		yield setError( 'getInstalledPlugins', error );
 	}

--- a/packages/data/src/plugins/test/reducer.js
+++ b/packages/data/src/plugins/test/reducer.js
@@ -19,11 +19,17 @@ describe( 'plugins reducer', () => {
 		expect( state ).not.toBe( defaultState );
 	} );
 
-	it( 'should handle UPDATE_ACTIVE_PLUGINS', () => {
-		const state = reducer( defaultState, {
-			type: TYPES.UPDATE_ACTIVE_PLUGINS,
-			active: [ 'jetpack' ],
-		} );
+	it( 'should handle UPDATE_ACTIVE_PLUGINS with replace', () => {
+		const state = reducer(
+			{
+				active: [ 'plugins', 'to', 'overwrite' ],
+			},
+			{
+				type: TYPES.UPDATE_ACTIVE_PLUGINS,
+				active: [ 'jetpack' ],
+				replace: true,
+			}
+		);
 
 		/* eslint-disable dot-notation */
 
@@ -35,7 +41,7 @@ describe( 'plugins reducer', () => {
 		expect( state.active[ 0 ] ).toBe( 'jetpack' );
 	} );
 
-	it( 'should handle UPDATE_ACTIVE_PLUGINS with added plugins', () => {
+	it( 'should handle UPDATE_ACTIVE_PLUGINS with active plugins', () => {
 		const state = reducer(
 			{
 				active: [ 'jetpack' ],
@@ -46,7 +52,7 @@ describe( 'plugins reducer', () => {
 			{
 				type: TYPES.UPDATE_ACTIVE_PLUGINS,
 				installed: null,
-				added: [ 'woocommerce-services' ],
+				active: [ 'woocommerce-services' ],
 			}
 		);
 
@@ -60,11 +66,17 @@ describe( 'plugins reducer', () => {
 		expect( state.active[ 1 ] ).toBe( 'woocommerce-services' );
 	} );
 
-	it( 'should handle UPDATE_INSTALLED_PLUGINS', () => {
-		const state = reducer( defaultState, {
-			type: TYPES.UPDATE_INSTALLED_PLUGINS,
-			installed: [ 'jetpack' ],
-		} );
+	it( 'should handle UPDATE_INSTALLED_PLUGINS with replace', () => {
+		const state = reducer(
+			{
+				active: [ 'plugins', 'to', 'overwrite' ],
+			},
+			{
+				type: TYPES.UPDATE_INSTALLED_PLUGINS,
+				installed: [ 'jetpack' ],
+				replace: true,
+			}
+		);
 
 		/* eslint-disable dot-notation */
 
@@ -76,7 +88,7 @@ describe( 'plugins reducer', () => {
 		expect( state.installed[ 0 ] ).toBe( 'jetpack' );
 	} );
 
-	it( 'should handle UPDATE_INSTALLED_PLUGINS with added plugins', () => {
+	it( 'should handle UPDATE_INSTALLED_PLUGINS with installed plugins', () => {
 		const state = reducer(
 			{
 				active: [ 'jetpack' ],
@@ -86,8 +98,7 @@ describe( 'plugins reducer', () => {
 			},
 			{
 				type: TYPES.UPDATE_INSTALLED_PLUGINS,
-				installed: null,
-				added: [ 'woocommerce-services' ],
+				installed: [ 'woocommerce-services' ],
 			}
 		);
 

--- a/packages/data/src/plugins/test/reducer.js
+++ b/packages/data/src/plugins/test/reducer.js
@@ -35,6 +35,31 @@ describe( 'plugins reducer', () => {
 		expect( state.active[ 0 ] ).toBe( 'jetpack' );
 	} );
 
+	it( 'should handle UPDATE_ACTIVE_PLUGINS with added plugins', () => {
+		const state = reducer(
+			{
+				active: [ 'jetpack' ],
+				installed: [ 'jetpack' ],
+				requesting: {},
+				errors: {},
+			},
+			{
+				type: TYPES.UPDATE_ACTIVE_PLUGINS,
+				installed: null,
+				added: [ 'woocommerce-services' ],
+			}
+		);
+
+		/* eslint-disable dot-notation */
+
+		expect( state.requesting[ 'getActivePlugins' ] ).toBe( false );
+		expect( state.errors[ 'getActivePlugins' ] ).toBe( false );
+		/* eslint-enable dot-notation */
+
+		expect( state.active ).toHaveLength( 2 );
+		expect( state.active[ 1 ] ).toBe( 'woocommerce-services' );
+	} );
+
 	it( 'should handle UPDATE_INSTALLED_PLUGINS', () => {
 		const state = reducer( defaultState, {
 			type: TYPES.UPDATE_INSTALLED_PLUGINS,

--- a/packages/data/src/plugins/with-plugins-hydration.js
+++ b/packages/data/src/plugins/with-plugins-hydration.js
@@ -34,8 +34,11 @@ export const withPluginsHydration = ( data ) => ( OriginalComponent ) => {
 				startResolution( 'getActivePlugins', [] );
 				startResolution( 'getInstalledPlugins', [] );
 				startResolution( 'isJetpackConnected', [] );
-				updateActivePlugins( dataRef.current.activePlugins );
-				updateInstalledPlugins( dataRef.current.installedPlugins );
+				updateActivePlugins( dataRef.current.activePlugins, true );
+				updateInstalledPlugins(
+					dataRef.current.installedPlugins,
+					true
+				);
 				updateIsJetpackConnected(
 					dataRef.current.jetpackStatus &&
 						dataRef.current.jetpackStatus.isActive


### PR DESCRIPTION
Fixes #4363 

* Adds the Jetpack connection to the plugin benefits screen.
* Adds an `autoConnect` and `onError` prop to `Connect`.
* Fixes an issue where existing `activePlugins` were overwritten in state on plugin activation.

### Screenshots
<img width="592" alt="Screen Shot 2020-05-14 at 7 00 35 PM" src="https://user-images.githubusercontent.com/10561050/81957499-543d3b00-9615-11ea-9e36-81b39e5cacd5.png">

### Detailed test instructions:

1. Deactivate and/or uninstall Jetpack and WCS.
1. Walk through the wizard attempting to install and connect via "Yes please!"
1. Make sure plugins are installed and you're redirect to the Jetpack connection flow.
1. Walk through the wizard attempt to skip by clicking "No thanks"
1. Make sure that you land in the task list without installing or connecting to Jetpack.
1. Re-enable the profiler and attempt these all steps again with Jetpack already connected.