### PR TITLE
Remove item "profiler" from the menu

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -222,7 +222,7 @@ class Loader {
 		// Potentially enqueue minified JavaScript.
 		if ( 'js' === $ext ) {
 			$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-			$suffix = self::should_use_minified_js_file( $script_debug ) ? '.min' : '';
+			$suffix       = self::should_use_minified_js_file( $script_debug ) ? '.min' : '';
 		}
 
 		return plugins_url( self::get_path( $ext ) . $file . $suffix . '.' . $ext, WC_ADMIN_PLUGIN_FILE );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -295,7 +295,7 @@ class Loader {
 		wc_admin_register_page(
 			array(
 				'title'  => 'Profiler',
-				'parent' => 'woocommerce',
+				'parent' => '',
 				'path'   => '/profiler',
 			)
 		);


### PR DESCRIPTION
This PR removes the item "profiler" from the menu.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
Before:
![profiler-item-1](https://user-images.githubusercontent.com/1314156/88186734-fb3ce500-cc0b-11ea-9e82-998ba9ad2a56.png)

Now:
![profiler-item-2](https://user-images.githubusercontent.com/1314156/88186755-009a2f80-cc0c-11ea-8e07-323ce56b0654.png)


### Detailed test instructions:

- Verify the item `Profiler` is no longer visible in the menu.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:
Fix: Removed item "profiler" from the menu
<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
