### PR TITLE
make revenue total sales column optional

### DIFF
--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -100,7 +100,7 @@ class RevenueReportTable extends Component {
 			{
 				label: __( 'Total Sales', 'woocommerce-admin' ),
 				key: 'total_sales',
-				required: true,
+				required: false,
 				isSortable: true,
 				isNumeric: true,
 			},


### PR DESCRIPTION
In Canada, businesses that charge sales tax collect GST/HST which is a net zero tax for the business. The business both pays GST/HST on inventory and service purchases and charges it to customers. 

On a monthly basis, businesses file GST/HST returns to remit or request a refund on the difference between the tax paid and collected. Because the net tax is always zero, it does not appear elsewhere in the businesses financials.

This PR changes the settings on the column to allow it to be toggled off on the revenue table.

### Detailed test instructions:

- Check that the `Total Sales` column on the Revenue report can be toggled off.

### Changelog Note:

Tweak: make revenue report total sales column optional.