### PR TITLE
When toggling the task list, record a track event.

### DIFF
--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -1053,8 +1053,17 @@ class Onboarding {
 			return;
 		}
 
-		$new_value = 1 === absint( $_GET['reset_task_list'] ) ? 'no' : 'yes'; // phpcs:ignore CSRF ok.
+		$previous_value = 1 === absint( $_GET['reset_task_list'] ) ? 'yes' : 'no'; // phpcs:ignore CSRF ok.
+		$new_value      = 'no' === $previous_value ? 'yes' : 'no'; // phpcs:ignore CSRF ok.
+
 		update_option( 'woocommerce_task_list_hidden', $new_value );
+		wc_admin_record_tracks_event(
+			'wcadmin_tasklist_toggled',
+			array(
+				'previous'  => $previous_value,
+				'new_value' => $new_value,
+			)
+		);
 		wp_safe_redirect( wc_admin_url() );
 		exit;
 	}

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -1053,15 +1053,13 @@ class Onboarding {
 			return;
 		}
 
-		$previous_value = 1 === absint( $_GET['reset_task_list'] ) ? 'yes' : 'no'; // phpcs:ignore CSRF ok.
-		$new_value      = 'no' === $previous_value ? 'yes' : 'no'; // phpcs:ignore CSRF ok.
+		$task_list_hidden = 1 === absint( $_GET['reset_task_list'] ) ? 'no' : 'yes'; // phpcs:ignore CSRF ok.
+		update_option( 'woocommerce_task_list_hidden', $task_list_hidden );
 
-		update_option( 'woocommerce_task_list_hidden', $new_value );
 		wc_admin_record_tracks_event(
-			'wcadmin_tasklist_toggled',
+			'tasklist_toggled',
 			array(
-				'previous'  => $previous_value,
-				'new_value' => $new_value,
+				'status' => 'yes' === $task_list_hidden ? 'disabled' : 'enabled',
 			)
 		);
 		wp_safe_redirect( wc_admin_url() );


### PR DESCRIPTION
Fixes #4760 

### Detailed test instructions:

To test this, ensure that the task list toggle is still working correctly.

1. Go to `WooCommerce > Settings`
2. Click `Help` in the top right
3. Click `Setup Wizard` on the left side menu
4. The button will either say `Enable` or `Disable` depending on current state
5. Click the button, it should redirect to `WooCommerce > Home`
6. Go back to the settings as per steps 1-3.
7. The button should say `Enable` if it said `Disable` before and vice versa.

### Changelog Note:

Tweak: When toggling the task list, record a track event.
