### PR TITLE
Enable the coupons feature in core

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -4,7 +4,7 @@
 		"analytics": true,
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
-		"coupons": false,
+		"coupons": true,
 		"devdocs": false,
 		"marketing": true,
 		"onboarding": true,


### PR DESCRIPTION
Sets the feature flag for "coupons" in core to be enabled.

Moves the **WooCommerce > Coupons** dashboard menu item to **Marketing > Coupons**.

Details on the feature can be found in the original [feature pull request](https://github.com/woocommerce/woocommerce-admin/pull/4526).

### Updates Since 1.3

**Primarily style tweaks in #4794**

* Style Improvements (e.g. use admin theme colors) 
* Update to recommend coupon extension icons
* Move to use local icons instead of icons hosted on WCCOM

### Other additional items

* Additional internal users testing
* Been in contact with 3PDs (e.g regarding updates to smart coupons)
* Additional plugin testing (below)
* [Made public announcement](https://woocommerce.wordpress.com/2020/07/09/centralized-coupon-management-available-for-testing/)
* [Proof of concept code for adding submenu items](https://gist.github.com/jconroy/b97289eb6ad2843feb15bfd1fba4196a)  https://d.pr/i/XalHqh
* Additional checking in Edge and IE11 of styles

**Additional Plugins Testing**

* Woo Subscriptions - extra fields tested fine https://d.pr/i/at7wUd
* Coupons Campaigns - taxonomy created tested fine https://d.pr/i/hLbcGa (Coupon Generator menu item could be moved)

### Disabling

We've setup the marketing tab and this coupons change as features in wc-admin so you can actually use the [woocommerce_admin_features](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L129) filter to get selective about what features you wish to enable/disable if you wish.

I've updated my [original gist](https://gist.github.com/jconroy/e21c146aefa4301397b65d430f80dc05) with a basic example.

### Detailed Testing Instructions (Global Step etc.)

https://github.com/woocommerce/woocommerce-admin/wiki/Testing-Coupons-Feature-in-WC-4.x

### Changelog Note:

Enhancement: Move the **WooCommerce > Coupons** dashboard menu item to **Marketing > Coupons**.
