### PR TITLE
Homepage: Add tracks events to Stats List period changes

### DIFF
--- a/client/homepage/stats-overview/index.js
+++ b/client/homepage/stats-overview/index.js
@@ -100,6 +100,11 @@ export const StatsOverview = ( { userPrefs, updateCurrentUserData } ) => {
 		>
 			<TabPanel
 				className="woocommerce-stats-overview__tabs"
+				onSelect={ ( period ) => {
+					recordEvent( 'statsoverview_date_picker_update', {
+						period,
+					} );
+				} }
 				tabs={ [
 					{
 						title: __( 'Today', 'woocommerce-admin' ),

--- a/client/homepage/stats-overview/test/index.js
+++ b/client/homepage/stats-overview/test/index.js
@@ -44,6 +44,29 @@ describe( 'StatsOverview tracking', () => {
 			}
 		);
 	} );
+
+	it( 'should record an event when a period is clicked', () => {
+		render(
+			<StatsOverview
+				userPrefs={ {
+					hiddenStats: null,
+				} }
+				updateCurrentUserData={ () => {} }
+			/>
+		);
+
+		const monthBtn = screen.getByRole( 'tab', {
+			name: 'Month to date',
+		} );
+		fireEvent.click( monthBtn );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'statsoverview_date_picker_update',
+			{
+				period: 'month',
+			}
+		);
+	} );
 } );
 
 describe( 'StatsOverview toggle and persist stat preference', () => {


### PR DESCRIPTION
Adds Tracks events when the tab panel in Stats List is clicked to update a time period.

### Detailed test instructions:

1. Visit the Homepage.
2. Change the stats list period to "Month to date".
3. See the debug statement in the console.
4. See tests passing.

### Changelog Note:

none
