### PR TITLE
Update/components deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7973,10 +7973,10 @@
 			"requires": {
 				"@babel/runtime-corejs2": "7.11.2",
 				"@woocommerce/csv-export": "1.2.0",
-				"@woocommerce/currency": "2.0.0",
-				"@woocommerce/data": "1.0.0",
+				"@woocommerce/currency": "3.0.0",
+				"@woocommerce/data": "1.1.0",
 				"@woocommerce/date": "2.0.0",
-				"@woocommerce/navigation": "4.0.0",
+				"@woocommerce/navigation": "5.1.0",
 				"@wordpress/components": "10.0.0",
 				"@wordpress/compose": "3.13.1",
 				"@wordpress/date": "3.9.0",
@@ -8044,23 +8044,24 @@
 					}
 				},
 				"@woocommerce/currency": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-2.0.0.tgz",
-					"integrity": "sha512-zoQbVBZTlgqT5uGTrEHhqQ5iUFZHuYZDyf/+nit3v2a9vUzZAQm1zuqRgu1cd8LbaAQgNHumEUArvXFzacsyVQ==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-3.0.0.tgz",
+					"integrity": "sha512-uNck3JUgGo1RGoWJ/3qm1mhpikNAeTtVCgR0qb3/jti5Mm7pTM6WInGqQV8uP63PMDlPq2dnuhbvmXEER04jBQ==",
 					"dev": true,
 					"requires": {
-						"@babel/runtime-corejs2": "7.7.4",
-						"@woocommerce/number": "2.0.0"
+						"@babel/runtime-corejs2": "7.10.5",
+						"@woocommerce/number": "2.0.0",
+						"@wordpress/deprecated": "^2.9.0"
 					},
 					"dependencies": {
 						"@babel/runtime-corejs2": {
-							"version": "7.7.4",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-							"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+							"version": "7.10.5",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+							"integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
 							"dev": true,
 							"requires": {
 								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.2"
+								"regenerator-runtime": "^0.13.4"
 							}
 						},
 						"core-js": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.1
+
+-   Update dependencies.
+
 # 5.1.0
 
 -   Fix default value for `<Table />` component `onQueryChange` prop.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "5.1.0",
+	"version": "5.1.1",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,10 +23,10 @@
 	"dependencies": {
 		"@babel/runtime-corejs2": "7.11.2",
 		"@woocommerce/csv-export": "1.2.0",
-		"@woocommerce/currency": "2.0.0",
-		"@woocommerce/data": "1.0.0",
+		"@woocommerce/currency": "3.0.0",
+		"@woocommerce/data": "1.1.0",
 		"@woocommerce/date": "2.0.0",
-		"@woocommerce/navigation": "4.0.0",
+		"@woocommerce/navigation": "5.1.0",
 		"@wordpress/components": "10.0.0",
 		"@wordpress/compose": "3.13.1",
 		"@wordpress/date": "3.9.0",


### PR DESCRIPTION
In working on https://github.com/woocommerce/navigation/issues/91 I added `@woocommerce/components` dependency which caused the following error:

<img width="598" alt="Screen Shot 2020-09-17 at 9 01 06 PM" src="https://user-images.githubusercontent.com/1922453/93451121-dffc0680-f92a-11ea-8954-f39eb9c128f4.png">

This was caused by a mis-matched dependency as `packages/components/package.json` had not been updated. The Currency package had a breaking change, causing the above error. This PR updates to the latest for all wc-admin packages.

### Detailed test instructions:

If you are really, really keen you can create any application with `@woocommerce/components` as a dependency and see the error. Then, switch to this branch of wc-admin and use npm link ([instructions here](https://github.com/woocommerce/navigation)) to see the error disappear. Note, you'll need to carefully install, build and link in that order.

Or... you can double check the updated versions for data, currency, and navigation are correct 😄 . Since these would be the same versions that wc-admin itself uses on master, its safe to say they are matched correctly.

This PR also preps for a package release point because `@woocommerce/components` is broken.

### Changelog Note:

- Dev: Bump `@woocommerce/components` dependencies.
