### PR TITLE
Fix WCPay sometimes not appearing on the task list

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -40,6 +40,13 @@ if ( appRoot ) {
 	let HydratedPageLayout = withSettingsHydration( settingsGroup, window.wcSettings )(
 		PageLayout
 	);
+	const hydrateSettings =
+	window.wcSettings.preloadSettings &&
+	window.wcSettings.preloadSettings.general;
+
+	if ( hydrateSettings ) {
+		HydratedPageLayout = withSettingsHydration( 'general', { general: window.wcSettings.preloadSettings.general, } )( HydratedPageLayout );
+	}
 	if ( hydrateUser ) {
 		HydratedPageLayout = withCurrentUserHydration( hydrateUser )( HydratedPageLayout );
 	}

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -14,7 +14,6 @@ import { updateQueryString } from '@woocommerce/navigation';
 import {
 	ONBOARDING_STORE_NAME,
 	PLUGINS_STORE_NAME,
-	withSettingsHydration,
 	withPluginsHydration,
 } from '@woocommerce/data';
 
@@ -240,10 +239,6 @@ class ProfileWizard extends Component {
 	}
 }
 
-const hydrateSettings =
-	window.wcSettings.preloadSettings &&
-	window.wcSettings.preloadSettings.general;
-
 export default compose(
 	withSelect( ( select ) => {
 		const { getNotes } = select( 'wc-api' );
@@ -279,11 +274,6 @@ export default compose(
 			updateProfileItems,
 		};
 	} ),
-	hydrateSettings
-		? withSettingsHydration( 'general', {
-				general: window.wcSettings.preloadSettings.general,
-		  } )
-		: identity,
 	window.wcSettings.plugins
 		? withPluginsHydration( {
 				...window.wcSettings.plugins,

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -396,7 +396,6 @@ export default compose(
 		const profileItems = getProfileItems();
 
 		const optionNames = [
-			'woocommerce_default_country',
 			'woocommerce_woocommerce_payments_settings',
 			'woocommerce_stripe_settings',
 			'woocommerce_ppec_paypal_settings',
@@ -415,7 +414,7 @@ export default compose(
 			return result;
 		}, {} );
 		const countryCode = getCountryCode(
-			generalSettings.woocommerce_default_country || options.woocommerce_default_country
+			generalSettings.woocommerce_default_country
 		);
 
 		const methods = getPaymentMethods( {

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -22,6 +22,7 @@ import {
 	OPTIONS_STORE_NAME,
 	PLUGINS_STORE_NAME,
 	pluginNames,
+	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
 
 /**
@@ -388,6 +389,8 @@ export default compose(
 		const { getActivePlugins, isJetpackConnected } = select(
 			PLUGINS_STORE_NAME
 		);
+		const { getSettings } = select( SETTINGS_STORE_NAME );
+		const { general: generalSettings = {} } = getSettings( 'general' );
 
 		const activePlugins = getActivePlugins();
 		const profileItems = getProfileItems();
@@ -412,7 +415,7 @@ export default compose(
 			return result;
 		}, {} );
 		const countryCode = getCountryCode(
-			options.woocommerce_default_country
+			generalSettings.woocommerce_default_country || options.woocommerce_default_country
 		);
 
 		const methods = getPaymentMethods( {

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -607,7 +607,6 @@ class Onboarding {
 		$options[] = 'wc_square_refresh_tokens';
 		$options[] = 'woocommerce_square_credit_card_settings';
 		$options[] = 'woocommerce_payfast_settings';
-		$options[] = 'woocommerce_default_country';
 		$options[] = 'woocommerce_kco_settings';
 		$options[] = 'woocommerce_klarna_payments_settings';
 		$options[] = 'woocommerce_cod_settings';
@@ -625,10 +624,6 @@ class Onboarding {
 	 * @return array
 	 */
 	public function preload_settings( $options ) {
-		if ( ! self::should_show_profiler() ) {
-			return $options;
-		}
-
 		$options[] = 'general';
 
 		return $options;


### PR DESCRIPTION
Fixes #4628 
Fixes https://github.com/woocommerce/woocommerce/issues/26812

Fixes a bug in the Payments task list that made WCPay not appear on a clean install.

Many payment methods are region-specific, so the setup checklist needs to know which country the store is setup on to show/hide some of the payment options. For example, WCPay is only available in the US.

The Payments setup screen was using `getOption('woocommerce_default_country')` to get the store country. The problem is that the value of `getOption(...)` doesn't change until the page is refreshed. So, if a user goes through the whole Setup Wizard and lands in the Payments screen without ever refreshing the page (entirely possible since all that flow uses client-side navigation), then whatever address they put in the "Store Details" step won't be picked up by the Payments page logic.

By default, new WooCommerce stores are set in `GB` (Great Britain). So, if a user starts with a clean site and goes through the whole setup wizard, the options they'll see in the Payments page will be as if they were in the UK (Stripe and PayPal, but no WCPay).

Other steps of the wizard that rely on country data (for example, to show or hide the "CBD" option) use the `getSettings('general')` API instead, which is automatically updated without requiring a page reload. So in this PR I do exactly that for the Payments page. I added a fallback to `getOption(...)` so the user doesn't see the wrong payments for a second if they go directly to the Payments page.

### Detailed test instructions:

Follow the steps to reproduce [here](https://github.com/woocommerce/woocommerce/issues/26812).

Alternatively, this is an easier way I found to trigger the bug:
- Set your store address to Spain, for example (or South Africa if you want to see the Stripe card dissapear too).
- Go to the Setup Wizard.
- On the first step, change your store address to someplace in the US.
- **Without reloading the page**, go through the whole setup wizard (you can pretty much skip all the other steps). You'll be dropped in the setup checklist.
- Click on `Set up payments`. You won't see WCPay (and, if you originally set your address to South Africa, you won't see Stripe either).
- Refresh the page. WCPay (and Stripe) will appear, but at this point the user is confused and sad.

If you repeat the steps but reverse the countries (start with a `US` store, change it to Spain in the wizard), you'll see the same problem in reverse: WCPay appears when it shouldn't.