### PR TITLE
Settings: Save all settings of a group, not just the update

### DIFF
--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -86,6 +86,7 @@ class StoreDetails extends Component {
 			isProfileItemsError,
 			updateAndPersistSettingsForGroup,
 			profileItems,
+			settings,
 		} = this.props;
 
 		const currencySettings = this.deriveCurrencySettings(
@@ -102,6 +103,7 @@ class StoreDetails extends Component {
 
 		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
+				...settings,
 				woocommerce_store_address: values.addressLine1,
 				woocommerce_store_address_2: values.addressLine2,
 				woocommerce_default_country: values.countryState,
@@ -240,13 +242,14 @@ export default compose(
 			getSettingsError,
 			isGetSettingsRequesting,
 		} = select( SETTINGS_STORE_NAME );
-		const {
-			getOnboardingError,
-			getProfileItems
-		} = select( ONBOARDING_STORE_NAME );
+		const { getOnboardingError, getProfileItems } = select(
+			ONBOARDING_STORE_NAME
+		);
 
 		const profileItems = getProfileItems();
-		const isProfileItemsError = Boolean( getOnboardingError( 'updateProfileItems' ) );
+		const isProfileItemsError = Boolean(
+			getOnboardingError( 'updateProfileItems' )
+		);
 
 		const { general: settings = {} } = getSettings( 'general' );
 		const isSettingsError = Boolean( getSettingsError( 'general' ) );

--- a/client/task-list/tasks/steps/location.js
+++ b/client/task-list/tasks/steps/location.js
@@ -30,10 +30,12 @@ export default class StoreLocation extends Component {
 			createNotice,
 			isSettingsError,
 			updateAndPersistSettingsForGroup,
+			settings,
 		} = this.props;
 
 		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
+				...settings,
 				woocommerce_store_address: values.addressLine1,
 				woocommerce_store_address_2: values.addressLine2,
 				woocommerce_default_country: values.countryState,

--- a/client/task-list/tasks/tax.js
+++ b/client/task-list/tasks/tax.js
@@ -180,6 +180,7 @@ class Tax extends Component {
 			this.setState( { isPending: true } );
 			await updateAndPersistSettingsForGroup( 'general', {
 				general: {
+					...generalSettings,
 					woocommerce_calc_taxes: 'yes',
 				},
 			} );
@@ -191,17 +192,24 @@ class Tax extends Component {
 	}
 
 	async updateAutomatedTax() {
-		const { createNotice, updateAndPersistSettingsForGroup } = this.props;
+		const {
+			createNotice,
+			updateAndPersistSettingsForGroup,
+			generalSettings,
+			taxSettings,
+		} = this.props;
 		const { automatedTaxEnabled } = this.state;
 
 		await updateAndPersistSettingsForGroup( 'tax', {
 			tax: {
+				...taxSettings,
 				wc_connect_taxes_enabled: automatedTaxEnabled ? 'yes' : 'no',
 			},
 		} );
 
 		await updateAndPersistSettingsForGroup( 'general', {
 			general: {
+				...generalSettings,
 				woocommerce_calc_taxes: 'yes',
 			},
 		} );


### PR DESCRIPTION
Settings that were updated and persisted often times deleted existing properties. I'm not sure how we've only discovered this now, but this PR ensures all properties are saved by desctructuring the current settings objects.

### Test

1. In the Task List use the tax setup and make sure it behaves as it should.
2. Be sure to also try with a jetpack connected US store with WooCommerce Services enabled too.
3. Proceed also to the Payments screen. All WC Pay should be available for US stores before and after a refresh.