### PR TITLE
Bind onClick event handler for marketing kb article click

### DIFF
--- a/client/marketing/overview/knowledge-base/index.js
+++ b/client/marketing/overview/knowledge-base/index.js
@@ -74,7 +74,7 @@ class KnowledgeBase extends Component {
 							className="woocommerce-marketing-knowledgebase-card__post"
 							href={ post.link }
 							key={ index }
-							onClick={ this.onPostClick( this, post ) }
+							onClick={ this.onPostClick.bind( this, post ) }
 							target="_blank"
 							rel="noopener noreferrer"
 						>


### PR DESCRIPTION
Correctly bind the onclick event hander for the Marketing knowledge base article.

Post/post title is currently `undefined` and I don't think the event is triggering properly. I think we lost the bind as part of some refactoring.

### Detailed test instructions:

- Pull branch
- Modify the `onPostClick()` to add some logging

```
	onPostClick( post, e ) {
		e.preventDefault();
		console.log( post );
		recordEvent( 'marketing_knowledge_article', { title: post.title } );
	}
```

- Build
- Go to Marketing Tab on test site
- Click kb article
- See post object in console e.g. https://d.pr/i/gyNEVo
