### PR TITLE
Customize webpack jsonpFunction to avoid potential collision with other Webpack bundles

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,7 @@ const webpackConfig = {
 		path: path.join( __dirname, 'dist' ),
 		library: [ 'wc', '[modulename]' ],
 		libraryTarget: 'this',
+		jsonpFunction: '__wcAdmin_webpackJsonp',
 	},
 	externals,
 	module: {


### PR DESCRIPTION
Fixes #4614 (related)

This PR configures the [`output.jsonpFunction`](https://webpack.js.org/configuration/output/#outputjsonpfunction) for Webpack to use a unique name, specific to woocommerce-admin instead of the default. This prevents potential conflicts with other Webpack bundles that might be loaded at the same time as the bundle uses this global variable for its function to asynchronously load chunks or join multiple initial chunks.

This is an otherwise harmless change as this function is generated and used internally by Webpack.

See
* https://webpack.js.org/configuration/output/#outputjsonpfunction
* https://github.com/google/site-kit-wp/pull/1690

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
