### PR TITLE
Update hubspot-for-woocommerce extension info

### DIFF
--- a/src/Marketing/InstalledExtensions.php
+++ b/src/Marketing/InstalledExtensions.php
@@ -68,7 +68,7 @@ class InstalledExtensions {
 			'mailchimp-for-woocommerce',
 			'facebook-for-woocommerce',
 			'kliken-marketing-for-google',
-			'hubwoo-integration',
+			'hubspot-for-woocommerce',
 			'woocommerce-amazon-ebay-integration',
 		];
 	}
@@ -190,7 +190,7 @@ class InstalledExtensions {
 	 * @return array|bool
 	 */
 	protected static function get_hubspot_extension_data() {
-		$slug = 'hubwoo-integration';
+		$slug = 'hubspot-for-woocommerce';
 
 		if ( ! PluginsHelper::is_plugin_installed( $slug ) ) {
 			return false;
@@ -207,7 +207,7 @@ class InstalledExtensions {
 			}
 
 			$data['settingsUrl'] = admin_url( 'admin.php?page=hubwoo' );
-			$data['docsUrl']     = 'https://docs.makewebbetter.com/hubspot-woocommerce-integration/';
+			$data['docsUrl']     = 'https://docs.makewebbetter.com/hubspot-integration-for-woocommerce/';
 		}
 
 		return $data;


### PR DESCRIPTION
Fixes #4265

Updates the extension information for hubspot to use the new plugin available on WooCommerce.com at https://woocommerce.com/products/hubspot-for-woocommerce/

https://d.pr/i/GeEjO1

To test the plugin
* Hubspot requires an account - a free one will do
* Needs a HTTPS site to connect / finish setup

@danielbitzer I'm getting the following error when attempting to activate the plugin

```
[11-Jun-2020 04:56:07 UTC] PHP Warning:  session_start(): Cannot start session when headers already sent in /Users/jconroy/Sites/local/wp-content/plugins/hubspot-for-woocommerce/public/class-hubwoo-public.php on line 310
```

Clicking activate twice gets the plugin activated. Other plugins don't appear to have this issue - 

I'm 99% sure will be something that needs to be fixed on the plugin end but I was hoping to get your 👀 to double check my thinking.

(I've just tried activating it normally and still get the session_start() warnings)
