### PR TITLE
Remove new WP 5.5 meta box arrows in the shipping banner

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -2,6 +2,10 @@
 @import '@wordpress/components/src/visually-hidden/style';
 
 #woocommerce-admin-print-label {
+	.postbox-header {
+		display: none;
+	}
+
 	min-height: 100px;
 
 	.hndle,


### PR DESCRIPTION
Fixes #4913 

Removes new WordPress 5.5 meta box arrows in the shipping banner.

### Screenshots
Before:
![image](https://ucce03c14706e43319200b0103f9.previews.dropboxusercontent.com/p/thumb/AA4xdD7p82HkUCceSB5HRXR6JCPlPSVBCP4ch-f6l6tKdfTsD6QYeB1NtbVKbCwOll618gyrnzN1X7PWkRCYzoXwipfhK8UkSzHqWtNp7cDXZxG0YWAWLJX5l49j_KSzyRNGefYva1-Yvq2YsXy4mFmRS8YQed4Ntr6n0RkMojLj2tHp9JONLLn-GUWLh4Vbc7biEymRbZ4JUcLHKA2kbao2-hZd0dbSid5y06F0PXBuSK6zN9SjkhaSdyZKzVCtpB84mRGZnSn_7uZbJI8IPfnSz2YGCzLT3RSluGFMCa6C3xTA_R8KBgDhMWLmy5KCnEaKyvIJCpjX2uJJfGUMpWSAtOisJb3mX7neERKYiGihFw0hcpiv_9bqQwkVV0Iz3Nx_05v9piLkHleN3m913yjv/p.png?fv_content=true&size_mode=5)

After:
![image](https://uc250dc8f9dfd724a6863f8bc4a9.previews.dropboxusercontent.com/p/thumb/AA4kMxekJ5lCV85qpWtq3dMZqQCq1fUayfddttQ2rBskPzMM_CD9syMuOKJ8KiAIIEIcTo5Fg0Es5EdNSx4x0ED00Wr4zn8bFfMX4Z5dgGx20k7mWvP55J87D3LvjA2H46mtxVnGXZYUwE6helqGL_Vf70K0tVhXA9-_BQl-xuY1Pby964kSbXaAbqONT3fIRbuxeu-e6UKlANbrm4l2SW3JUOxEwPgu_cO9LlP-sXN9Q7BUi5F59gYN3qnCNGJTSuRpD3xK0iH1E_LEgnRWfBFAyNirRBAmBbdMnGkBaOVTN5eWJi1qnum2jwhtr7MiaVHi2Wax9D3WxQVpHMn1ubocvQ4ua7-v_wWqumDiqGtzuRIJUUKry_Mz92NKYw4RjPsljZMWVzmrprPFu6B_vaod/p.png?fv_content=true&size_mode=5)

### Detailed test instructions:

1. Create a test site that uses latest WordPress RC 5.5. I used `5.5-RC1-48698`.
2. Open an order so the shipping banner will be displayed. Check the conditions needed to display the banner in https://github.com/woocommerce/woocommerce-admin/blob/fix/shipping-banner-meta-box-arrows-4913/src/Features/ShippingLabelBannerDisplayRules.php#L101