### PR TITLE
Search component: Behavior and styling tweaks

### DIFF
--- a/packages/components/src/select-control/index.js
+++ b/packages/components/src/select-control/index.js
@@ -220,7 +220,20 @@ export class SelectControl extends Component {
 	}
 
 	search( query ) {
-		this.setState( { query, isFocused: true } );
+		const searchOptions = this.searchOptions || [];
+		const filteredOptions =
+			query !== null && ! query.length && ! this.props.hideBeforeSearch
+				? searchOptions
+				: this.getFilteredOptions( searchOptions, query );
+
+		this.setState( {
+			query,
+			isFocused: true,
+			selectedIndex: 0,
+			filteredOptions,
+			isExpanded: Boolean( filteredOptions.length ),
+		} );
+
 		this.updateFilteredOptions( query );
 	}
 
@@ -235,6 +248,8 @@ export class SelectControl extends Component {
 				// or else we might end triggering a race condition updating the state.
 				return;
 			}
+
+			this.searchOptions = searchOptions;
 
 			// Get all options if `hideBeforeSearch` is enabled and query is not null.
 			const filteredOptions =

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -48,6 +48,7 @@
 			width: 100%;
 			line-height: 24px;
 			text-align: left;
+			letter-spacing: inherit;
 			background: transparent;
 
 			&::-webkit-search-cancel-button {

--- a/packages/components/src/tag/style.scss
+++ b/packages/components/src/tag/style.scss
@@ -29,6 +29,7 @@
 
 	.woocommerce-tag__remove {
 		cursor: pointer;
+		height: inherit;
 		padding: 0 2px;
 		border-radius: 0 12px 12px 0;
 		color: $gray-700;


### PR DESCRIPTION
A few slight changes to the Search component:

- https://github.com/woocommerce/woocommerce-admin/commit/44e51bb1900663dba0836cfb0ef8c49f1bd1468d fixes vertical misalignment of the "X" button inside the tag:

`master` | this branch
-- | --
<img width="268" alt="misaligned-remove-tag-button" src="https://user-images.githubusercontent.com/1867547/94267864-4d4eff00-ff0a-11ea-8224-b450b0c33ec4.png"> | <img width="272" alt="aligned-remove-tag-button" src="https://user-images.githubusercontent.com/1867547/94267874-5213b300-ff0a-11ea-9b1e-9e11a3a45207.png">

- https://github.com/woocommerce/woocommerce-admin/commit/70edf5074276cc2d5d05cd130a4086bad5d9457d addresses just a slight visual glitch with inconsistent letter spacing between renditions of the placeholder:

`master` | this branch
-- | --
![inconsistent-letter-spacing](https://user-images.githubusercontent.com/1867547/94267968-753e6280-ff0a-11ea-8d8e-7bb22c088799.gif) | ![consistent-letter-spacing](https://user-images.githubusercontent.com/1867547/94267972-766f8f80-ff0a-11ea-88b2-501396be2d65.gif)

- https://github.com/woocommerce/woocommerce-admin/commit/8cead2f590b352c1e28dcd63bfee8f9757a0b8f7 is a proposed change to the debounced search behavior, which has the filtered options update (prepending free text options in the cases I was testing) _before_ the debounce delay, in addition to _after_ resolution of search results. Unless I'm missing different usages of these props, the main effect is to have the options added (e.g. free text search) in real-time, without waiting for an update, and being able to hit enter without a potentially non-current query being added as a tag.

`master` | this branch
-- | --
![debounced-filtering](https://user-images.githubusercontent.com/1867547/94268051-97d07b80-ff0a-11ea-934e-111539f09c3c.gif) | ![immediate-filtering](https://user-images.githubusercontent.com/1867547/94268059-9901a880-ff0a-11ea-8a44-853007158a6e.gif)

(I think there may be a somewhat broader / adjacent concern here too, around indicating the loading status of search options and/or clearing them when the query changes, but the current behavior – caching of search results until new ones are in – is unaffected here, aside from being mixed with the updated filtered options.)

Side-note: I'd also made a brief attempt at addressing the autocomplete popping back up after reset – seen at the end of those screen captures, or when typing and immediately defocusing – but having the `reset` method set `this.activePromise` to `null` didn't seem to work.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Detailed test instructions:

On a screen with a search input (such as WooCommerce » Customers), verify that the top search suggestion (and new tag, after pressing enter) tracks the current input without a delay, and that the input placeholder and "remove tag" button both appear properly.

### Changelog Note:
Fix: visual issues in the Search component.
