### PR TITLE
Fixed PHP notice about undefined index of items

### DIFF
--- a/src/API/Reports/Coupons/Stats/Controller.php
+++ b/src/API/Reports/Coupons/Stats/Controller.php
@@ -358,6 +358,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 
 		return $params;

--- a/src/API/Reports/Customers/Stats/Controller.php
+++ b/src/API/Reports/Customers/Stats/Controller.php
@@ -368,6 +368,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 
 		return $params;

--- a/src/API/Reports/Downloads/Stats/Controller.php
+++ b/src/API/Reports/Downloads/Stats/Controller.php
@@ -375,6 +375,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 
 		return $params;

--- a/src/API/Reports/Orders/Stats/Controller.php
+++ b/src/API/Reports/Orders/Stats/Controller.php
@@ -518,6 +518,9 @@ class Controller extends \Automattic\WooCommerce\Admin\API\Reports\Controller {
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 
 		return $params;

--- a/src/API/Reports/Products/Stats/Controller.php
+++ b/src/API/Reports/Products/Stats/Controller.php
@@ -420,6 +420,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 
 		return $params;

--- a/src/API/Reports/Taxes/Stats/Controller.php
+++ b/src/API/Reports/Taxes/Stats/Controller.php
@@ -393,6 +393,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'type'              => 'array',
 			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 
 		return $params;


### PR DESCRIPTION
It fixes a notice caused by the missing 'items' param required for 'array' types.

> [14-May-2020 18:15:39 UTC] PHP Notice:  Undefined index: items in /var/www/woo/wp-includes/rest-api.php on line 1246

Fixes #4280

### Detailed test instructions:

- Turn on your PHP logger, you can enable the WP logger by introducing the code bellow to your `wp-config.php`:
```php
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
define( 'WP_DEBUG_DISPLAY', true );
```
- Go to the WC Admin Dashboard in `/wp-admin/admin.php?page=wc-admin`
- Now check the `wp-content/debug.log`, you should see messages like:
> PHP Notice:  Undefined index: items in /var/www/woo/wp-includes/rest-api.php on line 1246
- Finally apply this patch and reload the dashboard page, check that all notices are gone now.

Note: Tested with WooCommerce 4.1.x and 4.2 beta 1.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: REST API collections schema.