### PR TITLE
fix linter errors

### DIFF
--- a/client/profile-wizard/steps/product-types.js
+++ b/client/profile-wizard/steps/product-types.js
@@ -32,12 +32,10 @@ function getLabel( description, yearlyPrice ) {
 		__( '$%f per month, billed annually', 'woocommerce-admin' ),
 		monthlyPrice
 	);
-	/* eslint-disable @wordpress/i18n-no-collapsible-whitespace */
 	const toolTipText = __(
 		"This product type requires a paid extension.\nWe'll add this to a cart so that\nyou can purchase and install it later.",
 		'woocommerce-admin'
 	);
-	/* eslint-enable @wordpress/i18n-no-collapsible-whitespace */
 
 	return (
 		<Fragment>


### PR DESCRIPTION
Fixes linter error on the release branch.

<img width="834" alt="Screen Shot 2020-07-31 at 8 38 23 AM" src="https://user-images.githubusercontent.com/1922453/88972155-383e6100-d309-11ea-906f-64a6d0236b8c.png">

I'm not entirely sure what happened, but our eslint-plugin is 4 major versions behind latest and it may be a dependency mismatch.

### Test

1. npm install
2. npm run lint