### PR TITLE
Try: WC Pay payment method with custom onClick handler

### DIFF
--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -43,6 +43,7 @@ class Payments extends Component {
 		);
 		this.state = {
 			enabledMethods,
+			recommendedMethod: this.getRecommendedMethod(),
 		};
 
 		this.completeTask = this.completeTask.bind( this );
@@ -50,26 +51,22 @@ class Payments extends Component {
 		this.skipTask = this.skipTask.bind( this );
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( prevProps === this.props ) {
-			return;
-		}
-		const { methods } = this.props;
+	componentDidUpdate() {
+		const { recommendedMethod } = this.state;
 
-		let recommendedMethod = 'stripe';
-		methods.forEach( ( method ) => {
-			const { key, visible } = method;
-
-			if ( key === 'wcpay' && visible ) {
-				recommendedMethod = 'wcpay';
-			}
-		} );
-
-		if ( this.state.recommendedMethod !== recommendedMethod ) {
+		const method = this.getRecommendedMethod();
+		if ( recommendedMethod !== method ) {
 			this.setState( {
-				recommendedMethod,
+				recommendedMethod: method,
 			} );
 		}
+	}
+
+	getRecommendedMethod() {
+		const { methods } = this.props;
+		return (
+			methods.find( ( m ) => m.key === 'wcpay' && m.visible ) || 'stripe'
+		);
 	}
 
 	async completeTask() {

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -212,8 +212,6 @@ class Payments extends Component {
 		const { methods } = this.props;
 		const { key, onClick } = method;
 
-		this.setState( { busyMethod: key } );
-
 		recordEvent( 'tasklist_payment_setup', {
 			options: methods.map( ( option ) => option.key ),
 			selected: key,

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -373,7 +373,18 @@ class Payments extends Component {
 }
 
 export default compose(
-	withSelect( ( select ) => {
+	withDispatch( ( dispatch ) => {
+		const { createNotice } = dispatch( 'core/notices' );
+		const { installAndActivatePlugins } = dispatch( PLUGINS_STORE_NAME );
+		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
+		return {
+			createNotice,
+			installAndActivatePlugins,
+			updateOptions,
+		};
+	} ),
+	withSelect( ( select, props ) => {
+		const { createNotice, installAndActivatePlugins } = props;
 		const { getProfileItems } = select( ONBOARDING_STORE_NAME );
 		const { getOption, isOptionsUpdating } = select( OPTIONS_STORE_NAME );
 		const { getActivePlugins, isJetpackConnected } = select(
@@ -409,6 +420,8 @@ export default compose(
 		const methods = getPaymentMethods( {
 			activePlugins,
 			countryCode,
+			createNotice,
+			installAndActivatePlugins,
 			isJetpackConnected: isJetpackConnected(),
 			options,
 			profileItems,
@@ -423,14 +436,6 @@ export default compose(
 			options,
 			methods,
 			requesting,
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { createNotice } = dispatch( 'core/notices' );
-		const { updateOptions } = dispatch( OPTIONS_STORE_NAME );
-		return {
-			createNotice,
-			updateOptions,
 		};
 	} )
 )( Payments );

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -65,9 +65,9 @@ class Payments extends Component {
 
 	getRecommendedMethod() {
 		const { methods } = this.props;
-		return (
-			methods.find( ( m ) => m.key === 'wcpay' && m.visible ) || 'stripe'
-		);
+		return methods.find( ( m ) => m.key === 'wcpay' && m.visible )
+			? 'wcpay'
+			: 'stripe';
 	}
 
 	async completeTask() {

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -34,7 +34,6 @@ import PayFast from './payfast';
 export function getPaymentMethods( {
 	activePlugins,
 	countryCode,
-	isJetpackConnected,
 	options,
 	profileItems,
 } ) {
@@ -118,10 +117,11 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <WCPayIcon />,
+			after: <div>
+				{ __( 'Set up wc pay', 'woocommerce-admin' ) }
+			</div>,
 			visible:
-				[ 'US' ].includes( countryCode ) &&
-				! hasCbdIndustry &&
-				isJetpackConnected,
+				[ 'US', 'PR' ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConnected,

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -117,11 +117,10 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <WCPayIcon />,
-			after: <div>
-				{ __( 'Set up wc pay', 'woocommerce-admin' ) }
-			</div>,
-			visible:
-				[ 'US', 'PR' ].includes( countryCode ) && ! hasCbdIndustry,
+			onClick: ( resolve ) => {
+				resolve();
+			},
+			visible: [ 'US', 'PR' ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],
 			container: <WCPay />,
 			isConfigured: wcPayIsConnected,
@@ -151,7 +150,8 @@ export function getPaymentMethods( {
 			),
 			before: <img src={ wcAssetUrl + 'images/stripe.png' } alt="" />,
 			visible:
-				stripeSupportedCountries.includes( countryCode ) && ! hasCbdIndustry,
+				stripeSupportedCountries.includes( countryCode ) &&
+				! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
 			isConfigured:

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -3,6 +3,7 @@
  */
 
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 import { Fragment } from '@wordpress/element';
 import { filter, some } from 'lodash';
 import interpolateComponents from 'interpolate-components';
@@ -16,6 +17,7 @@ import {
 	WC_ASSET_URL as wcAssetUrl,
 } from '@woocommerce/wc-admin-settings';
 import { Link } from '@woocommerce/components';
+import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
 
 /**
  * Internal dependencies
@@ -23,6 +25,7 @@ import { Link } from '@woocommerce/components';
 import Bacs from './bacs';
 import BacsIcon from './images/bacs';
 import CodIcon from './images/cod';
+import { createNoticesFromResponse } from 'lib/notices';
 import Stripe from './stripe';
 import Square from './square';
 import WCPay from './wcpay';
@@ -34,6 +37,8 @@ import PayFast from './payfast';
 export function getPaymentMethods( {
 	activePlugins,
 	countryCode,
+	createNotice,
+	installAndActivatePlugins,
 	options,
 	profileItems,
 } ) {
@@ -117,8 +122,32 @@ export function getPaymentMethods( {
 				</Fragment>
 			),
 			before: <WCPayIcon />,
-			onClick: ( resolve ) => {
-				resolve();
+			onClick: ( resolve, reject ) => {
+				const errorMessage = __(
+					'There was an error connecting to WooCommerce Payments. Please try again or connect later in store settings.',
+					'woocommerce-admin'
+				);
+
+				const connect = () => {
+					apiFetch( {
+						path: WC_ADMIN_NAMESPACE + '/plugins/connect-wcpay',
+						method: 'POST',
+					} )
+						.then( ( response ) => {
+							window.location = response.connectUrl;
+						} )
+						.catch( () => {
+							createNotice( 'error', errorMessage );
+							reject();
+						} );
+				};
+
+				installAndActivatePlugins( [ 'woocommerce-payments' ] )
+					.then( () => connect() )
+					.catch( ( error ) => {
+						createNoticesFromResponse( error );
+						reject();
+					} );
 			},
 			visible: [ 'US', 'PR' ].includes( countryCode ) && ! hasCbdIndustry,
 			plugins: [ 'woocommerce-payments' ],

--- a/client/task-list/tasks/payments/wcpay.js
+++ b/client/task-list/tasks/payments/wcpay.js
@@ -3,16 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 
 /**
  * WooCommerce dependencies
  */
 import { getQuery } from '@woocommerce/navigation';
-import { WC_ADMIN_NAMESPACE } from 'wc-api/constants';
-import { Stepper } from '@woocommerce/components';
 
 class WCPay extends Component {
 	constructor( props ) {
@@ -41,70 +37,8 @@ class WCPay extends Component {
 		}
 	}
 
-	async connect() {
-		const { createNotice } = this.props;
-		this.setState( { isPending: true } );
-
-		const errorMessage = __(
-			'There was an error connecting to WooCommerce Payments. Please try again or skip to connect later in store settings.',
-			'woocommerce-admin'
-		);
-
-		try {
-			// Fetch the business verification (connect) URL (Stripe KYC) from the backend
-			const result = await apiFetch( {
-				path: WC_ADMIN_NAMESPACE + '/plugins/connect-wcpay',
-				method: 'POST',
-			} );
-
-			if ( ! result || ! result.connectUrl ) {
-				this.setState( { isPending: false } );
-				createNotice( 'error', errorMessage );
-				return;
-			}
-
-			this.setState( { isPending: true } );
-			window.location = result.connectUrl;
-		} catch ( error ) {
-			this.setState( { isPending: false } );
-			createNotice( 'error', errorMessage );
-		}
-	}
-
 	render() {
-		const { installStep } = this.props;
-		const { isPending } = this.state;
-
-		return (
-			<Stepper
-				isVertical
-				isPending={ ! installStep.isComplete || isPending }
-				currentStep={ installStep.isComplete ? 'connect' : 'install' }
-				steps={ [
-					installStep,
-					{
-						key: 'connect',
-						label: __(
-							'Verify business details',
-							'woocommerce-admin'
-						),
-						description: __(
-							'Verify your business details with our payment partner, Stripe.',
-							'woocommerce-admin'
-						),
-						content: (
-							<Button
-								isPrimary
-								isBusy={ isPending }
-								onClick={ this.connect }
-							>
-								{ __( 'Verify details', 'woocommerce-admin' ) }
-							</Button>
-						),
-					},
-				] }
-			/>
-		);
+		return null;
 	}
 }
 

--- a/client/task-list/tasks/payments/wcpay.js
+++ b/client/task-list/tasks/payments/wcpay.js
@@ -11,16 +11,6 @@ import { withDispatch } from '@wordpress/data';
 import { getQuery } from '@woocommerce/navigation';
 
 class WCPay extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			isPending: false,
-		};
-
-		this.connect = this.connect.bind( this );
-	}
-
 	componentDidMount() {
 		const { createNotice, markConfigured } = this.props;
 		const query = getQuery();


### PR DESCRIPTION
Fixes #4416

This branch is an attempt to allow custom click handlers in payment methods.

In a future PR we may want to look at removing the WC Pay container entirely or rethinking how payment containers work, but the existing one is needed for redirect and marking the payment complete.

### Screenshots
<img width="810" alt="Screen Shot 2020-06-11 at 1 49 33 PM" src="https://user-images.githubusercontent.com/10561050/84376933-8927b800-abea-11ea-823b-2a8d9e24adf2.png">

### Detailed test instructions:

1. Follow testing instructions in https://github.com/woocommerce/woocommerce-admin/pull/4499
1. Make sure no regressions occur in other payment methods.