### PR TITLE
WCPay: Remove Jetpack requirement

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -37,12 +37,18 @@ class Payments extends Component {
 		const { methods } = props;
 
 		const enabledMethods = {};
-		methods.forEach(
-			( method ) => ( enabledMethods[ method.key ] = method.isEnabled )
-		);
+		let recommendedMethod = 'stripe';
+		methods.forEach( ( { isEnabled, key, visible } ) => {
+			enabledMethods[ key ] = isEnabled;
+			if ( key === 'wcpay' && visible ) {
+				recommendedMethod = 'wcpay';
+			}
+		} );
+
 		this.state = {
 			enabledMethods,
 			configuringMethods: {},
+			recommendedMethod,
 		};
 
 		this.completeTask = this.completeTask.bind( this );
@@ -59,14 +65,7 @@ class Payments extends Component {
 		}
 		const { createNotice, errors, methods, requesting } = this.props;
 
-		let recommendedMethod = 'stripe';
-		methods.forEach( ( method ) => {
-			const { key, title, visible } = method;
-
-			if ( key === 'wcpay' && visible ) {
-				recommendedMethod = 'wcpay';
-			}
-
+		methods.forEach( ( { key, title } ) => {
 			if (
 				prevProps.requesting[ key ] &&
 				! requesting[ key ] &&
@@ -84,12 +83,6 @@ class Payments extends Component {
 				);
 			}
 		} );
-
-		if ( this.state.recommendedMethod !== recommendedMethod ) {
-			this.setState( {
-				recommendedMethod,
-			} );
-		}
 	}
 
 	completeTask() {
@@ -247,7 +240,11 @@ class Payments extends Component {
 	render() {
 		const currentMethod = this.getCurrentMethod();
 		const { methods } = this.props;
-		const { enabledMethods, recommendedMethod, configuringMethods } = this.state;
+		const {
+			enabledMethods,
+			recommendedMethod,
+			configuringMethods,
+		} = this.state;
 		const configuredMethods = methods.filter(
 			( method ) => method.isConfigured
 		).length;

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -53,9 +53,7 @@ class Payments extends Component {
 
 		this.completeTask = this.completeTask.bind( this );
 		this.markConfigured = this.markConfigured.bind( this );
-		this.markConfigurationFinished = this.markConfigurationFinished.bind(
-			this
-		);
+		this.markNotConfiguring = this.markNotConfiguring.bind( this );
 		this.skipTask = this.skipTask.bind( this );
 	}
 
@@ -132,7 +130,7 @@ class Payments extends Component {
 	markConfigured( method ) {
 		const { enabledMethods } = this.state;
 
-		this.markConfigurationFinished( method );
+		this.markNotConfiguring( method );
 		this.setState( {
 			enabledMethods: {
 				...enabledMethods,
@@ -147,7 +145,7 @@ class Payments extends Component {
 		} );
 	}
 
-	markConfigurationFinished( method ) {
+	markNotConfiguring( method ) {
 		this.setState( {
 			configuringMethods: {
 				[ method ]: false,
@@ -191,9 +189,7 @@ class Payments extends Component {
 							plugins: currentMethod.plugins,
 						} );
 					} }
-					onError={ () =>
-						this.markConfigurationFinished( currentMethod )
-					}
+					onError={ () => this.markNotConfiguring( currentMethod ) }
 					autoInstall
 					pluginSlugs={ currentMethod.plugins }
 				/>
@@ -228,7 +224,7 @@ class Payments extends Component {
 			query: this.props.query,
 			installStep: this.getInstallStep( method ),
 			markConfigured: this.markConfigured,
-			markConfigurationFinished: this.markConfigurationFinished.bind(
+			markNotConfiguring: this.markNotConfiguring.bind(
 				this,
 				method.key
 			),

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -332,6 +332,7 @@ class Payments extends Component {
 										isPrimary={ key === recommendedMethod }
 										isDefault={ key !== recommendedMethod }
 										isBusy={ configuringMethods[ key ] }
+										disabled={ configuringMethods[ key ] }
 										onClick={ () => {
 											recordEvent(
 												'tasklist_payment_setup',

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -230,7 +230,6 @@ class Payments extends Component {
 				method.key
 			),
 			hasCbdIndustry: method.hasCbdIndustry,
-			key: 'setup-' + method.key,
 		} );
 	}
 
@@ -258,7 +257,12 @@ class Payments extends Component {
 					</Card>
 				);
 			} else if ( configuringMethods[ key ] ) {
-				return this.getSetupElement( method );
+				// Payment methods that have "inline setup" must not show any UI, the setupElement must just trigger the setup.
+				return (
+					<div style={ { display: 'none' } } key={ 'setup-' + key }>
+						{ this.getSetupElement( method ) }
+					</div>
+				);
 			}
 			return null;
 		} );

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -47,6 +47,7 @@ class Payments extends Component {
 
 		this.state = {
 			enabledMethods,
+			// List of methods that are currently being installed/configured, and have the "hasInlineSetup" capability.
 			configuringMethods: {},
 			recommendedMethod,
 		};

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -266,7 +266,7 @@ class Payments extends Component {
 			return null;
 		} );
 
-		const methodsList = (
+		const methodsList = currentMethod ? null : (
 			<div className="woocommerce-task-payments">
 				{ methods.map( ( method ) => {
 					const {

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -47,7 +47,7 @@ class Payments extends Component {
 
 		this.state = {
 			enabledMethods,
-			// List of methods that are currently being installed/configured, and have the "hasInlineSetup" capability.
+			// List of methods that are currently being installed/configured, and have the "hasAutoSetup" capability.
 			configuringMethods: {},
 			recommendedMethod,
 		};
@@ -257,7 +257,7 @@ class Payments extends Component {
 					</Card>
 				);
 			} else if ( configuringMethods[ key ] ) {
-				// Payment methods that have "inline setup" must not show any UI, the setupElement must just trigger the setup.
+				// Payment methods that have "auto setup" must not show any UI, the setupElement must just trigger the setup.
 				return (
 					<div style={ { display: 'none' } } key={ 'setup-' + key }>
 						{ this.getSetupElement( method ) }
@@ -278,7 +278,7 @@ class Payments extends Component {
 						key,
 						title,
 						visible,
-						hasInlineSetup,
+						hasAutoSetup,
 					} = method;
 
 					if ( ! visible ) {
@@ -348,7 +348,7 @@ class Payments extends Component {
 													selected: key,
 												}
 											);
-											if ( hasInlineSetup ) {
+											if ( hasAutoSetup ) {
 												this.setState( {
 													configuringMethods: {
 														[ key ]: true,

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -363,9 +363,7 @@ export default compose(
 			isUpdateOptionsRequesting,
 		} = select( 'wc-api' );
 
-		const { getActivePlugins, isJetpackConnected } = select(
-			PLUGINS_STORE_NAME
-		);
+		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 		const activePlugins = getActivePlugins();
 		const profileItems = getProfileItems();
 		const options = getOptions( [
@@ -389,7 +387,6 @@ export default compose(
 		const methods = getPaymentMethods( {
 			activePlugins,
 			countryCode,
-			isJetpackConnected: isJetpackConnected(),
 			options,
 			profileItems,
 		} );

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -118,8 +118,15 @@ export function getPaymentMethods( {
 			),
 			before: <WCPayIcon />,
 			visible:
-				[ 'US' ].includes( countryCode ) &&
-				! hasCbdIndustry,
+				[
+					'US',
+					'AS',
+					'PR',
+					'VI',
+					'GU',
+					'MP',
+					'UM', // U.S. and its territories (which WooCommerce classifies as countries)
+				].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConnected,
@@ -149,7 +156,8 @@ export function getPaymentMethods( {
 			),
 			before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
 			visible:
-				stripeSupportedCountries.includes( countryCode ) && ! hasCbdIndustry,
+				stripeSupportedCountries.includes( countryCode ) &&
+				! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
 			isConfigured:

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -34,7 +34,6 @@ import PayFast from './payfast';
 export function getPaymentMethods( {
 	activePlugins,
 	countryCode,
-	isJetpackConnected,
 	options,
 	profileItems,
 } ) {
@@ -120,8 +119,7 @@ export function getPaymentMethods( {
 			before: <WCPayIcon />,
 			visible:
 				[ 'US' ].includes( countryCode ) &&
-				! hasCbdIndustry &&
-				isJetpackConnected,
+				! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConnected,

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -118,15 +118,7 @@ export function getPaymentMethods( {
 			),
 			before: <WCPayIcon />,
 			visible:
-				[
-					'US',
-					'AS',
-					'PR',
-					'VI',
-					'GU',
-					'MP',
-					'UM', // U.S. and its territories (which WooCommerce classifies as countries)
-				].includes( countryCode ) && ! hasCbdIndustry,
+				[ 'US', 'PR', ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConnected,

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -117,8 +117,7 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <WCPayIcon />,
-			visible:
-				[ 'US', 'PR', ].includes( countryCode ) && ! hasCbdIndustry,
+			visible: [ 'US', 'PR' ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConnected,
@@ -127,6 +126,7 @@ export function getPaymentMethods( {
 				options.woocommerce_woocommerce_payments_settings.enabled ===
 					'yes',
 			optionName: 'woocommerce_woocommerce_payments_settings',
+			hasInlineSetup: true,
 		} );
 	}
 

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -126,7 +126,7 @@ export function getPaymentMethods( {
 				options.woocommerce_woocommerce_payments_settings.enabled ===
 					'yes',
 			optionName: 'woocommerce_woocommerce_payments_settings',
-			hasInlineSetup: true,
+			hasAutoSetup: true,
 		} );
 	}
 

--- a/client/task-list/tasks/payments/wcpay.js
+++ b/client/task-list/tasks/payments/wcpay.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
 /**
@@ -38,6 +37,17 @@ class WCPay extends Component {
 				)
 			);
 			markConfigured( 'wcpay' );
+		} else if ( this.props.installStep.isComplete ) {
+			this.connect();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		if (
+			! prevProps.installStep.isComplete &&
+			this.props.installStep.isComplete
+		) {
+			this.connect();
 		}
 	}
 
@@ -75,35 +85,17 @@ class WCPay extends Component {
 		const { installStep } = this.props;
 		const { isPending } = this.state;
 
+		// When being redirected from the WCPay onboarding flow, don't render the Stepper so there isn't an extra "Plugins successfully activated" notice.
+		if ( getQuery()[ 'wcpay-connection-success' ] ) {
+			return null;
+		}
+
 		return (
 			<Stepper
 				isVertical
 				isPending={ ! installStep.isComplete || isPending }
-				currentStep={ installStep.isComplete ? 'connect' : 'install' }
-				steps={ [
-					installStep,
-					{
-						key: 'connect',
-						label: __(
-							'Verify business details',
-							'woocommerce-admin'
-						),
-						description: __(
-							'Verify your business details with our payment partner, Stripe.',
-							'woocommerce-admin'
-						),
-						content: (
-							<Button
-								isPrimary
-								isDefault
-								isBusy={ isPending }
-								onClick={ this.connect }
-							>
-								{ __( 'Verify details', 'woocommerce-admin' ) }
-							</Button>
-						),
-					},
-				] }
+				currentStep="install"
+				steps={ [ installStep ] }
 			/>
 		);
 	}

--- a/client/task-list/tasks/payments/wcpay.js
+++ b/client/task-list/tasks/payments/wcpay.js
@@ -49,7 +49,7 @@ class WCPay extends Component {
 	}
 
 	async connect() {
-		const { createNotice, markConfigurationFinished } = this.props;
+		const { createNotice, markNotConfiguring } = this.props;
 
 		const errorMessage = __(
 			'There was an error connecting to WooCommerce Payments. Please try again or connect later in store settings.',
@@ -64,14 +64,14 @@ class WCPay extends Component {
 			} );
 
 			if ( ! result || ! result.connectUrl ) {
-				markConfigurationFinished();
+				markNotConfiguring();
 				createNotice( 'error', errorMessage );
 				return;
 			}
 
 			window.location = result.connectUrl;
 		} catch ( error ) {
-			markConfigurationFinished();
+			markNotConfiguring();
 			createNotice( 'error', errorMessage );
 		}
 	}


### PR DESCRIPTION
Fixes #4416

cc/ @vbelolapotkov I know you're AFK, so this is just an FYI, you don't need to review it. I think @dechov has enough context to test this :)

- In https://github.com/woocommerce/woocommerce-admin/commit/fbd53439007e893ea413f72ad1c5c8c67a2b5c2d, remove the Jetpack requirement to show the WCPay card in the Payments page of the task list.
- In https://github.com/woocommerce/woocommerce-admin/commit/573f9947da82b097045ac0b37d40bb17b50b0e0f, add all the US territories to the list of "countries" we should show the WCPay payment method in.
- In https://github.com/woocommerce/woocommerce-admin/commit/313a9d637bdd25bcf062483df8f60cfa9df80e7a, remove the "Verify details" call to action after installing & activating WCPay. Instead, after the plugin is installed & activated, the Stripe KYC (or Jetpack connection) process is automatically started.

### Detailed test instructions:

- Clone the `woocommerce-payments` repo, checkout the `jetpack/trigger-jetpack-connection-flow` branch.
- In the `woocommerce-payments` folder, run `rm -rf node_modules vendor` if you already had the repo cloned.
- Run `npm install && npm run release`, that should generate a `zip` file in `/release/woocommerce-payments.zip`. Copy it to a different folder if you want.
- Start with a site that only has this branch of WooCommerce Admin installed. No Jetpack, no WCPay, nothing else.
- Add this code to your site. It will ensure that, when installing WCPay from "wordpress.org", WC-Admin will "download" and install the `zip` you generated instead.
```php
add_filter( 'plugins_api_result', function ( $res, $action, $args ) {
	if ( ! is_wp_error( $res ) && 'plugin_information' === $action && isset( $args->slug ) && 'woocommerce-payments' === $args->slug ) {
		// Replace this path to where you have the ZIP. If your site is not on your local machine, you'll need to upload the ZIP to a known folder of the server you're using
		$res->download_link = '/Users/daniel/Downloads/woocommerce-payments.zip';
	}
	return $res;
}, 10, 3 );
```
- Make sure the site you're using has US as its store address (or an US territory).
- You should see WCPay in the Payments task list, and you should be able to install it, activate it, and start the Jetpack connection process with a single click.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Enhancement: Jetpack is no longer required to enable WooCommerce Payments.
