### PR TITLE
Remove check for Jetpack and WCS from Stripe onboarding task

### DIFF
--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -31,6 +31,7 @@ class Stripe extends Component {
 	}
 
 	componentDidMount() {
+		const { oAuthConnectFailed } = this.state;
 		const { stripeSettings } = this.props;
 		const query = getQuery();
 
@@ -45,7 +46,7 @@ class Stripe extends Component {
 			}
 		}
 
-		if ( ! this.requiresManualConfig() ) {
+		if ( ! oAuthConnectFailed ) {
 			this.fetchOAuthConnectURL();
 		}
 	}
@@ -61,13 +62,6 @@ class Stripe extends Component {
 		) {
 			this.fetchOAuthConnectURL();
 		}
-	}
-
-	requiresManualConfig() {
-		const { isJetpackConnected } = this.props;
-		const { oAuthConnectFailed } = this.state;
-
-		return ! isJetpackConnected || oAuthConnectFailed;
 	}
 
 	completeMethod() {
@@ -317,13 +311,10 @@ class Stripe extends Component {
 export default compose(
 	withSelect( ( select ) => {
 		const { getOption, isOptionsUpdating } = select( OPTIONS_STORE_NAME );
-		const { getActivePlugins, isJetpackConnected } = select(
-			PLUGINS_STORE_NAME
-		);
+		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 
 		return {
 			activePlugins: getActivePlugins(),
-			isJetpackConnected: isJetpackConnected(),
 			isOptionsUpdating: isOptionsUpdating(),
 			stripeSettings: getOption( 'woocommerce_stripe_settings' ) || [],
 		};

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -64,14 +64,10 @@ class Stripe extends Component {
 	}
 
 	requiresManualConfig() {
-		const { activePlugins, isJetpackConnected } = this.props;
+		const { isJetpackConnected } = this.props;
 		const { oAuthConnectFailed } = this.state;
 
-		return (
-			! isJetpackConnected ||
-			! activePlugins.includes( 'woocommerce-services' ) ||
-			oAuthConnectFailed
-		);
+		return ! isJetpackConnected || oAuthConnectFailed;
 	}
 
 	completeMethod() {

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -258,6 +258,42 @@ class Stripe extends Component {
 		);
 	}
 
+	renderOauthConfig() {
+		const tosPrompt = interpolateComponents( {
+			mixedString: __(
+				'By clicking "Connect," you agree to the {{tosLink}}Terms of Service{{/tosLink}}. Or {{manualConfigLink}}manually enter your Stripe API details{{/manualConfigLink}} instead.',
+				'woocommerce-admin'
+			),
+			components: {
+				tosLink: (
+					<Link
+						href="https://wordpress.com/tos"
+						target="_blank"
+						type="external"
+					/>
+				),
+				manualConfigLink: (
+					<Link
+						href="#"
+						onClick={ () => {
+							this.setState( {
+								connectURL: null,
+							} );
+
+							return false;
+						} }
+					/>
+				),
+			},
+		} );
+
+		return (
+			<Fragment>
+				<p>{ this.renderConnectButton() }</p>
+				{ tosPrompt }
+			</Fragment>
+		);
+	}
 	getConnectStep() {
 		const { connectURL, isPending, oAuthConnectFailed } = this.state;
 
@@ -277,7 +313,7 @@ class Stripe extends Component {
 					'A Stripe account is required to process payments.',
 					'woocommerce-admin'
 				),
-				content: this.renderConnectButton(),
+				content: this.renderOauthConfig(),
 			};
 		}
 

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -273,14 +273,12 @@ class Stripe extends Component {
 					/>
 				),
 				manualConfigLink: (
-					<Link
-						href="#"
+					<Button
+						isLink
 						onClick={ () => {
 							this.setState( {
 								connectURL: null,
 							} );
-
-							return false;
 						} }
 					/>
 				),


### PR DESCRIPTION
This removes the check for Jetpack and WCS during the Stripe onboarding task.

This is part of the work to move Stripe OAuth code from WC Services over to Stipe while also removing the Jetpack dependency from the connection process.

### Detailed test instructions:

The changes in this PR are dependent on the following two PRs in [woocommerce-connect-server](https://github.com/Automattic/woocommerce-connect-server/pull/1443) and [woocommerce-gateway-stripe](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1267) checked out.

You can test this now, or wait for the Connect Server PR to be merged as it won't impact the current OAuth flow.

To test now, you will need to have both of the above installed/running locally. Be sure to set the `WOOCOMMERCE_CONNECT_SERVER_URL` constant set in your test site.

- With the above conditions, make sure you have a fresh installation of WordPress set up and WooCommerce is installed. (Make sure Jetpack has not been activated)
- Go through the onboarding wizard, being sure to skip the WCS/Jetpack installation step
- You should be able to complete the oauth flow for the Stripe Payment task with this branch checked out.

Note: When testing with a sandbox Stripe account, you will need to manually change instances of `publishable_key` and `secret_key` to `test_publishable_key` and `test_secret_key` in the following files:

-  client/task-list/tasks/payments/stripe.js
-  client/task-list/tasks/payments/methods.js

### Changelog Note:

- Enhancement: Setting up Stripe via the onboarding task list no longer requires WooCommerce Services or Jetpack to be installed.