### PR TITLE
Only load the performance indicators API endpoints if called from WP Admin.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23625,7 +23625,7 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "1.19.1",
+			"version": "npm:prettier@1.19.1",
 			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
 			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
 			"dev": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -23625,7 +23625,7 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:prettier@1.19.1",
+			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
 			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
 			"dev": true

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -88,9 +88,10 @@ class Init {
 			);
 		}
 
-		// The performance indicators controller must be registered last, after other /stats endpoints have been registered.
-		$controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
-
+		if ( strpos( strtolower( wp_get_referer() ), strtolower( admin_url() ) ) === 0 ) {
+			// The performance indicators controller must be registered last, after other /stats endpoints have been registered.
+			$controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
+		}
 		$controllers = apply_filters( 'woocommerce_admin_rest_controllers', $controllers );
 
 		foreach ( $controllers as $controller ) {

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -88,10 +88,12 @@ class Init {
 			);
 		}
 
+		// Only register performance indicators when requested from WordPress Admin.
 		if ( strpos( strtolower( wp_get_referer() ), strtolower( admin_url() ) ) === 0 ) {
 			// The performance indicators controller must be registered last, after other /stats endpoints have been registered.
 			$controllers[] = 'Automattic\WooCommerce\Admin\API\Reports\PerformanceIndicators\Controller';
 		}
+
 		$controllers = apply_filters( 'woocommerce_admin_rest_controllers', $controllers );
 
 		foreach ( $controllers as $controller ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,6 +65,11 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		// load the WP testing environment.
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
 
+		// Set referer so that the requests run in the same context as in WordPress Admin.
+		// phpcs:disable WordPress.VIP.SuperGlobalInputUsage.AccessDetected
+		$_SERVER['HTTP_REFERER'] = admin_url();
+		// phpcs:enable WordPress.VIP.SuperGlobalInputUsage.AccessDetected
+
 		// load WC testing framework.
 		$this->includes();
 	}


### PR DESCRIPTION
First stab at fixing #4751.

The work to register those endpoints should not be necessary on the front end and contexts others than WP Admin.
This is similar to other endpoints, but that work requires more thorough checks and decoupling some items (like data stores) from the API initialisation.

Fixes #4751.

Please see the issue. TL;DR is that I think it's not necessary to load all the API endpoints on screens outside WP Admin area, unless some of the endpoints provide infrastructure to pages on the front end/in other contexts (but it seems to me most of the stats endpoints return 401 for guests and customers on front end, so switching it to 404 should not be a big deal). Also, this should prevent the problem with the performance indicators registration function call to Jetpack and creating too many wp_options.

### Detailed test instructions:

1. Install WC & Jetpack. 
2. Apply changes
3. Test that performance indicators are still working in the admin area:
 - WooCommerce > Home (if you have the home screen feature enabled), and
 - Analytics > Overview


### Changelog Note:

> Fix: Register performance indicators API endpoints only when called from WordPress admin/backend area.