### PR TITLE
Update import to new pluginNames location

### DIFF
--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -11,8 +11,7 @@ import { withSelect, withDispatch } from '@wordpress/data';
 /**
  * WooCommerce dependencies
  */
-import { PLUGINS_STORE_NAME } from '@woocommerce/data';
-import { pluginNames } from 'wc-api/onboarding/constants';
+import { pluginNames, PLUGINS_STORE_NAME } from '@woocommerce/data';
 
 export class Plugins extends Component {
 	constructor() {
@@ -108,12 +107,7 @@ export class Plugins extends Component {
 	}
 
 	render() {
-		const {
-			isRequesting,
-			skipText,
-			autoInstall,
-			pluginSlugs,
-		} = this.props;
+		const { isRequesting, skipText, autoInstall, pluginSlugs } = this.props;
 		const { hasErrors } = this.state;
 
 		if ( hasErrors ) {


### PR DESCRIPTION
Fixes #4459 

Fixes a conflict between https://github.com/woocommerce/woocommerce-admin/pull/4411 and https://github.com/woocommerce/woocommerce-admin/pull/4433.

On this same topic, I'm not sure if the `pluginNames` belongs in the `data` package or `components` package inside of `plugins`.  Open for discussion if anyone has an opinion.

### Detailed test instructions:

1. Build this branch. Make sure no errors occur.
1. Run the profiler and make sure you can use the plugin installers without issue.