### PR TITLE
Fix error handling for plugins on server error

### DIFF
--- a/packages/components/src/plugins/index.js
+++ b/packages/components/src/plugins/index.js
@@ -55,7 +55,7 @@ export class Plugins extends Component {
 		const installs = await installPlugins( pluginSlugs );
 
 		if ( installs.errors && Object.keys( installs.errors.errors ).length ) {
-			this.handleErrors( installs.errors.errors );
+			this.handleErrors( installs.errors );
 			return;
 		}
 
@@ -66,24 +66,31 @@ export class Plugins extends Component {
 			return;
 		}
 
-		this.handleErrors( activations.errors.errors );
+		if ( activations.errors ) {
+			this.handleErrors( activations.errors );
+		}
 	}
 
 	handleErrors( errors ) {
 		const { onError, createNotice } = this.props;
+		const { errors: pluginErrors } = errors;
 
-		Object.keys( errors ).forEach( ( plugin ) => {
-			createNotice(
-				'error',
-				// Replace the slug with a plugin name if a constant exists.
-				pluginNames[ plugin ]
-					? errors[ plugin ][ 0 ].replace(
-							`\`${ plugin }\``,
-							pluginNames[ plugin ]
-					  )
-					: errors[ plugin ][ 0 ]
-			);
-		} );
+		if ( pluginErrors ) {
+			Object.keys( pluginErrors ).forEach( ( plugin ) => {
+				createNotice(
+					'error',
+					// Replace the slug with a plugin name if a constant exists.
+					pluginNames[ plugin ]
+						? pluginErrors[ plugin ][ 0 ].replace(
+								`\`${ plugin }\``,
+								pluginNames[ plugin ]
+						  )
+						: pluginErrors[ plugin ][ 0 ]
+				);
+			} );
+		} else if ( errors.message ) {
+			createNotice( 'error', errors.message );
+		}
 
 		this.setState( { hasErrors: true } );
 		onError( errors );

--- a/packages/components/src/plugins/test/index.js
+++ b/packages/components/src/plugins/test/index.js
@@ -103,10 +103,12 @@ describe( 'Installing and activating', () => {
 describe( 'Installing and activating errors', () => {
 	let pluginsWrapper;
 	const errors = {
-		'failed-plugin': [ 'error message' ],
+		errors: {
+			'failed-plugin': [ 'error message' ],
+		},
 	};
 	const installPlugins = jest.fn().mockReturnValue( {
-		errors: { errors },
+		errors,
 	} );
 	const activatePlugins = jest.fn().mockReturnValue( {
 		success: false,
@@ -140,7 +142,7 @@ describe( 'Installing and activating errors', () => {
 
 		expect( createNotice ).toHaveBeenCalledWith(
 			'error',
-			errors[ 'failed-plugin' ][ 0 ]
+			errors.errors[ 'failed-plugin' ][ 0 ]
 		);
 	} );
 


### PR DESCRIPTION
Fixes #4454

Individual plugin errors were previously shown, but server errors were broken since my last PR.  This catches general server errors and displays them if no individual plugin error messages exist.

### Screenshots
<img width="499" alt="Screen Shot 2020-05-28 at 4 42 24 PM" src="https://user-images.githubusercontent.com/10561050/83150271-bf9e0700-a103-11ea-8029-b963ffb118e9.png">

### Detailed test instructions:

1. Install Jetpack beta in a `jetpack-dev` folder.
1. Also install a version in `jetpack`.
1. Activate the `jetpack-dev` version.
1. Walk through the profiler under the benefits screen and attempt to install.
1. Note an error is shown.
1. Note that no console errors are shown.
1. Optionally: intentionally force an error to make sure individual errors still work as expected. E.g.,
`if ( is_wp_error( $api ) ) { -> if ( is_wp_error( $api ) || true ) {`