### PR TITLE
Overview: fix reference to old wc-api method

### DIFF
--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -325,12 +325,8 @@ class CustomizableDashboard extends Component {
 
 export default compose(
 	withSelect( ( select ) => {
-		const {
-			getCurrentUserData,
-			isGetProfileItemsRequesting,
-			getOptions,
-			isGetOptionsRequesting,
-		} = select( 'wc-api' );
+		const { getCurrentUserData, getOptions } = select( 'wc-api' );
+
 		const userData = getCurrentUserData();
 		const { woocommerce_default_date_range: defaultDateRange } = select(
 			SETTINGS_STORE_NAME
@@ -339,7 +335,6 @@ export default compose(
 		const withSelectData = {
 			userPrefSections: userData.dashboard_sections,
 			defaultDateRange,
-			requesting: false,
 		};
 
 		if ( isOnboardingEnabled() ) {
@@ -355,14 +350,6 @@ export default compose(
 				[ 'woocommerce_task_list_complete' ],
 				false
 			);
-			withSelectData.requesting =
-				withSelectData.requesting || isGetProfileItemsRequesting();
-			withSelectData.requesting =
-				withSelectData.requesting ||
-				isGetOptionsRequesting( [
-					'woocommerce_task_list_payments',
-					'woocommerce_task_list_hidden',
-				] );
 		}
 
 		return withSelectData;


### PR DESCRIPTION
`customizable.js` was referencing a function no longer available `isGetProfileItemsRequesting`, breaking the entire page. The function was removed in https://github.com/woocommerce/woocommerce-admin/pull/4433.

I noticed that it was used to create a prop `requesting`, which wasn't used anywhere. So I removed all its logic.

### To reproduce

1. Change the `woocommerce_onboarding_opt_in` option to "yes"
2. Visit Analytics > Overview

### Detailed test instructions:

Same as above, just with this branch

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

none
