### PR TITLE
Task list: Turn off Stripe test mode when submitting live keys

### DIFF
--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -140,6 +140,7 @@ class Stripe extends Component {
 				...stripeSettings,
 				publishable_key: values.publishable_key,
 				secret_key: values.secret_key,
+				testmode: 'no',
 				enabled: 'yes',
 			},
 		} );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5225

Disable the (default) **test mode** in the Stripe settings upon configuring **live keys** via the onboarding task.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots & detailed test instructions:

Start with the Stripe extension deactivated (or at least with test mode enabled), and navigate to the Stripe payment method on the Payments onboarding task.

With existing settings (populated on my test site but with test mode enabled, consistent with default):

<img width="400" alt="stripe-settings-before" src="https://user-images.githubusercontent.com/1867547/94701635-ddc28080-030a-11eb-8038-a6da697d96f5.png">

Go through onboarding task:

<img width="400" alt="entering-keys" src="https://user-images.githubusercontent.com/1867547/94701621-d9966300-030a-11eb-8b41-012fb557cee1.png">
<img width="400" alt="success" src="https://user-images.githubusercontent.com/1867547/94701632-dc915380-030a-11eb-982f-bde11229bd16.png">

Now test mode is disabled (after new settings page load):

<img width="400" alt="stripe-settings-after" src="https://user-images.githubusercontent.com/1867547/94701629-db602680-030a-11eb-8926-7ce6cf5cf43e.png">

…and the payment method is ready to use with no further configuration.

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
