### PR TITLE
Wrap search control selected items in list

### DIFF
--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -209,14 +209,19 @@ export class SearchListControl extends Component {
 						</Button>
 					) : null }
 				</div>
-				{ selected.map( ( item, i ) => (
-					<Tag
-						key={ i }
-						label={ item.name }
-						id={ item.id }
-						remove={ this.onRemove }
-					/>
-				) ) }
+				{ selectedCount > 0 ? (
+					<ul>
+						{ selected.map( ( item, i ) => (
+							<li key={ i }>
+								<Tag
+									label={ item.name }
+									id={ item.id }
+									remove={ this.onRemove }
+								/>
+							</li>
+						) ) }
+					</ul>
+				) : null }
 			</div>
 		);
 	}

--- a/packages/components/src/search-list-control/style.scss
+++ b/packages/components/src/search-list-control/style.scss
@@ -22,6 +22,14 @@
 	.woocommerce-tag__text {
 		max-width: 13em;
 	}
+
+	ul {
+		list-style: none;
+
+		li {
+			float: left;
+		}
+	}
 }
 
 .woocommerce-search-list__search {

--- a/packages/components/src/search-list-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/search-list-control/test/__snapshots__/index.js.snap
@@ -1676,47 +1676,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         Clear all
       </button>
     </div>
-    <span
-      className="woocommerce-tag has-remove"
-    >
-      <span
-        className="woocommerce-tag__text"
-        id="woocommerce-tag__label-0"
-      >
+    <ul>
+      <li>
         <span
-          className="screen-reader-text"
+          className="woocommerce-tag has-remove"
         >
-          Clementine
+          <span
+            className="woocommerce-tag__text"
+            id="woocommerce-tag__label-0"
+          >
+            <span
+              className="screen-reader-text"
+            >
+              Clementine
+            </span>
+            <span
+              aria-hidden="true"
+            >
+              Clementine
+            </span>
+          </span>
+          <button
+            aria-describedby="woocommerce-tag__label-0"
+            aria-label="Remove Clementine"
+            className="components-button woocommerce-tag__remove"
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="dashicon dashicons-dismiss"
+              focusable={false}
+              height={20}
+              role="img"
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm5 11l-3-3 3-3-2-2-3 3-3-3-2 2 3 3-3 3 2 2 3-3 3 3z"
+              />
+            </svg>
+          </button>
         </span>
-        <span
-          aria-hidden="true"
-        >
-          Clementine
-        </span>
-      </span>
-      <button
-        aria-describedby="woocommerce-tag__label-0"
-        aria-label="Remove Clementine"
-        className="components-button woocommerce-tag__remove"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="dashicon dashicons-dismiss"
-          focusable={false}
-          height={20}
-          role="img"
-          viewBox="0 0 20 20"
-          width={20}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm5 11l-3-3 3-3-2-2-3 3-3-3-2 2 3 3-3 3 2 2 3-3 3 3z"
-          />
-        </svg>
-      </button>
-    </span>
+      </li>
+    </ul>
   </div>
   <div
     className="woocommerce-search-list__search"
@@ -2011,88 +2015,94 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         Clear all
       </button>
     </div>
-    <span
-      className="woocommerce-tag has-remove"
-    >
-      <span
-        className="woocommerce-tag__text"
-        id="woocommerce-tag__label-1"
-      >
+    <ul>
+      <li>
         <span
-          className="screen-reader-text"
+          className="woocommerce-tag has-remove"
         >
-          Clementine
+          <span
+            className="woocommerce-tag__text"
+            id="woocommerce-tag__label-1"
+          >
+            <span
+              className="screen-reader-text"
+            >
+              Clementine
+            </span>
+            <span
+              aria-hidden="true"
+            >
+              Clementine
+            </span>
+          </span>
+          <button
+            aria-describedby="woocommerce-tag__label-1"
+            aria-label="Remove Clementine"
+            className="components-button woocommerce-tag__remove"
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="dashicon dashicons-dismiss"
+              focusable={false}
+              height={20}
+              role="img"
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm5 11l-3-3 3-3-2-2-3 3-3-3-2 2 3 3-3 3 2 2 3-3 3 3z"
+              />
+            </svg>
+          </button>
         </span>
+      </li>
+      <li>
         <span
-          aria-hidden="true"
+          className="woocommerce-tag has-remove"
         >
-          Clementine
+          <span
+            className="woocommerce-tag__text"
+            id="woocommerce-tag__label-2"
+          >
+            <span
+              className="screen-reader-text"
+            >
+              Guava
+            </span>
+            <span
+              aria-hidden="true"
+            >
+              Guava
+            </span>
+          </span>
+          <button
+            aria-describedby="woocommerce-tag__label-2"
+            aria-label="Remove Guava"
+            className="components-button woocommerce-tag__remove"
+            onClick={[Function]}
+            type="button"
+          >
+            <svg
+              aria-hidden={true}
+              className="dashicon dashicons-dismiss"
+              focusable={false}
+              height={20}
+              role="img"
+              viewBox="0 0 20 20"
+              width={20}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm5 11l-3-3 3-3-2-2-3 3-3-3-2 2 3 3-3 3 2 2 3-3 3 3z"
+              />
+            </svg>
+          </button>
         </span>
-      </span>
-      <button
-        aria-describedby="woocommerce-tag__label-1"
-        aria-label="Remove Clementine"
-        className="components-button woocommerce-tag__remove"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="dashicon dashicons-dismiss"
-          focusable={false}
-          height={20}
-          role="img"
-          viewBox="0 0 20 20"
-          width={20}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm5 11l-3-3 3-3-2-2-3 3-3-3-2 2 3 3-3 3 2 2 3-3 3 3z"
-          />
-        </svg>
-      </button>
-    </span>
-    <span
-      className="woocommerce-tag has-remove"
-    >
-      <span
-        className="woocommerce-tag__text"
-        id="woocommerce-tag__label-2"
-      >
-        <span
-          className="screen-reader-text"
-        >
-          Guava
-        </span>
-        <span
-          aria-hidden="true"
-        >
-          Guava
-        </span>
-      </span>
-      <button
-        aria-describedby="woocommerce-tag__label-2"
-        aria-label="Remove Guava"
-        className="components-button woocommerce-tag__remove"
-        onClick={[Function]}
-        type="button"
-      >
-        <svg
-          aria-hidden={true}
-          className="dashicon dashicons-dismiss"
-          focusable={false}
-          height={20}
-          role="img"
-          viewBox="0 0 20 20"
-          width={20}
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 2c4.42 0 8 3.58 8 8s-3.58 8-8 8-8-3.58-8-8 3.58-8 8-8zm5 11l-3-3 3-3-2-2-3 3-3-3-2 2 3 3-3 3 2 2 3-3 3 3z"
-          />
-        </svg>
-      </button>
-    </span>
+      </li>
+    </ul>
   </div>
   <div
     className="woocommerce-search-list__search"


### PR DESCRIPTION
Fixes #3647 

Wrap selected items in `SearchListControl` with `ul` and `li` to improve accessibility.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
<img width="723" alt="Screen Shot 2020-09-30 at 11 55 24 AM" src="https://user-images.githubusercontent.com/10561050/94747248-0ee09680-0387-11eb-914a-986b97079a75.png">


### Detailed test instructions:

1. Fire up devdocs (make sure `SCRIPT_DEBUG` is `true` in your wp-config).  Looks like this might be broken on `main` but going to an analytics pages and clicking back to devdocs seems to get it working.
1. Select some items in the `SearchListControl`.
1. Check that styling is the same.
1. Check that tests pass.
1. Fire up a screen reader.
1. Check that items can be selected/read in the list.