### PR TITLE
Add install Jetpack CTA to stats on home page

### DIFF
--- a/client/homepage/stats-overview/index.js
+++ b/client/homepage/stats-overview/index.js
@@ -30,6 +30,7 @@ import withSelect from 'wc-api/with-select';
 import { DEFAULT_STATS, DEFAULT_HIDDEN_STATS } from './defaults';
 import StatsList from './stats-list';
 import { recordEvent } from 'lib/tracks';
+import InstallJetpackCta from './install-jetpack-cta';
 
 const { performanceIndicators } = getSetting( 'dataEndpoints', {
 	performanceIndicators: [],
@@ -116,13 +117,16 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 				] }
 			>
 				{ ( tab ) => (
-					<StatsList
-						query={ {
-							period: tab.name,
-							compare: 'previous_period',
-						} }
-						stats={ activeStats }
-					/>
+					<Fragment>
+						<InstallJetpackCta />
+						<StatsList
+							query={ {
+								period: tab.name,
+								compare: 'previous_period',
+							} }
+							stats={ activeStats }
+						/>
+					</Fragment>
 				) }
 			</TabPanel>
 			<div className="woocommerce-stats-overview__footer">

--- a/client/homepage/stats-overview/index.js
+++ b/client/homepage/stats-overview/index.js
@@ -47,8 +47,9 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 
 	const toggleStat = ( stat ) => {
 		const nextHiddenStats = xor( hiddenStats, [ stat ] );
+		userPrefs.hiddenStats = nextHiddenStats;
 		updateCurrentUserData( {
-			homepage_stats: { hiddenStats: nextHiddenStats },
+			homepage_stats: userPrefs,
 		} );
 		recordEvent( 'statsoverview_indicators_toggle', {
 			indicator_name: stat,

--- a/client/homepage/stats-overview/install-jetpack-cta.js
+++ b/client/homepage/stats-overview/install-jetpack-cta.js
@@ -31,7 +31,7 @@ function InstallJetpackCta( props ) {
 	const [ isInstalling, setIsInstalling ] = useState( false );
 	const [ isConnecting, setIsConnecting ] = useState( false );
 	const [ isDismissed, setIsDismissed ] = useState(
-		getCurrentUserData().homepage_stats.installJetpackDismissed
+		( getCurrentUserData().homepage_stats || {} ).installJetpackDismissed
 	);
 	const plugins = getSetting( 'plugins', {
 		installedPlugins: [],
@@ -50,11 +50,12 @@ function InstallJetpackCta( props ) {
 			return;
 		}
 
-		updateCurrentUserData( {
-			homepage_stats: {
-				installJetpackDismissed: true,
-			},
-		} );
+		const homepageStats = getCurrentUserData().homepage_stats || {};
+
+		homepageStats.installJetpackDismissed = true;
+
+		updateCurrentUserData( { homepage_stats: homepageStats } );
+
 		setIsDismissed( true );
 		recordEvent( 'statsoverview_dismiss_install_jetpack' );
 	}

--- a/client/homepage/stats-overview/install-jetpack-cta.js
+++ b/client/homepage/stats-overview/install-jetpack-cta.js
@@ -1,0 +1,154 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
+import { Button } from '@wordpress/components';
+import { useState } from 'react';
+import { withDispatch } from '@wordpress/data';
+import PropTypes from 'prop-types';
+
+/**
+ * WooCommerce dependencies
+ */
+import { H, Plugins } from '@woocommerce/components';
+import { getAdminLink, getSetting } from '@woocommerce/wc-admin-settings';
+import { PLUGINS_STORE_NAME } from '@woocommerce/data';
+
+/**
+ * Internal dependencies
+ */
+import withSelect from 'wc-api/with-select';
+import Connect from 'dashboard/components/connect';
+import { recordEvent } from 'lib/tracks';
+
+function InstallJetpackCta( props ) {
+	const {
+		isJetpackConnected,
+		getCurrentUserData,
+		updateCurrentUserData,
+	} = props;
+	const [ isInstalling, setIsInstalling ] = useState( false );
+	const [ isConnecting, setIsConnecting ] = useState( false );
+	const [ isDismissed, setIsDismissed ] = useState(
+		getCurrentUserData().homepage_stats.installJetpackDismissed
+	);
+	const plugins = getSetting( 'plugins', {
+		installedPlugins: [],
+		activePlugins: [],
+	} );
+	const isJetpackInstalled = plugins.installedPlugins.includes( 'jetpack' );
+	const isJetpackActivated = plugins.activePlugins.includes( 'jetpack' );
+
+	function install() {
+		setIsInstalling( true );
+		recordEvent( 'statsoverview_install_jetpack' );
+	}
+
+	function dismiss() {
+		if ( isInstalling || isConnecting ) {
+			return;
+		}
+
+		updateCurrentUserData( {
+			homepage_stats: {
+				installJetpackDismissed: true,
+			},
+		} );
+		setIsDismissed( true );
+		recordEvent( 'statsoverview_dismiss_install_jetpack' );
+	}
+
+	function getPluginInstaller() {
+		return (
+			<Plugins
+				autoInstall
+				onComplete={ () => {
+					setIsInstalling( false );
+					setIsConnecting( ! isJetpackConnected );
+				} }
+				onError={ () => {
+					setIsInstalling( false );
+				} }
+				pluginSlugs={ [ 'jetpack' ] }
+			/>
+		);
+	}
+
+	function getConnector() {
+		return (
+			<Connect
+				autoConnect
+				onError={ () => setIsConnecting( false ) }
+				redirectUrl={ getAdminLink(
+					'admin.php?page=wc-admin&reset-profiler=0'
+				) }
+			/>
+		);
+	}
+
+	if ( isDismissed || isJetpackInstalled || isJetpackActivated ) {
+		return null;
+	}
+
+	return (
+		<article className="woocommerce-stats-overview__install-jetpack-promo">
+			<H>
+				{ __( 'Get traffic stats with Jetpack', 'woocommerce-admin' ) }
+			</H>
+			<p>
+				{ __(
+					'Keep an eye on your views and visitors metrics with ' +
+						'Jetpack. Requires Jetpack plugin and a WordPress.com ' +
+						'account.',
+					'woocommerce-admin'
+				) }
+			</p>
+			<footer>
+				<Button isPrimary onClick={ install } isBusy={ isInstalling }>
+					{ __( 'Get Jetpack', 'woocommerce-admin' ) }
+				</Button>
+				<Button onClick={ dismiss } isBusy={ isInstalling }>
+					{ __( 'No thanks', 'woocommerce-admin' ) }
+				</Button>
+			</footer>
+
+			{ isInstalling && getPluginInstaller() }
+			{ isConnecting && getConnector() }
+		</article>
+	);
+}
+
+InstallJetpackCta.propTypes = {
+	/**
+	 * Is the Jetpack plugin connected.
+	 */
+	isJetpackConnected: PropTypes.bool.isRequired,
+	/**
+	 * A method to get user meta.
+	 */
+	getCurrentUserData: PropTypes.func.isRequired,
+	/**
+	 * A method to update user meta.
+	 */
+	updateCurrentUserData: PropTypes.func.isRequired,
+};
+
+export default compose(
+	withSelect( ( select ) => {
+		const { isJetpackConnected } = select( PLUGINS_STORE_NAME );
+		const { getCurrentUserData } = select( 'wc-api' );
+
+		return {
+			isJetpackConnected: isJetpackConnected(),
+			getCurrentUserData,
+		};
+	} ),
+	withDispatch( ( dispatch ) => {
+		const { updateCurrentUserData } = dispatch( 'wc-api' );
+
+		return {
+			updateCurrentUserData,
+		};
+	} )
+)( InstallJetpackCta );

--- a/client/homepage/stats-overview/install-jetpack-cta.js
+++ b/client/homepage/stats-overview/install-jetpack-cta.js
@@ -87,7 +87,7 @@ function InstallJetpackCta( props ) {
 		);
 	}
 
-	if ( isDismissed || isJetpackInstalled || isJetpackActivated ) {
+	if ( isDismissed || ( isJetpackInstalled && isJetpackActivated ) ) {
 		return null;
 	}
 
@@ -106,7 +106,9 @@ function InstallJetpackCta( props ) {
 			</p>
 			<footer>
 				<Button isPrimary onClick={ install } isBusy={ isInstalling }>
-					{ __( 'Get Jetpack', 'woocommerce-admin' ) }
+					{ ! isJetpackInstalled
+						? __( 'Get Jetpack', 'woocommerce-admin' )
+						: __( 'Activate Jetpack', 'woocommerce-admin' ) }
 				</Button>
 				<Button onClick={ dismiss } isBusy={ isInstalling }>
 					{ __( 'No thanks', 'woocommerce-admin' ) }

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -112,8 +112,11 @@ article.woocommerce-stats-overview__install-jetpack-promo {
 			background: transparent;
 			border: 1px solid $action-color;
 
-			&:hover {
-				color: $action-color;
+			&:hover,
+			&:focus {
+				color: $core-grey-dark-500;
+				background-color: #fafafa;
+				border-color: #999;
 			}
 
 			&.is-busy:not(:disabled) {

--- a/client/homepage/stats-overview/style.scss
+++ b/client/homepage/stats-overview/style.scss
@@ -1,5 +1,7 @@
 // Set up some local color variables to make the CSS more clear
 $outer-border: $core-grey-light-700;
+$promo-actions-border: $core-grey-light-500;
+$action-color: #3858e9;
 
 .woocommerce-stats-overview {
 	.woocommerce-card__body {
@@ -24,33 +26,33 @@ $outer-border: $core-grey-light-700;
 		display: flex;
 		justify-content: space-between;
 		border-bottom: 1px solid $outer-border;
-	}
 
-	.components-button {
-		display: block;
-		padding: $gap;
-		width: 33.33%;
-		margin-bottom: 4px;
+		.components-button {
+			display: block;
+			padding: $gap;
+			width: 33.33%;
+			margin-bottom: 4px;
 
-		&:focus {
-			outline: none;
-			box-shadow: none;
-		}
+			&:focus {
+				outline: none;
+				box-shadow: none;
+			}
 
-		&.is-active {
-			border-bottom: 4px solid $studio-blue-50;
-			// Avoid the text "jumping" when border-bottom applied.
-			margin-bottom: 0;
-		}
+			&.is-active {
+				border-bottom: 4px solid $action-color;
+				// Avoid the text "jumping" when border-bottom applied.
+				margin-bottom: 0;
+			}
 
-		&:first-child {
-			text-align: left;
-			padding-right: 0;
-		}
+			&:first-child {
+				text-align: left;
+				padding-right: 0;
+			}
 
-		&:last-child {
-			text-align: right;
-			padding-left: 0;
+			&:last-child {
+				text-align: right;
+				padding-left: 0;
+			}
 		}
 	}
 }
@@ -73,5 +75,51 @@ $outer-border: $core-grey-light-700;
 
 	.woocommerce-summary__item-container:nth-of-type(even) .woocommerce-summary__item {
 		border-right: none;
+	}
+}
+
+article.woocommerce-stats-overview__install-jetpack-promo {
+	h3 {
+		margin: 16px 24px 8px;
+	}
+	p {
+		margin: 0 24px 16px;
+	}
+	footer {
+		border-top: 1px solid $promo-actions-border;
+
+		// All of this added specificity is required because styles that
+		// need overriding are already specified at a high level.
+		.woocommerce-layout & button.components-button,
+		.woocommerce-layout & button.components-button.is-button {
+			padding: 8px 16px;
+			margin: 16px 4px;
+			height: inherit;
+			color: $action-color;
+			cursor: pointer;
+			line-height: 2;
+			border-radius: 3px;
+
+			&.is-busy {
+				background-image: linear-gradient(-45deg, lighten($action-color, 40%) 28%, #fff 0, #fff 72%, lighten($action-color, 40%) 0);
+				cursor: progress;
+				color: lighten($action-color, 20%);
+			}
+		}
+
+		.woocommerce-layout & button.components-button.is-button.is-primary {
+			margin-left: 24px;
+			background: transparent;
+			border: 1px solid $action-color;
+
+			&:hover {
+				color: $action-color;
+			}
+
+			&.is-busy:not(:disabled) {
+				background-image: linear-gradient(-45deg, $action-color 28%, darken($action-color, 20%) 0, darken($action-color, 20%) 72%, $action-color 0) !important;
+				color: $action-color;
+			}
+		}
 	}
 }

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -15,6 +15,12 @@ jest.mock( 'lib/tracks' );
 jest.mock( '../stats-list', () =>
 	jest.fn().mockImplementation( () => <div>mocked stats list</div> )
 );
+// Mock the Install Jetpack CTA
+jest.mock( '../install-jetpack-cta', () => {
+	return jest
+		.fn()
+		.mockImplementation( () => <div>mocked install jetpack cta</div> );
+} );
 
 describe( 'StatsOverview tracking', () => {
 	it( 'should record an event when a stat is toggled', () => {


### PR DESCRIPTION
Partially fixes #4084

This adds a CTA to install Jetpack to the stats panel on the home page, if Jetpack hasn't been installed or activated.

Busy state animations and colours have been inferred by the existing controls.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/) - not in the busy state

### Screenshots

![image](https://user-images.githubusercontent.com/224531/82860010-c25df800-9f5b-11ea-84bb-787eb01014be.png)
![image](https://user-images.githubusercontent.com/224531/82860114-00f3b280-9f5c-11ea-89c7-7521ef08eb1b.png)

### Detailed test instructions:

- Deactivate and delete the Jetpack plugin
- Visit the home page. The CTA should be displayed.
- Click "Get Jetpack". The plugin should install and activate and then redirect to the sign up flow.
- Deactivate (but don't delete) the Jetpack plugin.
- Go back to the home page. The CTA should be displayed but the primary button text should be "Activate Jetpack".
- click "Activate Jetpack". The plugin should activate and then redirect to the sign up flow.
- Deactivate the plugin again and go back to the home page.
- Click "No thanks". The CTA should be dismissed, and stay dismissed on page reload.
