### PR TITLE
REST API: Add support for legacy public function install_plugin.

### DIFF
--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -201,7 +201,20 @@ class Plugins extends \WC_REST_Data_Controller {
 	}
 
 	/**
-	 * Installs the requested plugin.
+	 * Install the requested plugin.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|array Plugin Status
+	 */
+	public function install_plugin( $request ) {
+		wc_deprecated_function( 'install_plugin', '4.3', '\Automattic\WooCommerce\Admin\API\Plugins()->install_plugins' );
+		// This method expects a `plugin` argument to be sent, install plugins requires plugins.
+		$request['plugins'] = $request['plugin'];
+		return self::install_plugins( $request );
+	}
+
+	/**
+	 * Installs the requested plugins.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return WP_Error|array Plugin Status

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -130,7 +130,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 * @param WC_Admin_Note $note Note being acted upon.
 	 */
 	public function install( $note ) {
-		if ( self::NOTE_NAME === $note->get_name() ) {
+		if ( self::NOTE_NAME === $note->get_name() && current_user_can( 'install_plugins' ) ) {
 			$install_request = array( 'plugins' => self::PLUGIN_SLUG );
 			$installer       = new \Automattic\WooCommerce\Admin\API\Plugins();
 			$result          = $installer->install_plugins( $install_request );

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -131,9 +131,9 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 */
 	public function install( $note ) {
 		if ( self::NOTE_NAME === $note->get_name() ) {
-			$install_request = array( 'plugin' => self::PLUGIN_SLUG );
+			$install_request = array( 'plugins' => self::PLUGIN_SLUG );
 			$installer       = new \Automattic\WooCommerce\Admin\API\Plugins();
-			$result          = $installer->install_plugin( $install_request );
+			$result          = $installer->install_plugins( $install_request );
 
 			if ( is_wp_error( $result ) ) {
 				return;


### PR DESCRIPTION
Fixes #4708

In #4411 a public method on the plugins REST API class was renamed from `install_plugin` to `install_plugins`. As @franticpsyx pointed out, we need to still properly deprecate the old `install_plugin` method name in case other developers are using it. And as he also pointed out, we have code in our own repository that would break with this change too.

In this branch I implemented the suggested solution of simply passing along any call to `install_plugin` to `install_plugins` and adjust the `plugin` param to `plugins` as is expected by the new method. Additionally I updated our own usage of `install_plugin` to use the new non-deprecated method.

/cc @joshuatf in case you have any other ideas here.

### Detailed test instructions:
Given I have updated the local usage of `install_plugin` in this PR, one way to test this out is to revert the changes to `src/Notes/WC_Admin_Notes_WooCommerce_Payments.php` and action the note.

### Changelog Note:

Dev: Add deprecation notice for `install_plugin()`

