### PR TITLE
Add copy that WCS TOS will be accepted upon install.

### DIFF
--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -7,11 +7,13 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { filter } from 'lodash';
+import interpolateComponents from 'interpolate-components';
 
 /**
  * WooCommerce dependencies
  */
-import { Card, H } from '@woocommerce/components';
+import { Card, H, Link } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {
 	pluginNames,
 	ONBOARDING_STORE_NAME,
@@ -212,6 +214,13 @@ class Benefits extends Component {
 		);
 		const isInstallAction =
 			isInstallingActivating || ! pluginsRemaining.length;
+		const isAcceptingTos = ! this.isWcsActive;
+		const pluralizedPlugins = _n(
+			'plugin',
+			'plugins',
+			this.pluginsToInstall.length,
+			'woocommerce-admin'
+		);
 
 		return (
 			<Card className="woocommerce-profile-wizard__benefits-card">
@@ -246,19 +255,34 @@ class Benefits extends Component {
 				</div>
 
 				<p className="woocommerce-profile-wizard__benefits-install-notice">
-					{ sprintf(
-						__(
-							'%s %s will be installed & activated for free.',
-							'woocommerce-admin'
-						),
-						pluginNamesString,
-						_n(
-							'plugin',
-							'plugins',
-							this.pluginsToInstall.length,
-							'woocommerce-admin'
-						)
-					) }
+					{ isAcceptingTos
+						? interpolateComponents( {
+								mixedString: sprintf(
+									__(
+										'%s %s will be installed & activated for free, and you agree to our {{link}}Terms of Service{{/link}}.',
+										'woocommerce-admin'
+									),
+									pluginNamesString,
+									pluralizedPlugins
+								),
+								components: {
+									link: (
+										<Link
+											href="https://wordpress.com/tos/"
+											target="_blank"
+											type="external"
+										/>
+									),
+								},
+						  } )
+						: sprintf(
+								__(
+									'%s %s will be installed & activated for free.',
+									'woocommerce-admin'
+								),
+								pluginNamesString,
+								pluralizedPlugins
+						  ) }
 				</p>
 			</Card>
 		);

--- a/client/profile-wizard/steps/benefits/index.js
+++ b/client/profile-wizard/steps/benefits/index.js
@@ -13,7 +13,6 @@ import interpolateComponents from 'interpolate-components';
  * WooCommerce dependencies
  */
 import { Card, H, Link } from '@woocommerce/components';
-import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import {
 	pluginNames,
 	ONBOARDING_STORE_NAME,


### PR DESCRIPTION
Fixes #4696

Adds note to installation copy that the ToS will be accepted when WooCommerce Services is installed and activated. As noted in #4696, the ToS are automatically accepted currently, so the copy should make note of that.

### Screenshots

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/6209518/87199880-42dc7c00-c2b0-11ea-9afd-432d8347b3a2.png">

### Detailed test instructions:

- Go through onboarding until you reach the benefits screen
- Make sure ToS link is visible and correct if WCS needs to be activated
- Make sure ToS link is not shown if WCS is already active


### Changelog Note:

Tweak: Add note in OBW that ToS will be accepted when WCS is installed.
