### PR TITLE
Add version 1.3.0 option update callback.

### DIFF
--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -100,3 +100,10 @@ function wc_admin_update_130_remove_dismiss_action_from_tracking_opt_in_note() {
 
 	$wpdb->query( "DELETE actions FROM {$wpdb->prefix}wc_admin_note_actions actions INNER JOIN {$wpdb->prefix}wc_admin_notes notes USING (note_id) WHERE actions.name = 'tracking-dismiss' AND notes.name = 'wc-admin-usage-tracking-opt-in'" );
 }
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_130_db_version() {
+	Installer::update_db_version( '1.3.0' );
+}

--- a/src/Install.php
+++ b/src/Install.php
@@ -46,6 +46,7 @@ class Install {
 		),
 		'1.3.0'  => array(
 			'wc_admin_update_130_remove_dismiss_action_from_tracking_opt_in_note',
+			'wc_admin_update_130_db_version',
 		),
 	);
 


### PR DESCRIPTION
The callback for updating the DB version to `1.3.0` (necessary when performing other callback, for now) was missed.

### Detailed test instructions:

- Check out this branch
- Verify that a DB update action is scheduled
- Verify that the DB version is updated

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - unreleased bug