### PR TITLE
Theme Activation :: Fix unable to activate theme with uppercase name

### DIFF
--- a/src/API/OnboardingThemes.php
+++ b/src/API/OnboardingThemes.php
@@ -86,19 +86,18 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 	 */
 	public function install_theme( $request ) {
 		$allowed_themes = Onboarding::get_allowed_themes();
-		$theme          = sanitize_title_with_dashes( $request['theme'] );
+		$theme          = sanitize_text_field( $request['theme'] );
 
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce-admin' ), 404 );
 		}
 
-		$slug             = sanitize_key( $theme );
 		$installed_themes = wp_get_themes();
 
-		if ( in_array( $slug, array_keys( $installed_themes ), true ) ) {
+		if ( in_array( $theme, array_keys( $installed_themes ), true ) ) {
 			return( array(
-				'slug'   => $slug,
-				'name'   => $installed_themes[ $slug ]->get( 'Name' ),
+				'slug'   => $theme,
+				'name'   => $installed_themes[ $theme ]->get( 'Name' ),
 				'status' => 'success',
 			) );
 		}
@@ -112,7 +111,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 		$api = themes_api(
 			'theme_information',
 			array(
-				'slug'   => $slug,
+				'slug'   => $theme,
 				'fields' => array(
 					'sections' => false,
 				),
@@ -125,7 +124,7 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 				sprintf(
 					/* translators: %s: theme slug (example: woocommerce-services) */
 					__( 'The requested theme `%s` could not be installed. Theme API call failed.', 'woocommerce-admin' ),
-					$slug
+					$theme
 				),
 				500
 			);
@@ -140,14 +139,14 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 				sprintf(
 					/* translators: %s: theme slug (example: woocommerce-services) */
 					__( 'The requested theme `%s` could not be installed.', 'woocommerce-admin' ),
-					$slug
+					$theme
 				),
 				500
 			);
 		}
 
 		return array(
-			'slug'   => $slug,
+			'slug'   => $theme,
 			'name'   => $api->name,
 			'status' => 'success',
 		);
@@ -161,24 +160,23 @@ class OnboardingThemes extends \WC_REST_Data_Controller {
 	 */
 	public function activate_theme( $request ) {
 		$allowed_themes = Onboarding::get_allowed_themes();
-		$theme          = sanitize_title_with_dashes( $request['theme'] );
+		$theme          = sanitize_text_field( $request['theme'] );
 		if ( ! in_array( $theme, $allowed_themes, true ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_theme', __( 'Invalid theme.', 'woocommerce-admin' ), 404 );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/theme.php';
 
-		$slug             = sanitize_key( $theme );
 		$installed_themes = wp_get_themes();
 
 		if ( ! in_array( $theme, array_keys( $installed_themes ), true ) ) {
 			/* translators: %s: theme slug (example: woocommerce-services) */
-			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce-admin' ), $slug ), 404 );
+			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'Invalid theme %s.', 'woocommerce-admin' ), $theme ), 404 );
 		}
 
 		$result = switch_theme( $theme );
 		if ( ! is_null( $result ) ) {
-			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'The requested theme could not be activated.', 'woocommerce-admin' ), $slug ), 500 );
+			return new \WP_Error( 'woocommerce_rest_invalid_theme', sprintf( __( 'The requested theme could not be activated.', 'woocommerce-admin' ), $theme ), 500 );
 		}
 
 		return( array(

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -457,7 +457,7 @@ class Onboarding {
 	 */
 	public static function get_theme_data( $theme ) {
 		return array(
-			'slug'                    => sanitize_title( $theme->stylesheet ),
+			'slug'                    => sanitize_text_field( $theme->stylesheet ),
 			'title'                   => $theme->get( 'Name' ),
 			'price'                   => '0.00',
 			'is_installed'            => true,


### PR DESCRIPTION
Fixes #4393

Sorry if the PR description is too long, I just want to explain it as clear as possible.

### Issues
There are 2 issues I found related to uppercase theme activation during Onboarding Theme setup. Let's say, I have Narwidian theme with uppercase directory name (`Narwidian`).

1. When it's installed, we **can't choose** to activate it. An error says `Invalid theme narwidian` appear. 

![WooCommerce Admin - Issue - Choose installed theme](https://user-images.githubusercontent.com/9313128/85818019-c61ead80-b799-11ea-9928-94fb69cd7476.gif)

2. When it's already activated, it's **not highlighted as active theme** and we **can't choose/continue with it**. Similar error appear as well.

![WooCommerce Admin - Issue - Continue with activeacted theme](https://user-images.githubusercontent.com/9313128/85817649-c36f8880-b798-11ea-9106-2dc39ebc4176.gif)

### Solution
I tried the PR submitted by @travisseitler here https://github.com/woocommerce/woocommerce-admin/pull/4599, but it doesn't solve the issues I mention above. It's never pass allowed themes validation here: https://github.com/woocommerce/woocommerce-admin/blob/be5fd8b1953f3a4b9ce5fc14f1e275eaa5d188e4/src/API/OnboardingThemes.php#L165

I follow the PR and @joshuatf feedback to replace `sanitize_title_with_dashes` with `sanitize_text_field` on `OnboardingThemes-> activate_theme()` and `OnboardingThemes-> install_theme()`. Thanks for the feedback! I agree with this approach because we need the theme slug not converted into lowercase there to pass themes validation. I also remove another `sanitize_title` and `$slug` variable because they are no longer needed. We can use `$theme` value directly to check whether current theme is allowed to activate and whether it's one of the installed themes. It solves issue no. 1. In addition, I do similar thing on `Onboarding::get_theme_data()` to ensure the theme data contains the correct theme slug. And it solves issue no. 2.

### Screenshots

Here the GIFs how it works with uppercase theme. Let's use the same example above.

1. When it's installed, we **can choose** to activate it.

![WooCommerce Admin - Theme Name Fixed - Activate Theme](https://user-images.githubusercontent.com/9313128/85821126-1e59ad80-b7a2-11ea-9300-29d319103680.gif)

2. When it's already activated, it's **highlighted as active theme** and we **can continue with it** as well.

![WooCommerce Admin - Theme Name Fixed - Continue Active Theme](https://user-images.githubusercontent.com/9313128/85820400-58c24b00-b7a0-11ea-9a88-4677e420911f.gif)

### Detailed test instructions:
In order to make it's easier to test, I attached an example [Narwidian.zip](https://github.com/woocommerce/woocommerce-admin/files/4835205/Narwidian.zip) theme with uppercase directory name. Don't forget to install it before you test it.

There are 2 cases should be tested here.

1. We should be able to activate the uppercase theme on WooCommerce Onboarding Theme setup.

- Go to _WooCommerce > Settings > Help > Setup Wizard_, then enable **Profile Setup Wizard**.
- Fill in all store details, industry, product types, and business details until you arrive on Theme setup.
- Find Narwidian theme and choose it.
- You should be able to choose it, no error appear, and move to the next step (benefits page).

2. The activated theme should be highlighted as active theme and you can continue with it.

- Go to _WooCommerce > Settings > Help > Setup Wizard_, then enable **Profile Setup Wizard**.
- Fill in all store details, industry, product types, and business details until you arrive on Theme setup.
- Narwidian theme should be on top left of the list and the button label is **Continue with my active theme** instead of **Choose**.
- You should be able to continue, no error appear, and move to the next step (benefits page).

Please let me know if there is any test case I missed here.

### Changelog Note:
Fix: unable to activate theme with uppercase name #4393