### PR TITLE
Inbox header: Update styles

### DIFF
--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -4,12 +4,13 @@
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { __experimentalText as Text } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { EllipsisMenu, H } from '@woocommerce/components';
+import { EllipsisMenu } from '@woocommerce/components';
 
 class ActivityHeader extends Component {
 	render() {
@@ -25,14 +26,16 @@ class ActivityHeader extends Component {
 
 		return (
 			<div className={ cardClassName }>
-				<H className="woocommerce-layout__activity-panel-header-title">
+				<Text variant="title.small">
 					{ title }
-					{ countUnread > 0 && <span>{ unreadMessages }</span> }
-				</H>
+					{ countUnread > 0 && (
+						<span className="woocommerce-layout__inbox-badge">
+							{ unreadMessages }
+						</span>
+					) }
+				</Text>
 				{ subtitle && (
-					<div className="woocommerce-layout__activity-panel-header-subtitle">
-						{ subtitle }
-					</div>
+					<Text variant="subtitle.small">{ subtitle }</Text>
 				) }
 				{ menu && (
 					<div className="woocommerce-layout__activity-panel-header-menu">

--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -27,8 +27,8 @@ class ActivityHeader extends Component {
 		return (
 			<div className={ cardClassName }>
 				<div className="woocommerce-layout__inbox-title">
-					<Text variant="title.small">
-						{ title }
+					<Text variant="title.small">{ title }</Text>
+					<Text variant="button">
 						{ countUnread > 0 && (
 							<span className="woocommerce-layout__inbox-badge">
 								{ unreadMessages }

--- a/client/header/activity-panel/activity-header/index.js
+++ b/client/header/activity-panel/activity-header/index.js
@@ -26,17 +26,21 @@ class ActivityHeader extends Component {
 
 		return (
 			<div className={ cardClassName }>
-				<Text variant="title.small">
-					{ title }
-					{ countUnread > 0 && (
-						<span className="woocommerce-layout__inbox-badge">
-							{ unreadMessages }
-						</span>
+				<div className="woocommerce-layout__inbox-title">
+					<Text variant="title.small">
+						{ title }
+						{ countUnread > 0 && (
+							<span className="woocommerce-layout__inbox-badge">
+								{ unreadMessages }
+							</span>
+						) }
+					</Text>
+				</div>
+				<div className="woocommerce-layout__inbox-subtitle">
+					{ subtitle && (
+						<Text variant="body.small">{ subtitle }</Text>
 					) }
-				</Text>
-				{ subtitle && (
-					<Text variant="subtitle.small">{ subtitle }</Text>
-				) }
+				</div>
 				{ menu && (
 					<div className="woocommerce-layout__activity-panel-header-menu">
 						{ menu }

--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -38,7 +38,7 @@
 
 .woocommerce-layout__inbox-badge {
 	margin-left: $gap-small / 2;
-	background-color: $medium-gray-text;
+	background-color: $dark-gray-primary;
 	border-radius: 13px;
 	color: $white;
 	display: inline-block;

--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -28,23 +28,21 @@
 	}
 }
 
-.woocommerce-layout__inbox-panel-header {
-	h2.woocommerce-layout__activity-panel-header-title,
-	h3.woocommerce-layout__activity-panel-header-title {
-		margin: 0 0 $gap-small / 2;
-		font-size: 20px;
-		line-height: 28px;
-		font-weight: 400;
-		span {
-			margin-left: $gap-small / 2;
-			background: $core-grey-dark-600;
-			border-radius: 13px;
-			color: $core-grey-light-200;
-			display: inline-block;
-			text-align: center;
-			width: 27px;
-			font-size: 16px;
-			vertical-align: top;
-		}
-	}
+.woocommerce-layout__inbox-title {
+	color: $dark-gray-primary;
+}
+
+.woocommerce-layout__inbox-subtitle {
+	color: $medium-gray-text;
+}
+
+.woocommerce-layout__inbox-badge {
+	margin-left: $gap-small / 2;
+	background-color: $medium-gray-text;
+	border-radius: 13px;
+	color: $white;
+	display: inline-block;
+	text-align: center;
+	width: 27px;
+	vertical-align: top;
 }

--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -38,7 +38,7 @@
 
 .woocommerce-layout__inbox-badge {
 	margin-left: $gap-small / 2;
-	background-color: $dark-gray-primary;
+	background-color: $medium-gray-text;
 	border-radius: 13px;
 	color: $white;
 	display: inline-block;

--- a/client/header/activity-panel/activity-header/style.scss
+++ b/client/header/activity-panel/activity-header/style.scss
@@ -30,6 +30,8 @@
 
 .woocommerce-layout__inbox-title {
 	color: $dark-gray-primary;
+	display: flex;
+	align-items: center;
 }
 
 .woocommerce-layout__inbox-subtitle {
@@ -40,9 +42,9 @@
 	margin-left: $gap-small / 2;
 	background-color: $medium-gray-text;
 	border-radius: 13px;
+	padding: 0 $gap-small / 2;
 	color: $white;
 	display: inline-block;
 	text-align: center;
-	width: 27px;
 	vertical-align: top;
 }

--- a/client/header/activity-panel/panels/inbox/action.js
+++ b/client/header/activity-panel/panels/inbox/action.js
@@ -66,12 +66,10 @@ class InboxNoteAction extends Component {
 
 	render() {
 		const { action, dismiss, label } = this.props;
-		const isPrimary = dismiss || action.primary;
 
 		return (
 			<Button
-				isPrimary={ isPrimary }
-				isSecondary={ ! isPrimary }
+				isSecondary
 				isBusy={ this.state.inAction }
 				disabled={ this.state.inAction }
 				href={ action ? action.url : undefined }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/4603

Fix inbox header styles.

### Before

<img width="430" alt="Screen Shot 2020-06-25 at 11 30 12 AM" src="https://user-images.githubusercontent.com/1922453/85637635-d53d2700-b6d7-11ea-8c71-aa4fe31b3ccf.png">


### After

<img width="431" alt="Screen Shot 2020-06-25 at 11 27 57 AM" src="https://user-images.githubusercontent.com/1922453/85637630-d2dacd00-b6d7-11ea-8faf-eaa06f819bb3.png">

### Detailed test instructions:

1. Visit homepage, see the inbox header styles
2. Review this comment to make sure the right styles are applied: https://github.com/woocommerce/woocommerce-admin/issues/4603#issuecomment-648701092

### Changelog Note:

none: this fixes styles to an unreleased feature
