### PR TITLE
Correctly set parent path when a wc-admin registered page is used as a breadcrumb parent

### DIFF
--- a/src/PageController.php
+++ b/src/PageController.php
@@ -168,6 +168,11 @@ class PageController {
 			while ( $parent_id ) {
 				if ( isset( $this->pages[ $parent_id ] ) ) {
 					$parent = $this->pages[ $parent_id ];
+
+					if ( 0 === strpos( $parent['path'], self::PAGE_ROOT ) ) {
+						$parent['path'] = 'admin.php?page=' . self::PAGE_ROOT . '&path=' . $parent['path'];
+					}
+
 					array_unshift( $breadcrumbs, array( $parent['path'], reset( $parent['title'] ) ) );
 					$parent_id = isset( $parent['parent'] ) ? $parent['parent'] : false;
 				} else {

--- a/tests/page-controller.php
+++ b/tests/page-controller.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * PageController tests
+ *
+ * @package WooCommerce Admin\Tests\PageController
+ */
+
+use \Automattic\WooCommerce\Admin\PageController;
+
+/**
+ * WC_Admin_Tests_Page_Controller Class
+ *
+ * @package WooCommerce Admin\Tests\PageController
+ */
+class WC_Admin_Tests_Page_Controller extends WP_UnitTestCase {
+
+	/**
+	 * Test get_breadcrumbs()
+	 */
+	public function test_get_breadcrumbs_no_parent() {
+
+		// orders page registration data.
+		$orders_page = array(
+			'id'        => 'woocommerce-orders',
+			'screen_id' => 'edit-shop_order',
+			'path'      => add_query_arg( 'post_type', 'shop_order', 'edit.php' ),
+			'title'     => array( 'Orders' ),
+		);
+
+		$controller = PageController::get_instance();
+
+		// Connect existing pages to wc-admin.
+		$controller->connect_page( $orders_page );
+
+		// Need to set current screen to use "get_current_screen()".
+		set_current_screen( 'edit-shop_order' );
+
+		// Set the private current_page variable to order page.
+		$reflection = new \ReflectionClass( $controller );
+		$property   = $reflection->getProperty( 'current_page' );
+		$property->setAccessible( true );
+		$property->setValue( $controller, $orders_page );
+
+		$breadcrumbs = $controller->get_breadcrumbs();
+
+		$this->assertEquals(
+			2,
+			count( $breadcrumbs ),
+			'Orders page should have 2 breacrumbs items.'
+		);
+
+		$this->assertEquals(
+			array(
+				'admin.php?page=wc-admin',
+				'WooCommerce',
+			),
+			$breadcrumbs[0],
+			'Orders home breadcrumb should be WooCommerce.'
+		);
+
+		$this->assertEquals(
+			'Orders',
+			$breadcrumbs[1],
+			'Orders current breadcrumb should be a simple "Orders" string.'
+		);
+	}
+
+	/**
+	 * Test get_breadcrumbs()
+	 */
+	public function test_get_breadcrumbs_with_parent() {
+
+		// coupon page registration data.
+		$coupon_page = array(
+			'id'        => 'woocommerce-coupons',
+			'parent'    => 'woocommerce-marketing',
+			'screen_id' => 'edit-shop_coupon',
+			'path'      => add_query_arg( 'post_type', 'shop_coupon', 'edit.php' ),
+			'title'     => array( 'Coupons' ),
+		);
+
+		// marketing page registration data.
+		$marketing_page = array(
+			'id'       => 'woocommerce-marketing',
+			'title'    => 'Marketing',
+			'path'     => '/marketing',
+			'icon'     => 'dashicons-megaphone',
+			'position' => 58,
+		);
+
+		$controller = PageController::get_instance();
+
+		// Connect existing pages to wc-admin.
+		$controller->connect_page( $coupon_page );
+
+		// Register wc-admin JS page.
+		$controller->register_page( $marketing_page );
+
+		// Need to set current screen to use "get_current_screen()".
+		set_current_screen( 'edit-shop_coupon' );
+
+		// Set the private current_page variable to coupon page.
+		$reflection = new \ReflectionClass( $controller );
+		$property   = $reflection->getProperty( 'current_page' );
+		$property->setAccessible( true );
+		$property->setValue( $controller, $coupon_page );
+
+		$breadcrumbs = $controller->get_breadcrumbs();
+
+		$this->assertEquals(
+			3,
+			count( $breadcrumbs ),
+			'Coupons page should have 3 breacrumbs items.'
+		);
+
+		$this->assertEquals(
+			array(
+				'admin.php?page=wc-admin',
+				'WooCommerce',
+			),
+			$breadcrumbs[0],
+			'Coupons home breadcrumb should be WooCommerce.'
+		);
+
+		$this->assertEquals(
+			array(
+				'admin.php?page=wc-admin&path=wc-admin&path=/marketing',
+				'Marketing',
+			),
+			$breadcrumbs[1],
+			'Coupons parent should be Marketing.'
+		);
+
+		$this->assertEquals(
+			'Coupons',
+			$breadcrumbs[2],
+			'Coupons current breadcrumb should be a simple "Coupons" string.'
+		);
+	}
+}

--- a/tests/page-controller.php
+++ b/tests/page-controller.php
@@ -46,7 +46,7 @@ class WC_Admin_Tests_Page_Controller extends WP_UnitTestCase {
 		$this->assertEquals(
 			2,
 			count( $breadcrumbs ),
-			'Orders page should have 2 breacrumbs items.'
+			'Orders page should have 2 breadcrumbs items.'
 		);
 
 		$this->assertEquals(
@@ -110,7 +110,7 @@ class WC_Admin_Tests_Page_Controller extends WP_UnitTestCase {
 		$this->assertEquals(
 			3,
 			count( $breadcrumbs ),
-			'Coupons page should have 3 breacrumbs items.'
+			'Coupons page should have 3 breadcrumbs items.'
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
### Background

We are looking at moving the Coupons admin pages e.g. wp-admin/edit.php?post_type=shop_coupon to be under the new "Marketing" top level menu item.

The Marketing top level menu item is a [wc-admin registered page](https://github.com/woocommerce/woocommerce-admin/blob/master/src/Features/Marketing.php#L66) e.g. wp-admin/admin.php?page=wc-admin&path=/marketing

### Problem

The current coupons page is a [wc admin connected page](https://github.com/woocommerce/woocommerce-admin/blob/master/includes/connect-existing-pages.php#L155) - if we set a parent to be the marketing page e.g. 

```
// WooCommerce > Coupons.
wc_admin_connect_page(
	array(
		'id'        => 'woocommerce-coupons',
		'parent'    => 'woocommerce-marketing',
		'screen_id' => 'edit-shop_coupon',
		'title'     => __( 'Coupons', 'woocommerce-admin' ),
		'path'      => add_query_arg( 'post_type', 'shop_coupon', $posttype_list_base ),
	)
);
```

The Breadcrumbs look ok  https://d.pr/i/Jo8xmi but the actual url is missing part of the path (specifically `admin.php?page=wc-admin&path=`) and ends up being something like

http://example.woo/wp-admin/wc-admin&path=/marketing

Instead of 

http://example.woo/wp-admin/admin.php?page=wc-admin&path=wc-admin&path=/marketing 

It appears like wc-admin registered pages are not currently being fully handled as parent pages of **wc-admin connected** pages. 

### Fix

This PR adjust the `get_breadcrumbs()` method to check if the parent path starts with `wc-admin` then prepends with `admin.php?page=wc-admin&path=` so that the breadcrumb parent ends up as `admin.php?page=wc-admin&path=wc-admin&path=/marketing`

### Detailed test instructions:

- Clone branch
- Set a parent for the [coupons page](https://github.com/woocommerce/woocommerce-admin/blob/master/includes/connect-existing-pages.php#L155) - you can use `woocommerce-marketing` or any other wc-admin registered page e.g. `woocommerce-analytics`
- Go to the coupons admin page and check that the parent breadcrumb url is correct.
- Confirm other breadcrumbs are still ok by browsing to other admin pages like Reports.
- You can also set the parent to be another woocommerce connected page to confirm they still work e.g. `woocommerce-orders`

I've added some unit tests to help with coverage - happy to tweak

(Note this PR does not move the coupon menu item around)
