### PR TITLE
Separate Jetpack connection logic in shipping task

### DIFF
--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -145,23 +145,26 @@ class Shipping extends Component {
 	}
 
 	getPluginsToActivate() {
-		const { countryCode, isJetpackConnected } = this.props;
+		const { countryCode } = this.props;
 
 		const plugins = [];
 		if ( [ 'GB', 'CA', 'AU' ].includes( countryCode ) ) {
 			plugins.push( 'woocommerce-shipstation-integration' );
 		} else if ( countryCode === 'US' ) {
 			plugins.push( 'woocommerce-services' );
-
-			if ( ! isJetpackConnected ) {
-				plugins.push( 'jetpack' );
-			}
+			plugins.push( 'jetpack' );
 		}
 		return difference( plugins, this.activePlugins );
 	}
 
 	getSteps() {
+		const { activePlugins, countryCode, isJetpackConnected } = this.props;
 		const pluginsToActivate = this.getPluginsToActivate();
+		// This requirement may change dynamically, so don't use cached plugins array.
+		const requiresJetpackConnection =
+			! isJetpackConnected &&
+			countryCode === 'US' &&
+			activePlugins.includes( 'jetpack' );
 
 		const steps = [
 			{
@@ -197,7 +200,8 @@ class Shipping extends Component {
 				content: (
 					<ShippingRates
 						buttonText={
-							pluginsToActivate.length
+							pluginsToActivate.length ||
+							requiresJetpackConnection
 								? __( 'Proceed', 'woocommerce-admin' )
 								: __( 'Complete task', 'woocommerce-admin' )
 						}
@@ -279,7 +283,9 @@ class Shipping extends Component {
 						} }
 					/>
 				),
-				visible: pluginsToActivate.includes( 'jetpack' ),
+				visible:
+					! pluginsToActivate.includes( 'jetpack' ) &&
+					requiresJetpackConnection,
 			},
 		];
 

--- a/client/dashboard/task-list/tasks/shipping/index.js
+++ b/client/dashboard/task-list/tasks/shipping/index.js
@@ -158,13 +158,10 @@ class Shipping extends Component {
 	}
 
 	getSteps() {
-		const { activePlugins, countryCode, isJetpackConnected } = this.props;
+		const { countryCode, isJetpackConnected } = this.props;
 		const pluginsToActivate = this.getPluginsToActivate();
-		// This requirement may change dynamically, so don't use cached plugins array.
 		const requiresJetpackConnection =
-			! isJetpackConnected &&
-			countryCode === 'US' &&
-			activePlugins.includes( 'jetpack' );
+			! isJetpackConnected && countryCode === 'US';
 
 		const steps = [
 			{
@@ -283,9 +280,7 @@ class Shipping extends Component {
 						} }
 					/>
 				),
-				visible:
-					! pluginsToActivate.includes( 'jetpack' ) &&
-					requiresJetpackConnection,
+				visible: requiresJetpackConnection,
 			},
 		];
 


### PR DESCRIPTION
Fixes #4372 

Fixes a regression where the Jetpack connection step was not shown if Jetpack was already active.

### Screenshots
<img width="462" alt="Screen Shot 2020-05-15 at 3 34 35 PM" src="https://user-images.githubusercontent.com/10561050/82052245-ff0c3280-96c3-11ea-959c-7e0605df6981.png">


### Detailed test instructions:

Test the following scenarios:
1. No Jetpack installed/activated - should show plugins and connect step should be shown after activating Jetpack.
1. Jetpack and WCS active but not connected - should show the connect step, but no plugins step.
1. Jetpack and WCS active and connected - should not show the connect or plugins steps.
1. Jetpack active and connected, but WCS not active - should install WCS but not show connect step.
1. Jetpack not connected or active in non-US store - should not install Jetpack or WCS and should not show connect step, but should install `woocommerce-shipstation-integration` if not active.