### PR TITLE
Added new notification to ask about starting a dropshipping business.

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -19,6 +19,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Personalize_Store;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Marketing;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Start_Dropshipping_Business;
 
 /**
  * WC_Admin_Events Class.
@@ -72,5 +73,6 @@ class Events {
 		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
 		WC_Admin_Notes_Marketing::possibly_add_note();
 		WC_Admin_Notes_Giving_Feedback_Notes::possibly_add_note();
+		WC_Admin_Notes_Start_Dropshipping_Business::possibly_add_note();
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Start_Dropshipping_Business.php
+++ b/src/Notes/WC_Admin_Notes_Start_Dropshipping_Business.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WooCommerce Admin: Starting a dropshipping business.
+ *
+ * Adds a note to ask the client if they are considering starting a dropshipping business.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Start_Dropshipping_Business.
+ */
+class WC_Admin_Notes_Start_Dropshipping_Business {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-start-dropshipping-business';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+
+		// We want to show the note after one day.
+		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS ) ) {
+			return;
+		}
+
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			! isset( $onboarding_profile['product_count'] ) ||
+			! isset( $onboarding_profile['revenue'] )
+		) {
+			return;
+		}
+
+		// Make sure the client is not setup.
+		if ( $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
+		// We need to show the notification when product number is 0 or the revenue is 'none' or 'up to 2500'.
+		if (
+			0 !== (int) $onboarding_profile['product_count'] &&
+			'none' !== $onboarding_profile['revenue'] &&
+			'up-to-2500' !== $onboarding_profile['revenue']
+		) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Are you considering starting a dropshipping business?', 'woocommerce-admin' ) );
+		$note->set_content( __( 'The ability to add inventory without having to deal with production, stocking, or fulfilling orders may seem like a dream. But is dropshipping worth it? Let’s explore some of the advantages and disadvantages to help you make the best decision for your business.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'choose-niche',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/is-dropshipping-worth-it-pros-cons/?utm_source=inbox',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+		return $note;
+	}
+}


### PR DESCRIPTION
Fixes #4197 

This PR adds a new notification to ask the client if they are considering starting a dropshipping business.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:
This notification should be visible for:
New users with `setup_client`: `false` on`woocommerce_onboarding_profile`
AND
one of the following values on `woocommerce_onboarding_profile`
`product_count`: `0`
`revenue`: `none`
`revenue`: `up to 2500`

To set these values it's necessary to:
- Go to the `Business Details` step (in the new onboarding).
![screenshot-one wordpress test-2020 05 25-15_51_04](https://user-images.githubusercontent.com/1314156/82837668-1c998300-9ea0-11ea-9fe2-6d26a3769af1.png)

- Set `How many products do you plan to display?` to `I don't have any products yet.`
- Set `What's your current annual revenue?` to `$0.00 (I'm just getting started)` or `Up to $2,500.00`.

- Also, this note should be visible one day after the plugin was installed.

- Verify the note is created and appears.
- Verify the action button works properly.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: Added new notification to ask the client if they are considering starting a dropshipping business.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
