### PR TITLE
Fix theme match on mixed-case directory name

### DIFF
--- a/src/API/OnboardingThemes.php
+++ b/src/API/OnboardingThemes.php
@@ -92,7 +92,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce-admin' ), 404 );
 		}
 
-		$slug             = sanitize_key( $theme );
+		$slug             = sanitize_text_field( $theme );
 		$installed_themes = wp_get_themes();
 
 		if ( in_array( $slug, array_keys( $installed_themes ), true ) ) {
@@ -168,10 +168,10 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 
 		require_once ABSPATH . 'wp-admin/includes/theme.php';
 
-		$slug             = sanitize_key( $theme );
+		$slug             = sanitize_text_field( $theme );
 		$installed_themes = wp_get_themes();
 
-		if ( ! in_array( $theme, array_keys( $installed_themes ), true ) ) {
+		if ( ! in_array( $slug, array_keys( $installed_themes ), true ) ) {
 			/* translators: %s: theme slug (example: woocommerce-services) */
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce-admin' ), $slug ), 404 );
 		}


### PR DESCRIPTION
Fixes #4393.

This is an update to the Onboarding Themes Controller so that it can handle cases where a theme directory name includes mixed-case characters.

The change in how directory names are sanitized reflects how a similar bug was addressed in WordPress Core _(Trac #37924, [Cannot delete or update themes in directories containing an uppercase letter from Appearance > Themes](https://core.trac.wordpress.org/ticket/37924))_.

### Changelog Note:

Fix: During theme installation and activation, preserve the character case in theme directory names in our validation checks.
