### PR TITLE
OBW: JP step - use the correct store name for updating profile items.

### DIFF
--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -13,7 +13,11 @@ import { filter } from 'lodash';
  */
 import { Card, H, Plugins } from '@woocommerce/components';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
-import { pluginNames, PLUGINS_STORE_NAME } from '@woocommerce/data';
+import {
+	pluginNames,
+	ONBOARDING_STORE_NAME,
+	PLUGINS_STORE_NAME,
+} from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -26,7 +30,6 @@ import ShippingLabels from './images/shipping_labels';
 import SpeedIcon from './images/speed';
 import withSelect from 'wc-api/with-select';
 import { recordEvent } from 'lib/tracks';
-import { ONBOARDING_STORE_NAME } from '../../../../packages/data/src';
 
 class Benefits extends Component {
 	constructor( props ) {
@@ -325,7 +328,8 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch ) => {
-		const { updateProfileItems, updateOptions } = dispatch( 'wc-api' );
+		const { updateProfileItems } = dispatch( ONBOARDING_STORE_NAME );
+		const { updateOptions } = dispatch( 'wc-api' );
 		const { createNotice } = dispatch( 'core/notices' );
 
 		return {


### PR DESCRIPTION
Partially addresses #4467.

This PR fixes the store name for using `updateProfileItems()`.

There is still an issue where the buttons on the benefits step of the OBW require 2 clicks to move forward.

cc @joshuatf - can you help fix the buttons?

### Screenshots

![2020-05-28 15 05 43](https://user-images.githubusercontent.com/63922/83195606-b6a73880-a0f7-11ea-88be-9dc954aa18b2.gif)


### Detailed test instructions:

- Ex: Open page `url`
- Click XYZ…

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
