### PR TITLE
Added new notification to ask about migrating from Shopify.

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -19,6 +19,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Onboarding_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Personalize_Store;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_WooCommerce_Payments;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Marketing;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Migrate_From_Shopify;
 
 /**
  * WC_Admin_Events Class.
@@ -72,5 +73,6 @@ class Events {
 		WC_Admin_Notes_WooCommerce_Payments::possibly_add_note();
 		WC_Admin_Notes_Marketing::possibly_add_note();
 		WC_Admin_Notes_Giving_Feedback_Notes::possibly_add_note();
+		WC_Admin_Notes_Migrate_From_Shopify::possibly_add_note();
 	}
 }

--- a/src/Notes/WC_Admin_Notes_Migrate_From_Shopify.php
+++ b/src/Notes/WC_Admin_Notes_Migrate_From_Shopify.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WooCommerce Admin: Migrate from Shopify to WooCommerce.
+ *
+ * Adds a note to ask the client if they want to migrate from Shopify to WooCommerce.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Migrate_From_Shopify.
+ */
+class WC_Admin_Notes_Migrate_From_Shopify {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-migrate-from-shopify';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+
+		// We want to show the note after two days.
+		$two_days = 2 * DAY_IN_SECONDS;
+		if ( ! self::wc_admin_active_for( $two_days ) ) {
+			return;
+		}
+
+		$onboarding_profile = get_option( 'woocommerce_onboarding_profile', array() );
+		if (
+			! isset( $onboarding_profile['setup_client'] ) ||
+			! isset( $onboarding_profile['selling_venues'] ) ||
+			! isset( $onboarding_profile['other_platform'] )
+		) {
+			return;
+		}
+
+		// Make sure the client is not setup.
+		if ( $onboarding_profile['setup_client'] ) {
+			return;
+		}
+
+		// We will show the notification when the client already is selling and is using Shopify.
+		if (
+			'other' !== $onboarding_profile['selling_venues'] ||
+			'shopify' !== $onboarding_profile['other_platform']
+		) {
+			return;
+		}
+
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Do you want to migrate from Shopify to WooCommerce?', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Changing eCommerce platforms might seem like a big hurdle to overcome, but it is easier than you might think to move your products, customers, and orders to WooCommerce. This article will help you with going through this process.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'choose-niche',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/posts/migrate-from-shopify-to-woocommerce/?utm_source=inbox',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+		return $note;
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Migrate_From_Shopify.php
+++ b/src/Notes/WC_Admin_Notes_Migrate_From_Shopify.php
@@ -67,7 +67,7 @@ class WC_Admin_Notes_Migrate_From_Shopify {
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
-			'choose-niche',
+			'migrate-from-shopify',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/posts/migrate-from-shopify-to-woocommerce/?utm_source=inbox',
 			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,


### PR DESCRIPTION
Fixes #4198

This PR adds a new notification to ask the client if they want to migrate from Shopify to WooCommerce.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Detailed test instructions:
This notification should be visible for:
New users with `setup_client`: `false` on`woocommerce_onboarding_profile`
AND
the following values on `woocommerce_onboarding_profile`
`already_selling`: `true`
`used_platform`: `shopify`

To set these values it's necessary to:
- Go to the `Business Details` step (in the new onboarding).
![screenshot-one wordpress test-2020 05 28-13_30_21](https://user-images.githubusercontent.com/1314156/83169419-63c68480-a0e9-11ea-9b03-4212dc0981e4.png)


- Set `Currently selling elsewhere?` to `Yes, on another platform`
- Set `Which platform is the store using?` to `Shopify`.

- Also, this note should be visible two days after the plugin was installed.

- Trigger the `cron`.
- Verify the note is created and appears.
- Verify the action button works properly.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: Added a new notification to ask the client about migrating from Shopify.
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->