### PR TITLE
Inbox notification: added new placeholder and empty card

### DIFF
--- a/client/header/activity-panel/activity-card/index.js
+++ b/client/header/activity-panel/activity-card/index.js
@@ -36,9 +36,14 @@ class ActivityCard extends Component {
 				{ unread && (
 					<span className="woocommerce-activity-card__unread" />
 				) }
-				<span className="woocommerce-activity-card__icon" aria-hidden>
-					{ icon }
-				</span>
+				{ icon && (
+					<span
+						className="woocommerce-activity-card__icon"
+						aria-hidden
+					>
+						{ icon }
+					</span>
+				) }
 				<header className="woocommerce-activity-card__header">
 					<H className="woocommerce-activity-card__title">
 						{ title }

--- a/client/header/activity-panel/activity-card/style.scss
+++ b/client/header/activity-panel/activity-card/style.scss
@@ -8,15 +8,18 @@
 	border-bottom: 1px solid $core-grey-light-400;
 	color: $gray-text;
 	@include font-size( 13 );
-	display: grid;
-	grid-template-columns: 84px 1fr;
-	grid-template-areas:
-		'icon header'
-		'icon body'
-		'icon actions';
 
-	@include breakpoint( '<782px' ) {
-		grid-template-columns: 76px 1fr;
+	&:not(.woocommerce-empty-activity-card) {
+		display: grid;
+		grid-template-columns: 84px 1fr;
+		grid-template-areas:
+			'icon header'
+			'icon body'
+			'icon actions';
+
+		@include breakpoint( '<782px' ) {
+			grid-template-columns: 76px 1fr;
+		}
 	}
 }
 
@@ -51,6 +54,14 @@
 		margin: 0;
 		@include font-size( 13 );
 		order: 2;
+
+		.woocommerce-empty-activity-card & {
+			color: $dark-gray-primary;
+			@include font-size( 16 );
+			font-style: normal;
+			line-height: 24px;
+			font-weight: normal;
+		}
 	}
 
 	.woocommerce-activity-card__date {
@@ -99,6 +110,13 @@
 
 	& > p:last-child {
 		margin-bottom: 0;
+	}
+	.woocommerce-empty-activity-card & {
+		color: $medium-gray-text;
+		font-style: normal;
+		font-weight: normal;
+		@include font-size( 14 );
+		line-height: 20px;
 	}
 }
 
@@ -359,9 +377,7 @@
 }
 
 .woocommerce-empty-activity-card {
-	grid-template-columns: 72px 1fr;
-
-	@include breakpoint( '<782px' ) {
-		grid-template-columns: 64px 1fr;
-	}
+	background: $core-grey-light-200;
+	margin: 20px;
+	border-bottom: unset;
 }

--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -15,7 +15,10 @@ class ActivityHeader extends Component {
 	render() {
 		const { className, menu, subtitle, title, unreadMessages } = this.props;
 		const cardClassName = classnames(
-			subtitle ? 'woocommerce-layout__inbox-panel-header' : 'woocommerce-layout__activity-panel-header',
+			{
+				'woocommerce-layout__inbox-panel-header': subtitle,
+				'woocommerce-layout__activity-panel-header': ! subtitle,
+			},
 			className
 		);
 		const countUnread = unreadMessages ? unreadMessages : 0;
@@ -24,11 +27,7 @@ class ActivityHeader extends Component {
 			<div className={ cardClassName }>
 				<H className="woocommerce-layout__activity-panel-header-title">
 					{ title }
-					{ countUnread > 0 && (
-						<span>
-							{ unreadMessages }
-						</span>
-					) }
+					{ countUnread > 0 && <span>{ unreadMessages }</span> }
 				</H>
 				{ subtitle && (
 					<div className="woocommerce-layout__activity-panel-header-subtitle">

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -249,23 +249,8 @@ class InboxNoteCard extends Component {
 		);
 	}
 
-	render() {
-		const { lastRead, note } = this.props;
-		const { isDismissModalOpen } = this.state;
-		const {
-			actions: noteActions,
-			content,
-			date_created: dateCreated,
-			date_created_gmt: dateCreatedGmt,
-			id: noteId,
-			image,
-			layout,
-			title,
-		} = note;
-
-		if ( note.is_deleted ) {
-			return null;
-		}
+	renderActions( note ) {
+		const { actions: noteActions, id: noteId } = note;
 
 		const getButtonsFromActions = () => {
 			if ( ! noteActions ) {
@@ -280,12 +265,41 @@ class InboxNoteCard extends Component {
 			) );
 		};
 
+		const actions = getButtonsFromActions( note );
+		const actionsList = Array.isArray( actions ) ? actions : [ actions ];
+
+		return (
+			actions && (
+				<Fragment>
+					{ actionsList.map( ( item, i ) =>
+						cloneElement( item, { key: i } )
+					) }
+				</Fragment>
+			)
+		);
+	}
+
+	render() {
+		const { lastRead, note } = this.props;
+		const { isDismissModalOpen } = this.state;
+		const {
+			content,
+			date_created: dateCreated,
+			date_created_gmt: dateCreatedGmt,
+			image,
+			is_deleted: isDeleted,
+			layout,
+			title,
+		} = note;
+
+		if ( isDeleted ) {
+			return null;
+		}
+
 		const unread =
 			! lastRead ||
 			! dateCreatedGmt ||
 			new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead;
-		const actions = getButtonsFromActions( note );
-		const actionsList = Array.isArray( actions ) ? actions : [ actions ];
 		const date = dateCreated;
 		const hasImage = layout !== 'plain' && layout !== '';
 		const cardClassName = classnames( 'woocommerce-inbox-message', layout, {
@@ -320,13 +334,7 @@ class InboxNoteCard extends Component {
 							</Section>
 						</div>
 						<div className="woocommerce-inbox-message__actions">
-							{ actions && (
-								<Fragment>
-									{ actionsList.map( ( item, i ) =>
-										cloneElement( item, { key: i } )
-									) }
-								</Fragment>
-							) }
+							{ this.renderActions( note ) }
 							{ this.renderDismissButton() }
 						</div>
 					</div>

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -265,11 +265,10 @@ class InboxNoteCard extends Component {
 			) );
 		};
 
-		const actions = getButtonsFromActions( note );
-		const actionsList = Array.isArray( actions ) ? actions : [ actions ];
+		const actionsList = getButtonsFromActions( note );
 
 		return (
-			actions && (
+			actionsList && (
 				<Fragment>
 					{ actionsList.map( ( item, i ) =>
 						cloneElement( item, { key: i } )

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -246,22 +246,19 @@ class InboxNoteCard extends Component {
 
 	renderActions( note ) {
 		const { actions: noteActions, id: noteId } = note;
-
-		const getButtonsFromActions = () => {
-			if ( ! noteActions ) {
-				return [];
-			}
-			return noteActions.map( ( action, index ) => (
-				<NoteAction key={ index } noteId={ noteId } action={ action } />
-			) );
-		};
-
-		const actionsList = getButtonsFromActions( note );
-
+		if ( ! noteActions ) {
+			return [];
+		}
 		return (
-			actionsList && (
-				<Fragment>{ actionsList.map( ( action ) => action ) }</Fragment>
-			)
+			<Fragment>
+				{ noteActions.map( ( action, index ) => (
+					<NoteAction
+						key={ index }
+						noteId={ noteId }
+						action={ action }
+					/>
+				) ) }
+			</Fragment>
 		);
 	}
 

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	cloneElement,
-	Component,
-	createRef,
-	Fragment,
-} from '@wordpress/element';
+import { Component, createRef, Fragment } from '@wordpress/element';
 import { Button, Dropdown, Modal } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import VisibilitySensor from 'react-visibility-sensor';
@@ -256,12 +251,8 @@ class InboxNoteCard extends Component {
 			if ( ! noteActions ) {
 				return [];
 			}
-			return noteActions.map( ( action ) => (
-				<NoteAction
-					key={ noteId }
-					noteId={ noteId }
-					action={ action }
-				/>
+			return noteActions.map( ( action, index ) => (
+				<NoteAction key={ index } noteId={ noteId } action={ action } />
 			) );
 		};
 
@@ -269,11 +260,7 @@ class InboxNoteCard extends Component {
 
 		return (
 			actionsList && (
-				<Fragment>
-					{ actionsList.map( ( item, i ) =>
-						cloneElement( item, { key: i } )
-					) }
-				</Fragment>
+				<Fragment>{ actionsList.map( ( action ) => action ) }</Fragment>
 			)
 		);
 	}

--- a/client/header/activity-panel/panels/inbox/card.js
+++ b/client/header/activity-panel/panels/inbox/card.js
@@ -247,7 +247,7 @@ class InboxNoteCard extends Component {
 	renderActions( note ) {
 		const { actions: noteActions, id: noteId } = note;
 		if ( ! noteActions ) {
-			return [];
+			return;
 		}
 		return (
 			<Fragment>

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -69,7 +69,7 @@ class InboxPanel extends Component {
 			if ( isDismissUndoRequesting === note.id ) {
 				return (
 					<InboxNotePlaceholder
-						className={ 'banner message-is-unread' }
+						className="banner message-is-unread"
 						key={ note.id }
 					/>
 				);

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -68,6 +68,7 @@ class InboxPanel extends Component {
 				return (
 					<InboxNotePlaceholder
 						className={ 'banner message-is-unread' }
+						key={ note.id }
 					/>
 				);
 			}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import { filter, has } from 'lodash';
+import { filter } from 'lodash';
 
 /**
  * Internal dependencies
@@ -71,8 +71,7 @@ class InboxPanel extends Component {
 
 		const validNotes = filter( notes, ( note ) => {
 			const { is_deleted: isDeleted } = note;
-			const noteActive = has( note, 'is_deleted' ) ? ! isDeleted : true;
-			return noteActive;
+			return ! isDeleted;
 		} );
 		return validNotes.length > 0;
 	}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -4,14 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import Gridicon from 'gridicons';
 import { withDispatch } from '@wordpress/data';
 import { filter, has } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { ActivityCard, ActivityCardPlaceholder } from '../../activity-card';
+import { ActivityCard } from '../../activity-card';
+import InboxNotePlaceholder from './placeholder';
 import ActivityHeader from '../../activity-header';
 import InboxNoteCard from './card';
 import { EmptyContent, Section } from '@woocommerce/components';
@@ -55,7 +55,7 @@ class InboxPanel extends Component {
 			<ActivityCard
 				className="woocommerce-empty-activity-card"
 				title={ __( 'Your inbox is empty', 'woocommerce-admin' ) }
-				icon={ <Gridicon icon="checkmark" size={ 48 } /> }
+				icon={ false }
 			>
 				{ __(
 					'As things begin to happen in your store your inbox will start to fill up. ' +
@@ -66,16 +66,21 @@ class InboxPanel extends Component {
 		);
 	}
 
-	renderNotes() {
-		const { lastRead, notes } = this.props;
+	hasValidNotes() {
+		const { notes } = this.props;
 
 		const validNotes = filter( notes, ( note ) => {
 			const { is_deleted: isDeleted } = note;
 			const noteActive = has( note, 'is_deleted' ) ? ! isDeleted : true;
 			return noteActive;
 		} );
+		return validNotes.length > 0;
+	}
 
-		if ( validNotes.length === 0 ) {
+	renderNotes( hasNotes ) {
+		const { lastRead, notes } = this.props;
+
+		if ( ! hasNotes ) {
 			return this.renderEmptyCard();
 		}
 
@@ -116,26 +121,25 @@ class InboxPanel extends Component {
 			);
 		}
 
+		const hasNotes = this.hasValidNotes();
+
 		return (
 			<Fragment>
-				<ActivityHeader
-					title={ __( 'Inbox', 'woocommerce-admin' ) }
-					subtitle={ __(
-						'Insights and growth tips for your business',
-						'woocommerce-admin'
-					) }
-					unreadMessages={ this.getUnreadNotesCount() }
-				/>
+				{ ( hasNotes || isRequesting ) && (
+					<ActivityHeader
+						title={ __( 'Inbox', 'woocommerce-admin' ) }
+						subtitle={ __(
+							'Insights and growth tips for your business',
+							'woocommerce-admin'
+						) }
+						unreadMessages={ this.getUnreadNotesCount() }
+					/>
+				) }
 				<Section>
 					{ isRequesting ? (
-						<ActivityCardPlaceholder
-							className="woocommerce-inbox-activity-card"
-							hasAction
-							hasDate
-							lines={ 2 }
-						/>
+						<InboxNotePlaceholder className={ 'banner' } />
 					) : (
-						this.renderNotes()
+						this.renderNotes( hasNotes )
 					) }
 				</Section>
 			</Fragment>

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -88,9 +88,7 @@ class InboxPanel extends Component {
 		if ( isRequesting || isDismissAllUndoRequesting ) {
 			return (
 				<Section>
-					<InboxNotePlaceholder
-						className={ 'banner message-is-unread' }
-					/>
+					<InboxNotePlaceholder className="banner message-is-unread" />
 				</Section>
 			);
 		}

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -84,16 +84,6 @@ class InboxPanel extends Component {
 		} );
 	}
 
-	renderNotePlaceholder( isRequesting, isDismissAllUndoRequesting ) {
-		if ( isRequesting || isDismissAllUndoRequesting ) {
-			return (
-				<Section>
-					<InboxNotePlaceholder className="banner message-is-unread" />
-				</Section>
-			);
-		}
-	}
-
 	render() {
 		const {
 			isError,
@@ -144,9 +134,10 @@ class InboxPanel extends Component {
 						) }
 					/>
 				) }
-				{ this.renderNotePlaceholder(
-					isRequesting,
-					isDismissAllUndoRequesting
+				{ ( isRequesting || isDismissAllUndoRequesting ) && (
+					<Section>
+						<InboxNotePlaceholder className="banner message-is-unread" />
+					</Section>
 				) }
 				<Section>
 					{ ! isRequesting &&

--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -48,9 +48,14 @@ class InboxPanel extends Component {
 	}
 
 	renderNotes( hasNotes ) {
-		const { isUndoRequesting, lastRead, notes } = this.props;
+		const {
+			isDismissUndoRequesting,
+			isDismissAllUndoRequesting,
+			lastRead,
+			notes,
+		} = this.props;
 
-		if ( isUndoRequesting === 'undo-dismiss-all' ) {
+		if ( isDismissAllUndoRequesting ) {
 			return;
 		}
 
@@ -61,10 +66,7 @@ class InboxPanel extends Component {
 		const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
 		return notesArray.map( ( note ) => {
-			const showPlaceholder = isUndoRequesting
-				? isUndoRequesting === note.id
-				: false;
-			if ( showPlaceholder ) {
+			if ( isDismissUndoRequesting === note.id ) {
 				return (
 					<InboxNotePlaceholder
 						className={ 'banner message-is-unread' }
@@ -82,8 +84,8 @@ class InboxPanel extends Component {
 		} );
 	}
 
-	renderNotePlaceholder( isRequesting, isUndoRequesting ) {
-		if ( isRequesting || isUndoRequesting === 'undo-dismiss-all' ) {
+	renderNotePlaceholder( isRequesting, isDismissAllUndoRequesting ) {
+		if ( isRequesting || isDismissAllUndoRequesting ) {
 			return (
 				<Section>
 					<InboxNotePlaceholder
@@ -99,6 +101,7 @@ class InboxPanel extends Component {
 			isError,
 			isRequesting,
 			isUndoRequesting,
+			isDismissAllUndoRequesting,
 			lastRead,
 			notes,
 		} = this.props;
@@ -143,11 +146,14 @@ class InboxPanel extends Component {
 						) }
 					/>
 				) }
-				{ this.renderNotePlaceholder( isRequesting, isUndoRequesting ) }
+				{ this.renderNotePlaceholder(
+					isRequesting,
+					isDismissAllUndoRequesting
+				) }
 				<Section>
 					{ ! isRequesting &&
-						isUndoRequesting !== 'undo-dismiss-all' &&
-						this.renderNotes( hasNotes, isUndoRequesting ) }
+						! isDismissAllUndoRequesting &&
+						this.renderNotes( hasNotes ) }
 				</Section>
 			</Fragment>
 		);
@@ -161,7 +167,7 @@ export default compose(
 			getNotes,
 			getNotesError,
 			isGetNotesRequesting,
-			isUndoDismissRequesting,
+			getUndoDismissRequesting,
 		} = select( 'wc-api' );
 		const userData = getCurrentUserData();
 		const inboxQuery = {
@@ -190,13 +196,19 @@ export default compose(
 		const notes = getNotes( inboxQuery );
 		const isError = Boolean( getNotesError( inboxQuery ) );
 		const isRequesting = isGetNotesRequesting( inboxQuery );
-		const isUndoRequesting = isUndoDismissRequesting();
+		const {
+			isUndoRequesting,
+			isDismissUndoRequesting,
+			isDismissAllUndoRequesting,
+		} = getUndoDismissRequesting();
 
 		return {
 			notes,
 			isError,
 			isRequesting,
 			isUndoRequesting,
+			isDismissUndoRequesting,
+			isDismissAllUndoRequesting,
 			lastRead: userData.activity_panel_inbox_last_read,
 		};
 	} ),

--- a/client/header/activity-panel/panels/inbox/placeholder.js
+++ b/client/header/activity-panel/panels/inbox/placeholder.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+class InboxNotePlaceholder extends Component {
+	render() {
+		const { className } = this.props;
+		const cardClassName = classnames(
+			'woocommerce-inbox-message',
+			'is-placeholder',
+			className
+		);
+
+		return (
+			<div className={ cardClassName } aria-hidden>
+				<div className="woocommerce-inbox-message__image">
+					<div className="banner-block" />
+				</div>
+				<div className="woocommerce-inbox-message__wrapper">
+					<div className="woocommerce-inbox-message__content">
+						<div className="woocommerce-inbox-message__date">
+							<div className="sixth-line" />
+						</div>
+						<div className="woocommerce-inbox-message__title">
+							<div className="line" />
+							<div className="line" />
+						</div>
+						<div className="woocommerce-inbox-message__text">
+							<div className="line" />
+							<div className="third-line" />
+						</div>
+					</div>
+					<div className="woocommerce-inbox-message__actions">
+						<div className="fifth-line" />
+						<div className="fifth-line" />
+					</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+InboxNotePlaceholder.propTypes = {
+	className: PropTypes.string,
+};
+
+export default InboxNotePlaceholder;

--- a/client/header/activity-panel/panels/inbox/placeholder.js
+++ b/client/header/activity-panel/panels/inbox/placeholder.js
@@ -1,21 +1,17 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 class InboxNotePlaceholder extends Component {
 	render() {
 		const { className } = this.props;
-		const cardClassName = classnames(
-			'woocommerce-inbox-message',
-			'is-placeholder',
-			className
-		);
-
 		return (
-			<div className={ cardClassName } aria-hidden>
+			<div
+				className={ `woocommerce-inbox-message is-placeholder ${ className }` }
+				aria-hidden
+			>
 				<div className="woocommerce-inbox-message__image">
 					<div className="banner-block" />
 				</div>

--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -11,6 +11,22 @@
 		border: 1px solid $light-gray-secondary;
 		background: $studio-white;
 	}
+
+	.line {
+		width: 100%;
+	}
+
+	.third-line {
+		width: 33%;
+	}
+
+	.fifth-line {
+		width: 20%;
+	}
+
+	.sixth-line {
+		width: 16%;
+	}
 }
 
 .woocommerce-inbox-message__content {
@@ -25,6 +41,14 @@
 		.message-is-unread & {
 			font-weight: bold;
 		}
+
+		.is-placeholder & {
+			& > div {
+				@include placeholder();
+				margin: 5px 0;
+			}
+			margin-bottom: 10px;
+		}
 	}
 
 	.woocommerce-inbox-message__date {
@@ -34,6 +58,12 @@
 		font-style: normal;
 		font-weight: normal;
 		line-height: 16px;
+		.is-placeholder & {
+			& > div {
+				@include placeholder();
+			}
+			margin-bottom: 10px;
+		}
 	}
 }
 
@@ -49,6 +79,13 @@
 
 	& > p:last-child {
 		margin-bottom: 0;
+	}
+
+	.is-placeholder & {
+		& > div {
+			@include placeholder();
+			margin: 5px 0;
+		}
 	}
 }
 
@@ -87,6 +124,14 @@
 		}
 	}
 
+	.is-placeholder & {
+		& > div {
+			@include placeholder();
+			float: left;
+			height: 28px;
+			margin-right: 8px;
+		}
+	}
 }
 .woocommerce-inbox-dismiss-confirmation_modal {
 	text-align: left;
@@ -134,4 +179,17 @@
 
 .woocommerce-inbox-message__wrapper > div {
 	padding: $gap $gap-large;
+	.is-placeholder & {
+		padding: 10px 0;
+	}
+}
+
+.woocommerce-inbox-message__image {
+	.banner-block {
+		.is-placeholder & {
+			@include placeholder();
+			width: 100%;
+			height: 120px;
+		}
+	}
 }

--- a/client/header/activity-panel/panels/inbox/style.scss
+++ b/client/header/activity-panel/panels/inbox/style.scss
@@ -7,8 +7,11 @@
 	border-radius: 2px;
 	@include font-size( 13 );
 
-	&.message-is-unread {
+	&:not(.is-placeholder) {
 		border: 1px solid $light-gray-secondary;
+	}
+
+	&.message-is-unread {
 		background: $studio-white;
 	}
 
@@ -180,7 +183,8 @@
 .woocommerce-inbox-message__wrapper > div {
 	padding: $gap $gap-large;
 	.is-placeholder & {
-		padding: 10px 0;
+		padding: 10px 24px;
+		display: flow-root;
 	}
 }
 

--- a/client/header/activity-panel/panels/inbox/utils.js
+++ b/client/header/activity-panel/panels/inbox/utils.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
+ * Get the count of the unread notes.
+ *
+ * @param {Array} notes - List of notes, contains read and unread notes.
+ * @param {number} lastRead - The timestamp that the user read a note.
+ * @return {number} - Unread notes count.
+ */
+export function getUnreadNotesCount( notes, lastRead ) {
+	const unreadNotes = filter( notes, ( note ) => {
+		const {
+			is_deleted: isDeleted,
+			date_created_gmt: dateCreatedGmt,
+		} = note;
+		if ( ! isDeleted ) {
+			return (
+				! lastRead ||
+				! dateCreatedGmt ||
+				new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead
+			);
+		}
+	} );
+	return unreadNotes.length;
+}
+
+/**
+ * Verifies if there are any valid notes in the list.
+ *
+ * @param {Array} notes - List of notes, contains read and unread notes.
+ * @return {boolean} - Whether there are valid notes or not.
+ */
+export function hasValidNotes( notes ) {
+	const validNotes = filter( notes, ( note ) => {
+		const { is_deleted: isDeleted } = note;
+		return ! isDeleted;
+	} );
+	return validNotes.length > 0;
+}

--- a/client/wc-api/notes/selectors.js
+++ b/client/wc-api/notes/selectors.js
@@ -37,8 +37,19 @@ const isGetNotesRequesting = ( getResource ) => ( query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
+const isUndoDismissRequesting = ( getResource ) => () => {
+	const resourceName = 'note-undo-dismiss';
+	const { note, requesting } = getResource( resourceName );
+
+	if ( requesting ) {
+		return note;
+	}
+	return false;
+};
+
 export default {
 	getNotes,
 	getNotesError,
 	isGetNotesRequesting,
+	isUndoDismissRequesting,
 };

--- a/client/wc-api/notes/selectors.js
+++ b/client/wc-api/notes/selectors.js
@@ -37,19 +37,14 @@ const isGetNotesRequesting = ( getResource ) => ( query = {} ) => {
 	return lastRequested > lastReceived;
 };
 
-const isUndoDismissRequesting = ( getResource ) => () => {
+const getUndoDismissRequesting = ( getResource ) => () => {
 	const resourceName = 'note-undo-dismiss';
-	const { note, requesting } = getResource( resourceName );
-
-	if ( requesting ) {
-		return note;
-	}
-	return false;
+	return getResource( resourceName );
 };
 
 export default {
 	getNotes,
 	getNotesError,
 	isGetNotesRequesting,
-	isUndoDismissRequesting,
+	getUndoDismissRequesting,
 };


### PR DESCRIPTION
Fixes #partially-4099

This PR adds:
- The new designs for the inbox panel when it's empty
- The new design for the placeholder when the inbox notification list is loading in the inbox panel.


_[Here](https://woostartp2.wordpress.com/2020/04/09/home-screen-mvp-i2/) are the designs_:

> **_NOTE:_**  As this is a part of a big functionality this branch will be merged with the branch `add/4099`, and it will be that branch that will be merged with `master`.
To make the code reviewing easier, this PR only has the code referring to the functionality described in the title.
If you want to test everything together, all the changes are merged in the branch: `add/4099_test_branch`.

### Detailed test instructions:

- Press the `Inbox` button in the navbar to open the inbox notifications.
- Verify that while loading the new loading placeholder is visible
![screenshot-loading](https://user-images.githubusercontent.com/1314156/81985479-b2b1eb80-960c-11ea-97ed-01900e24854d.png)

- Delete all the inbox messages.
- Verify that the new design for the empty inbox message list in the inbox panel is visible.
![screenshot-empty](https://user-images.githubusercontent.com/1314156/81985436-a594fc80-960c-11ea-878a-5356f40783ef.png)


### Update
After dismissing an item and `undoing` the dismiss, a placeholder should appear while the item is being undismissed.
When undoing `Dismiss all` only the placeholder will be visible.
It will look like this:

![Screen Capture on 2020-05-26 at 19-36-36](https://user-images.githubusercontent.com/1314156/82956977-6362a800-9f88-11ea-8e8c-b38b0e6c03c2.gif)


### Changelog Note:
Enhancement: added new placeholder and empty card to the inbox notifications panel
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
