### PR TITLE
Onboarding: Missing CSS Change for Business Extensions Step

### DIFF
--- a/client/profile-wizard/style.scss
+++ b/client/profile-wizard/style.scss
@@ -104,7 +104,6 @@
 		}
 
 		.components-popover__content {
-			white-space: pre;
 			font-size: 16px;
 
 			> div {
@@ -522,9 +521,15 @@
 	.woocommerce-business-extensions__benefits {
 		padding: 4px;
 		display: grid;
-		grid-template-columns: 1fr;
-		max-width: 592px;
+		grid-template-columns: 1fr 1fr;
+		max-width: 100%;
+		min-width: 580px;
 		font-size: 14px;
+
+		@include breakpoint( '<782px' ) {
+			grid-template-columns: 1fr;
+			min-width: 300px;
+		}
 
 		.woocommerce-business-extensions__benefit {
 			padding: 10px;


### PR DESCRIPTION
This is a follow up to #4907 - where I failed to push up the last revision of my changes, but still merged them anyways. Because Monday!

The steps to test this are the same as what I left in the original PR: 

### Detailed test instructions:

- Enable the onboarding wizard via the Orders > Help menu
- Enter a US store address
- On industries select fashion/apparel
- Proceed to the Business Details step and interact with the popover at various breakpoints

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->