### PR TITLE
Store details step - add contextual information and skip link

### DIFF
--- a/client/profile-wizard/steps/store-details.js
+++ b/client/profile-wizard/steps/store-details.js
@@ -3,18 +3,27 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { Button, CheckboxControl } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	CheckboxControl,
+	FlexItem,
+	Icon,
+	Tooltip,
+} from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { recordEvent } from 'lib/tracks';
 
 /**
  * WooCommerce dependencies
  */
-import { H, Card, Form } from '@woocommerce/components';
+import { H, Form } from '@woocommerce/components';
 import { getCurrencyData } from '@woocommerce/currency';
 import { ONBOARDING_STORE_NAME, SETTINGS_STORE_NAME } from '@woocommerce/data';
+import { ADMIN_URL as adminUrl } from '@woocommerce/wc-admin-settings';
 
 /**
  * Internal dependencies
@@ -26,10 +35,11 @@ import {
 } from 'dashboard/components/settings/general/store-address';
 import UsageModal from './usage-modal';
 import { CurrencyContext } from 'lib/currency-context';
+import { recordEvent } from 'lib/tracks';
 
 class StoreDetails extends Component {
 	constructor( props ) {
-		super( ...arguments );
+		super( props );
 		const { profileItems, settings } = props;
 
 		this.state = {
@@ -167,67 +177,110 @@ class StoreDetails extends Component {
 		return (
 			<Fragment>
 				<H className="woocommerce-profile-wizard__header-title">
-					{ __( 'Where is your store based?', 'woocommerce-admin' ) }
+					{ __( 'Welcome to WooCommerce', 'woocommerce-admin' ) }
 				</H>
 				<H className="woocommerce-profile-wizard__header-subtitle">
 					{ __(
-						'This will help us configure your store and get you started quickly',
+						"Tell us about your store and we'll get you set up in no time",
 						'woocommerce-admin'
 					) }
+
+					<Tooltip
+						text={ __(
+							'Your store address will help us configure currency\n options and shipping rules automatically.\n This information will not be publicly visible and can\n easily be changed later.',
+							'woocommerce-admin'
+						) }
+					>
+						<span className="woocommerce-profile-wizard__tooltip-icon">
+							<Icon icon="info-outline" size={ 16 } />
+						</span>
+					</Tooltip>
 				</H>
 
-				<Card>
-					<Form
-						initialValues={ this.initialValues }
-						onSubmitCallback={ this.onSubmit }
-						validate={ validateStoreAddress }
-					>
-						{ ( {
-							getInputProps,
-							handleSubmit,
-							values,
-							isValidForm,
-							setValue,
-						} ) => (
-							<Fragment>
-								{ showUsageModal && (
-									<UsageModal
-										onContinue={ () =>
-											this.onContinue( values )
-										}
-										onClose={ () =>
-											this.setState( {
-												showUsageModal: false,
-											} )
-										}
-									/>
-								) }
+				<Form
+					initialValues={ this.initialValues }
+					onSubmitCallback={ this.onSubmit }
+					validate={ validateStoreAddress }
+				>
+					{ ( {
+						getInputProps,
+						handleSubmit,
+						values,
+						isValidForm,
+						setValue,
+					} ) => (
+						<Card>
+							{ showUsageModal && (
+								<UsageModal
+									onContinue={ () =>
+										this.onContinue( values )
+									}
+									onClose={ () =>
+										this.setState( {
+											showUsageModal: false,
+										} )
+									}
+								/>
+							) }
+							<CardBody>
 								<StoreAddress
 									getInputProps={ getInputProps }
 									setValue={ setValue }
 								/>
+							</CardBody>
 
-								<div className="woocommerce-profile-wizard__client">
-									<CheckboxControl
-										label={ __(
-											"I'm setting up a store for a client",
-											'woocommerce-admin'
-										) }
-										{ ...getInputProps( 'isClient' ) }
-									/>
-								</div>
+							<CardFooter>
+								<FlexItem align="center">
+									<div className="woocommerce-profile-wizard__client">
+										<CheckboxControl
+											label={ __(
+												"I'm setting up a store for a client",
+												'woocommerce-admin'
+											) }
+											{ ...getInputProps( 'isClient' ) }
+										/>
+									</div>
+								</FlexItem>
+							</CardFooter>
 
-								<Button
-									isPrimary
-									onClick={ handleSubmit }
-									disabled={ ! isValidForm }
-								>
-									{ __( 'Continue', 'woocommerce-admin' ) }
-								</Button>
-							</Fragment>
-						) }
-					</Form>
-				</Card>
+							<CardFooter justify="center">
+								<FlexItem>
+									<div className="woocommerce-profile-wizard__submit">
+										<Button
+											isPrimary
+											onClick={ handleSubmit }
+											disabled={ ! isValidForm }
+										>
+											{ __(
+												'Continue',
+												'woocommerce-admin'
+											) }
+										</Button>
+									</div>
+								</FlexItem>
+							</CardFooter>
+						</Card>
+					) }
+				</Form>
+				<div className="woocommerce-profile-wizard__footer">
+					<a
+						className="woocommerce-profile-wizard__footer-link"
+						href={ adminUrl }
+					>
+						{ __( 'Skip setup wizard', 'woocommerce-admin' ) }
+
+						<Tooltip
+							text={ __(
+								'Manual setup is only recommended for\n experienced WooCommerce users or developers.',
+								'woocommerce-admin'
+							) }
+						>
+							<span className="woocommerce-profile-wizard__tooltip-icon">
+								<Icon icon="info-outline" size={ 16 } />
+							</span>
+						</Tooltip>
+					</a>
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -101,7 +101,6 @@
 
 		.components-popover__content {
 			white-space: pre;
-			font-size: 16px;
 
 			> div {
 				padding: 11px 16px;

--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -1,5 +1,3 @@
-
-
 .woocommerce-profile-wizard__body {
 	.woocommerce-profile-wizard__container a {
 		color: $studio-pink-50;
@@ -46,11 +44,16 @@
 		background: $studio-white;
 	}
 
+	.woocommerce-profile-wizard__header-title,
+	.woocommerce-profile-wizard__header-subtitle {
+		font-weight: 400;
+		text-align: center;
+	}
+
 	.woocommerce-profile-wizard__header-title {
 		color: $studio-gray-80;
 		font-size: 24px;
 		line-height: 32px;
-		font-weight: 400;
 		margin-bottom: $gap-smaller;
 	}
 
@@ -58,9 +61,11 @@
 		color: $studio-gray-60;
 		font-size: 16px;
 		line-height: 24px;
-		font-weight: 400;
 		margin-top: $gap-smaller;
-		margin-bottom: $gap;
+		margin-bottom: $gap * 2;
+		margin-right: $gap-smaller;
+		display: flex;
+		justify-content: center;
 	}
 
 	.woocommerce-profile-wizard__intro-paragraph {
@@ -72,9 +77,10 @@
 		margin-top: $gap-larger;
 		margin-left: auto;
 		margin-right: auto;
+		text-align: left;
 
 		> * {
-			max-width: 476px;
+			max-width: 504px;
 			margin-left: auto;
 			margin-right: auto;
 		}
@@ -93,8 +99,30 @@
 			font-weight: 400;
 		}
 
+		.components-popover__content {
+			white-space: pre;
+			font-size: 16px;
+
+			> div {
+				padding: 11px 16px;
+			}
+		}
+
 		.woocommerce-card ~ p {
 			font-size: 14px;
+		}
+
+		.woocommerce-profile-wizard__footer {
+			margin: 34px auto 0 auto;
+			display: flex;
+			justify-content: center;
+		}
+
+		.woocommerce-profile-wizard__footer-link {
+			display: flex;
+			text-decoration: none;
+			font-size: 14px;
+			color: var(--wp-admin-theme-color);
 		}
 	}
 
@@ -236,7 +264,7 @@
 	}
 
 	.woocommerce-profile-wizard__client {
-		margin-bottom: $gap-large;
+		margin: $gap-smaller 0;
 	}
 
 	.woocommerce-profile-wizard__checkbox-group {
@@ -423,6 +451,18 @@
 	.woocommerce-stepper__steps {
 		margin: 0;
 	}
+}
+
+.woocommerce-profile-wizard__submit {
+	margin-bottom: $gap-small;
+}
+
+.woocommerce-profile-wizard__tooltip-icon {
+	color: $studio-gray-60;
+	display: flex;
+	align-items: center;
+	margin-left: 8px;
+	cursor: pointer;
 }
 
 .components-modal__frame.woocommerce-profile-wizard__usage-modal {

--- a/client/stylesheets/abstracts/_breakpoints.scss
+++ b/client/stylesheets/abstracts/_breakpoints.scss
@@ -22,13 +22,15 @@ $breakpoints: 320px, 400px, 600px, 782px, 960px, 1280px, 1440px;
 					@media (max-width: $breakpoint) {
 						@content;
 					}
-				} @else {
+				}
+				@else {
 					@if $size == $and-larger {
 						$approved-value: 2;
 						@media (min-width: $breakpoint + 1) {
 							@content;
 						}
-					} @else {
+					}
+					@else {
 						@each $breakpoint-end in $breakpoints {
 							$range: $breakpoint + '-' + $breakpoint-end;
 							@if $size == $range {
@@ -48,7 +50,8 @@ $breakpoints: 320px, 400px, 600px, 782px, 960px, 1280px, 1440px;
 				}
 				@warn 'ERROR in breakpoint( #{ $size } ) : You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
 			}
-		} @else {
+		}
+		@else {
 			$sizes: '';
 			@each $breakpoint in $breakpoints {
 				$sizes: $sizes + ' ' + $breakpoint;

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -134,11 +134,13 @@
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
 		}
-	} @else if $property == 'animation' {
+	}
+	@else if $property == 'animation' {
 		@media (prefers-reduced-motion: reduce) {
 			animation-duration: 1ms;
 		}
-	} @else {
+	}
+	@else {
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
 			animation-duration: 1ms;

--- a/client/stylesheets/abstracts/_mixins.scss
+++ b/client/stylesheets/abstracts/_mixins.scss
@@ -134,13 +134,11 @@
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
 		}
-	}
-	@else if $property == 'animation' {
+	} @else if $property == 'animation' {
 		@media (prefers-reduced-motion: reduce) {
 			animation-duration: 1ms;
 		}
-	}
-	@else {
+	} @else {
 		@media (prefers-reduced-motion: reduce) {
 			transition-duration: 0s;
 			animation-duration: 1ms;

--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -6,6 +6,8 @@
 @import 'node_modules/@wordpress/base-styles/animations';
 @import 'node_modules/@wordpress/base-styles/z-index';
 
+@include wordpress-admin-schemes;
+
 $fallback-gutter: 24px;
 $fallback-gutter-large: 40px;
 $gutter: var(--main-gap);
@@ -62,9 +64,9 @@ $wp-admin-background: #f1f1f1;
 $wp-admin-sidebar: #24292d;
 
 // Muriel
-$muriel-box-shadow-1dp: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),
-	0 1px 3px 0 rgba(0, 0, 0, 0.12);
-$muriel-box-shadow-6dp: 0 3px 5px rgba(0, 0, 0, 0.2), 0 1px 18px rgba(0, 0, 0, 0.12),
-	0 6px 10px rgba(0, 0, 0, 0.14);
-$muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14),
-	0 3px 14px 2px rgba(0, 0, 0, 0.12);
+$muriel-box-shadow-1dp: 0 2px 1px -1px rgba(0, 0, 0, 0.2),
+	0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+$muriel-box-shadow-6dp: 0 3px 5px rgba(0, 0, 0, 0.2),
+	0 1px 18px rgba(0, 0, 0, 0.12), 0 6px 10px rgba(0, 0, 0, 0.14);
+$muriel-box-shadow-8dp: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+	0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6285,9 +6285,9 @@
 			}
 		},
 		"@wordpress/base-styles": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.8.0.tgz",
-			"integrity": "sha512-NXcR72DgB61dgcjEmRbbssRlvm5eTuCSOtMvvK7nzkN4J72sLfxXHEONeqzePt92D/60sX+AifmO8DmKN0zzPQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-1.11.0.tgz",
+			"integrity": "sha512-CV7NsA0SzLGKFmhhTIhi6pWeijeSaBl16hwp+x7OcyQKy/MMbVx2gXsHf3KjGNY18FT1Uf2MlhcdIeBM22RpWQ==",
 			"dev": true
 		},
 		"@wordpress/browserslist-config": {
@@ -6296,61 +6296,128 @@
 			"integrity": "sha512-vRgzGoxhcNVChBP30XZlyK4w6r/9ZpO+Fi1dzmButp31lUEb1pT5WBxTIQl3HE0JZ9YTEJ00WWGO5sjGi5MHZA=="
 		},
 		"@wordpress/components": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.6.0.tgz",
-			"integrity": "sha512-moGKwpkwpXvKPfYPQ+q9leDv9eQKaMeeTfy83FmFtLCMWRXANJuNUPYJVS1rtAXuAx+dkxx9a6AYdRpoF7iTNQ==",
+			"version": "9.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.9.0.tgz",
+			"integrity": "sha512-EtDQ7sf7GuEMo+oWW7CDob0YrVynxR+t0FXGDZw3IP8msKAvVmsCD0DoSEOfX/DTWNaaHstaw6xE4+Tgk1XUWQ==",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@emotion/core": "^10.0.22",
 				"@emotion/css": "^10.0.22",
 				"@emotion/native": "^10.0.22",
 				"@emotion/styled": "^10.0.23",
-				"@wordpress/a11y": "^2.9.0",
-				"@wordpress/compose": "^3.15.0",
-				"@wordpress/deprecated": "^2.8.0",
-				"@wordpress/dom": "^2.9.0",
-				"@wordpress/element": "^2.14.0",
-				"@wordpress/hooks": "^2.8.0",
-				"@wordpress/i18n": "^3.12.0",
-				"@wordpress/icons": "^2.0.0",
-				"@wordpress/is-shallow-equal": "^2.0.0",
-				"@wordpress/keycodes": "^2.12.0",
-				"@wordpress/primitives": "^1.5.0",
-				"@wordpress/rich-text": "^3.16.0",
-				"@wordpress/warning": "^1.1.0",
+				"@wordpress/a11y": "^2.11.0",
+				"@wordpress/compose": "^3.18.0",
+				"@wordpress/deprecated": "^2.9.0",
+				"@wordpress/dom": "^2.12.0",
+				"@wordpress/element": "^2.15.0",
+				"@wordpress/hooks": "^2.9.0",
+				"@wordpress/i18n": "^3.14.0",
+				"@wordpress/icons": "^2.3.0",
+				"@wordpress/is-shallow-equal": "^2.1.0",
+				"@wordpress/keycodes": "^2.14.0",
+				"@wordpress/primitives": "^1.6.0",
+				"@wordpress/rich-text": "^3.19.0",
+				"@wordpress/warning": "^1.2.0",
 				"classnames": "^2.2.5",
-				"clipboard": "^2.0.1",
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^4.0.5",
 				"gradient-parser": "^0.1.5",
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",
 				"moment": "^2.22.1",
-				"re-resizable": "^6.0.0",
+				"re-resizable": "^6.4.0",
 				"react-dates": "^17.1.1",
 				"react-spring": "^8.0.20",
-				"reakit": "^1.0.0-rc.2",
+				"react-use-gesture": "^7.0.15",
+				"reakit": "^1.1.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^7.0.2"
 			},
 			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.14.0.tgz",
-					"integrity": "sha512-msSkGecq2Z8lBoj95D0vxj64lbGx7c7Q8VxsNLA3G813HVybeY5gYeWFokWKfok+tszCwjJI4ZgR4DxRsYNTig==",
+				"@wordpress/a11y": {
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.11.0.tgz",
+					"integrity": "sha512-Phu3l9bFue3NnmB9SLmlSZtcaenfOiprCClC1Gk6Dxyf7dFincW65XcEZ5k8OZZQcT9mizMSQI4jTV64QiWanQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/escape-html": "^1.8.0",
+						"@wordpress/dom-ready": "^2.10.0",
+						"@wordpress/i18n": "^3.14.0"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.18.0.tgz",
+					"integrity": "sha512-EHVn7h1iYX9pMfcet6vF+/22nvaBf6beaPLh+QXMEma0H9d/ag5sqLazyVdBqLIJsGZWeR6s2cBnYmbdPApgFw==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/element": "^2.15.0",
+						"@wordpress/is-shallow-equal": "^2.1.0",
+						"@wordpress/priority-queue": "^1.7.0",
+						"clipboard": "^2.0.1",
+						"lodash": "^4.17.15",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.0.1"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.9.0.tgz",
+					"integrity": "sha512-rknpxSuzS/cWzYuOlvAAMVjkSTNHq4ljrXAzX0Y81xzu2KgicwdDvbLQbC7diD8TOO4hWbz87FDI1gDN5/m4IQ==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/hooks": "^2.9.0"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.12.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.12.0.tgz",
+					"integrity": "sha512-GYVawQlPcH5awLw1N/w8lQKVphguT7YR5yqDTmQ6O02bqtd+4/h5K2xXE8IINC4jBx6VyLV/dEYmrZvsiutNvg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"lodash": "^4.17.15"
+					}
+				},
+				"@wordpress/dom-ready": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.10.0.tgz",
+					"integrity": "sha512-ibeuUU0bz66ZtFxu4jyo9YLxTkmLZCSiSo/NApwtzbyE3+cGS05XrAAhM/M79OjysOFaKNyh6sp0YA7ZZU47eg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.15.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.15.0.tgz",
+					"integrity": "sha512-XXJxvjlQo0+1L+QFUXSWc8HCPR3I9aG0yxs+kJ8k8SHQxkUOZkqLQLYtwoNJpAlvgyKeFQNigpoddjoVbDDm7Q==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.15",
 						"react": "^16.9.0",
 						"react-dom": "^16.9.0"
 					}
 				},
+				"@wordpress/escape-html": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.9.0.tgz",
+					"integrity": "sha512-XW0GGqxpFauOgTjfQ9603hCDnUE+HhD0HVFMIEphIrTpTreLW3lJbfTibPTn0dWWPATqanH2TlPurOagUubh4g==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.9.0.tgz",
+					"integrity": "sha512-RL7bIIwy1BJWPOicwtDdC1cO+0HqHhnRtry8qeatv+/qN7O5YrJaslCMot7R4Y9cIgzX8C8Vj2BN2QsXLqUAGg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
 				"@wordpress/i18n": {
-					"version": "3.13.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.13.0.tgz",
-					"integrity": "sha512-eMlOvg2vYKmGV4C1vPrWuOEyskxMeCGoQJ0N3mQ6t7iWKs4bKWAJGlGL5QXMwN7xJJ863h3L7mrbLM3zKVrF1g==",
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
+					"integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"gettext-parser": "^1.3.1",
@@ -6360,15 +6427,56 @@
 						"tannin": "^1.2.0"
 					}
 				},
-				"@wordpress/keycodes": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.13.0.tgz",
-					"integrity": "sha512-Bm3N4Qf5qLXds+eflM+JXD15VEW/7IQ7eqWt9/UhsssuDTMTMbXnYjxOAh5zoVi2toAMSMs8EYpV28V+Qv0ZjA==",
+				"@wordpress/icons": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.3.0.tgz",
+					"integrity": "sha512-8+6I5nE+J2GY8sN1WIAaA7FbhI2EoCmWgS+2pCSttYltcIGCGyL/fNBOKVY+ZtFMsOan08NMOQaxMywLjFeP7A==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/i18n": "^3.13.0",
+						"@wordpress/element": "^2.15.0",
+						"@wordpress/primitives": "^1.6.0"
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.1.0.tgz",
+					"integrity": "sha512-xCphAZG60mnLhn+LitwfoercNxsPMvc0Yo96kBY7HAZgrPt+jNQ5Rv4M+FTlVnyLrkyxVxNdtGyuyR+Hpgi8Pg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.14.0.tgz",
+					"integrity": "sha512-R/0orMutajuQ1d1kFFIvksXKR5C5TtszEkbnxSfdNlKaOW7p9Srv8+8m2QqM+AKNvEGMaq6cn7BfDtTbZ33Dbw==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/i18n": "^3.14.0",
 						"lodash": "^4.17.15"
 					}
+				},
+				"@wordpress/primitives": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.6.0.tgz",
+					"integrity": "sha512-QsvdzJX6/DikIRmWuU6g9O0Wse96/ZdIOealygO8FUj8HxB6kqFXBqk7L7pJKPYUuUyltu1oHblwT+IsxA1Agg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/element": "^2.15.0",
+						"classnames": "^2.2.5"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.7.0.tgz",
+					"integrity": "sha512-fwHOW48lYRV2CpP43LwET+ZQrNDK325V9fFMMpc0tgJfdSfgT9gwztOEx5vbbfkwzJXIdxTW+ILhoH20CuiSug==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
+				"@wordpress/warning": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.2.0.tgz",
+					"integrity": "sha512-Q3WqbXHaoEuGddpFvVEmG9Xwpr5QMhi/NT+Q1td6J414fyNhafkmwGVd3roJB7/2y+ek2UDDegc32B8lkyW19A=="
 				}
 			}
 		},
@@ -6835,36 +6943,51 @@
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.18.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.18.0.tgz",
-			"integrity": "sha512-V5y3cUbchFd+VpAS7gZgYbvfIBsDA6zowoG0zHkXAEtFh8Rf+jnRWo3tBYKw8B8hmM3hYPLDVYTAEulsDYILvg==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.19.0.tgz",
+			"integrity": "sha512-QhzIketHwieMJXN2zk0TF07Xp13N+31JvR3gGZOXNasm6G+AXDrBaUMOOLftcOuPREX7weGKDeUqYMySmSAJUA==",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.17.0",
-				"@wordpress/data": "^4.20.0",
-				"@wordpress/deprecated": "^2.8.0",
-				"@wordpress/element": "^2.14.0",
-				"@wordpress/escape-html": "^1.8.0",
-				"@wordpress/is-shallow-equal": "^2.0.0",
-				"@wordpress/keycodes": "^2.13.0",
+				"@wordpress/compose": "^3.18.0",
+				"@wordpress/data": "^4.21.0",
+				"@wordpress/deprecated": "^2.9.0",
+				"@wordpress/element": "^2.15.0",
+				"@wordpress/escape-html": "^1.9.0",
+				"@wordpress/is-shallow-equal": "^2.1.0",
+				"@wordpress/keycodes": "^2.14.0",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.15",
 				"memize": "^1.1.0",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.20.0.tgz",
-					"integrity": "sha512-zSCwZrH8hrBWAmDKzvfDynr/8qAk5im3B5IjczssDeKMB3ERjgr0RU8HctkiWlvQyJjaQdrfGR7ird6uJYhCOw==",
+				"@wordpress/compose": {
+					"version": "3.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.18.0.tgz",
+					"integrity": "sha512-EHVn7h1iYX9pMfcet6vF+/22nvaBf6beaPLh+QXMEma0H9d/ag5sqLazyVdBqLIJsGZWeR6s2cBnYmbdPApgFw==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.17.0",
-						"@wordpress/deprecated": "^2.8.0",
-						"@wordpress/element": "^2.14.0",
-						"@wordpress/is-shallow-equal": "^2.0.0",
-						"@wordpress/priority-queue": "^1.6.0",
-						"@wordpress/redux-routine": "^3.9.0",
+						"@wordpress/element": "^2.15.0",
+						"@wordpress/is-shallow-equal": "^2.1.0",
+						"@wordpress/priority-queue": "^1.7.0",
+						"clipboard": "^2.0.1",
+						"lodash": "^4.17.15",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.0.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "4.21.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.21.0.tgz",
+					"integrity": "sha512-+KU4+XKtVUqnPRBUlqD5yJXQNVoAPBZsp6KWNojd9Zhm4Sg/+8DGNo+fSpt5RQ+VJmUoRAqAk8UifQ6LZSuzQg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/compose": "^3.18.0",
+						"@wordpress/deprecated": "^2.9.0",
+						"@wordpress/element": "^2.15.0",
+						"@wordpress/is-shallow-equal": "^2.1.0",
+						"@wordpress/priority-queue": "^1.7.0",
+						"@wordpress/redux-routine": "^3.10.0",
 						"equivalent-key-map": "^0.2.2",
 						"is-promise": "^4.0.0",
 						"lodash": "^4.17.15",
@@ -6874,22 +6997,47 @@
 						"use-memo-one": "^1.1.1"
 					}
 				},
-				"@wordpress/element": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.14.0.tgz",
-					"integrity": "sha512-msSkGecq2Z8lBoj95D0vxj64lbGx7c7Q8VxsNLA3G813HVybeY5gYeWFokWKfok+tszCwjJI4ZgR4DxRsYNTig==",
+				"@wordpress/deprecated": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.9.0.tgz",
+					"integrity": "sha512-rknpxSuzS/cWzYuOlvAAMVjkSTNHq4ljrXAzX0Y81xzu2KgicwdDvbLQbC7diD8TOO4hWbz87FDI1gDN5/m4IQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/escape-html": "^1.8.0",
+						"@wordpress/hooks": "^2.9.0"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.15.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.15.0.tgz",
+					"integrity": "sha512-XXJxvjlQo0+1L+QFUXSWc8HCPR3I9aG0yxs+kJ8k8SHQxkUOZkqLQLYtwoNJpAlvgyKeFQNigpoddjoVbDDm7Q==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.15",
 						"react": "^16.9.0",
 						"react-dom": "^16.9.0"
 					}
 				},
+				"@wordpress/escape-html": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.9.0.tgz",
+					"integrity": "sha512-XW0GGqxpFauOgTjfQ9603hCDnUE+HhD0HVFMIEphIrTpTreLW3lJbfTibPTn0dWWPATqanH2TlPurOagUubh4g==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.9.0.tgz",
+					"integrity": "sha512-RL7bIIwy1BJWPOicwtDdC1cO+0HqHhnRtry8qeatv+/qN7O5YrJaslCMot7R4Y9cIgzX8C8Vj2BN2QsXLqUAGg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
 				"@wordpress/i18n": {
-					"version": "3.13.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.13.0.tgz",
-					"integrity": "sha512-eMlOvg2vYKmGV4C1vPrWuOEyskxMeCGoQJ0N3mQ6t7iWKs4bKWAJGlGL5QXMwN7xJJ863h3L7mrbLM3zKVrF1g==",
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
+					"integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"gettext-parser": "^1.3.1",
@@ -6899,14 +7047,41 @@
 						"tannin": "^1.2.0"
 					}
 				},
+				"@wordpress/is-shallow-equal": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.1.0.tgz",
+					"integrity": "sha512-xCphAZG60mnLhn+LitwfoercNxsPMvc0Yo96kBY7HAZgrPt+jNQ5Rv4M+FTlVnyLrkyxVxNdtGyuyR+Hpgi8Pg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
 				"@wordpress/keycodes": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.13.0.tgz",
-					"integrity": "sha512-Bm3N4Qf5qLXds+eflM+JXD15VEW/7IQ7eqWt9/UhsssuDTMTMbXnYjxOAh5zoVi2toAMSMs8EYpV28V+Qv0ZjA==",
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.14.0.tgz",
+					"integrity": "sha512-R/0orMutajuQ1d1kFFIvksXKR5C5TtszEkbnxSfdNlKaOW7p9Srv8+8m2QqM+AKNvEGMaq6cn7BfDtTbZ33Dbw==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/i18n": "^3.13.0",
+						"@wordpress/i18n": "^3.14.0",
 						"lodash": "^4.17.15"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.7.0.tgz",
+					"integrity": "sha512-fwHOW48lYRV2CpP43LwET+ZQrNDK325V9fFMMpc0tgJfdSfgT9gwztOEx5vbbfkwzJXIdxTW+ILhoH20CuiSug==",
+					"requires": {
+						"@babel/runtime": "^7.9.2"
+					}
+				},
+				"@wordpress/redux-routine": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.10.0.tgz",
+					"integrity": "sha512-i4YQq9veu3i0Q89b5mpVW6GL0Hn+2/rZp/iTfjdUsalfIvSQFg1BpTU1ixbeXymWH7RryjN/qLm28bUCITJKYg==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.15",
+						"rungen": "^0.3.2"
 					}
 				}
 			}
@@ -23625,7 +23800,7 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.19.1",
+			"version": "npm:prettier@1.19.1",
 			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
 			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
 			"dev": true
@@ -24286,9 +24461,9 @@
 			}
 		},
 		"re-resizable": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.4.0.tgz",
-			"integrity": "sha512-E8WOtM8RfcGv4kOdasdR10jw8IU45j5jVift/rSA6AZMnaBRxJdt6YAkPHFv/04vsMNNvNu3G8vlyNOsVwqPpA==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.5.1.tgz",
+			"integrity": "sha512-cOeFKFasRFKs9Z5qf4BbNd6hJhTnrOC8isKpgCbZRm9WdZay1MXUxYqWA6hka5XIpZLQ/QupKjFWmjRLkk0bkw==",
 			"requires": {
 				"fast-memoize": "^2.5.1"
 			}
@@ -25041,6 +25216,11 @@
 				"prop-types": "^15.6.2"
 			}
 		},
+		"react-use-gesture": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-7.0.15.tgz",
+			"integrity": "sha512-vHQkaa7oUbSDTAcFk9huQXa7E8KPrZH91erPuOMoqZT513qvtbb/SzTQ33lHc71/kOoJkMbzOkc4uoA4sT7Ogg=="
+		},
 		"react-visibility-sensor": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
@@ -25289,36 +25469,36 @@
 			"dev": true
 		},
 		"reakit": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.4.tgz",
-			"integrity": "sha512-v9tZoO40IBA7zX4SypyGco9z6+mDGcn/JsZfYRA+Qvmh2FjLX08m7FwhkQMgwccygHaZP+nEgVIsE6QUroCWrw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.1.1.tgz",
+			"integrity": "sha512-Ha/+TYBjJYDE1qQIhQX0CmVHMQuaK4qFasjHQgqIHLsvz4cHD8vCgRqwXWKSbBTH8hYpgvy057vVeyoQh6k/tQ==",
 			"requires": {
-				"@popperjs/core": "^2.4.0",
+				"@popperjs/core": "^2.4.2",
 				"body-scroll-lock": "^3.0.2",
-				"reakit-system": "^0.12.2",
-				"reakit-utils": "^0.12.1",
-				"reakit-warning": "^0.3.1"
+				"reakit-system": "^0.13.0",
+				"reakit-utils": "^0.13.0",
+				"reakit-warning": "^0.4.0"
 			}
 		},
 		"reakit-system": {
-			"version": "0.12.2",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.12.2.tgz",
-			"integrity": "sha512-+/tZ/atDbHhDOapcIxniNZd7z0cze1L9MJBEnvykqM/bdqUE59Eb/OQ6odPZwK35gcN1lNyZtw7DgnFrmsDi4w==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.13.0.tgz",
+			"integrity": "sha512-33HCSab1WS08H8P4aFU7X7sf089B383GKWilyj+Z0U5XNJPzRklbqdsfsyasEm9vr/gQyu9ZMLxX1YJBN/iekw==",
 			"requires": {
-				"reakit-utils": "^0.12.1"
+				"reakit-utils": "^0.13.0"
 			}
 		},
 		"reakit-utils": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.12.1.tgz",
-			"integrity": "sha512-P66TYzmQFD5CqNWcRvbPb6B5nXRLfiWqwTJhVGDUeOJTSdlnjfsBuOIauojfuS+p4yeyFVsUFsFwuBM6uZ8F3A=="
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.13.0.tgz",
+			"integrity": "sha512-/Ll+D4WllB6s2dNuWHTO32JNgdSHl1jf5y6QK3aCU4OEMtSCGz0TpXXHslWgRXWEQjKItVY640A8wugVQmKgWQ=="
 		},
 		"reakit-warning": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.3.1.tgz",
-			"integrity": "sha512-kFGASQG1ogpyknF0vlfab2emptCuW4a2Ku0SOeNkD+WGkMytJMNqrklqqfuWFEPqpuWGkBduOLbmEEyVLgSLZg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.4.0.tgz",
+			"integrity": "sha512-p5/dGY2AlWTV33AS9JPlm9Y5u0YUUyg53MIC90vl3p4J4VI2cxMnu42eCck1g0nwYgiEYLPU/90NNrAQf/Ck6g==",
 			"requires": {
-				"reakit-utils": "^0.12.1"
+				"reakit-utils": "^0.13.0"
 			}
 		},
 		"realpath-native": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
 		"@wordpress/babel-plugin-import-jsx-pragma": "1.1.3",
 		"@wordpress/babel-plugin-makepot": "2.1.3",
 		"@wordpress/babel-preset-default": "3.0.2",
-		"@wordpress/base-styles": "1.8.0",
+		"@wordpress/base-styles": "1.11.0",
 		"@wordpress/browserslist-config": "2.6.0",
 		"@wordpress/custom-templated-path-webpack-plugin": "1.6.0",
 		"@wordpress/eslint-plugin": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 	"dependencies": {
 		"@fresh-data/framework": "0.6.1",
 		"@wordpress/api-fetch": "2.2.8",
-		"@wordpress/components": "9.6.0",
+		"@wordpress/components": "9.9.0",
 		"@wordpress/data": "4.16.1",
 		"@wordpress/data-controls": "1.10.1",
 		"@wordpress/date": "3.9.0",

--- a/packages/components/src/list/style.scss
+++ b/packages/components/src/list/style.scss
@@ -20,7 +20,8 @@
 		padding: $gap $gap-large;
 
 		&:focus {
-			box-shadow: inset 0 0 0 1px $studio-wordpress-blue, inset 0 0 0 2px $studio-white;
+			box-shadow: inset 0 0 0 1px $studio-wordpress-blue,
+				inset 0 0 0 2px $studio-white;
 		}
 	}
 
@@ -53,7 +54,7 @@
 	$background-color: $white;
 	$background-color-hover: $light-gray-100;
 	$border-color: $light-gray-tertiary;
-	$foreground-color: $theme-color;
+	$foreground-color: var(--wp-admin-theme-color);
 	$foreground-color-hover: color($foreground-color shade(20%));
 
 	background-color: $background-color;
@@ -88,7 +89,7 @@
 
 	&.is-complete {
 		.woocommerce-task__icon {
-			background-color: $theme-color;
+			background-color: var(--wp-admin-theme-color);
 		}
 
 		.woocommerce-list__item-title {

--- a/packages/components/src/segmented-selection/style.scss
+++ b/packages/components/src/segmented-selection/style.scss
@@ -1,5 +1,3 @@
-
-
 .woocommerce-segmented-selection {
 	width: 100%;
 	color: $core-grey-dark-500;
@@ -62,7 +60,7 @@
 			content: '';
 			width: 8px;
 			height: 8px;
-			background-color: $theme-color;
+			background-color: var(--wp-admin-theme-color);
 			position: absolute;
 			top: 50%;
 			transform: translate(-20px, -50%);

--- a/packages/components/src/summary/style.scss
+++ b/packages/components/src/summary/style.scss
@@ -1,5 +1,3 @@
-
-
 // Set up some local color variables to make the CSS more clear
 $border: $light-gray-tertiary;
 
@@ -7,11 +5,13 @@ $border: $light-gray-tertiary;
 @mixin make-cols( $i ) {
 	grid-template-columns: repeat($i, 1fr);
 
-	.woocommerce-summary__item-container:nth-of-type(#{$i}n) .woocommerce-summary__item {
+	.woocommerce-summary__item-container:nth-of-type(#{$i}n)
+	.woocommerce-summary__item {
 		border-right-color: $border;
 	}
 
-	.woocommerce-summary__item-container:nth-of-type(#{$i}n+1):nth-last-of-type(-n+#{$i}) {
+	.woocommerce-summary__item-container:nth-of-type(#{$i}n
++ 1):nth-last-of-type(-n + #{$i}) {
 		.woocommerce-summary__item,
 		& ~ .woocommerce-summary__item-container .woocommerce-summary__item {
 			border-bottom-color: $border;
@@ -159,7 +159,8 @@ $border: $light-gray-tertiary;
 
 		&.has-9-items,
 		&.has-10-items {
-			.woocommerce-summary__item-container:nth-of-type(5n) .woocommerce-summary__item {
+			.woocommerce-summary__item-container:nth-of-type(5n)
+			.woocommerce-summary__item {
 				border-right-color: $border;
 			}
 		}
@@ -263,7 +264,7 @@ $border: $light-gray-tertiary;
 	border-right: 1px solid $border;
 	line-height: 1.4em;
 	text-decoration: none;
-	color: $theme-color;
+	color: var(--wp-admin-theme-color);
 
 	&.components-button {
 		height: auto;
@@ -271,10 +272,9 @@ $border: $light-gray-tertiary;
 		align-items: normal;
 	}
 
-
 	&:hover {
 		background-color: $light-gray-100;
-		color: color($theme-color shade(20%));
+		color: color(var(--wp-admin-theme-color-darker-20));
 	}
 
 	&:active {
@@ -283,14 +283,16 @@ $border: $light-gray-tertiary;
 
 	&:focus {
 		// !important to override button styles
-		box-shadow: inset -1px -1px 0 $core-grey-dark-300, inset 1px 1px 0 $core-grey-dark-300 !important;
+		box-shadow: inset -1px -1px 0 $core-grey-dark-300,
+			inset 1px 1px 0 $core-grey-dark-300 !important;
 	}
 
 	&.is-selected {
-
 		&:focus {
 			// !important to override button styles
-			box-shadow: inset -1px 1px 0 $core-grey-dark-300, inset 1px 0 0 $core-grey-dark-300, inset 0 -4px 0 $theme-color !important;
+			box-shadow: inset -1px 1px 0 $core-grey-dark-300,
+				inset 1px 0 0 $core-grey-dark-300,
+				inset 0 -4px 0 var(--wp-admin-theme-color) !important;
 		}
 	}
 
@@ -312,7 +314,7 @@ $border: $light-gray-tertiary;
 	.woocommerce-summary__item-label {
 		display: block;
 		margin-bottom: $gap;
-		color: $theme-color;
+		color: var(--wp-admin-theme-color);
 	}
 
 	.woocommerce-summary__item-value {
@@ -331,7 +333,7 @@ $border: $light-gray-tertiary;
 
 	&.is-selected {
 		background: $studio-white;
-		box-shadow: inset 0 -4px 0 $theme-color;
+		box-shadow: inset 0 -4px 0 var(--wp-admin-theme-color);
 
 		.woocommerce-summary__item-value {
 			font-weight: 600;

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -1,5 +1,3 @@
-
-
 .muriel-input-text {
 	background: $studio-white;
 	border: 1px solid $studio-gray-20;
@@ -24,7 +22,22 @@
 		}
 	}
 
-	.components-text-control__input {
+	// @wordpress/components styles for text control target all types, so we must also do that
+	// to increase specificity and override the styles.
+	.components-text-control__input,
+	.components-text-control__input[type='text'],
+	.components-text-control__input[type='tel'],
+	.components-text-control__input[type='time'],
+	.components-text-control__input[type='url'],
+	.components-text-control__input[type='week'],
+	.components-text-control__input[type='password'],
+	.components-text-control__input[type='color'],
+	.components-text-control__input[type='date'],
+	.components-text-control__input[type='datetime'],
+	.components-text-control__input[type='datetime-local'],
+	.components-text-control__input[type='email'],
+	.components-text-control__input[type='month'],
+	.components-text-control__input[type='number'] {
 		border: 0;
 		box-shadow: none;
 		font-size: 16px;


### PR DESCRIPTION
Fixes #4566 

Changes:

* Updated `@wordpress/components` and `@wordpress/base-styles`
* Use the new `Card` and `Flex` from `@wordpress/components`
* Add contextual tooltips
* Adjust existing styles to match [new designs](https://www.figma.com/file/JH9XMFUCOjfXdr3N09AHRD/On-boarding-iterations-June-'20)

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
<img width="1508" alt="Screenshot 2020-07-02 at 3 58 35 PM" src="https://user-images.githubusercontent.com/1281828/86314912-f58f5780-bc7c-11ea-97e6-4283a633819e.png">
<img width="1509" alt="Screenshot 2020-07-02 at 3 58 48 PM" src="https://user-images.githubusercontent.com/1281828/86314915-f9bb7500-bc7c-11ea-951f-7340d31c6632.png">

### Detailed test instructions:

- Start the setup wizard via the usual means (either after installing WooCommerce the first time or via `WooCommerce > Settings > Help > Setup Wizard`)
- Visually confirm that the page matches [the designs](https://www.figma.com/file/JH9XMFUCOjfXdr3N09AHRD/On-boarding-iterations-June-'20)
- Visually confirm that the tooltips work on hover and that the content is correct.
- You should also test that changing a user's color scheme still works. There are some good instructions on testing that [here](https://github.com/woocommerce/woocommerce-admin/pull/4558)

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->