### PR TITLE
Correctly remove reference to debounced updateSliderHeight method

### DIFF
--- a/client/marketing/components/slider/index.js
+++ b/client/marketing/components/slider/index.js
@@ -21,21 +21,18 @@ class Slider extends Component {
 		this.container = createRef();
 		this.onEnter = this.onEnter.bind( this );
 		this.updateSliderHeight = this.updateSliderHeight.bind( this );
+		this.debouncedUpdateSliderHeight = debounce( this.updateSliderHeight, 50 );
 	}
 
 	/**
 	 * Update the slider height on Resize
 	 */
 	componentDidMount() {
-		// Update the slider height on Resize
-		window.addEventListener(
-			'resize',
-			debounce( this.updateSliderHeight, 50 )
-		);
+		window.addEventListener( 'resize', this.debouncedUpdateSliderHeight );
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.updateSliderHeight )
+		window.removeEventListener( 'resize', this.debouncedUpdateSliderHeight );
 	}
 
 	updateSliderHeight() {


### PR DESCRIPTION
Fixes #4521

The slider component used on the marketing tab currently watches the resize event to adjust slide height. 

We're are currently adding the event listener with debounce but not correctly removing it. [Some information about the why we aren't doing it correctly is here for reference](https://chipcullen.com/troubleshooting-adding-and-removing-eventlisteners/).

As a result after viewing the marketing tab then browsing to another wc-admin page results in errors like `TypeError: can't access property "querySelector", this.container.current is null` because the listener is still trying to do its thing.

### Detailed test instructions:

- Pull branch
- Build
- Go to the marketing tab - resize screen etc.
- Go to WooCommerce -> Customers (or another wc-admin page like Analytics -> Orders
- resize, click around
- Check console to make sure you don't see the event / error firing off.
