### PR TITLE
Make it possible (far easier) to add menu items under 'Marketing'

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -166,10 +166,14 @@ export const getPages = () => {
 	if ( window.wcAdminFeatures.marketing ) {
 		pages.push( {
 			container: MarketingOverview,
-			path: '/marketing',
+			path: '/marketing/overview',
 			breadcrumbs: [
 				...initialBreadcrumbs,
-				__( 'Marketing', 'woocommerce-admin' ),
+				[
+					'/marketing/overview',
+					__( 'Marketing', 'woocommerce-admin' ),
+				],
+				__( 'Overview', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 		} );

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -171,7 +171,7 @@ export const getPages = () => {
 				...initialBreadcrumbs,
 				__( 'Marketing', 'woocommerce-admin' ),
 			],
-			wpOpenMenu: 'toplevel_page_wc-admin-path--marketing',
+			wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 		} );
 	}
 

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -166,11 +166,11 @@ export const getPages = () => {
 	if ( window.wcAdminFeatures.marketing ) {
 		pages.push( {
 			container: MarketingOverview,
-			path: '/marketing/overview',
+			path: '/marketing',
 			breadcrumbs: [
 				...initialBreadcrumbs,
 				[
-					'/marketing/overview',
+					'/marketing',
 					__( 'Marketing', 'woocommerce-admin' ),
 				],
 				__( 'Overview', 'woocommerce-admin' ),

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -87,7 +87,7 @@ class Marketing {
 			array(
 				'id'    => 'woocommerce-marketing-overview',
 				'title' => __( 'Overview', 'woocommerce-admin' ),
-				'path'  => '/marketing/overview',
+				'path'  => '/marketing',
 			),
 		);
 
@@ -116,7 +116,7 @@ class Marketing {
 		}
 
 		foreach ( $submenu[ $marketing_submenu_key ] as $submenu_key => $submenu_item ) {
-			if ( 'wc-admin&path=/marketing/overview' === $submenu_item[2] ) {
+			if ( 'wc-admin&path=/marketing' === $submenu_item[2] ) {
 				$overview_key = $submenu_key;
 			}
 		}

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -51,6 +51,7 @@ class Marketing {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'register_pages' ) );
+		add_action( 'admin_head', array( $this, 'modify_menu_structure' ) );
 
 		if ( ! is_admin() ) {
 			return;
@@ -64,13 +65,14 @@ class Marketing {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
+		add_menu_page( __( 'Marketing', 'woocommerce' ), __( 'Marketing', 'woocommerce' ), 'manage_woocommerce', 'woocommerce-marketing', null, 'dashicons-megaphone', 58 );
+
 		$marketing_pages = array(
 			array(
-				'id'       => 'woocommerce-marketing',
-				'title'    => __( 'Marketing', 'woocommerce-admin' ),
-				'path'     => '/marketing',
-				'icon'     => 'dashicons-megaphone',
-				'position' => 58, // After WooCommerce & Product menu items.
+				'id'     => 'woocommerce-marketing-overview',
+				'title'  => __( 'Overview', 'woocommerce-admin' ),
+				'path'   => '/marketing',
+				'parent' => 'woocommerce-marketing'
 			),
 		);
 
@@ -80,6 +82,36 @@ class Marketing {
 			if ( ! is_null( $marketing_page ) ) {
 				wc_admin_register_page( $marketing_page );
 			}
+		}
+	}
+
+	/**
+	 * Modify the Marketing menu structure
+	 */
+	public function modify_menu_structure() {
+		global $submenu;
+		// User does not have capabilites to see the submenu.
+		if ( ! current_user_can( 'manage_woocommerce' ) || empty( $submenu['woocommerce'] ) ) {
+			return;
+		}
+
+		$marketing_submenu_key = 'woocommerce-marketing';
+		$overview_key          = null;
+
+		foreach ( $submenu[ $marketing_submenu_key ] as $submenu_key => $submenu_item ) {
+			if ( 'wc-admin&path=/marketing' === $submenu_item[2] ) {
+				$overview_key = $submenu_key;
+			}
+		}
+
+		// Remove PHP powered top level page
+		unset( $submenu[ $marketing_submenu_key ][0] );
+
+		// Move overview menu item to top
+		if ( null !== $overview_key ) {
+			$menu = $submenu[ $marketing_submenu_key ][ $overview_key ];
+			unset( $submenu[ $marketing_submenu_key ][ $overview_key ] );
+			array_unshift( $submenu[ $marketing_submenu_key ], $menu );
 		}
 	}
 

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -98,13 +98,14 @@ class Marketing {
 	 */
 	public function modify_menu_structure() {
 		global $submenu;
-		// User does not have capabilites to see the submenu.
-		if ( ! current_user_can( 'manage_woocommerce' ) || empty( $submenu['woocommerce'] ) ) {
-			return;
-		}
 
 		$marketing_submenu_key = 'woocommerce-marketing';
 		$overview_key          = null;
+
+		// User does not have capabilites to see the submenu.
+		if ( ! current_user_can( 'manage_woocommerce' ) || empty( $submenu[ $marketing_submenu_key ] ) ) {
+			return;
+		}
 
 		foreach ( $submenu[ $marketing_submenu_key ] as $submenu_key => $submenu_item ) {
 			if ( 'wc-admin&path=/marketing/overview' === $submenu_item[2] ) {

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -65,7 +65,15 @@ class Marketing {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
-		add_menu_page( __( 'Marketing', 'woocommerce' ), __( 'Marketing', 'woocommerce' ), 'manage_woocommerce', 'woocommerce-marketing', null, 'dashicons-megaphone', 58 );
+		add_menu_page(
+			__( 'Marketing', 'woocommerce-admin' ),
+			__( 'Marketing', 'woocommerce-admin' ),
+			'manage_woocommerce',
+			'woocommerce-marketing',
+			null,
+			'dashicons-megaphone',
+			58
+		);
 
 		$marketing_pages = array(
 			array(
@@ -104,10 +112,10 @@ class Marketing {
 			}
 		}
 
-		// Remove PHP powered top level page
+		// Remove PHP powered top level page.
 		unset( $submenu[ $marketing_submenu_key ][0] );
 
-		// Move overview menu item to top
+		// Move overview menu item to top.
 		if ( null !== $overview_key ) {
 			$menu = $submenu[ $marketing_submenu_key ][ $overview_key ];
 			unset( $submenu[ $marketing_submenu_key ][ $overview_key ] );

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -79,7 +79,7 @@ class Marketing {
 			array(
 				'id'    => 'woocommerce-marketing-overview',
 				'title' => __( 'Overview', 'woocommerce-admin' ),
-				'path'  => '/marketing',
+				'path'  => '/marketing/overview',
 			),
 		);
 
@@ -107,7 +107,7 @@ class Marketing {
 		$overview_key          = null;
 
 		foreach ( $submenu[ $marketing_submenu_key ] as $submenu_key => $submenu_item ) {
-			if ( 'wc-admin&path=/marketing' === $submenu_item[2] ) {
+			if ( 'wc-admin&path=/marketing/overview' === $submenu_item[2] ) {
 				$overview_key = $submenu_key;
 			}
 		}

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -50,6 +50,7 @@ class Marketing {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'add_parent_menu_item' ), 9 );
 		add_action( 'admin_menu', array( $this, 'register_pages' ) );
 		add_action( 'admin_head', array( $this, 'modify_menu_structure' ) );
 
@@ -62,9 +63,11 @@ class Marketing {
 	}
 
 	/**
-	 * Registers report pages.
+	 * Add main marketing menu item.
+	 *
+	 * Uses priority of 9 so other items can easily be added at the default priority (10).
 	 */
-	public function register_pages() {
+	public function add_parent_menu_item() {
 		add_menu_page(
 			__( 'Marketing', 'woocommerce-admin' ),
 			__( 'Marketing', 'woocommerce-admin' ),
@@ -74,7 +77,12 @@ class Marketing {
 			'dashicons-megaphone',
 			58
 		);
+	}
 
+	/**
+	 * Registers report pages.
+	 */
+	public function register_pages() {
 		$marketing_pages = array(
 			array(
 				'id'    => 'woocommerce-marketing-overview',

--- a/src/Features/Marketing.php
+++ b/src/Features/Marketing.php
@@ -69,10 +69,9 @@ class Marketing {
 
 		$marketing_pages = array(
 			array(
-				'id'     => 'woocommerce-marketing-overview',
-				'title'  => __( 'Overview', 'woocommerce-admin' ),
-				'path'   => '/marketing',
-				'parent' => 'woocommerce-marketing'
+				'id'    => 'woocommerce-marketing-overview',
+				'title' => __( 'Overview', 'woocommerce-admin' ),
+				'path'  => '/marketing',
 			),
 		);
 
@@ -80,6 +79,7 @@ class Marketing {
 
 		foreach ( $marketing_pages as $marketing_page ) {
 			if ( ! is_null( $marketing_page ) ) {
+				$marketing_page['parent'] = 'woocommerce-marketing';
 				wc_admin_register_page( $marketing_page );
 			}
 		}


### PR DESCRIPTION
I've implemented the same technique used for the main WooCommerce menu to ensure that the overview page is always at the top and so it's easy to add submenu items.

Adding a PHP powered page to the submenu is done by setting the parent page to `woocommerce-marketing`. E.g.
```php
add_submenu_page( 'woocommerce-marketing', 'Hubspot', 'Hubspot', 'manage_woocommerce', 'hubwoo', function(){} );
``` 

Adding JS powered page to the submenu should be done by using the `woocommerce_marketing_menu_items` filter. E.g.
```php
add_filter( 'woocommerce_marketing_menu_items', function( $items ) {
	$items[] = array(
		'id'    => 'woocommerce-marketing-test',
		'title' => __( 'Test', 'woocommerce-admin' ),
		'path'  => '/marketing/test',
	);
	return $items;
} );
```

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![](https://d.pr/i/S7jQxu+)

### Detailed test instructions:

- Check out this branch
- Run `npm run dev`
- Add a menu item, e.g.
```php
add_action( 'admin_menu', function() {
	add_submenu_page( 'woocommerce-marketing', 'Hubspot', 'Hubspot', 'manage_woocommerce', 'hubwoo', function(){} );
});
```
- Assert that the menu item is added below the Marketing > Overview item

### Changelog Note:

- Tweak - Make it easier to add submenu items to the Marketing menu
