### PR TITLE
Currency package: make naming clearer

### DIFF
--- a/client/analytics/components/leaderboard/test/index.js
+++ b/client/analytics/components/leaderboard/test/index.js
@@ -7,7 +7,7 @@ import { mount, shallow } from 'enzyme';
  * WooCommerce dependencies
  */
 import { numberFormat } from '@woocommerce/number';
-import Currency from '@woocommerce/currency';
+import CurrencyFactory from '@woocommerce/currency';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ import { Leaderboard } from '../';
 import mockData from '../data/top-selling-products-mock-data';
 import { CURRENCY } from '@woocommerce/wc-admin-settings';
 
-const { formatCurrency, formatDecimal } = Currency( CURRENCY );
+const { formatAmount, formatDecimal } = CurrencyFactory( CURRENCY );
 
 const rows = mockData.map( ( row ) => {
 	const {
@@ -39,7 +39,7 @@ const rows = mockData.map( ( row ) => {
 			value: ordersCount,
 		},
 		{
-			display: formatCurrency( netRevenue ),
+			display: formatAmount( netRevenue ),
 			value: formatDecimal( netRevenue ),
 		},
 	];
@@ -107,7 +107,7 @@ describe( 'Leaderboard', () => {
 			numberFormat( CURRENCY, mockData[ 0 ].orders_count )
 		);
 		expect( tableItems.at( 3 ).text() ).toBe(
-			formatCurrency( mockData[ 0 ].net_revenue )
+			formatAmount( mockData[ 0 ].net_revenue )
 		);
 	} );
 } );

--- a/client/analytics/components/report-chart/index.js
+++ b/client/analytics/components/report-chart/index.js
@@ -168,7 +168,7 @@ export class ReportChart extends Component {
 		const emptyMessage = emptySearchResults
 			? __( 'No data for the current search', 'woocommerce-admin' )
 			: __( 'No data for the selected date range', 'woocommerce-admin' );
-		const { formatCurrency, getCurrency } = this.context;
+		const { formatAmount, getCurrencyConfig } = this.context;
 		return (
 			<Chart
 				allowedIntervals={ allowedIntervals }
@@ -195,13 +195,13 @@ export class ReportChart extends Component {
 				}
 				tooltipValueFormat={ getTooltipValueFormat(
 					selectedChart.type,
-					formatCurrency
+					formatAmount
 				) }
 				chartType={ getChartTypeForQuery( query ) }
 				valueType={ selectedChart.type }
 				xFormat={ formats.xFormat }
 				x2Format={ formats.x2Format }
-				currency={ getCurrency() }
+				currency={ getCurrencyConfig() }
 			/>
 		);
 	}
@@ -383,7 +383,7 @@ export default compose(
 			};
 		}
 
-		const fields = charts && charts.map( chart => chart.key ); 
+		const fields = charts && charts.map( ( chart ) => chart.key );
 
 		const primaryData = getReportChartData( {
 			endpoint,

--- a/client/analytics/components/report-filters/index.js
+++ b/client/analytics/components/report-filters/index.js
@@ -122,7 +122,7 @@ class ReportFilters extends Component {
 			<Filters
 				query={ query }
 				siteLocale={ LOCALE.siteLocale }
-				currency={ Currency.getCurrency() }
+				currency={ Currency.getCurrencyConfig() }
 				path={ path }
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -33,10 +33,10 @@ import { CurrencyContext } from 'lib/currency-context';
  */
 export class ReportSummary extends Component {
 	formatVal( val, type ) {
-		const { formatCurrency, getCurrency } = this.context;
+		const { formatAmount, getCurrencyConfig } = this.context;
 		return type === 'currency'
-			? formatCurrency( val )
-			: formatValue( getCurrency(), type, val );
+			? formatAmount( val )
+			: formatValue( getCurrencyConfig(), type, val );
 	}
 
 	getValues( key, type ) {
@@ -222,7 +222,7 @@ export default compose(
 			};
 		}
 
-		const fields = charts && charts.map( chart => chart.key );
+		const fields = charts && charts.map( ( chart ) => chart.key );
 
 		const { woocommerce_default_date_range: defaultDateRange } = select(
 			SETTINGS_STORE_NAME

--- a/client/analytics/report/categories/table.js
+++ b/client/analytics/report/categories/table.js
@@ -71,9 +71,9 @@ class CategoriesReportTable extends Component {
 		const {
 			render: renderCurrency,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
-		const currency = getCurrency();
+		const currency = getCurrencyConfig();
 
 		return map( categoryStats, ( categoryStat ) => {
 			const {
@@ -138,8 +138,8 @@ class CategoriesReportTable extends Component {
 			net_revenue: netRevenue = 0,
 			orders_count: ordersCount = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -161,7 +161,7 @@ class CategoriesReportTable extends Component {
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
-				value: formatCurrency( netRevenue ),
+				value: formatAmount( netRevenue ),
 			},
 			{
 				label: _n(

--- a/client/analytics/report/coupons/table.js
+++ b/client/analytics/report/coupons/table.js
@@ -72,9 +72,9 @@ class CouponsReportTable extends Component {
 		const persistedQuery = getPersistedQuery( query );
 		const dateFormat = getSetting( 'dateFormat', defaultTableDateFormat );
 		const {
-			formatCurrency,
+			formatAmount,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
 
 		return map( coupons, ( coupon ) => {
@@ -111,7 +111,11 @@ class CouponsReportTable extends Component {
 			} );
 			const ordersLink = (
 				<Link href={ ordersUrl } type="wc-admin">
-					{ formatValue( getCurrency(), 'number', ordersCount ) }
+					{ formatValue(
+						getCurrencyConfig(),
+						'number',
+						ordersCount
+					) }
 				</Link>
 			);
 
@@ -125,7 +129,7 @@ class CouponsReportTable extends Component {
 					value: ordersCount,
 				},
 				{
-					display: formatCurrency( amount ),
+					display: formatAmount( amount ),
 					value: getCurrencyFormatDecimal( amount ),
 				},
 				{
@@ -162,8 +166,8 @@ class CouponsReportTable extends Component {
 			orders_count: ordersCount = 0,
 			amount = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -185,7 +189,7 @@ class CouponsReportTable extends Component {
 			},
 			{
 				label: __( 'amount discounted', 'woocommerce-admin' ),
-				value: formatCurrency( amount ),
+				value: formatAmount( amount ),
 			},
 		];
 	}
@@ -209,11 +213,7 @@ class CouponsReportTable extends Component {
 				getHeadersContent={ this.getHeadersContent }
 				getRowsContent={ this.getRowsContent }
 				getSummary={ this.getSummary }
-				summaryFields={ [
-					'coupons_count',
-					'orders_count',
-					'amount',
-				] }
+				summaryFields={ [ 'coupons_count', 'orders_count', 'amount' ] }
 				isRequesting={ isRequesting }
 				itemIdField="coupon_id"
 				query={ query }

--- a/client/analytics/report/customers/table.js
+++ b/client/analytics/report/customers/table.js
@@ -115,9 +115,9 @@ class CustomersReportTable extends Component {
 	getRowsContent( customers ) {
 		const dateFormat = getSetting( 'dateFormat', defaultTableDateFormat );
 		const {
-			formatCurrency,
+			formatAmount,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
 
 		return customers.map( ( customer ) => {
@@ -193,18 +193,18 @@ class CustomersReportTable extends Component {
 				},
 				{
 					display: formatValue(
-						getCurrency(),
+						getCurrencyConfig(),
 						'number',
 						ordersCount
 					),
 					value: ordersCount,
 				},
 				{
-					display: formatCurrency( totalSpend ),
+					display: formatAmount( totalSpend ),
 					value: getCurrencyFormatDecimal( totalSpend ),
 				},
 				{
-					display: formatCurrency( avgOrderValue ),
+					display: formatAmount( avgOrderValue ),
 					value: getCurrencyFormatDecimal( avgOrderValue ),
 				},
 				{
@@ -234,8 +234,8 @@ class CustomersReportTable extends Component {
 			avg_total_spend: avgTotalSpend = 0,
 			avg_avg_order_value: avgAvgOrderValue = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -257,11 +257,11 @@ class CustomersReportTable extends Component {
 			},
 			{
 				label: __( 'average lifetime spend', 'woocommerce-admin' ),
-				value: formatCurrency( avgTotalSpend ),
+				value: formatAmount( avgTotalSpend ),
 			},
 			{
 				label: __( 'average order value', 'woocommerce-admin' ),
-				value: formatCurrency( avgAvgOrderValue ),
+				value: formatAmount( avgAvgOrderValue ),
 			},
 		];
 	}

--- a/client/analytics/report/downloads/table.js
+++ b/client/analytics/report/downloads/table.js
@@ -162,7 +162,7 @@ class CouponsReportTable extends Component {
 		const after = moment( dates.primary.after );
 		const before = moment( dates.primary.before );
 		const days = before.diff( after, 'days' ) + 1;
-		const currency = this.context.getCurrency();
+		const currency = this.context.getCurrencyConfig();
 
 		return [
 			{

--- a/client/analytics/report/orders/table.js
+++ b/client/analytics/report/orders/table.js
@@ -105,7 +105,7 @@ class OrdersReportTable extends Component {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 		const dateFormat = getSetting( 'dateFormat', defaultTableDateFormat );
-		const { render: renderCurrency, getCurrency } = this.context;
+		const { render: renderCurrency, getCurrencyConfig } = this.context;
 
 		return map( tableData, ( row ) => {
 			const {
@@ -207,7 +207,7 @@ class OrdersReportTable extends Component {
 				},
 				{
 					display: formatValue(
-						getCurrency(),
+						getCurrencyConfig(),
 						'number',
 						numItemsSold
 					),
@@ -242,8 +242,8 @@ class OrdersReportTable extends Component {
 			coupons_count: couponsCount = 0,
 			net_revenue: netRevenue = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -301,7 +301,7 @@ class OrdersReportTable extends Component {
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
-				value: formatCurrency( netRevenue ),
+				value: formatAmount( netRevenue ),
 			},
 		];
 	}

--- a/client/analytics/report/products/table-variations.js
+++ b/client/analytics/report/products/table-variations.js
@@ -88,9 +88,9 @@ class VariationsReportTable extends Component {
 		const { query } = this.props;
 		const persistedQuery = getPersistedQuery( query );
 		const {
-			formatCurrency,
+			formatAmount,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
 
 		return map( data, ( row ) => {
@@ -134,11 +134,15 @@ class VariationsReportTable extends Component {
 					value: sku,
 				},
 				{
-					display: formatValue( getCurrency(), 'number', itemsSold ),
+					display: formatValue(
+						getCurrencyConfig(),
+						'number',
+						itemsSold
+					),
 					value: itemsSold,
 				},
 				{
-					display: formatCurrency( netRevenue ),
+					display: formatAmount( netRevenue ),
 					value: getCurrencyFormatDecimal( netRevenue ),
 				},
 				{
@@ -186,8 +190,8 @@ class VariationsReportTable extends Component {
 			net_revenue: netRevenue = 0,
 			orders_count: ordersCount = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -209,7 +213,7 @@ class VariationsReportTable extends Component {
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
-				value: formatCurrency( netRevenue ),
+				value: formatAmount( netRevenue ),
 			},
 			{
 				label: _n(

--- a/client/analytics/report/products/table.js
+++ b/client/analytics/report/products/table.js
@@ -105,9 +105,9 @@ class ProductsReportTable extends Component {
 		const {
 			render: renderCurrency,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
-		const currency = getCurrency();
+		const currency = getCurrencyConfig();
 
 		return map( data, ( row ) => {
 			const {
@@ -281,8 +281,8 @@ class ProductsReportTable extends Component {
 			net_revenue: netRevenue = 0,
 			orders_count: ordersCount = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -304,7 +304,7 @@ class ProductsReportTable extends Component {
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
-				value: formatCurrency( netRevenue ),
+				value: formatAmount( netRevenue ),
 			},
 			{
 				label: _n(

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -110,10 +110,10 @@ class RevenueReportTable extends Component {
 	getRowsContent( data = [] ) {
 		const dateFormat = getSetting( 'dateFormat', defaultTableDateFormat );
 		const {
-			formatCurrency,
+			formatAmount,
 			render: renderCurrency,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
 
 		return data.map( ( row ) => {
@@ -138,7 +138,11 @@ class RevenueReportTable extends Component {
 					}
 					type="wp-admin"
 				>
-					{ formatValue( getCurrency(), 'number', ordersCount ) }
+					{ formatValue(
+						getCurrencyConfig(),
+						'number',
+						ordersCount
+					) }
 				</Link>
 			);
 			return [
@@ -160,11 +164,11 @@ class RevenueReportTable extends Component {
 					value: getCurrencyFormatDecimal( grossSales ),
 				},
 				{
-					display: formatCurrency( refunds ),
+					display: formatAmount( refunds ),
 					value: getCurrencyFormatDecimal( refunds ),
 				},
 				{
-					display: formatCurrency( coupons ),
+					display: formatAmount( coupons ),
 					value: getCurrencyFormatDecimal( coupons ),
 				},
 				{
@@ -198,8 +202,8 @@ class RevenueReportTable extends Component {
 			shipping = 0,
 			net_revenue: netRevenue = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n( 'day', 'days', totalResults, 'woocommerce-admin' ),
@@ -216,31 +220,31 @@ class RevenueReportTable extends Component {
 			},
 			{
 				label: __( 'gross sales', 'woocommerce-admin' ),
-				value: formatCurrency( grossSales ),
+				value: formatAmount( grossSales ),
 			},
 			{
 				label: __( 'returns', 'woocommerce-admin' ),
-				value: formatCurrency( refunds ),
+				value: formatAmount( refunds ),
 			},
 			{
 				label: __( 'coupons', 'woocommerce-admin' ),
-				value: formatCurrency( coupons ),
+				value: formatAmount( coupons ),
 			},
 			{
 				label: __( 'net sales', 'woocommerce-admin' ),
-				value: formatCurrency( netRevenue ),
+				value: formatAmount( netRevenue ),
 			},
 			{
 				label: __( 'taxes', 'woocommerce-admin' ),
-				value: formatCurrency( taxes ),
+				value: formatAmount( taxes ),
 			},
 			{
 				label: __( 'shipping', 'woocommerce-admin' ),
-				value: formatCurrency( shipping ),
+				value: formatAmount( shipping ),
 			},
 			{
 				label: __( 'total sales', 'woocommerce-admin' ),
-				value: formatCurrency( totalSales ),
+				value: formatAmount( totalSales ),
 			},
 		];
 	}

--- a/client/analytics/report/stock/table.js
+++ b/client/analytics/report/stock/table.js
@@ -128,7 +128,7 @@ class StockReportTable extends Component {
 				{
 					display: manageStock
 						? formatValue(
-								this.context.getCurrency(),
+								this.context.getCurrencyConfig(),
 								'number',
 								stockQuantity
 						  )
@@ -147,7 +147,7 @@ class StockReportTable extends Component {
 			instock = 0,
 			onbackorder = 0,
 		} = totals;
-		const currency = this.context.getCurrency();
+		const currency = this.context.getCurrencyConfig();
 		return [
 			{
 				label: _n(

--- a/client/analytics/report/taxes/table.js
+++ b/client/analytics/report/taxes/table.js
@@ -73,7 +73,7 @@ class TaxesReportTable extends Component {
 		const {
 			render: renderCurrency,
 			formatDecimal: getCurrencyFormatDecimal,
-			getCurrency,
+			getCurrencyConfig,
 		} = this.context;
 
 		return map( taxes, ( tax ) => {
@@ -126,7 +126,7 @@ class TaxesReportTable extends Component {
 				},
 				{
 					display: formatValue(
-						getCurrency(),
+						getCurrencyConfig(),
 						'number',
 						ordersCount
 					),
@@ -144,8 +144,8 @@ class TaxesReportTable extends Component {
 			shipping_tax: shippingTax = 0,
 			orders_count: ordersCount = 0,
 		} = totals;
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return [
 			{
 				label: _n(
@@ -158,15 +158,15 @@ class TaxesReportTable extends Component {
 			},
 			{
 				label: __( 'total tax', 'woocommerce-admin' ),
-				value: formatCurrency( totalTax ),
+				value: formatAmount( totalTax ),
 			},
 			{
 				label: __( 'order tax', 'woocommerce-admin' ),
-				value: formatCurrency( orderTax ),
+				value: formatAmount( orderTax ),
 			},
 			{
 				label: __( 'shipping tax', 'woocommerce-admin' ),
-				value: formatCurrency( shippingTax ),
+				value: formatAmount( shippingTax ),
 			},
 			{
 				label: _n(

--- a/client/dashboard/store-performance/index.js
+++ b/client/dashboard/store-performance/index.js
@@ -134,8 +134,8 @@ class StorePerformance extends Component {
 			compare === 'previous_period'
 				? __( 'Previous Period:', 'woocommerce-admin' )
 				: __( 'Previous Year:', 'woocommerce-admin' );
-		const { formatCurrency, getCurrency } = this.context;
-		const currency = getCurrency();
+		const { formatAmount, getCurrencyConfig } = this.context;
+		const currency = getCurrencyConfig();
 		return (
 			<SummaryList>
 				{ () =>
@@ -151,7 +151,7 @@ class StorePerformance extends Component {
 							primaryData,
 							secondaryData,
 							currency,
-							formatCurrency,
+							formatAmount,
 							persistedQuery,
 						} );
 

--- a/client/dashboard/store-performance/utils.js
+++ b/client/dashboard/store-performance/utils.js
@@ -32,7 +32,7 @@ export const getIndicatorValues = ( {
 	primaryData,
 	secondaryData,
 	currency,
-	formatCurrency,
+	formatAmount,
 	persistedQuery,
 } ) => {
 	const primaryItem = find(
@@ -59,10 +59,10 @@ export const getIndicatorValues = ( {
 
 	const delta = calculateDelta( primaryItem.value, secondaryItem.value );
 	const primaryValue = isCurrency
-		? formatCurrency( primaryItem.value )
+		? formatAmount( primaryItem.value )
 		: formatValue( currency, primaryItem.format, primaryItem.value );
 	const secondaryValue = isCurrency
-		? formatCurrency( secondaryItem.value )
+		? formatAmount( secondaryItem.value )
 		: formatValue( currency, secondaryItem.format, secondaryItem.value );
 	return {
 		primaryValue,

--- a/client/header/activity-panel/panels/orders.js
+++ b/client/header/activity-panel/panels/orders.js
@@ -195,7 +195,7 @@ class OrdersPanel extends Component {
 									productsCount
 								) }
 							</span>
-							<span>{ Currency.formatCurrency( total ) }</span>
+							<span>{ Currency.formatAmount( total ) }</span>
 						</div>
 					}
 					actions={

--- a/client/homescreen/stats-overview/stats-list.js
+++ b/client/homescreen/stats-overview/stats-list.js
@@ -35,12 +35,12 @@ export const StatsList = ( {
 	secondaryError,
 	query,
 } ) => {
-	const { formatCurrency, getCurrency } = useContext( CurrencyContext );
+	const { formatAmount, getCurrencyConfig } = useContext( CurrencyContext );
 	if ( primaryError || secondaryError ) {
 		return null;
 	}
 	const persistedQuery = getPersistedQuery( query );
-	const currency = getCurrency();
+	const currency = getCurrencyConfig();
 
 	return (
 		<ul
@@ -68,7 +68,7 @@ export const StatsList = ( {
 					primaryData,
 					secondaryData,
 					currency,
-					formatCurrency,
+					formatAmount,
 					persistedQuery,
 				} );
 

--- a/client/lib/currency-context.js
+++ b/client/lib/currency-context.js
@@ -7,23 +7,23 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * WooCommerce dependencies
  */
-import Currency from '@woocommerce/currency';
+import CurrencyFactory from '@woocommerce/currency';
 
 /**
  * Internal dependencies
  */
 import { CURRENCY } from '@woocommerce/wc-admin-settings';
 
-const appCurrency = Currency( CURRENCY );
+const appCurrency = CurrencyFactory( CURRENCY );
 
 export const getFilteredCurrencyInstance = ( query ) => {
-	const config = appCurrency.getCurrency();
+	const config = appCurrency.getCurrencyConfig();
 	const filteredConfig = applyFilters(
 		'woocommerce_admin_report_currency',
 		config,
 		query
 	);
-	return Currency( filteredConfig );
+	return CurrencyFactory( filteredConfig );
 };
 
 export const CurrencyContext = createContext(

--- a/client/profile-wizard/steps/business-details.js
+++ b/client/profile-wizard/steps/business-details.js
@@ -91,12 +91,12 @@ class BusinessDetails extends Component {
 			selling_venues: sellingVenues,
 		} = values;
 		const businessExtensions = this.getBusinessExtensions( values );
-		const { getCurrency } = this.context;
+		const { getCurrencyConfig } = this.context;
 
 		recordEvent( 'storeprofiler_store_business_details_continue', {
 			product_number: productCount,
 			already_selling: sellingVenues,
-			currency: getCurrency().code,
+			currency: getCurrencyConfig().code,
 			revenue,
 			used_platform: otherPlatform,
 			used_platform_name: otherPlatformName,
@@ -255,8 +255,8 @@ class BusinessDetails extends Component {
 	}
 
 	numberFormat( value ) {
-		const { getCurrency } = this.context;
-		return formatValue( getCurrency(), 'number', value );
+		const { getCurrencyConfig } = this.context;
+		return formatValue( getCurrencyConfig(), 'number', value );
 	}
 
 	getNumberRangeString( min, max = false, format = this.numberFormat ) {
@@ -398,7 +398,7 @@ class BusinessDetails extends Component {
 			isInstallingActivating,
 			hasInstallActivateError,
 		} = this.props;
-		const { formatCurrency } = this.context;
+		const { formatAmount } = this.context;
 		const productCountOptions = [
 			{
 				key: '0',
@@ -431,7 +431,7 @@ class BusinessDetails extends Component {
 				label: sprintf(
 					/* translators: %s: $0 revenue amount */
 					__( "%s (I'm just getting started)", 'woocommerce-admin' ),
-					formatCurrency( 0 )
+					formatAmount( 0 )
 				),
 			},
 			{
@@ -439,7 +439,7 @@ class BusinessDetails extends Component {
 				label: sprintf(
 					/* translators: %s: A given revenue amount, e.g., $2500 */
 					__( 'Up to %s', 'woocommerce-admin' ),
-					formatCurrency( this.convertCurrency( 2500 ) )
+					formatAmount( this.convertCurrency( 2500 ) )
 				),
 			},
 			{
@@ -447,7 +447,7 @@ class BusinessDetails extends Component {
 				label: this.getNumberRangeString(
 					this.convertCurrency( 2500 ),
 					this.convertCurrency( 10000 ),
-					formatCurrency
+					formatAmount
 				),
 			},
 			{
@@ -455,7 +455,7 @@ class BusinessDetails extends Component {
 				label: this.getNumberRangeString(
 					this.convertCurrency( 10000 ),
 					this.convertCurrency( 50000 ),
-					formatCurrency
+					formatAmount
 				),
 			},
 			{
@@ -463,7 +463,7 @@ class BusinessDetails extends Component {
 				label: this.getNumberRangeString(
 					this.convertCurrency( 50000 ),
 					this.convertCurrency( 250000 ),
-					formatCurrency
+					formatAmount
 				),
 			},
 			{
@@ -471,7 +471,7 @@ class BusinessDetails extends Component {
 				label: sprintf(
 					/* translators: %s: A given revenue amount, e.g., $250000 */
 					__( 'More than %s', 'woocommerce-admin' ),
-					formatCurrency( this.convertCurrency( 250000 ) )
+					formatAmount( this.convertCurrency( 250000 ) )
 				),
 			},
 		];

--- a/client/task-list/tasks/shipping/rates.js
+++ b/client/task-list/tasks/shipping/rates.js
@@ -131,7 +131,7 @@ class ShippingRates extends Component {
 	}
 
 	renderInputPrefix() {
-		const { symbolPosition, symbol } = this.context.getCurrency();
+		const { symbolPosition, symbol } = this.context.getCurrencyConfig();
 		if ( symbolPosition.indexOf( 'right' ) === 0 ) {
 			return null;
 		}
@@ -143,7 +143,7 @@ class ShippingRates extends Component {
 	}
 
 	renderInputSuffix( rate ) {
-		const { symbolPosition, symbol } = this.context.getCurrency();
+		const { symbolPosition, symbol } = this.context.getCurrencyConfig();
 		if ( symbolPosition.indexOf( 'right' ) === 0 ) {
 			return (
 				<span className="woocommerce-shipping-rate__control-suffix">

--- a/client/wc-api/reports/utils.js
+++ b/client/wc-api/reports/utils.js
@@ -387,13 +387,13 @@ export function getReportChartData( options ) {
  * Returns a formatting function or string to be used by d3-format
  *
  * @param  {string} type Type of number, 'currency', 'number', 'percent', 'average'
- * @param  {Function} formatCurrency format currency function
+ * @param  {Function} formatAmount format currency function
  * @return {string|Function}  returns a number format based on the type or an overriding formatting function
  */
-export function getTooltipValueFormat( type, formatCurrency ) {
+export function getTooltipValueFormat( type, formatAmount ) {
 	switch ( type ) {
 		case 'currency':
-			return formatCurrency;
+			return formatAmount;
 		case 'percent':
 			return '.0%';
 		case 'number':

--- a/packages/components/src/advanced-filters/number-filter.js
+++ b/packages/components/src/advanced-filters/number-filter.js
@@ -11,7 +11,7 @@ import { sprintf, __, _x } from '@wordpress/i18n';
 /**
  * WooCommerce dependencies
  */
-import Currency from '@woocommerce/currency';
+import CurrencyFactory from '@woocommerce/currency';
 
 /**
  * Internal dependencies
@@ -42,9 +42,9 @@ class NumberFilter extends Component {
 		const inputType = get( config, [ 'input', 'type' ], 'number' );
 
 		if ( inputType === 'currency' ) {
-			const { formatCurrency } = Currency( currency );
-			rangeStart = formatCurrency( rangeStart );
-			rangeEnd = formatCurrency( rangeEnd );
+			const { formatAmount } = CurrencyFactory( currency );
+			rangeStart = formatAmount( rangeStart );
+			rangeEnd = formatAmount( rangeEnd );
 		}
 
 		let filterStr = rangeStart;

--- a/packages/components/src/filters/index.js
+++ b/packages/components/src/filters/index.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import { updateQueryString } from '@woocommerce/navigation';
 import { getDateParamsFromQuery, getCurrentDates } from '@woocommerce/date';
-import Currency from '@woocommerce/currency';
+import CurrencyFactory from '@woocommerce/currency';
 
 /**
  * Internal dependencies
@@ -231,7 +231,7 @@ ReportFilters.defaultProps = {
 	query: {},
 	showDatePicker: true,
 	onDateSelect: () => {},
-	currency: Currency().getCurrency(),
+	currency: CurrencyFactory().getCurrencyConfig(),
 };
 
 export default ReportFilters;

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Breaking changes
 - Currency is now a factory function instead of a class.
 
-- Add getCurrency method to retrieve currency config.
+- Add getCurrencyConfig method to retrieve currency config.
 
 # 2.0.0
 

--- a/packages/currency/README.md
+++ b/packages/currency/README.md
@@ -15,19 +15,19 @@ _This package assumes that your code will run in an **ES2015+** environment. If 
 ## Usage
 
 ```JS
-import Currency from '@woocommerce/currency';
+import CurrencyFactory from '@woocommerce/currency';
 
-const storeCurrency = Currency(); // pass store settings into constructor.
+const storeCurrency = CurrencyFactory(); // pass store settings into constructor.
 
 // Formats money with a given currency symbol. Uses site's currency settings for formatting,
 // from the settings api. Defaults to symbol=`$`, precision=2, decimalSeparator=`.`, thousandSeparator=`,`
-const total = storeCurrency.formatCurrency( 20.923 ); // '$20.92'
+const total = storeCurrency.formatAmount( 20.923 ); // '$20.92'
 
 // Get the rounded decimal value of a number at the precision used for the current currency,
 // from the settings api. Defaults to 2.
 const total = storeCurrency.formatDecimal( '6.2892' ); // 6.29 https://google.com/?q=test
 
 // Get the string representation of a floating point number to the precision used by the current
-// currency. This is different from `formatCurrency` by not returning the currency symbol.
+// currency. This is different from `formatAmount` by not returning the currency symbol.
 const total = storeCurrency.formatDecimalString( 1088.478 ); // '1088.48'
 ```

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -8,7 +8,7 @@ import { sprintf } from '@wordpress/i18n';
  */
 import { numberFormat } from '@woocommerce/number';
 
-const Currency = ( currencySetting ) => {
+const CurrencyFactory = ( currencySetting ) => {
 	let currency;
 
 	setCurrency( currencySetting );
@@ -39,7 +39,7 @@ const Currency = ( currencySetting ) => {
 	 * @param   {number|string} number number to format
 	 * @return {?string} A formatted string.
 	 */
-	function formatCurrency( number ) {
+	function formatAmount( number ) {
 		const formattedNumber = numberFormat( currency, number );
 
 		if ( formattedNumber === '' ) {
@@ -78,11 +78,11 @@ const Currency = ( currencySetting ) => {
 	}
 
 	return {
-		getCurrency: () => {
+		getCurrencyConfig: () => {
 			return { ...currency };
 		},
 		setCurrency,
-		formatCurrency,
+		formatAmount,
 		getPriceFormat,
 
 		/**
@@ -108,7 +108,7 @@ const Currency = ( currencySetting ) => {
 
 		/**
 		 * Get the string representation of a floating point number to the precision used by the current currency.
-		 * This is different from `formatCurrency` by not returning the currency symbol.
+		 * This is different from `formatAmount` by not returning the currency symbol.
 		 *
 		 * @param  {number|string} number A floating point number (or integer), or string that converts to a number
 		 * @return {string}               The original number rounded to a decimal point
@@ -137,16 +137,16 @@ const Currency = ( currencySetting ) => {
 			if ( number < 0 ) {
 				return (
 					<span className="is-negative">
-						{ formatCurrency( number ) }
+						{ formatAmount( number ) }
 					</span>
 				);
 			}
-			return formatCurrency( number );
+			return formatAmount( number );
 		},
 	};
 };
 
-export default Currency;
+export default CurrencyFactory;
 
 /**
  * Returns currency data by country/region. Contains code, symbol, position, thousands separator, decimal separator, and precision.

--- a/packages/currency/test/index.js
+++ b/packages/currency/test/index.js
@@ -3,11 +3,11 @@
  */
 import Currency from '../src';
 
-describe( 'formatCurrency', () => {
+describe( 'formatAmount', () => {
 	it( 'should use defaults (USD) when currency not passed in', () => {
 		const currency = Currency();
-		expect( currency.formatCurrency( 9.99 ) ).toBe( '$9.99' );
-		expect( currency.formatCurrency( 30 ) ).toBe( '$30.00' );
+		expect( currency.formatAmount( 9.99 ) ).toBe( '$9.99' );
+		expect( currency.formatAmount( 30 ) ).toBe( '$30.00' );
 	} );
 
 	it( 'should uses store currency settings, not locale-based', () => {
@@ -19,16 +19,16 @@ describe( 'formatCurrency', () => {
 			thousandSeparator: '.',
 			decimalSeparator: ',',
 		} );
-		expect( currency.formatCurrency( 9.49258 ) ).toBe( '9,493¥' );
-		expect( currency.formatCurrency( 3000 ) ).toBe( '3.000,000¥' );
-		expect( currency.formatCurrency( 3.0002 ) ).toBe( '3,000¥' );
+		expect( currency.formatAmount( 9.49258 ) ).toBe( '9,493¥' );
+		expect( currency.formatAmount( 3000 ) ).toBe( '3.000,000¥' );
+		expect( currency.formatAmount( 3.0002 ) ).toBe( '3,000¥' );
 	} );
 
 	it( "should return empty string when given an input that isn't a number", () => {
 		const currency = Currency();
-		expect( currency.formatCurrency( 'abc' ) ).toBe( '' );
-		expect( currency.formatCurrency( false ) ).toBe( '' );
-		expect( currency.formatCurrency( null ) ).toBe( '' );
+		expect( currency.formatAmount( 'abc' ) ).toBe( '' );
+		expect( currency.formatAmount( false ) ).toBe( '' );
+		expect( currency.formatAmount( null ) ).toBe( '' );
 	} );
 } );
 

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -132,7 +132,7 @@ class Init {
 
 	/**
 	 * Add the currency symbol (in addition to currency code) to each Order
-	 * object in REST API responses. For use in formatCurrency().
+	 * object in REST API responses. For use in formatAmount().
 	 *
 	 * @param {WP_REST_Response} $response REST response object.
 	 * @returns {WP_REST_Response}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4394

Currency package naming was confusing and not intuitive. This PR renames functions and method to make it easier to understand.

Changed parts of the API now look like this:

```js
const currency = CurrencyFactory( {
	code: 'JPY',
	symbol: '¥',
	precision: 3,
	priceFormat: '%2$s%1$s',
	thousandSeparator: '.',
	decimalSeparator: ',',
} );

currency.formatAmount( 9.49258 ) // '9,493¥'
currency.getCurrencyConfig()
/**
 * 
 {
	code: 'JPY',
	symbol: '¥',
	precision: 3,
	priceFormat: '%2$s%1$s',
	thousandSeparator: '.',
	decimalSeparator: ',',
}
 */
```

### Detailed test instructions:

1. Check the app for errors.

### Changelog Note:

Dev: Rename Currency package methods
