### PR TITLE
Fixed missing 'items' in collection params

### DIFF
--- a/src/API/Reports/Customers/Controller.php
+++ b/src/API/Reports/Customers/Controller.php
@@ -474,6 +474,9 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
@@ -491,6 +494,9 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 		$params['orders_count_min']        = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'woocommerce-admin' ),
@@ -508,6 +514,9 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
 		);
 		$params['total_spend_min']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'woocommerce-admin' ),
@@ -523,6 +532,9 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
 		);
 		$params['avg_order_value_min']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'woocommerce-admin' ),
@@ -538,6 +550,9 @@ class Controller extends \WC_REST_Reports_Controller implements ExportableInterf
 			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
 		);
 		$params['last_order_before']       = array(
 			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),

--- a/src/API/Reports/Customers/Stats/Controller.php
+++ b/src/API/Reports/Customers/Stats/Controller.php
@@ -277,6 +277,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 		$params['registered_before']       = array(
 			'description'       => __( 'Limit response to objects registered before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),
@@ -294,6 +297,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'description'       => __( 'Limit response to objects last active between two given ISO8601 compliant datetime.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_date_arg' ),
+			'items'             => array(
+				'type' => 'string',
+			),
 		);
 		$params['orders_count_min']        = array(
 			'description'       => __( 'Limit response to objects with an order count greater than or equal to given integer.', 'woocommerce-admin' ),
@@ -311,6 +317,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'description'       => __( 'Limit response to objects with an order count between two given integers.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
 		);
 		$params['total_spend_min']         = array(
 			'description'       => __( 'Limit response to objects with a total order spend greater than or equal to given number.', 'woocommerce-admin' ),
@@ -326,6 +335,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'description'       => __( 'Limit response to objects with a total order spend between two given numbers.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
 		);
 		$params['avg_order_value_min']     = array(
 			'description'       => __( 'Limit response to objects with an average order spend greater than or equal to given number.', 'woocommerce-admin' ),
@@ -341,6 +353,9 @@ class Controller extends \WC_REST_Reports_Controller {
 			'description'       => __( 'Limit response to objects with an average order spend between two given numbers.', 'woocommerce-admin' ),
 			'type'              => 'array',
 			'validate_callback' => array( '\Automattic\WooCommerce\Admin\API\Reports\TimeInterval', 'rest_validate_between_numeric_arg' ),
+			'items'             => array(
+				'type' => 'integer',
+			),
 		);
 		$params['last_order_before']       = array(
 			'description'       => __( 'Limit response to objects with last order before (or at) a given ISO8601 compliant datetime.', 'woocommerce-admin' ),


### PR DESCRIPTION
It fixes a notice caused by the missing `items` param required for 'array' types.
Seems like now there's some new items to fix since #4377

> [14-May-2020 18:15:39 UTC] PHP Notice:  Undefined index: items in /var/www/woo/wp-includes/rest-api.php on line 1246

Fixes #4280

### Detailed test instructions:

- Turn on your PHP logger, you can enable the WP logger by introducing the code bellow to your `wp-config.php`:
```php
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
define( 'WP_DEBUG_DISPLAY', true );
```
- Go to the WC Admin Dashboard in `/wp-admin/admin.php?page=wc-admin`
- Now check the `wp-content/debug.log`, you should see messages like:
> PHP Notice:  Undefined index: items in /var/www/woo/wp-includes/rest-api.php on line 1246
- Finally apply this patch and reload the dashboard page, check that all notices are gone now.

Note: Tested with WooCommerce 4.1.x and 4.2 beta 1.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

Fix: REST API collections schema.