### PR TITLE
Avoid PHP8 warning by declaring __wakeup() as public.

### DIFF
--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -313,5 +313,7 @@ class FeaturePlugin {
 	/**
 	 * Prevent unserializing.
 	 */
-	private function __wakeup() {}
+	public function __wakeup() {
+		die();
+	}
 }


### PR DESCRIPTION
PHP requires that all magic methods be public. As of PHP8, `__wakeup()` being declared as non-public causes a warning.

```
php -l woocommerce/packages/woocommerce-admin/src/FeaturePlugin.php

PHP Warning:  The magic method Automattic\WooCommerce\Admin\FeaturePlugin::__wakeup() must have public visibility in woocommerce/packages/woocommerce-admin/src/FeaturePlugin.php on line 314
```

Attached **untested** patch simply moves it to public, calls `die()` for safety.

See also: https://github.com/Automattic/jetpack/pull/17200 https://github.com/woocommerce/woocommerce/pull/27707

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Ex: Open page `url`
- Click XYZ…

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
