### PR TITLE
add QuantitySelector component (from WooCommerce blocks)

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -34,6 +34,7 @@ export { default as Pill } from './pill';
 export { default as Plugins } from './plugins';
 export { default as ProductImage } from './product-image';
 export { default as ProductRating } from './rating/product';
+export { default as QuantitySelector } from './quantity-selector';
 export { default as Rating } from './rating';
 export { default as ReportFilters } from './filters';
 export { default as ReviewRating } from './rating/review';

--- a/packages/components/src/quantity-selector/index.js
+++ b/packages/components/src/quantity-selector/index.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useCallback } from '@wordpress/element';
+import { DOWN, UP } from '@wordpress/keycodes';
+
+/**
+ * A control for selecting the quantity of a product to add to cart.
+ * Similar to a number up/down control, with plus & minus buttons.
+ * Can be used in place of a standard integer number input.
+ *
+ * @param {Object} props
+ * @param {string} props.className
+ * @param {number} props.quantity
+ * @param {number} props.minimum
+ * @param {number} props.maximum
+ * @param {Function} props.onChange
+ * @param {string} props.itemName
+ * @param {boolean} props.disabled
+ * @return {Object} -
+ */
+const QuantitySelector = ( {
+	className,
+	quantity = 1,
+	minimum = 1,
+	maximum,
+	onChange = () => null,
+	itemName = '',
+	disabled,
+} ) => {
+	const classes = classNames(
+		'wc-block-components-quantity-selector',
+		className
+	);
+
+	const hasMaximum = typeof maximum !== 'undefined';
+	const canDecrease = quantity > minimum;
+	const canIncrease = ! hasMaximum || quantity < maximum;
+
+	/**
+	 * Handles keyboard up and down keys to change quantity value.
+	 *
+	 * @param {Object} event event data.
+	 */
+	const quantityInputOnKeyDown = useCallback(
+		( event ) => {
+			const isArrowDown =
+				typeof event.key !== undefined
+					? event.key === 'ArrowDown'
+					: event.keyCode === DOWN;
+			const isArrowUp =
+				typeof event.key !== undefined
+					? event.key === 'ArrowUp'
+					: event.keyCode === UP;
+
+			if ( isArrowDown && canDecrease ) {
+				event.preventDefault();
+				onChange( quantity - 1 );
+			}
+
+			if ( isArrowUp && canIncrease ) {
+				event.preventDefault();
+				onChange( quantity + 1 );
+			}
+		},
+		[ quantity, onChange, canIncrease, canDecrease ]
+	);
+
+	return (
+		<div className={ classes }>
+			<input
+				className="wc-block-components-quantity-selector__input"
+				disabled={ disabled }
+				type="number"
+				step="1"
+				min="0"
+				value={ quantity }
+				onKeyDown={ quantityInputOnKeyDown }
+				onChange={ ( event ) => {
+					let value =
+						isNaN( event.target.value ) || ! event.target.value
+							? 0
+							: parseInt( event.target.value, 10 );
+					if ( hasMaximum ) {
+						value = Math.min( value, maximum );
+					}
+					value = Math.max( value, minimum );
+					if ( value !== quantity ) {
+						onChange( value );
+					}
+				} }
+				aria-label={ sprintf(
+					__(
+						// translators: %s Item name.
+						'Quantity of %s in your cart.',
+						'woo-gutenberg-products-block'
+					),
+					itemName
+				) }
+			/>
+			<button
+				aria-label={ __(
+					'Reduce quantity',
+					'woo-gutenberg-products-block'
+				) }
+				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+				disabled={ disabled || ! canDecrease }
+				onClick={ () => {
+					const newQuantity = quantity - 1;
+					onChange( newQuantity );
+					speak(
+						sprintf(
+							__(
+								// translators: %s Quantity amount.
+								'Quantity reduced to %s.',
+								'woo-gutenberg-products-block'
+							),
+							newQuantity
+						)
+					);
+				} }
+			>
+				&#65293;
+			</button>
+			<button
+				aria-label={ __(
+					'Increase quantity',
+					'woo-gutenberg-products-block'
+				) }
+				disabled={ disabled || ! canIncrease }
+				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+				onClick={ () => {
+					const newQuantity = quantity + 1;
+					onChange( newQuantity );
+					speak(
+						sprintf(
+							__(
+								// translators: %s Quantity amount.
+								'Quantity increased to %s.',
+								'woo-gutenberg-products-block'
+							),
+							newQuantity
+						)
+					);
+				} }
+			>
+				&#65291;
+			</button>
+		</div>
+	);
+};
+
+QuantitySelector.propTypes = {
+	className: PropTypes.string,
+	quantity: PropTypes.number,
+	minimum: PropTypes.number,
+	maximum: PropTypes.number,
+	onChange: PropTypes.func,
+	itemName: PropTypes.string,
+	disabled: PropTypes.bool,
+};
+
+export default QuantitySelector;

--- a/packages/components/src/quantity-selector/stories/index.js
+++ b/packages/components/src/quantity-selector/stories/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { boolean } from '@storybook/addon-knobs';
+import { useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import QuantitySelector from '../';
+
+export default {
+	title: 'WooCommerce Blocks/@base-components/QuantitySelector',
+	component: QuantitySelector,
+};
+
+export const Default = () => {
+	const [ quantity, changeQuantity ] = useState();
+
+	return (
+		<div style={ { width: 100 } }>
+			<QuantitySelector
+				disabled={ boolean( 'Disabled', false ) }
+				quantity={ quantity }
+				onChange={ changeQuantity }
+				itemName="widgets"
+			/>
+		</div>
+	);
+};

--- a/packages/components/src/quantity-selector/style.scss
+++ b/packages/components/src/quantity-selector/style.scss
@@ -1,0 +1,107 @@
+@mixin reset-button {
+	border: 0;
+	padding: 0;
+	margin: 0;
+	background: none transparent;
+	box-shadow: none;
+
+	&:focus {
+		outline: 2px solid $core-grey-light-600;
+	}
+}
+
+.wc-block-components-quantity-selector {
+	display: flex;
+	min-width: 100px;
+	border: 1px solid $core-grey-light-600;
+	background: #fff;
+	border-radius: 4px;
+	// needed so that buttons fill the container.
+	box-sizing: content-box;
+
+	.has-dark-controls & {
+		background-color: transparent;
+		border-color: $input-border-dark;
+	}
+
+	// Extra label for specificity needed in the editor.
+	input.wc-block-components-quantity-selector__input {
+		@include font-size(regular);
+		order: 2;
+		min-width: 40px;
+		flex: 1 1 auto;
+		border: 0;
+		padding: 0.4em 0;
+		margin: 0;
+		text-align: center;
+		background: transparent;
+		box-shadow: none;
+		color: #000;
+		line-height: 1;
+		vertical-align: middle;
+		-moz-appearance: textfield;
+
+		&:focus {
+			background: $core-grey-light-200;
+			outline: 1px solid $core-grey-light-600;
+		}
+		&:disabled {
+			color: $core-grey-dark-100;
+		}
+
+		.has-dark-controls & {
+			color: $input-text-dark;
+			background: transparent;
+
+			&:focus {
+				background: transparent;
+			}
+			&:disabled {
+				color: $input-disabled-dark;
+			}
+		}
+	}
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+	.wc-block-components-quantity-selector__button {
+		@include reset-button;
+		@include font-size(regular);
+		min-width: 30px;
+		cursor: pointer;
+		color: $core-grey-dark-700;
+		font-style: normal;
+		text-align: center;
+
+		&:hover,
+		&:focus {
+			@include reset-button;
+			color: $core-grey-dark-900;
+		}
+		&:disabled {
+			color: $core-grey-dark-100;
+			cursor: default;
+			@include reset-button;
+		}
+
+		.has-dark-controls & {
+			color: $input-text-dark;
+
+			&:hover,
+			&:focus {
+				color: $input-text-dark;
+			}
+			&:disabled {
+				color: $input-disabled-dark;
+			}
+		}
+	}
+	.wc-block-components-quantity-selector__button--minus {
+		order: 1;
+	}
+	.wc-block-components-quantity-selector__button--plus {
+		order: 3;
+	}
+}

--- a/packages/components/src/quantity-selector/style.scss
+++ b/packages/components/src/quantity-selector/style.scss
@@ -1,3 +1,16 @@
+// Totally hacked in these colours to get this going.
+// Will need to review this and adjust so is appropriate for wc-admin
+// and other contexts.
+$input-border-dark: $studio-gray-40;
+$input-text-dark: $studio-gray-80;
+$input-disabled-dark: $studio-gray-40;
+// Also used $studio-gray in place of various $core-gray-*-*.
+$core-grey-light-200: $studio-gray-20;
+$core-grey-light-600: $studio-gray-60;
+$core-grey-dark-100: $studio-gray-10;
+$core-grey-dark-700: $studio-gray-70;
+$core-grey-dark-900: $studio-gray-90;
+
 @mixin reset-button {
 	border: 0;
 	padding: 0;

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -23,6 +23,7 @@
 @import 'pagination/style.scss';
 @import 'pill/style.scss';
 @import 'product-image/style.scss';
+@import 'quantity-selector/style.scss';
 @import 'rating/style.scss';
 @import 'search/style.scss';
 @import 'search-list-control/style.scss';


### PR DESCRIPTION
_In progress_

Fixes #

This PR adds the [`QuantitySelector` component from WooCommerce Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/main/assets/js/base/components/quantity-selector) into `@woocommerce/components` package.

This is a generally useful up/down control which allows the user to enter a number within a given range. In blocks this is used for tweaking the number of each line item in the cart. Could potentially be used in various other places in the front end and in admin too, and will hopefully be useful for clients of the components package.

This PR is a draft for now as the colours used in the styles are hacked in, I need to revise these to align with the other components. 

Also this needs to have a working demo soon - either storybook or the components docs webapp, or (?) use in wc-admin somewhere. I'm shooting for Storybook, but it looks like we need some maintenance on Storybook (saw issues locally) and there's a [new Storybook 6 out which could be good to adopt](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3041). (I'm keen to help with all of that once I've confirmed it's 👌 in blocks repo.) 🚆 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Ex: Open page `url`
- Click XYZ…

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
