### PR TITLE
Navigation package: Version bump

### DIFF
--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.1
+
+-   Version bump to undeprecate the package.
+
 # 5.1.0
 
 -   Support multiple advanced filter instances in getActiveFiltersFromQuery() and getQueryFromActiveFilters().

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/navigation",
-	"version": "5.1.0",
+	"version": "5.1.1",
 	"description": "WooCommerce navigation utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
After erroneously publishing a faulty package and deprecating that version, this PR prepares to re-release @woocommerce/navigation 5.1.0 as 5.1.1 so the latest version isn't deprecated anymore.

See the deprecation at https://www.npmjs.com/package/@woocommerce/navigation