### PR TITLE
Tracks: Change isEmbedded prop to is_embedded

### DIFF
--- a/client/layout/index.js
+++ b/client/layout/index.js
@@ -80,7 +80,7 @@ class _Layout extends Component {
 
 		if ( isEmbedded ) {
 			const path = document.location.pathname + document.location.search;
-			recordPageView( path, { isEmbedded } );
+			recordPageView( path, { is_embedded: true } );
 			return;
 		}
 
@@ -193,7 +193,11 @@ class _PageLayout extends Component {
 								path={ page.path }
 								exact
 								render={ ( props ) => (
-									<Layout page={ page } homepageEnabled={ homepageEnabled } { ...props } />
+									<Layout
+										page={ page }
+										homepageEnabled={ homepageEnabled }
+										{ ...props }
+									/>
 								) }
 							/>
 						);
@@ -212,7 +216,8 @@ export const PageLayout = compose(
 		const options = getOptions( [ 'woocommerce_homescreen_enabled' ] );
 		const homepageEnabled =
 			window.wcAdminFeatures.homepage &&
-			get( options, [ 'woocommerce_homescreen_enabled' ], false ) === 'yes';
+			get( options, [ 'woocommerce_homescreen_enabled' ], false ) ===
+				'yes';
 		return { homepageEnabled };
 	} )
 )( _PageLayout );


### PR DESCRIPTION
Fixes #4528

We have a tracks prop that is causing page view tracks on "embedded" pages ( i.e. legacy Woo PHP pages ) from being recorded properly. See p7Ldg5-xz-p2 for full details

### Screenshots

__Before__
![isEmbedded](https://user-images.githubusercontent.com/22080/84177390-a8321880-aa37-11ea-8276-76769965654a.png)

__After__
![is_embedded](https://user-images.githubusercontent.com/22080/84177401-ad8f6300-aa37-11ea-983e-69f6e2652f94.png)

### Detailed test instructions:

- In your browser console, execute the following to see tracks debugging: `localStorage.setItem( 'debug', 'wc-admin:*' )`
- Then view a legacy Woo page, like orders listing: `/wp-admin/edit.php?post_type=shop_order`
- Verify the props on the track has the prop of `is_embedded` instead of `isEmbedded`
