### PR TITLE
Add WooCommerce Admin Facebook Marketing Expert Note Provider.

### DIFF
--- a/src/Events.php
+++ b/src/Events.php
@@ -36,6 +36,7 @@ use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Learn_More_About_Product_
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Online_Clothing_Store;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_First_Product;
 use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Customize_Store_With_Blocks;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes_Facebook_Marketing_Expert;
 
 /**
  * WC_Admin_Events Class.
@@ -103,6 +104,7 @@ class Events {
 		WC_Admin_Notes_Choose_Niche::possibly_add_note();
 		WC_Admin_Notes_Real_Time_Order_Alerts::possibly_add_note();
 		WC_Admin_Notes_Customize_Store_With_Blocks::possibly_add_note();
+		WC_Admin_Notes_Facebook_Marketing_Expert::possibly_add_note();
 
 		if ( Loader::is_feature_enabled( 'remote-inbox-notifications' ) ) {
 			DataSourcePoller::read_specs_from_data_sources();

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -36,18 +36,18 @@ class WC_Admin_Notes_Facebook_Marketing_Expert {
 	 */
 	public static function possibly_add_note() {
 
-		// Only show the note to stores with Facebook for WooCommerce installed.
+		// Check if the note can and should be added.
+		if ( ! self::can_be_added() ) {
+			return;
+		}
+
+		// Only add the note to stores with Facebook for WooCommerce installed.
 		if ( ! self::is_facebook_for_woocommerce_installed() ) {
 			return;
 		}
 
-		// Only show the note to stores with at least 30 orders in the last month.
-		if ( ! self::orders_last_month() >= 2 ) {
-			return;
-		}
-
-		// Final check if the note can and should be added.
-		if ( ! self::can_be_added() ) {
+		// Only add the note to stores with at least 30 orders in the last month.
+		if ( ! self::orders_last_month() >= 30 ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -60,7 +60,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert {
 	 */
 	public static function get_note() {
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Get 1:1 business support from a Facebook Marketing Expert', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Create and optimise your Facebook ad campaigns with the help of a Facebook Marketing Expert', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Get 1:1 business support from a Facebook Marketing Expert who will work you and your business to create and optimize your Facebook ads campaign. Discover new strategies used by similar businesses in your market and industry. Learn more here and confirm your eligibility for this exclusive offer.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * WooCommerce Admin Facebook Marketing Expert Note Provider.
+ *
+ * Adds notes to the merchant's inbox concerning Facebook Marketing Expert.
+ *
+ * @package WooCommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Admin_Notes_Facebook_Marketing_Expert
+ */
+class WC_Admin_Notes_Facebook_Marketing_Expert {
+
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-facebook-marketing-expert';
+
+	/**
+	 * Name of plugin file.
+	 */
+	const PLUGIN_FILE = 'facebook-for-woocommerce/facebook-for-woocommerce.php';
+
+	/**
+	 * Possibly add note.
+	 */
+	public static function possibly_add_note() {
+
+		// Only show the note to stores with Facebook for WooCommerce installed.
+		if ( ! self::is_facebook_for_woocommerce_installed() ) {
+			return;
+		}
+
+		// Only show the note to stores with at least 30 orders in the last month.
+		if ( ! self::orders_last_month() >= 2 ) {
+			return;
+		}
+
+		// Final check if the note can and should be added.
+		if ( ! self::can_be_added() ) {
+			return;
+		}
+
+		$note = self::get_note();
+		$note->save();
+	}
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Get 1:1 business support from a Facebook Marketing Expert', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Get 1:1 business support from a Facebook Marketing Expert who will work you and your business to create and optimize your Facebook ads campaign. Discover new strategies used by similar businesses in your market and industry. Learn more here and confirm your eligibility for this exclusive offer.', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://www.facebook.com/business/m/facebook-marketing-experts-program?content_id=UxWvEceBNtpQLhU',
+			WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+		return $note;
+	}
+
+	/**
+	 * Determine if Facebook for WooCommerce is already active or installed
+	 *
+	 * @return bool
+	 */
+	protected static function is_facebook_for_woocommerce_installed() {
+		if ( class_exists( 'WC_Facebookcommerce_Integration' ) ) {
+			return true;
+		}
+		include_once ABSPATH . '/wp-admin/includes/plugin.php';
+		return 0 === validate_plugin( self::PLUGIN_FILE );
+	}
+
+	/**
+	 * Determine the number of orders in the last month
+	 *
+	 * @return int
+	 */
+	protected static function orders_last_month() {
+
+		$date = new \DateTime();
+
+		$args = array(
+			'date_created' => '>' . $date->modify( '-1 month' )->format( 'Y-m-d' ),
+		);
+
+		return count( wc_get_orders( $args ) );
+	}
+}

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -47,7 +47,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert {
 		}
 
 		// Only add the note to stores with at least 30 orders in the last month.
-		if ( ! self::orders_last_month() >= 30 ) {
+		if ( self::orders_last_month() < 30 ) {
 			return;
 		}
 

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -60,8 +60,8 @@ class WC_Admin_Notes_Facebook_Marketing_Expert {
 	 */
 	public static function get_note() {
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Create and optimise your Facebook ad campaigns with the help of a Facebook Marketing Expert', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Get 1:1 business support from a Facebook Marketing Expert who will work you and your business to create and optimize your Facebook ads campaign. Discover new strategies used by similar businesses in your market and industry. Learn more here and confirm your eligibility for this exclusive offer.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Create and optimise your Facebook ads with the help of a Facebook Marketing Expert', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Get 1:1 business support from a Facebook Marketing Expert who will work with you and your business to create and optimize your Facebook ads. Discover new strategies used by similar businesses in your market and industry. Check whether you are eligible to make use of this offer.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -11,6 +11,8 @@ namespace Automattic\WooCommerce\Admin\Notes;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\PluginsHelper;
+
 /**
  * WC_Admin_Notes_Facebook_Marketing_Expert
  */
@@ -85,8 +87,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert {
 		if ( class_exists( 'WC_Facebookcommerce_Integration' ) ) {
 			return true;
 		}
-		include_once ABSPATH . '/wp-admin/includes/plugin.php';
-		return 0 === validate_plugin( self::PLUGIN_FILE );
+		return PluginsHelper::is_plugin_installed( self::PLUGIN_FILE );
 	}
 
 	/**

--- a/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
+++ b/src/Notes/WC_Admin_Notes_Facebook_Marketing_Expert.php
@@ -100,6 +100,7 @@ class WC_Admin_Notes_Facebook_Marketing_Expert {
 
 		$args = array(
 			'date_created' => '>' . $date->modify( '-1 month' )->format( 'Y-m-d' ),
+			'return'       => 'ids',
 		);
 
 		return count( wc_get_orders( $args ) );


### PR DESCRIPTION
Fixes #4784

Adds a inbox note highlighting Facebook Marketing Experts offer.

Note should be displayed if Facebook for Woocommerce is installed and the store has at least 30 orders in the past month.

### Screenshots

![Screen Shot on 2020-07-15 at 13-51-25](https://user-images.githubusercontent.com/355014/87503064-66ce0200-c6a2-11ea-9705-15c9ad24e869.png)

### Detailed test instructions:

- Create 30 tests orders on your test site in the past month (if you don't already have that many) or adjust `possibly_add_note()` to check for a lower number.
- Install Facebook for WooCommerce from [here](https://woocommerce.com/products/facebook/) or [here](https://wordpress.org/plugins/facebook-for-woocommerce/)
- Run `wc_admin_daily` cron event (I use WP Crontrol) just to ensure the note event is run.
- Check you have a new inbox note about the Facebook Marketing Expert offer.

### Changelog Note:

Enhancement: Add Facebook Marketing Expert Offer Inbox Note
