### PR TITLE
add runtime feature flag filter

### DIFF
--- a/src/Features/AnalyticsDashboard.php
+++ b/src/Features/AnalyticsDashboard.php
@@ -8,6 +8,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\Loader;
+
 /**
  * Contains backend logic for the dashboard feature.
  */
@@ -80,9 +82,8 @@ class AnalyticsDashboard {
 	 * Registers dashboard page.
 	 */
 	public function register_page() {
-		$features = wc_admin_get_feature_config();
-		$id       = $features['homepage'] ? 'woocommerce-home' : 'woocommerce-dashboard';
-		$title    = $features['homepage'] ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
+		$id       = Loader::is_feature_enabled( 'homepage' ) ? 'woocommerce-home' : 'woocommerce-dashboard';
+		$title    = Loader::is_feature_enabled( 'homepage' ) ? __( 'Home', 'woocommerce-admin' ) : __( 'Dashboard', 'woocommerce-admin' );
 
 		wc_admin_register_page(
 			array(

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -121,12 +121,27 @@ class Loader {
 	}
 
 	/**
-	 * Gets an array of enabled WooCommerce Admin features/sections.
+	 * Gets a build configured array of enabled WooCommerce Admin features/sections.
 	 *
-	 * @return bool Enabled Woocommerce Admin features/sections.
+	 * @return array Enabled Woocommerce Admin features/sections.
 	 */
 	public static function get_features() {
 		return apply_filters( 'woocommerce_admin_features', array() );
+	}
+
+	/**
+	 * Gets a runtime array of enabled WooCommerce Admin features/sections.
+	 *
+	 * @return array Woocommerce Admin features/sections.
+	 */
+	protected static function get_enabled_features() {
+		$features_mask    = apply_filters( 'woocommerce_admin_features_to_enable_disable', array() );
+		$add_features     = array_filter( $features_mask );
+		$remove_features  = array_keys( array_diff_key( $features_mask, $add_features ) );
+
+		$enabled_features = self::get_features();
+		$enabled_features = array_diff( $enabled_features, $remove_features );
+		return array_merge( $enabled_features, array_keys( $add_features ) );
 	}
 
 	/**
@@ -162,14 +177,14 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
-		$features = self::get_features();
+		$features = self::get_enabled_features();
 		return in_array( $feature, $features, true );
 	}
 
 	/**
 	 * Returns if the onboarding feature of WooCommerce Admin should be enabled.
 	 *
-	 * While we preform an a/b test of onboarding, the feature will be enabled within the plugin build, but only if the user recieved the test/opted in.
+	 * While we preform an a/b test of onboarding, the feature will be enabled within the plugin build, but only if the user received the test/opted in.
 	 *
 	 * @return bool Returns true if the onboarding is enabled.
 	 */
@@ -233,7 +248,7 @@ class Loader {
 	 * Class loader for enabled WooCommerce Admin features/sections.
 	 */
 	public static function load_features() {
-		$features = self::get_features();
+		$features = self::get_enabled_features();
 		foreach ( $features as $feature ) {
 			$feature = str_replace( '-', '', ucwords( strtolower( $feature ), '-' ) );
 			$feature = 'Automattic\\WooCommerce\\Admin\\Features\\' . $feature;
@@ -681,7 +696,7 @@ class Loader {
 			$classes[] = 'woocommerce-admin-is-loading';
 		}
 
-		$features = self::get_features();
+		$features = self::get_enabled_features();
 		foreach ( $features as $feature_key ) {
 			$classes[] = sanitize_html_class( 'woocommerce-feature-enabled-' . $feature_key );
 		}


### PR DESCRIPTION
Fixes #4417

This PR introduces the `woocommerce_admin_features_to_enable_disable` filter which allows enabling or disabling a feature through `wcSettings`. If the feature being disabled has a menu item then the `woocommerce_admin_features` filter needs to be used to remove the menu item.

### Detailed test instructions:

- Build the branch
- Add the filter 
```
add_filter( 'woocommerce_admin_features_to_enable_disable', function( $features ) {
	$features[ 'homepage' ] = true;
	return $features;
} );
```
- The home page should show on the `WooCommerce` menu item
- Change it to `false`
- The dashboard should show on the `WooCommerce` menu item
- Change the filter and add the second filter
```
add_filter( 'woocommerce_admin_features_to_enable_disable', function( $features ) {
	$features[ 'homepage' ] = true;
	$features[ 'marketing' ] = false;
	return $features;
} );
```
- The `Marketing` menu item should be removed
- Navigating to `?page=wc-admin&path=marketing` should render an empty screen

### Changelog Note:

Enhancement: Allow runtime feature toggling.