### PR TITLE
Navigation: Update PHP registration 

### DIFF
--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -116,8 +116,7 @@ class Analytics {
 			array(
 				'id'       => 'woocommerce-analytics',
 				'title'    => __( 'Analytics', 'woocommerce-admin' ),
-				'path'     => '/analytics/overview',
-				'path'     => '/analytics/overview',
+				// 'path'     => '/analytics/overview', this needs to be conditional
 				'icon'     => 'dashicons-chart-bar',
 				'position' => 56, // After WooCommerce & Product menu items.
 			),

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -112,14 +112,19 @@ class Analytics {
 	 * Registers report pages.
 	 */
 	public function register_pages() {
+		$overview_page = array(
+			'id'       => 'woocommerce-analytics',
+			'title'    => __( 'Analytics', 'woocommerce-admin' ),
+			'path'     => '/analytics/overview',
+			'icon'     => 'dashicons-chart-bar',
+			'position' => 56, // After WooCommerce & Product menu items.
+		);
+		if ( class_exists( '\Automattic\WooCommerce\Navigation\Menu' ) ) {
+			unset( $overview_page['path'] );
+		}
+
 		$report_pages = array(
-			array(
-				'id'       => 'woocommerce-analytics',
-				'title'    => __( 'Analytics', 'woocommerce-admin' ),
-				// 'path'     => '/analytics/overview', this needs to be conditional
-				'icon'     => 'dashicons-chart-bar',
-				'position' => 56, // After WooCommerce & Product menu items.
-			),
+			$overview_page,
 			array(
 				'id'     => 'woocommerce-analytics-overview',
 				'title'  => __( 'Overview', 'woocommerce-admin' ),

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -439,14 +439,18 @@ class PageController {
 			);
 
 			if ( method_exists( '\Automattic\WooCommerce\Navigation\Menu', 'add_category' ) ) {
-				\Automattic\WooCommerce\Navigation\Menu::add_category(
-					array(
-						'id'         => $options['id'],
-						'title'      => $options['title'],
-						'capability' => $options['capability'],
-						'url'        => $options['path'],
-					)
+				$category_options = array(
+					'id'                    => $options['id'],
+					'title'                 => $options['title'],
+					'capability'            => $options['capability'],
+					'url'                   => $options['path'],
+					'is_top_level_category' => true,
 				);
+
+				if ( 'wc-admin&path=' === $options['path'] ) {
+					unset( $category_options['url'] );
+				}
+				\Automattic\WooCommerce\Navigation\Menu::add_category( $category_options );
 			}
 		} else {
 			$parent_path = $this->get_path_from_id( $options['parent'] );
@@ -461,13 +465,15 @@ class PageController {
 			);
 
 			if ( method_exists( '\Automattic\WooCommerce\Navigation\Menu', 'add_item' ) ) {
+				$top_level_ids = array( 'woocommerce-home', 'woocommerce-analytics-customers' );
 				\Automattic\WooCommerce\Navigation\Menu::add_item(
 					array(
-						'id'         => $options['id'],
-						'parent'     => $options['parent'],
-						'title'      => $options['title'],
-						'capability' => $options['capability'],
-						'url'        => $options['path'],
+						'id'                => $options['id'],
+						'parent'            => $options['parent'],
+						'title'             => $options['title'],
+						'capability'        => $options['capability'],
+						'url'               => $options['path'],
+						'is_top_level_item' => in_array( $options['id'], $top_level_ids, true ),
 					)
 				);
 			}

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -440,11 +440,11 @@ class PageController {
 
 			if ( method_exists( '\Automattic\WooCommerce\Navigation\Menu', 'add_category' ) ) {
 				$category_options = array(
-					'id'                    => $options['id'],
-					'title'                 => $options['title'],
-					'capability'            => $options['capability'],
-					'url'                   => $options['path'],
-					'is_top_level_category' => true,
+					'id'           => $options['id'],
+					'title'        => $options['title'],
+					'capability'   => $options['capability'],
+					'url'          => $options['path'],
+					'is_top_level' => true,
 				);
 
 				// If there is no path option, remove url because its a parent category item.
@@ -469,12 +469,12 @@ class PageController {
 				$top_level_ids = array( 'woocommerce-home', 'woocommerce-analytics-customers' );
 				\Automattic\WooCommerce\Navigation\Menu::add_item(
 					array(
-						'id'                => $options['id'],
-						'parent'            => $options['parent'],
-						'title'             => $options['title'],
-						'capability'        => $options['capability'],
-						'url'               => $options['path'],
-						'is_top_level_item' => in_array( $options['id'], $top_level_ids, true ),
+						'id'           => $options['id'],
+						'parent'       => $options['parent'],
+						'title'        => $options['title'],
+						'capability'   => $options['capability'],
+						'url'          => $options['path'],
+						'is_top_level' => in_array( $options['id'], $top_level_ids, true ),
 					)
 				);
 			}

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -447,6 +447,7 @@ class PageController {
 					'is_top_level_category' => true,
 				);
 
+				// If there is no path option, remove url because its a parent category item.
 				if ( 'wc-admin&path=' === $options['path'] ) {
 					unset( $category_options['url'] );
 				}


### PR DESCRIPTION
As a companion to https://github.com/woocommerce/navigation/pull/117, this PR updates registration in a few ways:

* `is_top_level_category` is required for all top level categories (Analytics)
* `is_top_level_item` is required for all top level items (Home, Customers)

Categories don't have a url in the new Navigation system because they open the menu to a set of children. So I conditionally removed the `path` parameter from registration for parent categories. ie, Analytics no longer navigates to Overview page, but instead is a parent category.

### Detailed test instructions:

1. Use the WC Navigation branch from https://github.com/woocommerce/navigation/pull/117
2. Follow setup instructions on the [README](https://github.com/woocommerce/navigation/blob/main/README.md). 
3. See that all elements are present.

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

none: fix to unreleased changes
