### PR TITLE
Update style on shipping banner

### DIFF
--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -24,13 +24,17 @@
 		margin-right: 8px;
 	}
 
+	.wc-admin-shipping-banner-blob {
+		margin-right: 8px;
+	}
+
 	h3 {
 		margin: 0;
 		font-size: 1.15em;
 	}
 
 	p {
-		margin: 2px 0 11px;
+		margin: 0;
 		font-size: 15px;
 		line-height: 19px;
 	}

--- a/client/wp-admin-scripts/print-shipping-label-banner/style.scss
+++ b/client/wp-admin-scripts/print-shipping-label-banner/style.scss
@@ -35,7 +35,7 @@
 		line-height: 19px;
 	}
 
-	.components-button.is-button {
+	.components-button.is-primary {
 		margin: 10px 61px 10px auto;
 		padding: 0 30px;
 		font-size: 14px;
@@ -44,10 +44,6 @@
 		text-decoration: none;
 		text-shadow: none;
 		overflow: visible;
-		&:hover {
-			background-color: #ff3997;
-			border-color: #ff3997;
-		}
 	}
 
 	.notice-dismiss {
@@ -110,7 +106,7 @@
 	.wc-admin-shipping-banner__dismiss-modal-actions {
 		text-align: right;
 
-		.components-button.is-button {
+		.components-button.is-primary {
 			height: 30px;
 			padding-left: 15px;
 			padding-right: 15px;
@@ -136,7 +132,7 @@
 			flex-wrap: wrap;
 			justify-content: center;
 		}
-		.components-button.is-button {
+		.components-button.is-primary {
 			margin: 10px 0 0 0;
 		}
 		p {


### PR DESCRIPTION
Fixes #4938, https://github.com/Automattic/woocommerce-services/issues/2106

Fix the button style in shipping banner after wordpress component upgrade. 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
The shipping banner button should no longer cover the "x" and pad nicely on the right of the text.
![image](https://user-images.githubusercontent.com/572862/89578691-c7f37c00-d7ef-11ea-8102-3a31e405e66a.png)
![image](https://user-images.githubusercontent.com/572862/89579373-e6a64280-d7f0-11ea-96c2-369554edb0d1.png)
![image](https://user-images.githubusercontent.com/572862/89579402-f3c33180-d7f0-11ea-8c8c-4c70f8ce2095.png)
![image](https://user-images.githubusercontent.com/572862/89579432-fde53000-d7f0-11ea-9736-c96136b580f4.png)
![image](https://user-images.githubusercontent.com/572862/89579571-38e76380-d7f1-11ea-88a9-256cf1aa8c0f.png)

### Detailed test instructions:

1. Have shipping banner show up. I did this by going to [src/Features/ShippingLabelBannerDisplayRules.php](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/ShippingLabelBannerDisplayRules.php#L102)  and replace this line to `return true || $this->banner_not_dismissed() &&` to force banner to show.
2. Make sure the banner doesn't look like the screenshot described in https://github.com/Automattic/woocommerce-services/issues/2106#issue-668163737

### Notes
The original ticket was created in WooCommerce Service issue https://github.com/Automattic/woocommerce-services/issues/2106 and the conversation was left there. 