### PR TITLE
Inbox notification: add client unit tests

### DIFF
--- a/client/header/activity-panel/panels/inbox/test/index.js
+++ b/client/header/activity-panel/panels/inbox/test/index.js
@@ -7,6 +7,7 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import InboxNoteCard from '../card';
+import { getUnreadNotesCount, hasValidNotes } from '../utils';
 
 describe( 'InboxNoteCard', () => {
 	const note = {
@@ -31,6 +32,7 @@ describe( 'InboxNoteCard', () => {
 		layout: 'plain',
 		image: '',
 		date_created_gmt: '2020-05-10T16:57:31',
+		is_deleted: false,
 	};
 	const lastRead = 1589285995243;
 
@@ -140,5 +142,66 @@ describe( 'InboxNoteCard', () => {
 			}
 		);
 		expect( card.children() ).toHaveLength( 0 );
+	} );
+} );
+
+const notes = [
+	{
+		id: 1,
+		date_created_gmt: '2019-05-10T16:57:31',
+		is_deleted: false,
+	},
+	{
+		id: 2,
+		date_created_gmt: '2020-05-12T16:57:31',
+		is_deleted: false,
+	},
+	{
+		id: 3,
+		date_created_gmt: '2020-05-14T16:57:31',
+		is_deleted: false,
+	},
+	{
+		id: 4,
+		date_created_gmt: '2020-05-15T16:57:31',
+		is_deleted: false,
+	},
+];
+
+describe( 'getUnreadNotesCount', () => {
+	const lastRead = 1589285995243;
+
+	test( 'should return 3, 1 of the notes was read', () => {
+		const unreadCount = getUnreadNotesCount( notes, lastRead );
+		expect( unreadCount ).toEqual( 3 );
+	} );
+
+	test( 'should return 2, 1 of the notes was read and 1 is deleted', () => {
+		notes[ 3 ].is_deleted = true;
+		const unreadCount = getUnreadNotesCount( notes, lastRead );
+		expect( unreadCount ).toEqual( 2 );
+	} );
+
+	test( 'should return 1, 2 of the notes were read and 1 is deleted', () => {
+		notes[ 1 ].date_created_gmt = '2020-05-05T16:57:31';
+		const unreadCount = getUnreadNotesCount( notes, lastRead );
+		expect( unreadCount ).toEqual( 1 );
+	} );
+
+	test( 'should return 0, 2 of the notes were read and 2 are deleted', () => {
+		notes[ 2 ].is_deleted = true;
+		const unreadCount = getUnreadNotesCount( notes, lastRead );
+		expect( unreadCount ).toEqual( 0 );
+	} );
+} );
+
+describe( 'hasValidNotes', () => {
+	test( 'should return true, 2 notes are deleted', () => {
+		expect( hasValidNotes( notes ) ).toBeTruthy();
+	} );
+	test( 'should return false, 4 notes are deleted', () => {
+		notes[ 0 ].is_deleted = true;
+		notes[ 3 ].is_deleted = true;
+		expect( hasValidNotes( notes ) ).toBeTruthy();
 	} );
 } );

--- a/client/header/activity-panel/panels/inbox/test/index.js
+++ b/client/header/activity-panel/panels/inbox/test/index.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import InboxNoteCard from '../card';
+
+describe( 'InboxNoteCard', () => {
+	const note = {
+		id: 1,
+		name: 'wc-admin-wc-helper-connection',
+		type: 'info',
+		title: 'Connect to WooCommerce.com',
+		content: 'Connect to get important product notifications and updates.',
+		status: 'unactioned',
+		date_created: '2020-05-10T16:57:31',
+		actions: [
+			{
+				id: 1,
+				name: 'connect',
+				label: 'Connect',
+				query: '',
+				status: 'unactioned',
+				primary: false,
+				url: 'http://test.com',
+			},
+		],
+		layout: 'plain',
+		image: '',
+		date_created_gmt: '2020-05-10T16:57:31',
+	};
+	const lastRead = 1589285995243;
+
+	test( 'should render a notification type banner', () => {
+		note.layout = 'banner';
+		const card = shallow(
+			<InboxNoteCard
+				key={ note.id }
+				note={ note }
+				lastRead={ lastRead }
+			/>,
+			{
+				disableLifecycleMethods: true,
+			}
+		);
+		const noteBanner = card.find( '.banner' );
+		expect( noteBanner ).toHaveLength( 1 );
+	} );
+
+	test( 'should render a notification type thumbnail', () => {
+		note.layout = 'thumbnail';
+		const card = shallow(
+			<InboxNoteCard
+				key={ note.id }
+				note={ note }
+				lastRead={ lastRead }
+			/>,
+			{
+				disableLifecycleMethods: true,
+			}
+		);
+		const noteThumbnail = card.find( '.thumbnail' );
+		expect( noteThumbnail ).toHaveLength( 1 );
+	} );
+
+	test( 'should render one action and the Dismiss button', () => {
+		const card = shallow(
+			<InboxNoteCard
+				key={ note.id }
+				note={ note }
+				lastRead={ lastRead }
+			/>,
+			{
+				disableLifecycleMethods: true,
+			}
+		);
+		const actionButtons = card.find(
+			'.woocommerce-inbox-message__actions'
+		);
+		const buttonList = actionButtons.children();
+		const dismissButton = card.find( 'Dropdown' ).dive();
+
+		expect( buttonList ).toHaveLength( 2 );
+		expect(
+			actionButtons.text().includes( 'InboxNoteAction' )
+		).toBeTruthy();
+		expect( dismissButton.find( 'ForwardRef(Button)' ).text() ).toEqual(
+			'Dismiss'
+		);
+	} );
+
+	test( 'should render only a Dismiss button', () => {
+		note.actions = [];
+		const card = shallow(
+			<InboxNoteCard
+				key={ note.id }
+				note={ note }
+				lastRead={ lastRead }
+			/>,
+			{
+				disableLifecycleMethods: true,
+			}
+		);
+		const dismissButton = card.find( 'Dropdown' ).dive();
+		expect( dismissButton.find( 'ForwardRef(Button)' ).text() ).toEqual(
+			'Dismiss'
+		);
+	} );
+
+	test( 'should render an unread notification', () => {
+		const olderLastRead = 1584015595000;
+		note.actions = [];
+		const card = shallow(
+			<InboxNoteCard
+				key={ note.id }
+				note={ note }
+				lastRead={ olderLastRead }
+			/>,
+			{
+				disableLifecycleMethods: true,
+			}
+		);
+		const unreadNote = card.find( '.message-is-unread' );
+		expect( unreadNote ).toHaveLength( 1 );
+	} );
+
+	test( 'should not render any notification', () => {
+		note.is_deleted = true;
+		const card = shallow(
+			<InboxNoteCard
+				key={ note.id }
+				note={ note }
+				lastRead={ lastRead }
+			/>,
+			{
+				disableLifecycleMethods: true,
+			}
+		);
+		expect( card.children() ).toHaveLength( 0 );
+	} );
+} );

--- a/client/header/activity-panel/panels/inbox/test/index.js
+++ b/client/header/activity-panel/panels/inbox/test/index.js
@@ -60,10 +60,7 @@ describe( 'InboxNoteCard', () => {
 				key={ note.id }
 				note={ note }
 				lastRead={ lastRead }
-			/>,
-			{
-				disableLifecycleMethods: true,
-			}
+			/>
 		);
 		const listNoteWithThumbnail = container.querySelector( '.thumbnail' );
 		expect( listNoteWithThumbnail ).not.toBeNull();

--- a/client/header/activity-panel/panels/inbox/test/index.js
+++ b/client/header/activity-panel/panels/inbox/test/index.js
@@ -1,13 +1,17 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import InboxNoteCard from '../card';
 import { getUnreadNotesCount, hasValidNotes } from '../utils';
+
+jest.mock( '../action', () =>
+	jest.fn().mockImplementation( () => <button>mocked button</button> )
+);
 
 describe( 'InboxNoteCard', () => {
 	const note = {
@@ -38,23 +42,20 @@ describe( 'InboxNoteCard', () => {
 
 	test( 'should render a notification type banner', () => {
 		note.layout = 'banner';
-		const card = shallow(
+		const { container } = render(
 			<InboxNoteCard
 				key={ note.id }
 				note={ note }
 				lastRead={ lastRead }
-			/>,
-			{
-				disableLifecycleMethods: true,
-			}
+			/>
 		);
-		const noteBanner = card.find( '.banner' );
-		expect( noteBanner ).toHaveLength( 1 );
+		const listNoteWithBanner = container.querySelector( '.banner' );
+		expect( listNoteWithBanner ).not.toBeNull();
 	} );
 
 	test( 'should render a notification type thumbnail', () => {
 		note.layout = 'thumbnail';
-		const card = shallow(
+		const { container } = render(
 			<InboxNoteCard
 				key={ note.id }
 				note={ note }
@@ -64,84 +65,54 @@ describe( 'InboxNoteCard', () => {
 				disableLifecycleMethods: true,
 			}
 		);
-		const noteThumbnail = card.find( '.thumbnail' );
-		expect( noteThumbnail ).toHaveLength( 1 );
+		const listNoteWithThumbnail = container.querySelector( '.thumbnail' );
+		expect( listNoteWithThumbnail ).not.toBeNull();
 	} );
 
-	test( 'should render one action and the Dismiss button', () => {
-		const card = shallow(
-			<InboxNoteCard
-				key={ note.id }
-				note={ note }
-				lastRead={ lastRead }
-			/>,
-			{
-				disableLifecycleMethods: true,
-			}
-		);
-		const actionButtons = card.find(
-			'.woocommerce-inbox-message__actions'
-		);
-		const buttonList = actionButtons.children();
-		const dismissButton = card.find( 'Dropdown' ).dive();
-
-		expect( buttonList ).toHaveLength( 2 );
-		expect(
-			actionButtons.text().includes( 'InboxNoteAction' )
-		).toBeTruthy();
-		expect( dismissButton.find( 'ForwardRef(Button)' ).text() ).toEqual(
-			'Dismiss'
-		);
-	} );
-
-	test( 'should render only a Dismiss button', () => {
+	test( 'should render a read notification', () => {
 		note.actions = [];
-		const card = shallow(
+		const { container } = render(
 			<InboxNoteCard
 				key={ note.id }
 				note={ note }
 				lastRead={ lastRead }
-			/>,
-			{
-				disableLifecycleMethods: true,
-			}
+			/>
 		);
-		const dismissButton = card.find( 'Dropdown' ).dive();
-		expect( dismissButton.find( 'ForwardRef(Button)' ).text() ).toEqual(
-			'Dismiss'
+		const unreadNote = container.querySelector( '.message-is-unread' );
+		const readNote = container.querySelector(
+			'.woocommerce-inbox-message'
 		);
+		expect( unreadNote ).toBeNull();
+		expect( readNote ).not.toBeNull();
 	} );
 
 	test( 'should render an unread notification', () => {
 		const olderLastRead = 1584015595000;
 		note.actions = [];
-		const card = shallow(
+		const { container } = render(
 			<InboxNoteCard
 				key={ note.id }
 				note={ note }
 				lastRead={ olderLastRead }
-			/>,
-			{
-				disableLifecycleMethods: true,
-			}
+			/>
 		);
-		const unreadNote = card.find( '.message-is-unread' );
-		expect( unreadNote ).toHaveLength( 1 );
+		const unreadNote = container.querySelector( '.message-is-unread' );
+		expect( unreadNote ).not.toBeNull();
 	} );
 
 	test( 'should not render any notification', () => {
 		note.is_deleted = true;
-		const card = shallow(
+		const { container } = render(
 			<InboxNoteCard
 				key={ note.id }
 				note={ note }
 				lastRead={ lastRead }
-			/>,
-			{
-				disableLifecycleMethods: true,
-			}
+			/>
 		);
-		expect( card.children() ).toHaveLength( 0 );
+		const unreadNote = container.querySelector(
+			'.woocommerce-inbox-message'
+		);
+		expect( unreadNote ).toBeNull();
 	} );
 } );
 

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -351,7 +351,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test undiong a single note delete.
+	 * Test undoing a single note delete.
 	 */
 	public function test_undo_single_notes_delete() {
 		wp_set_current_user( $this->user );


### PR DESCRIPTION
Fixes #partially-4099

This PR adds:
- Unit tests on client-side.


> **_NOTE:_**  As this is a part of a big functionality this branch will be merged with the branch `add/4099`, and it will be that branch that will be merged with `master`.
To make the code reviewing easier, this PR only has the code referring to the functionality described in the title.
If you want to test everything together, all the changes are merged in the branch: `add/4099_test_branch`.

### Detailed test instructions:

- Run unit tests: `npm run test`
- Verify there aren't errors.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: Added client unit tests to inbox notifications.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
