### PR TITLE
Add EU VAT extension note

### DIFF
--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -122,7 +122,7 @@ export default compose(
 		const inboxQuery = {
 			page: 1,
 			per_page: QUERY_DEFAULTS.pageSize,
-			type: 'info,warning',
+			type: QUERY_DEFAULTS.noteTypes,
 			orderby: 'date',
 			order: 'desc',
 			status: 'unactioned',

--- a/client/header/activity-panel/unread-indicators.js
+++ b/client/header/activity-panel/unread-indicators.js
@@ -8,6 +8,7 @@ import { SETTINGS_STORE_NAME } from '@woocommerce/data';
  */
 import { DEFAULT_ACTIONABLE_STATUSES } from 'analytics/settings/config';
 import { getSetting } from '@woocommerce/wc-admin-settings';
+import { QUERY_DEFAULTS } from 'wc-api/constants';
 
 export function getUnreadNotes( select ) {
 	const {
@@ -23,7 +24,7 @@ export function getUnreadNotes( select ) {
 	const notesQuery = {
 		page: 1,
 		per_page: 1,
-		type: 'info,warning',
+		type: QUERY_DEFAULTS.noteTypes,
 		orderby: 'date',
 		order: 'desc',
 	};

--- a/client/wc-api/constants.js
+++ b/client/wc-api/constants.js
@@ -22,4 +22,5 @@ export const QUERY_DEFAULTS = {
 	pageSize: 25,
 	period: 'month',
 	compare: 'previous_year',
+	noteTypes: 'info,warning,marketing',
 };

--- a/src/Events.php
+++ b/src/Events.php
@@ -17,6 +17,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Tracking_Opt_In;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Email_Marketing;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Personalize_Store;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_EU_VAT_Number;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Marketing;
 
@@ -70,6 +71,7 @@ class Events {
 		WC_Admin_Notes_Onboarding_Payments::possibly_add_note();
 		WC_Admin_Notes_Personalize_Store::possibly_add_note();
 		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
+		WC_Admin_Notes_EU_VAT_Number::possibly_add_note();
 		WC_Admin_Notes_Marketing::possibly_add_note();
 		WC_Admin_Notes_Giving_Feedback_Notes::possibly_add_note();
 	}

--- a/src/Notes/WC_Admin_Notes_EU_VAT_Number.php
+++ b/src/Notes/WC_Admin_Notes_EU_VAT_Number.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WooCommerce Admin: EU VAT Number Note.
+ *
+ * Adds a note for EU store to install the EU VAT Number extension.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_EU_VAT_Number
+ */
+class WC_Admin_Notes_EU_VAT_Number {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-eu-vat-number';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		if ( 'yes' !== get_option( 'wc_connect_taxes_enabled', 'no' ) ) {
+			return;
+		}
+
+		$country_code = WC()->countries->get_base_country();
+		$eu_countries = WC()->countries->get_european_union_countries();
+		if ( ! in_array( $country_code, $eu_countries, true ) ) {
+			return;
+		}
+
+		$content = __( "If your store is based in the EU, we recommend using the EU VAT Number extension in addition to automated taxes. It provides your checkout with a field to collect and validate a customer's EU VAT number, if they have one.", 'woocommerce-admin' );
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Collect and validate EU VAT numbers at checkout', 'woocommerce-admin' ) );
+		$note->set_content( $content );
+		$note->set_content_data( (object) array() );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/products/eu-vat-number/',
+			'actioned',
+			true
+		);
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #4351

* Adds the EU VAT extension note for EU stores with automatic tax enabled.
* Sets the default query for note types and includes `marketing`.  /cc @octaedro in case this affects any of the upcoming changes to notes.

### Screenshots
<img width="540" alt="Screen Shot 2020-05-27 at 3 54 16 PM" src="https://user-images.githubusercontent.com/10561050/83021547-d88ab780-a032-11ea-99ce-3da1f5c6acfe.png">

### Detailed test instructions:

1. Make sure marketing is enabled under `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`.
1. Enable automatic taxes.
1. In a non-EU base store, run the cron event `wc_admin_daily`.
1. Change your store country to one listed in https://ec.europa.eu/taxation_customs/business/vat/eu-vat-rules-topic/territorial-status-eu-countries-certain-territories_en
1. Run the cron event again.
1. Make sure the note is shown.