### PR TITLE
Handle multiple plugin installs in a single request

### DIFF
--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -76,6 +76,7 @@ export class Plugins extends Component {
 		Object.keys( errors ).forEach( ( plugin ) => {
 			createNotice(
 				'error',
+				// Replace the slug with a plugin name if a constant exists.
 				pluginNames[ plugin ]
 					? errors[ plugin ][ 0 ].replace(
 							`\`${ plugin }\``,
@@ -108,12 +109,12 @@ export class Plugins extends Component {
 
 	render() {
 		const {
-			hasErrors,
 			isRequesting,
 			skipText,
 			autoInstall,
 			pluginSlugs,
 		} = this.props;
+		const { hasErrors } = this.state;
 
 		if ( hasErrors ) {
 			return (

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -12,6 +12,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
  * WooCommerce dependencies
  */
 import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+import { pluginNames } from 'wc-api/onboarding/constants';
 
 export class Plugins extends Component {
 	constructor() {
@@ -54,26 +55,31 @@ export class Plugins extends Component {
 
 		const installs = await installPlugins( pluginSlugs );
 
-		if ( installs.errors && Object.keys( installs.errors ).length ) {
-			this.handleErrors( installs.errors );
+		if ( installs.errors && Object.keys( installs.errors.errors ).length ) {
+			this.handleErrors( installs.errors.errors );
 			return;
 		}
 
 		const activations = await activatePlugins( pluginSlugs );
 
-		if ( activations.status === 'success' ) {
+		if ( activations.success ) {
 			this.handleSuccess( activations.activePlugins );
 			return;
 		}
 
-		this.handleErrors( activations );
+		this.handleErrors( activations.errors.errors );
 	}
 
 	handleErrors( errors ) {
 		const { onError, createNotice } = this.props;
 
-		Object.keys( errors ).forEach( ( error ) => {
-			createNotice( 'error', errors[ error ] );
+		Object.keys( errors ).forEach( ( plugin ) => {
+			createNotice(
+				'error',
+				pluginNames[ plugin ]
+					? errors[ plugin ][0].replace( `\`${plugin}\``, pluginNames[ plugin ] )
+					: errors[ plugin ][0]
+			);
 		} );
 
 		this.setState( { hasErrors: true } );

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -62,8 +62,8 @@ export class Plugins extends Component {
 
 		const activations = await activatePlugins( pluginSlugs );
 
-		if ( activations.success ) {
-			this.handleSuccess( activations.activePlugins );
+		if ( activations.success && activations.data.activated ) {
+			this.handleSuccess( activations.data.activated );
 			return;
 		}
 
@@ -77,8 +77,11 @@ export class Plugins extends Component {
 			createNotice(
 				'error',
 				pluginNames[ plugin ]
-					? errors[ plugin ][0].replace( `\`${plugin}\``, pluginNames[ plugin ] )
-					: errors[ plugin ][0]
+					? errors[ plugin ][ 0 ].replace(
+							`\`${ plugin }\``,
+							pluginNames[ plugin ]
+					  )
+					: errors[ plugin ][ 0 ]
 			);
 		} );
 

--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -42,7 +42,7 @@ export class Plugins extends Component {
 
 		const {
 			isRequesting,
-			installPlugin,
+			installPlugins,
 			activatePlugins,
 			pluginSlugs,
 		} = this.props;
@@ -52,18 +52,10 @@ export class Plugins extends Component {
 			return false;
 		}
 
-		const installs = await Promise.all(
-			pluginSlugs.map( async ( slug ) => {
-				return await installPlugin( slug );
-			} )
-		);
+		const installs = await installPlugins( pluginSlugs );
 
-		const installErrors = installs.filter(
-			( install ) => install.status !== 'success'
-		);
-
-		if ( installErrors.length ) {
-			this.handleErrors( installErrors );
+		if ( installs.errors && Object.keys( installs.errors ).length ) {
+			this.handleErrors( installs.errors );
 			return;
 		}
 
@@ -80,8 +72,8 @@ export class Plugins extends Component {
 	handleErrors( errors ) {
 		const { onError, createNotice } = this.props;
 
-		errors.forEach( ( error ) => {
-			createNotice( 'error', error );
+		Object.keys( errors ).forEach( ( error ) => {
+			createNotice( 'error', errors[ error ] );
 		} );
 
 		this.setState( { hasErrors: true } );
@@ -209,7 +201,7 @@ export default compose(
 
 		const isRequesting =
 			isPluginsRequesting( 'activatePlugins' ) ||
-			isPluginsRequesting( 'installPlugin' );
+			isPluginsRequesting( 'installPlugins' );
 
 		return {
 			isRequesting,
@@ -219,14 +211,14 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { createNotice } = dispatch( 'core/notices' );
-		const { activatePlugins, installPlugin } = dispatch(
+		const { activatePlugins, installPlugins } = dispatch(
 			PLUGINS_STORE_NAME
 		);
 
 		return {
 			activatePlugins,
 			createNotice,
-			installPlugin,
+			installPlugins,
 		};
 	} )
 )( Plugins );

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -46,12 +46,14 @@ describe( 'Rendering', () => {
 
 describe( 'Installing and activating', () => {
 	let pluginsWrapper;
-	const installPlugin = jest.fn().mockReturnValue( {
-		status: 'success',
+	const installPlugins = jest.fn().mockReturnValue( {
+		success: true,
 	} );
 	const activatePlugins = jest.fn().mockReturnValue( {
-		status: 'success',
-		activePlugins: [ 'jetpack' ],
+		success: true,
+		data: {
+			activated: [ 'jetpack' ],
+		},
 	} );
 	const createNotice = jest.fn();
 	const onComplete = jest.fn();
@@ -61,18 +63,18 @@ describe( 'Installing and activating', () => {
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
 				onComplete={ onComplete }
-				installPlugin={ installPlugin }
+				installPlugins={ installPlugins }
 				activatePlugins={ activatePlugins }
 				createNotice={ createNotice }
 			/>
 		);
 	} );
 
-	it( 'should call installPlugin', async () => {
+	it( 'should call installPlugins', async () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		expect( installPlugin ).toHaveBeenCalledWith( 'jetpack' );
+		expect( installPlugins ).toHaveBeenCalledWith( [ 'jetpack' ] );
 	} );
 
 	it( 'should call activatePlugin', async () => {
@@ -100,10 +102,14 @@ describe( 'Installing and activating', () => {
 
 describe( 'Installing and activating errors', () => {
 	let pluginsWrapper;
-	const errorMessage = 'error message';
-	const installPlugin = jest.fn().mockReturnValue( errorMessage );
+	const errors = {
+		'failed-plugin': [ 'error message' ],
+	};
+	const installPlugins = jest.fn().mockReturnValue( {
+		errors: { errors },
+	} );
 	const activatePlugins = jest.fn().mockReturnValue( {
-		status: 'failed',
+		success: false,
 	} );
 	const createNotice = jest.fn();
 	const onError = jest.fn();
@@ -113,7 +119,7 @@ describe( 'Installing and activating errors', () => {
 			<Plugins
 				pluginSlugs={ [ 'jetpack' ] }
 				onComplete={ () => {} }
-				installPlugin={ installPlugin }
+				installPlugins={ installPlugins }
 				activatePlugins={ activatePlugins }
 				createNotice={ createNotice }
 				onError={ onError }
@@ -132,13 +138,16 @@ describe( 'Installing and activating errors', () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		expect( createNotice ).toHaveBeenCalledWith( 'error', errorMessage );
+		expect( createNotice ).toHaveBeenCalledWith(
+			'error',
+			errors[ 'failed-plugin' ][ 0 ]
+		);
 	} );
 
 	it( 'should call the onError callback', async () => {
 		const installButton = pluginsWrapper.find( Button ).at( 0 );
 		installButton.simulate( 'click' );
 
-		expect( onError ).toHaveBeenCalledWith( [ errorMessage ] );
+		expect( onError ).toHaveBeenCalledWith( errors );
 	} );
 } );

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -59,37 +59,6 @@ export function updateJetpackConnectUrl( redirectUrl, jetpackConnectUrl ) {
 	};
 }
 
-function getPluginErrorMessage( action, plugin ) {
-	const pluginName = pluginNames[ plugin ] || plugin;
-	switch ( action ) {
-		case 'install':
-			return sprintf(
-				__(
-					'There was an error installing %s. Please try again.',
-					'woocommerce-admin'
-				),
-				pluginName
-			);
-		case 'connect':
-			return sprintf(
-				__(
-					'There was an error connecting to %s. Please try again.',
-					'woocommerce-admin'
-				),
-				pluginName
-			);
-		case 'activate':
-		default:
-			return sprintf(
-				__(
-					'There was an error activating %s. Please try again.',
-					'woocommerce-admin'
-				),
-				pluginName
-			);
-	}
-}
-
 export function* installPlugins( plugins ) {
 	yield setIsRequesting( 'installPlugins', true );
 
@@ -142,7 +111,14 @@ export function* activatePlugins( plugins ) {
 	} catch ( error ) {
 		yield setError( 'activatePlugins', error );
 		return plugins.map( ( plugin ) => {
-			return getPluginErrorMessage( 'activate', plugin );
+			const pluginName = pluginNames[ plugin ] || plugin;
+			return sprintf(
+				__(
+					'There was an error activating %s. Please try again.',
+					'woocommerce-admin'
+				),
+				pluginName
+			);
 		} );
 	}
 }

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -73,11 +73,11 @@ export function* installPlugins( plugins ) {
 			throw new Error();
 		}
 
-		if ( results.installed_plugins ) {
-			yield updateInstalledPlugins( results.installed_plugins );
+		if ( results.success && results.data.installed ) {
+			yield updateInstalledPlugins( results.data.installed );
 		}
 
-		if ( Object.keys( results.errors ) ) {
+		if ( Object.keys( results.errors.errors ).length ) {
 			yield setError( 'installPlugins', results.errors );
 		}
 
@@ -102,8 +102,8 @@ export function* activatePlugins( plugins ) {
 			data: { plugins: plugins.join( ',' ) },
 		} );
 
-		if ( results && results.status === 'success' ) {
-			yield updateActivePlugins( results.activatedPlugins );
+		if ( results.success && results.data.activated ) {
+			yield updateActivePlugins( results.data.activated );
 			return results;
 		}
 

--- a/packages/data/src/plugins/actions.js
+++ b/packages/data/src/plugins/actions.js
@@ -81,13 +81,19 @@ export function* installPlugins( plugins ) {
 			yield setError( 'installPlugins', results.errors );
 		}
 
+		yield setIsRequesting( 'installPlugins', false );
+
 		return results;
 	} catch ( error ) {
 		const errorMsg = __(
 			'Something went wrong while trying to install your plugins.',
 			'woocommerce-admin'
 		);
+
 		yield setError( 'installPlugins', errorMsg );
+
+		yield setIsRequesting( 'installPlugins', false );
+
 		return errorMsg;
 	}
 }

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -206,7 +206,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		$plugins          = explode( ',', $request['plugins'] );
 		$existing_plugins = get_plugins();
 
-		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
+		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
 
@@ -222,10 +222,10 @@ class Plugins extends \WC_REST_Data_Controller {
 		$errors            = new \WP_Error();
 
 		foreach ( $plugins as $plugin ) {
-			$path = $allowed_plugins[ $plugin ];
 			$slug = sanitize_key( $plugin );
+			$path = isset( $allowed_plugins[ $slug ] ) ? $allowed_plugins[ $slug ] : false;
 
-			if ( ! in_array( $plugin, $allowed_plugins, true ) ) {
+			if ( ! $path ) {
 				$errors->add(
 					$plugin,
 					/* translators: %s: plugin slug (example: woocommerce-services) */
@@ -302,7 +302,7 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		return array(
 			'data'    => array(
-				'installed' => $plugins,
+				'installed' => $installed_plugins,
 				'results'   => $results,
 			),
 			'errors'  => $errors,
@@ -364,7 +364,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		$errors            = new \WP_Error();
 		$activated_plugins = array();
 
-		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
+		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
 
@@ -372,9 +372,9 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		foreach ( $plugins as $plugin ) {
 			$slug = $plugin;
-			$path = $allowed_plugins[ $slug ];
+			$path = isset( $allowed_plugins[ $slug ] ) ? $allowed_plugins[ $slug ] : false;
 
-			if ( ! in_array( $plugin, $allowed_plugins, true ) ) {
+			if ( ! $path ) {
 				$errors->add(
 					$plugin,
 					/* translators: %s: plugin slug (example: woocommerce-services) */

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -202,8 +202,8 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * @return WP_Error|array Plugin Status
 	 */
 	public function install_plugins( $request ) {
-		$allowed_plugins  = self::get_allowed_plugins();
-		$plugins          = explode( ',', $request['plugins'] );
+		$allowed_plugins = self::get_allowed_plugins();
+		$plugins         = explode( ',', $request['plugins'] );
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -204,7 +204,6 @@ class Plugins extends \WC_REST_Data_Controller {
 	public function install_plugins( $request ) {
 		$allowed_plugins  = self::get_allowed_plugins();
 		$plugins          = explode( ',', $request['plugins'] );
-		$existing_plugins = get_plugins();
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
@@ -217,6 +216,7 @@ class Plugins extends \WC_REST_Data_Controller {
 		include_once ABSPATH . '/wp-admin/includes/class-wp-upgrader.php';
 		include_once ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php';
 
+		$existing_plugins  = get_plugins();
 		$installed_plugins = array();
 		$results           = array();
 		$errors            = new \WP_Error();

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -297,7 +297,10 @@ class Plugins extends \WC_REST_Data_Controller {
 						$slug
 					)
 				);
+				continue;
 			}
+
+			$installed_plugins[] = $plugin;
 		}
 
 		return array(

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -203,8 +203,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function install_plugins( $request ) {
 		$allowed_plugins  = self::get_allowed_plugins();
-		$_plugins         = explode( ',', $request['plugins'] );
-		$plugins          = array_intersect( array_keys( $allowed_plugins ), $_plugins );
+		$plugins          = explode( ',', $request['plugins'] );
 		$existing_plugins = get_plugins();
 
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
@@ -225,6 +224,15 @@ class Plugins extends \WC_REST_Data_Controller {
 		foreach ( $plugins as $plugin ) {
 			$path = $allowed_plugins[ $plugin ];
 			$slug = sanitize_key( $plugin );
+
+			if ( ! in_array( $plugin, $allowed_plugins, true ) ) {
+				$errors->add(
+					$plugin,
+					/* translators: %s: plugin slug (example: woocommerce-services) */
+					sprintf( __( 'The requested plugin `%s`. is not in the list of allowed plugins.', 'woocommerce-admin' ), $slug )
+				);
+				continue;
+			}
 
 			if ( in_array( $path, array_keys( $existing_plugins ), true ) ) {
 				$installed_plugins[] = $plugin;
@@ -352,8 +360,7 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function activate_plugins( $request ) {
 		$allowed_plugins   = self::get_allowed_plugins();
-		$_plugins          = explode( ',', $request['plugins'] );
-		$plugins           = array_intersect( array_keys( $allowed_plugins ), $_plugins );
+		$plugins           = explode( ',', $request['plugins'] );
 		$errors            = new \WP_Error();
 		$activated_plugins = array();
 
@@ -367,11 +374,20 @@ class Plugins extends \WC_REST_Data_Controller {
 			$slug = $plugin;
 			$path = $allowed_plugins[ $slug ];
 
+			if ( ! in_array( $plugin, $allowed_plugins, true ) ) {
+				$errors->add(
+					$plugin,
+					/* translators: %s: plugin slug (example: woocommerce-services) */
+					sprintf( __( 'The requested plugin `%s`. is not in the list of allowed plugins.', 'woocommerce-admin' ), $slug )
+				);
+				continue;
+			}
+
 			if ( ! PluginsHelper::is_plugin_installed( $path ) ) {
 				$errors->add(
 					$plugin,
 					/* translators: %s: plugin slug (example: woocommerce-services) */
-					sprintf( __( 'The requested plugin `%s`. is not yet installed', 'woocommerce-admin' ), $slug )
+					sprintf( __( 'The requested plugin `%s`. is not yet installed.', 'woocommerce-admin' ), $slug )
 				);
 				continue;
 			}

--- a/tests/api/plugins.php
+++ b/tests/api/plugins.php
@@ -49,7 +49,7 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/install' );
 		$request->set_query_params(
 			array(
-				'plugin' => 'facebook-for-woocommerce',
+				'plugins' => 'facebook-for-woocommerce',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -71,7 +71,7 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'POST', $this->endpoint . '/install' );
 		$request->set_query_params(
 			array(
-				'plugin' => 'invalid-plugin-name',
+				'plugins' => 'invalid-plugin-name',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/api/plugins.php
+++ b/tests/api/plugins.php
@@ -57,8 +57,8 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$plugins  = get_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array( 'facebook-for-woocommerce' ), $data['installed_plugins'] );
-		$this->assertEquals( 'success', $data['status'] );
+		$this->assertEquals( array( 'facebook-for-woocommerce' ), $data['data']['installed'] );
+		$this->assertEquals( true, $data['success'] );
 		$this->assertArrayHasKey( 'facebook-for-woocommerce/facebook-for-woocommerce.php', $plugins );
 	}
 
@@ -97,8 +97,8 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$active_plugins = Plugins::get_active_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains( 'facebook-for-woocommerce', $data['activatedPlugins'] );
-		$this->assertEquals( 'success', $data['status'] );
+		$this->assertContains( 'facebook-for-woocommerce', $data['data']['activated'] );
+		$this->assertEquals( true, $data['success'] );
 		$this->assertContains( 'facebook-for-woocommerce', $active_plugins );
 	}
 
@@ -117,6 +117,6 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 'ss', $data['code'] );
+		$this->assertEquals( 'woocommerce_rest_invalid_plugins', $data['code'] );
 	}
 }

--- a/tests/api/plugins.php
+++ b/tests/api/plugins.php
@@ -57,7 +57,7 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$plugins  = get_plugins();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'facebook-for-woocommerce', $data['slug'] );
+		$this->assertEquals( array( 'facebook-for-woocommerce' ), $data['installed_plugins'] );
 		$this->assertEquals( 'success', $data['status'] );
 		$this->assertArrayHasKey( 'facebook-for-woocommerce/facebook-for-woocommerce.php', $plugins );
 	}
@@ -77,7 +77,7 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 'woocommerce_rest_invalid_plugin', $data['code'] );
+		$this->assertEquals( 'woocommerce_rest_invalid_plugins', $data['code'] );
 	}
 
 	/**
@@ -117,6 +117,6 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 'woocommerce_rest_invalid_plugins', $data['code'] );
+		$this->assertEquals( 'ss', $data['code'] );
 	}
 }


### PR DESCRIPTION
Fixes #3446 
~~Fixes (possibly) #3470~~
~~Fixes (possibly) #4399~~

Updates the plugins endpoint to allow multiple plugins to prevent failure when many plugins needed to be installed.

Previously, many simultaneous requests were made to install plugins which was either causing a timeout or causing the WordPress upgrader cache to be cleared mid-install.  This PR forces them to install synchronously.

Updates:
* Allows multiple plugins to be specified for install.
* Adds more specific error messages for failures shared between server and client.
* Updates the API response to better match WP standards.

### Screenshots
<img width="616" alt="Screen Shot 2020-05-20 at 8 31 53 PM" src="https://user-images.githubusercontent.com/10561050/82478038-f60ecd00-9ad8-11ea-8fa4-f1f7e6b9b41b.png">

### Detailed test instructions:

1. Delete `woocommerce-services`, `jetpack`, `facebook-for-woocommerce`, `mailchimp-for-woocommerce`, and `kliken-marketing-for-google` from your plugins directory.
1. Visit the business details step.
1. Continue, installing all plugins.
1. Make sure all our installed without error.
1. Continue through to Jetpack setup on the benefits step, installing plugins and attempting to connect.
1. Make sure the connection works as expected.
1. Test this locally, on JN sites, ephemeral, and other hosts if possible.
1. Optionally: intentionally force an error to make sure errors work as expected.  E.g.,

`if ( is_wp_error( $api ) ) {` -> `if ( is_wp_error( $api ) || true ) {`