### PR TITLE
Connect to Jetpack on the benefits OBW page

### DIFF
--- a/client/dashboard/components/connect/index.js
+++ b/client/dashboard/components/connect/index.js
@@ -1,0 +1,193 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import PropTypes from 'prop-types';
+import { withDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import withSelect from 'wc-api/with-select';
+
+class Connect extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.connectJetpack = this.connectJetpack.bind( this );
+		props.setIsPending( true );
+	}
+
+	componentDidMount() {
+		const { autoConnect, jetpackConnectUrl } = this.props;
+
+		if ( autoConnect && jetpackConnectUrl ) {
+			this.connectJetpack();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const {
+			autoConnect,
+			createNotice,
+			error,
+			isRequesting,
+			jetpackConnectUrl,
+			onError,
+			setIsPending,
+		} = this.props;
+
+		if ( prevProps.isRequesting && ! isRequesting ) {
+			setIsPending( false );
+		}
+
+		if ( error && error !== prevProps.error ) {
+			if ( onError ) {
+				onError();
+			}
+			createNotice( 'error', error );
+		}
+
+		if ( autoConnect && jetpackConnectUrl ) {
+			this.connectJetpack();
+		}
+	}
+
+	async connectJetpack() {
+		const { jetpackConnectUrl, onConnect } = this.props;
+
+		if ( onConnect ) {
+			onConnect();
+		}
+		window.location = jetpackConnectUrl;
+	}
+
+	render() {
+		const {
+			autoConnect,
+			hasErrors,
+			isRequesting,
+			onSkip,
+			skipText,
+		} = this.props;
+
+		if ( autoConnect ) {
+			return null;
+		}
+
+		return (
+			<Fragment>
+				{ hasErrors ? (
+					<Button
+						isPrimary
+						onClick={ () => window.location.reload() }
+					>
+						{ __( 'Retry', 'woocommerce-admin' ) }
+					</Button>
+				) : (
+					<Button
+						disabled={ isRequesting }
+						isPrimary
+						onClick={ this.connectJetpack }
+					>
+						{ __( 'Connect', 'woocommerce-admin' ) }
+					</Button>
+				) }
+				{ onSkip && (
+					<Button onClick={ onSkip }>
+						{ skipText || __( 'No thanks', 'woocommerce-admin' ) }
+					</Button>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+Connect.propTypes = {
+	/**
+	 * If connection should happen automatically, or requires user confirmation.
+	 */
+	autoConnect: PropTypes.bool,
+	/**
+	 * Method to create a displayed notice.
+	 */
+	createNotice: PropTypes.func.isRequired,
+	/**
+	 * Human readable error message.
+	 */
+	error: PropTypes.string,
+	/**
+	 * Bool to determine if the "Retry" button should be displayed.
+	 */
+	hasErrors: PropTypes.bool,
+	/**
+	 * Bool to check if the connection URL is still being requested.
+	 */
+	isRequesting: PropTypes.bool,
+	/**
+	 * Generated Jetpack connection URL.
+	 */
+	jetpackConnectUrl: PropTypes.string,
+	/**
+	 * Called before the redirect to Jetpack.
+	 */
+	onConnect: PropTypes.func,
+	/**
+	 * Called when the plugin has an error retrieving the jetpackConnectUrl.
+	 */
+	onError: PropTypes.func,
+	/**
+	 * Called when the plugin connection is skipped.
+	 */
+	onSkip: PropTypes.func,
+	/**
+	 * Redirect URL to encode as a URL param for the connection path.
+	 */
+	redirectUrl: PropTypes.string,
+	/**
+	 * Text used for the skip connection button.
+	 */
+	skipText: PropTypes.string,
+	/**
+	 * Control the `isPending` logic of the parent containing the Stepper.
+	 */
+	setIsPending: PropTypes.func,
+};
+
+Connect.defaultProps = {
+	autoConnect: false,
+	setIsPending: () => {},
+};
+
+export default compose(
+	withSelect( ( select, props ) => {
+		const {
+			getJetpackConnectUrl,
+			isGetJetpackConnectUrlRequesting,
+			getJetpackConnectUrlError,
+		} = select( 'wc-api' );
+
+		const queryArgs = {
+			redirect_url: props.redirectUrl || window.location.href,
+		};
+		const isRequesting = isGetJetpackConnectUrlRequesting();
+		const error = getJetpackConnectUrlError() || '';
+		const jetpackConnectUrl = getJetpackConnectUrl( queryArgs );
+
+		return {
+			error,
+			isRequesting,
+			jetpackConnectUrl,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { createNotice } = dispatch( 'core/notices' );
+
+		return {
+			createNotice,
+		};
+	} )
+)( Connect );

--- a/client/dashboard/profile-wizard/steps/benefits/index.js
+++ b/client/dashboard/profile-wizard/steps/benefits/index.js
@@ -12,24 +12,27 @@ import { filter } from 'lodash';
  * WooCommerce dependencies
  */
 import { Card, H } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
  */
+import Connect from 'dashboard/components/connect';
 import Logo from './logo';
 import ManagementIcon from './images/management';
-import Plugins from 'dashboard/task-list/tasks/steps/plugins';
 import SalesTaxIcon from './images/sales_tax';
 import ShippingLabels from './images/shipping_labels';
 import SpeedIcon from './images/speed';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
 import { pluginNames } from 'wc-api/onboarding/constants';
+import Plugins from '../../../task-list/tasks/steps/plugins';
 
 class Benefits extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
+			isConnecting: false,
 			isInstalling: false,
 			isPending: false,
 		};
@@ -46,18 +49,42 @@ class Benefits extends Component {
 			this.pluginsToInstall.push( 'woocommerce-services' );
 		}
 
+		recordEvent( 'storeprofiler_plugins_to_install', {
+			plugins: this.pluginsToInstall,
+		} );
+
 		this.startPluginInstall = this.startPluginInstall.bind( this );
 		this.skipPluginInstall = this.skipPluginInstall.bind( this );
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		const { goToNextStep, isRequesting } = this.props;
+		const {
+			activePlugins,
+			goToNextStep,
+			isJetpackConnected,
+			isRequesting,
+		} = this.props;
 		const { isInstalling, isPending } = this.state;
 
+		// Installation and requests are complete, begin Jetpack connection.
 		if (
-			isPending &&
-			! isRequesting && ! isInstalling &&
-			( prevProps.isRequesting || prevState.isInstalling )
+			! isInstalling &&
+			! isRequesting &&
+			( prevState.isInstalling || prevState.isRequesting ) &&
+			activePlugins.includes( 'jetpack' )
+		) {
+			if ( ! isJetpackConnected ) {
+				this.setState( { isConnecting: true } );
+			} else {
+				this.setState( { isPending: false } );
+			}
+		}
+
+		// No longer pending or update profile items, go to next step.
+		if (
+			! isPending &&
+			! isRequesting &&
+			( prevState.isPending || prevState.isRequesting )
 		) {
 			goToNextStep();
 		}
@@ -186,7 +213,7 @@ class Benefits extends Component {
 	}
 
 	render() {
-		const { isInstalling, isPending } = this.state;
+		const { isConnecting, isInstalling, isPending } = this.state;
 
 		const pluginNamesString = this.pluginsToInstall
 			.map( ( pluginSlug ) => pluginNames[ pluginSlug ] )
@@ -207,7 +234,7 @@ class Benefits extends Component {
 				<div className="woocommerce-profile-wizard__card-actions">
 					<Button
 						isPrimary
-						isBusy={ isPending && isInstalling }
+						isBusy={ isPending && ( isInstalling || isConnecting ) }
 						disabled={ isPending }
 						onClick={ this.startPluginInstall }
 						className="woocommerce-profile-wizard__continue"
@@ -216,7 +243,7 @@ class Benefits extends Component {
 					</Button>
 					<Button
 						isDefault
-						isBusy={ isPending && ! isInstalling }
+						isBusy={ isPending && ! isInstalling && ! isConnecting }
 						disabled={ isPending }
 						className="woocommerce-profile-wizard__skip"
 						onClick={ this.skipPluginInstall }
@@ -231,9 +258,26 @@ class Benefits extends Component {
 								this.setState( { isInstalling: false } )
 							}
 							onError={ () =>
-								this.setState( { isInstalling: false } )
+								this.setState( { isPending: false } )
 							}
 							pluginSlugs={ this.pluginsToInstall }
+						/>
+					) }
+
+					{ isConnecting && (
+						<Connect
+							autoConnect
+							onConnect={ () => {
+								recordEvent(
+									'storeprofiler_jetpack_connect_redirect'
+								);
+							} }
+							onError={ () =>
+								this.setState( { isPending: false } )
+							}
+							redirectUrl={ getAdminLink(
+								'admin.php?page=wc-admin&reset_profiler=0'
+							) }
 						/>
 					) }
 				</div>
@@ -262,9 +306,10 @@ export default compose(
 	withSelect( ( select ) => {
 		const {
 			getProfileItemsError,
-			getActivePlugins,
 			getProfileItems,
 			isGetProfileItemsRequesting,
+			getActivePlugins,
+			isJetpackConnected,
 		} = select( 'wc-api' );
 
 		const isProfileItemsError = Boolean( getProfileItemsError() );
@@ -275,6 +320,7 @@ export default compose(
 			activePlugins,
 			isProfileItemsError,
 			profileItems,
+			isJetpackConnected: isJetpackConnected(),
 			isRequesting: isGetProfileItemsRequesting(),
 		};
 	} ),


### PR DESCRIPTION
This is based on #4374 but ported back to `release/1.1.1` as #4374 uses the new data store stuff that has been added to master since the 1.1.1 branch was cut.

### Detailed test instructions:

- Deactivate Jetpack
- Go through the OBW
- Make sure you select Yes please on the benefits step
- It should activate Jetpack then redirect to the JP setup page
- Once you connect to JP it should redirect to the WC dashboard (if you're on a public server)