### PR TITLE
New Package: DependencyExtractionWebpackPlugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ languages/*
 woocommerce-admin.zip
 includes/feature-config.php
 storybook-static/
+packages/dependency-extraction-webpack-plugin/assets
 
 # Directories/files that may appear in your environment
 .DS_Store

--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -21,6 +21,7 @@
 	},
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
-		"@woocommerce/eslint-plugin": "1.0.0-beta.0"
+		"@woocommerce/eslint-plugin": "1.0.0-beta.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0"
 	}
 }

--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.0.0-beta.0",
-		"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.0.0-beta.0"
 	}
 }

--- a/bin/starter-pack/_webpack.config.js
+++ b/bin/starter-pack/_webpack.config.js
@@ -1,39 +1,5 @@
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
-
-const requestToExternal = ( request ) => {
-	const wcDepMap = {
-		'@woocommerce/components': [ 'window', 'wc', 'components' ],
-		'@woocommerce/csv-export': [ 'window', 'wc', 'csvExport' ],
-		'@woocommerce/currency': [ 'window', 'wc', 'currency' ],
-		'@woocommerce/date': [ 'window', 'wc', 'date' ],
-		'@woocommerce/navigation': [ 'window', 'wc', 'navigation' ],
-		'@woocommerce/number': [ 'window', 'wc', 'number' ],
-		'@woocommerce/settings': [ 'window', 'wc', 'wcSettings' ],
-		'@woocommerce/tracks': [ 'window', 'wc', 'tracks' ],
-	};
-
-	if ( wcDepMap[ request ] ) {
-		return wcDepMap[ request ];
-	}
-};
-
-const requestToHandle = ( request ) => {
-	const wcHandleMap = {
-		'@woocommerce/components': 'wc-components',
-		'@woocommerce/csv-export': 'wc-csv',
-		'@woocommerce/currency': 'wc-currency',
-		'@woocommerce/date': 'wc-date',
-		'@woocommerce/navigation': 'wc-navigation',
-		'@woocommerce/number': 'wc-number',
-		'@woocommerce/settings': 'wc-settings',
-		'@woocommerce/tracks': 'wc-tracks',
-	};
-
-	if ( wcHandleMap[ request ] ) {
-		return wcHandleMap[ request ];
-	}
-};
+const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
 
 module.exports = {
 	...defaultConfig,
@@ -42,10 +8,6 @@ module.exports = {
 			( plugin ) =>
 				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 		),
-		new DependencyExtractionWebpackPlugin( {
-			injectPolyfill: true,
-			requestToExternal,
-			requestToHandle,
-		} ),
+		new WooCommerceDependencyExtractionWebpackPlugin(),
 	],
 };

--- a/packages/dependency-extraction-webpack-plugin/.npmrc
+++ b/packages/dependency-extraction-webpack-plugin/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.0-beta.0
+
+-   Released package

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -12,7 +12,7 @@ npm install @woocommerce/dependency-extraction-webpack-plugin --save-dev
 
 ## Usage
 
-Use this as you would [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin). The API is exactly the same.
+Use this as you would [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin). The API is exactly the same, except that WooCommerce packages are also handled automatically.
 
 ```js
 // webpack.config.js

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -1,0 +1,25 @@
+# Dependency Extraction Webpack Plugin
+
+Extends Wordpress [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin) to automatically include WooCommerce dependencies in addition to WordPress dependencies.
+
+## Installation
+
+Install the module
+
+```
+npm install @woocommerce/dependency-extraction-webpack-plugin --save-dev
+```
+
+## Usage
+
+Use this as you would [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin). The API is exactly the same.
+
+```js
+// webpack.config.js
+const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+
+module.exports = {
+	// …snip
+	plugins: [ new WooCommerceDependencyExtractionWebpackPlugin() ],
+};
+```

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@woocommerce/dependency-extraction-webpack-plugin",
+	"version": "1.0.0-beta.0",
+	"description": "WooCommerce Dependency Extraction Webpack Plugin",
+	"author": "Automattic",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"woocommerce"
+	],
+	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/dependency-extraction-webpack-plugin/README.md",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+	},
+	"bugs": {
+		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+	},
+	"main": "build/index.js",
+	"module": "build-module/index.js",
+	"react-native": "src/index",
+	"dependencies": {
+		"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -1,0 +1,83 @@
+const WPDependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+
+const WOOCOMMERCE_NAMESPACE = '@woocommerce/';
+
+/**
+ * Given a string, returns a new string with dash separators converted to
+ * camelCase equivalent. This is not as aggressive as `_.camelCase` in
+ * converting to uppercase, where Lodash will also capitalize letters
+ * following numbers.
+ *
+ * @param {string} string Input dash-delimited string.
+ *
+ * @return {string} Camel-cased string.
+ */
+function camelCaseDash( string ) {
+	return string.replace( /-([a-z])/g, ( _, letter ) => letter.toUpperCase() );
+}
+
+const wooRequestToExternal = ( request ) => {
+	if ( request.startsWith( WOOCOMMERCE_NAMESPACE ) ) {
+		return [
+			'wc',
+			camelCaseDash( request.substring( WOOCOMMERCE_NAMESPACE.length ) ),
+		];
+	}
+};
+
+const wooRequestToHandle = ( request ) => {
+	if ( request.startsWith( WOOCOMMERCE_NAMESPACE ) ) {
+		return 'wc-' + request.substring( WOOCOMMERCE_NAMESPACE.length );
+	}
+};
+
+class DependencyExtractionWebpackPlugin extends WPDependencyExtractionWebpackPlugin {
+	externalizeWpDeps( _context, request, callback ) {
+		let externalRequest;
+
+		// Handle via options.requestToExternal first
+		if ( typeof this.options.requestToExternal === 'function' ) {
+			externalRequest = this.options.requestToExternal( request );
+		}
+
+		// Cascade to default if unhandled and enabled
+		if (
+			typeof externalRequest === 'undefined' &&
+			this.options.useDefaults
+		) {
+			externalRequest = wooRequestToExternal( request );
+		}
+
+		if ( externalRequest ) {
+			this.externalizedDeps.add( request );
+
+			return callback( null, { this: externalRequest } );
+		}
+
+		// Fall back to the WP method
+		return super.externalizeWpDeps( _context, request, callback );
+	}
+
+	mapRequestToDependency( request ) {
+		// Handle via options.requestToHandle first
+		if ( typeof this.options.requestToHandle === 'function' ) {
+			const scriptDependency = this.options.requestToHandle( request );
+			if ( scriptDependency ) {
+				return scriptDependency;
+			}
+		}
+
+		// Cascade to default if enabled
+		if ( this.options.useDefaults ) {
+			const scriptDependency = wooRequestToHandle( request );
+			if ( scriptDependency ) {
+				return scriptDependency;
+			}
+		}
+
+		// Fall back to the WP method
+		return super.mapRequestToDependency( request );
+	}
+}
+
+module.exports = DependencyExtractionWebpackPlugin;

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -1,4 +1,5 @@
 const WPDependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const packages = require( '../assets/packages' );
 
 const WOOCOMMERCE_NAMESPACE = '@woocommerce/';
 
@@ -17,7 +18,7 @@ function camelCaseDash( string ) {
 }
 
 const wooRequestToExternal = ( request ) => {
-	if ( request.startsWith( WOOCOMMERCE_NAMESPACE ) ) {
+	if ( packages.includes( request ) ) {
 		return [
 			'wc',
 			camelCaseDash( request.substring( WOOCOMMERCE_NAMESPACE.length ) ),
@@ -26,7 +27,7 @@ const wooRequestToExternal = ( request ) => {
 };
 
 const wooRequestToHandle = ( request ) => {
-	if ( request.startsWith( WOOCOMMERCE_NAMESPACE ) ) {
+	if ( packages.includes( request ) ) {
 		return 'wc-' + request.substring( WOOCOMMERCE_NAMESPACE.length );
 	}
 };


### PR DESCRIPTION
Partially Fixes https://github.com/woocommerce/woocommerce-admin/issues/3445

As `@woocommerce` packages continue to grow in number and usefulness, plugins wishing to consume them will continually need to amend webpack's [DependencyExtractionWebpackPlugin](https://github.com/WordPress/gutenberg/blob/master/packages/dependency-extraction-webpack-plugin/README.md) options `RequestToHandle` and `requestToExternal` so that dependencies can be handled correctly.

This PR introduces a woo-flavored DependencyExtractionWebpackPlugin that extends the WP version such that WC packages are also mapped automatically.

### Detailed test instructions:

The best way to test this is to create a new extension using `npm run create-wc-extension`. A project is scaffolded out, including use of DependencyExtractionWebpackPlugin. Once this simple case is confirmed, we can start using this package in wc-admin itself.

1. `npm run build`. This builds the packages for consumption later when we mock our new package (See step 3).
1. `npm run create-wc-extension` and give your new plugin a name.
2. Change this line in `<your-new-plugin>/webpack.config.js` to point to the new package since it does not yet exist in npm. There's probably a nice `npm link` solution here, but my tinkering didn't reveal it and this is easy enough.

```diff
- const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+ const WooCommerceDependencyExtractionWebpackPlugin = require("../woocommerce-admin/packages/dependency-extraction-webpack-plugin/src/index");
```
3. `npm start`
4. See `<your-new-plugin>/build/index.asset.php` exist and declare an empty array of dependencies because there aren't any just yet.
5. Install some dependencies: `npm install @wordpress/components` and `npm install @woocommerce/navigation`.
6. Use those dependencies by adding this to `<your-new-plugin>/src/index.js`:

```js
import { Button } from "@wordpress/components";
import { getHistory } from "@woocommerce/navigation";

console.log(Button, getHistory);
```
7. restart the proces `npm start`
8. See `<your-new-plugin>/build/index.asset.php` now reflect two dependencies.
9. Check the built js and see the dependencies gathered from `this`, which is the `window`
9. Bonus: Activate the plugin and visit the homescreen. See our consoled components.
10. Confirm that `window.wp.components` exists (wc-admin doesn't load it).

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

- Dev: Add WooCommerceDependencyExtractionWebpackPlugin package