### PR TITLE
Fix a bug where an event's data was recorded in camel case.

### DIFF
--- a/client/task-list/tasks/shipping/index.js
+++ b/client/task-list/tasks/shipping/index.js
@@ -253,14 +253,14 @@ class Shipping extends Component {
 						onComplete={ () => {
 							recordEvent( 'tasklist_shipping_label_printing', {
 								install: true,
-								pluginsToActivate,
+								plugins_to_activate: pluginsToActivate,
 							} );
 							this.completeStep();
 						} }
 						onSkip={ () => {
 							recordEvent( 'tasklist_shipping_label_printing', {
 								install: false,
-								pluginsToActivate,
+								plugins_to_activate: pluginsToActivate,
 							} );
 							getHistory().push( getNewPath( {}, '/', {} ) );
 						} }


### PR DESCRIPTION
Fixes #4464 

`wcadmin_tasklist_shipping_label_printing` events were being filtered into rejected events because the data being passed was in camel case instead of snake case. This fixes that issue.

### Detailed test instructions:

1. Go through store onboarding, under store details choose "Australia" for the country
2. After finishing onboarding you should be at the WooCommerce home screen
3. Enable debug of tracking by adding this code in browser console: `localStorage.setItem( 'debug', 'wc-admin:*' )`
4. Choose the "Setup shipping" task from the task list
5. Go through the steps up to install "woocommerce shipstation".
6. Click install
7. You should see the `wcadmin_tasklist_shipping_label_printing` with correct snake case argument `plugins_to_activate` in the console.
8. Repeat steps 1-5, then click dismiss you should also see the results from `7` again with correct snake case argument `plugins_to_activate`

### Changelog Note:
Fix: fix a bug where `wcadmin_tasklist_shipping_label_printing` events were not properly tracked.
