### PR TITLE
Navigation: Move PHP code to WC Admin

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -5,10 +5,10 @@
  * @package Woocommerce Admin
  */
 
-namespace Automattic\WooCommerce\Navigation;
+namespace Automattic\WooCommerce\Admin\Features\Navigation;
 
-use Automattic\WooCommerce\Navigation\Menu;
-use Automattic\WooCommerce\Navigation\Screen;
+use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
 
 
 /**

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -78,7 +78,7 @@ class CoreMenu {
 		// Marketing category.
 		Menu::add_category(
 			array(
-				'title'        => __( 'Marketing', 'woocommerce-navigation' ),
+				'title'        => __( 'Marketing', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
 				'id'           => 'woocommerce-marketing',
 				'order'        => 30,
@@ -90,7 +90,7 @@ class CoreMenu {
 		// Extensions category.
 		Menu::add_category(
 			array(
-				'title'        => __( 'Extensions', 'woocommerce-navigation' ),
+				'title'        => __( 'Extensions', 'woocommerce-admin' ),
 				'capability'   => 'activate_plugins',
 				'id'           => 'extensions',
 				'migrate'      => false,
@@ -102,7 +102,7 @@ class CoreMenu {
 		Menu::add_item(
 			array(
 				'parent'     => 'extensions',
-				'title'      => __( 'My extensions', 'woocommerce-navigation' ),
+				'title'      => __( 'My extensions', 'woocommerce-admin' ),
 				'capability' => 'manage_woocommerce',
 				'id'         => 'my-extensions',
 				'url'        => 'plugins.php',
@@ -113,7 +113,7 @@ class CoreMenu {
 		Menu::add_item(
 			array(
 				'parent'     => 'extensions',
-				'title'      => __( 'Marketplace', 'woocommerce-navigation' ),
+				'title'      => __( 'Marketplace', 'woocommerce-admin' ),
 				'capability' => 'manage_woocommerce',
 				'id'         => 'marketplace',
 				'url'        => 'wc-addons',
@@ -124,7 +124,7 @@ class CoreMenu {
 		// Settings category.
 		Menu::add_category(
 			array(
-				'title'        => __( 'Settings', 'woocommerce-navigation' ),
+				'title'        => __( 'Settings', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
 				'id'           => 'settings',
 				'menuId'       => 'secondary',
@@ -136,7 +136,7 @@ class CoreMenu {
 		// Tools category.
 		Menu::add_category(
 			array(
-				'title'        => __( 'Tools', 'woocommerce-navigation' ),
+				'title'        => __( 'Tools', 'woocommerce-admin' ),
 				'capability'   => 'manage_woocommerce',
 				'id'           => 'tools',
 				'menuId'       => 'secondary',
@@ -147,7 +147,7 @@ class CoreMenu {
 		Menu::add_item(
 			array(
 				'parent'     => 'tools',
-				'title'      => __( 'System status', 'woocommerce-navigation' ),
+				'title'      => __( 'System status', 'woocommerce-admin' ),
 				'capability' => 'manage_woocommerce',
 				'id'         => 'system-status',
 				'url'        => 'wc-status',
@@ -157,7 +157,7 @@ class CoreMenu {
 		Menu::add_item(
 			array(
 				'parent'     => 'tools',
-				'title'      => __( 'Import / Export', 'woocommerce-navigation' ),
+				'title'      => __( 'Import / Export', 'woocommerce-admin' ),
 				'capability' => 'import',
 				'id'         => 'import-export',
 				'url'        => 'import.php',
@@ -168,7 +168,7 @@ class CoreMenu {
 		Menu::add_item(
 			array(
 				'parent'     => 'tools',
-				'title'      => __( 'Utilities', 'woocommerce-navigation' ),
+				'title'      => __( 'Utilities', 'woocommerce-admin' ),
 				'capability' => 'manage_woocommerce',
 				'id'         => 'utilities',
 				'url'        => 'admin.php?page=wc-status&tab=tools',

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * WooCommerce Navigation Core Menu
+ *
+ * @package Woocommerce Admin
+ */
+
+namespace Automattic\WooCommerce\Navigation;
+
+use Automattic\WooCommerce\Navigation\Menu;
+use Automattic\WooCommerce\Navigation\Screen;
+
+
+/**
+ * CoreMenu class. Handles registering Core menu items.
+ */
+class CoreMenu {
+	/**
+	 * Class instance.
+	 *
+	 * @var Menu instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 */
+	final public static function instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Init.
+	 */
+	public function init() {
+		add_action( 'admin_menu', array( $this, 'add_core_items' ) );
+		add_action( 'admin_menu', array( $this, 'add_core_setting_items' ) );
+		add_filter( 'add_menu_classes', array( $this, 'migrate_child_items' ) );
+	}
+
+	/**
+	 * Add registered admin settings as menu items.
+	 */
+	public function add_core_setting_items() {
+		$setting_pages = \WC_Admin_Settings::get_settings_pages();
+		$settings      = array();
+		foreach ( $setting_pages as $setting_page ) {
+			$settings = $setting_page->add_settings_page( $settings );
+		}
+		foreach ( $settings as $key => $setting ) {
+			Menu::add_item(
+				array(
+					'parent'     => 'settings',
+					'title'      => $setting,
+					'capability' => 'manage_woocommerce',
+					'id'         => $key,
+					'url'        => 'admin.php?page=wc-settings&tab=' . $key,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Add the core menu items to the new navigation
+	 */
+	public function add_core_items() {
+		// Orders category.
+		Screen::register_post_type( 'shop_order', null );
+		Menu::add_post_type_category( 'shop_order', array( 'order' => 20 ) );
+
+		// Products category.
+		Screen::register_post_type( 'product', null );
+		Menu::add_post_type_category( 'product', array( 'order' => 40 ) );
+
+		// Marketing category.
+		Menu::add_category(
+			array(
+				'title'        => __( 'Marketing', 'woocommerce-navigation' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'woocommerce-marketing',
+				'order'        => 30,
+				'is_top_level' => true,
+			)
+		);
+		Screen::register_post_type( 'shop_coupon', 'woocommerce-marketing' );
+
+		// Extensions category.
+		Menu::add_category(
+			array(
+				'title'        => __( 'Extensions', 'woocommerce-navigation' ),
+				'capability'   => 'activate_plugins',
+				'id'           => 'extensions',
+				'migrate'      => false,
+				'menuId'       => 'secondary',
+				'order'        => 20,
+				'is_top_level' => true,
+			)
+		);
+		Menu::add_item(
+			array(
+				'parent'     => 'extensions',
+				'title'      => __( 'My extensions', 'woocommerce-navigation' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'my-extensions',
+				'url'        => 'plugins.php',
+				'migrate'    => false,
+				'menuId'     => 'secondary',
+			)
+		);
+		Menu::add_item(
+			array(
+				'parent'     => 'extensions',
+				'title'      => __( 'Marketplace', 'woocommerce-navigation' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'marketplace',
+				'url'        => 'wc-addons',
+				'menuId'     => 'secondary',
+			)
+		);
+
+		// Settings category.
+		Menu::add_category(
+			array(
+				'title'        => __( 'Settings', 'woocommerce-navigation' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'settings',
+				'menuId'       => 'secondary',
+				'order'        => 10,
+				'is_top_level' => true,
+			)
+		);
+
+		// Tools category.
+		Menu::add_category(
+			array(
+				'title'        => __( 'Tools', 'woocommerce-navigation' ),
+				'capability'   => 'manage_woocommerce',
+				'id'           => 'tools',
+				'menuId'       => 'secondary',
+				'order'        => 30,
+				'is_top_level' => true,
+			)
+		);
+		Menu::add_item(
+			array(
+				'parent'     => 'tools',
+				'title'      => __( 'System status', 'woocommerce-navigation' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'system-status',
+				'url'        => 'wc-status',
+				'menuId'     => 'secondary',
+			)
+		);
+		Menu::add_item(
+			array(
+				'parent'     => 'tools',
+				'title'      => __( 'Import / Export', 'woocommerce-navigation' ),
+				'capability' => 'import',
+				'id'         => 'import-export',
+				'url'        => 'import.php',
+				'migrate'    => false,
+				'menuId'     => 'secondary',
+			)
+		);
+		Menu::add_item(
+			array(
+				'parent'     => 'tools',
+				'title'      => __( 'Utilities', 'woocommerce-navigation' ),
+				'capability' => 'manage_woocommerce',
+				'id'         => 'utilities',
+				'url'        => 'admin.php?page=wc-status&tab=tools',
+				'menuId'     => 'secondary',
+			)
+		);
+	}
+
+	/**
+	 * Migrate any remaining WooCommerce child items.
+	 *
+	 * @param array $menu Menu items.
+	 * @return array
+	 */
+	public function migrate_child_items( $menu ) {
+		global $submenu;
+
+		if ( ! isset( $submenu['woocommerce'] ) ) {
+			return;
+		}
+
+		foreach ( $submenu['woocommerce'] as $menu_item ) {
+			if ( 'woocommerce' === $menu_item[2] ) {
+				continue;
+			}
+
+			// Don't add already added items.
+			$callbacks = Menu::instance()::get_callbacks();
+			if ( array_key_exists( $menu_item[2], $callbacks ) ) {
+				continue;
+			}
+
+			Menu::add_item(
+				array(
+					'parent'     => 'settings',
+					'title'      => $menu_item[0],
+					'capability' => $menu_item[1],
+					'id'         => sanitize_title( $menu_item[0] ),
+					'url'        => $menu_item[2],
+					'menuId'     => 'secondary',
+				)
+			);
+		}
+
+		return $menu;
+	}
+}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -1,0 +1,385 @@
+<?php
+/**
+ * WooCommerce Navigation Menu
+ *
+ * @package Woocommerce Navigation
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\Navigation;
+
+use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+
+/**
+ * Contains logic for the WooCommerce Navigation menu.
+ */
+class Menu {
+	/**
+	 * Class instance.
+	 *
+	 * @var Menu instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Array index of menu capability.
+	 *
+	 * @var int
+	 */
+	const CAPABILITY = 1;
+
+	/**
+	 * Array index of menu callback.
+	 *
+	 * @var int
+	 */
+	const CALLBACK = 2;
+
+	/**
+	 * Array index of menu callback.
+	 *
+	 * @var int
+	 */
+	const SLUG = 3;
+
+	/**
+	 * Array index of menu CSS class string.
+	 *
+	 * @var int
+	 */
+	const CSS_CLASSES = 4;
+
+	/**
+	 * Default parent menu
+	 *
+	 * @var string
+	 */
+	const DEFAULT_PARENT = 'settings';
+
+	/**
+	 * Store menu items.
+	 *
+	 * @var array
+	 */
+	protected static $menu_items = array();
+
+	/**
+	 * Registered callbacks or URLs with migration boolean as key value pairs.
+	 *
+	 * @var array
+	 */
+	protected static $callbacks = array();
+
+	/**
+	 * Get class instance.
+	 */
+	final public static function instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Init.
+	 */
+	public function init() {
+		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_data' ), 20 );
+		add_filter( 'add_menu_classes', array( $this, 'migrate_menu_items' ), 30 );
+	}
+
+	/**
+	 * Convert a WordPress menu callback to a URL.
+	 *
+	 * @param string $callback Menu callback.
+	 * @return string
+	 */
+	public static function get_callback_url( $callback ) {
+		$pos  = strpos( $callback, '?' );
+		$file = $pos > 0 ? substr( $callback, 0, $pos ) : $callback;
+		if ( file_exists( ABSPATH . "/wp-admin/$file" ) ) {
+			return $callback;
+		}
+		return 'admin.php?page=' . $callback;
+	}
+
+	/**
+	 * Get the parent key if one exists.
+	 *
+	 * @param string $callback Callback or URL.
+	 * @return string|null
+	 */
+	public static function get_parent_key( $callback ) {
+		global $submenu;
+
+		if ( ! $submenu ) {
+			return null;
+		}
+
+		// This is already a parent item.
+		if ( isset( $submenu[ $callback ] ) ) {
+			return null;
+		}
+
+		foreach ( $submenu as $key => $menu ) {
+			foreach ( $menu as $item ) {
+				if ( $item[ self::CALLBACK ] === $callback ) {
+					return $key;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Adds a top level menu item to the navigation.
+	 *
+	 * @param array $args Array containing the necessary arguments.
+	 *    $args = array(
+	 *      'id'         => (string) The unique ID of the menu item. Required.
+	 *      'title'      => (string) Title of the menu item. Required.
+	 *      'capability' => (string) Capability to view this menu item.
+	 *      'url'        => (string) URL or callback to be used. Required.
+	 *      'order'      => (int) Menu item order.
+	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'menuId'     => (string) The ID of the menu to add the category to.
+	 *    ).
+	 */
+	public static function add_category( $args ) {
+		if ( ! isset( $args['id'] ) || isset( self::$menu_items[ $args['id'] ] ) ) {
+			return;
+		}
+
+		$defaults           = array(
+			'id'              => '',
+			'title'           => '',
+			'capability'      => 'manage_woocommerce',
+			'order'           => 100,
+			'migrate'         => true,
+			'menuId'          => 'primary',
+			'isCategory'      => true,
+			'parent'          => self::DEFAULT_PARENT,
+			'backButtonLabel' => __(
+				'WooCommerce Home',
+				'woocommerce-navigation'
+			),
+			'is_top_level'    => false,
+		);
+		$menu_item          = wp_parse_args( $args, $defaults );
+		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
+		if ( isset( $menu_item['url'] ) ) {
+			$menu_item['url'] = self::get_callback_url( $menu_item['url'] );
+		}
+
+		if ( true === $menu_item['is_top_level'] ) {
+			$menu_item['parent'] = 'woocommerce';
+		} else {
+			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
+		}
+
+		self::$menu_items[ $menu_item['id'] ] = $menu_item;
+
+		if ( isset( $args['url'] ) ) {
+			self::$callbacks[ $args['url'] ] = $menu_item['migrate'];
+		}
+	}
+
+	/**
+	 * Adds a child menu item to the navigation.
+	 *
+	 * @param array $args Array containing the necessary arguments.
+	 *    $args = array(
+	 *      'id'         => (string) The unique ID of the menu item. Required.
+	 *      'title'      => (string) Title of the menu item. Required.
+	 *      'parent'     => (string) Parent menu item ID.
+	 *      'capability' => (string) Capability to view this menu item.
+	 *      'url'        => (string) URL or callback to be used. Required.
+	 *      'order'      => (int) Menu item order.
+	 *      'migrate'    => (bool) Whether or not to hide the item in the wp admin menu.
+	 *      'menuId'     => (string) The ID of the menu to add the item to.
+	 *    ).
+	 */
+	public static function add_item( $args ) {
+		if ( ! isset( $args['id'] ) || isset( self::$menu_items[ $args['id'] ] ) ) {
+			return;
+		}
+
+		$defaults           = array(
+			'id'           => '',
+			'title'        => '',
+			'parent'       => self::DEFAULT_PARENT,
+			'capability'   => 'manage_woocommerce',
+			'url'          => '',
+			'order'        => 100,
+			'migrate'      => true,
+			'menuId'       => 'primary',
+			'is_top_level' => false,
+		);
+		$menu_item          = wp_parse_args( $args, $defaults );
+		$menu_item['title'] = wp_strip_all_tags( wp_specialchars_decode( $menu_item['title'] ) );
+		$menu_item['url']   = self::get_callback_url( $menu_item['url'] );
+
+		if ( true === $menu_item['is_top_level'] ) {
+			$menu_item['parent'] = 'woocommerce';
+		} else {
+			$menu_item['parent'] = 'woocommerce' === $menu_item['parent'] ? self::DEFAULT_PARENT : $menu_item['parent'];
+		}
+
+		self::$menu_items[ $menu_item['id'] ] = $menu_item;
+
+		if ( isset( $args['url'] ) ) {
+			self::$callbacks[ $args['url'] ] = $menu_item['migrate'];
+		}
+	}
+
+	/**
+	 * Adds a post type as a menu category.
+	 *
+	 * @param string $post_type Post type.
+	 * @param array  $args Array of menu item args.
+	 */
+	public static function add_post_type_category( $post_type, $args = array() ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $post_type_object ) {
+			return;
+		}
+
+		self::add_category(
+			array_merge(
+				array(
+					'title'        => esc_attr( $post_type_object->labels->menu_name ),
+					'capability'   => $post_type_object->cap->edit_posts,
+					'id'           => $post_type,
+					'is_top_level' => true,
+				),
+				$args
+			)
+		);
+		self::add_item(
+			array(
+				'parent'     => $post_type,
+				'title'      => esc_attr( $post_type_object->labels->all_items ),
+				'capability' => $post_type_object->cap->edit_posts,
+				'id'         => "{$post_type}-all-items",
+				'url'        => "edit.php?post_type={$post_type}",
+			)
+		);
+		self::add_item(
+			array(
+				'parent'     => $post_type,
+				'title'      => esc_attr( $post_type_object->labels->add_new ),
+				'capability' => $post_type_object->cap->create_posts,
+				'id'         => "{$post_type}-add-new",
+				'url'        => "post-new.php?post_type={$post_type}",
+			)
+		);
+	}
+
+	/**
+	 * Hides all WP admin menus items and adds screen IDs to check for new items.
+	 *
+	 * @param array $menu Menu items.
+	 * @return array
+	 */
+	public static function migrate_menu_items( $menu ) {
+		global $submenu;
+
+		foreach ( $menu as $key => $menu_item ) {
+			if (
+				isset( self::$callbacks[ $menu_item[ self::CALLBACK ] ] ) &&
+				self::$callbacks[ $menu_item[ self::CALLBACK ] ]
+			) {
+				$menu[ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+			}
+		}
+
+		foreach ( $submenu as $parent_key => $parent ) {
+			foreach ( $parent as $key => $menu_item ) {
+				if (
+					isset( self::$callbacks[ $menu_item[ self::CALLBACK ] ] ) &&
+					self::$callbacks[ $menu_item[ self::CALLBACK ] ]
+				) {
+					// Disable phpcs since we need to override submenu classes.
+					// Note that `phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited` does not work to disable this check.
+					// phpcs:disable
+					if ( ! isset( $menu_item[ self::SLUG ] ) ) {
+						$submenu[ $parent_key ][ $key ][] = '';
+					}
+					if ( ! isset( $menu_item[ self::CSS_CLASSES ] ) ) {
+						$submenu[ $parent_key ][ $key ][] .= ' hide-if-js';
+					} else {
+						$submenu[ $parent_key ][ $key ][ self::CSS_CLASSES ] .= ' hide-if-js';
+					}
+					// phps:enable
+				}
+			}
+		}
+
+		foreach ( array_keys( self::$callbacks ) as $callback ) {
+			Screen::add_screen( $callback );
+		}
+
+		return $menu;
+	}
+
+	/**
+	 * Get registered menu items.
+	 *
+	 * @return array
+	 */
+	public static function get_items() {
+		return apply_filters( 'woocommerce_navigation_menu_items', self::$menu_items );
+	}
+
+	/**
+	 * Get registered callbacks.
+	 *
+	 * @return array
+	 */
+	public static function get_callbacks() {
+		return apply_filters( 'woocommerce_navigation_callbacks', self::$callbacks );
+	}
+
+	/**
+	 * Gets the menu item data for use in the client.
+	 *
+	 * @return array
+	 */
+	public static function get_prepared_menu_item_data() {
+		$menu_items = self::get_items();
+		foreach ( $menu_items as $index => $menu_item ) {
+			if ( $menu_item[ 'capability' ] && ! current_user_can( $menu_item[ 'capability' ] ) ) {
+				unset( $menu_items[ $index ] );
+			}
+		}
+
+		// Sort the menu items.
+		$order = array_column( $menu_items, 'order' );
+		array_multisort( $order, SORT_ASC, $menu_items );
+
+		return array_values( $menu_items );
+	}
+
+	/**
+	 * Add the menu to the page output.
+	 *
+	 * @param array $menu Menu items.
+	 * @return array
+	 */
+	public function enqueue_data( $menu ) {
+		global $submenu, $parent_file, $typenow, $self;
+
+		$data = array(
+			'adminUrl'     => get_admin_url(),
+			'dashboardUrl' => get_dashboard_url(),
+			'menuItems'    => self::get_prepared_menu_item_data(),
+			'siteTitle'    => get_bloginfo( 'name' ),
+			'siteUrl'      => get_site_url(),
+		);
+
+		wp_add_inline_script( 'woocommerce-navigation', 'window.wcNavigation = ' . wp_json_encode( $data ), 'before' );
+
+		return $menu;
+	}
+}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -161,7 +161,7 @@ class Menu {
 			'parent'          => self::DEFAULT_PARENT,
 			'backButtonLabel' => __(
 				'WooCommerce Home',
-				'woocommerce-navigation'
+				'woocommerce-admin'
 			),
 			'is_top_level'    => false,
 		);

--- a/src/Features/Navigation/Navigation.php
+++ b/src/Features/Navigation/Navigation.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+
 /**
  * Contains logic for the Navigation
  */
@@ -15,6 +17,7 @@ class Navigation {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
+		error_log( Screen::is_woocommerce_page() );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
 	}

--- a/src/Features/Navigation/Navigation.php
+++ b/src/Features/Navigation/Navigation.php
@@ -7,7 +7,10 @@
 
 namespace Automattic\WooCommerce\Admin\Features;
 
+use Automattic\WooCommerce\Admin\Loader;
 use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
+use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+use Automattic\WooCommerce\Admin\Features\Navigation\CoreMenu;
 
 /**
  * Contains logic for the Navigation
@@ -17,9 +20,16 @@ class Navigation {
 	 * Hook into WooCommerce.
 	 */
 	public function __construct() {
-		error_log( Screen::is_woocommerce_page() );
 		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_filter( 'woocommerce_admin_features', array( $this, 'maybe_remove_nav_feature' ), 0 );
+
+		if ( Loader::is_feature_enabled( 'navigation' ) ) {
+			add_action( 'in_admin_header', array( __CLASS__, 'embed_navigation' ) );
+
+			Menu::instance()->init();
+			CoreMenu::instance()->init();
+			Screen::instance()->init();
+		}
 	}
 
 		/**
@@ -44,5 +54,19 @@ class Navigation {
 		$options[] = 'woocommerce_navigation_enabled';
 
 		return $options;
+	}
+
+	/**
+	 * Set up a div for the navigation.
+	 * The initial contents here are meant as a place loader for when the PHP page initialy loads.
+	 */
+	public static function embed_navigation() {
+		if ( ! Screen::is_woocommerce_page() ) {
+			return;
+		}
+
+		?>
+		<div id="woocommerce-embedded-navigation"></div>
+		<?php
 	}
 }

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * WooCommerce Navigation Screen
+ *
+ * @package Woocommerce Navigation
+ */
+
+namespace Automattic\WooCommerce\Admin\Features\Navigation;
+
+use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
+
+/**
+ * Contains logic for the WooCommerce Navigation menu.
+ */
+class Screen {
+	/**
+	 * Class instance.
+	 *
+	 * @var Menu instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Screen IDs of registered pages.
+	 *
+	 * @var array
+	 */
+	protected static $screen_ids = array();
+
+	/**
+	 * Registered post types.
+	 *
+	 * @var array
+	 */
+	protected static $post_types = array();
+
+	/**
+	 * Get class instance.
+	 */
+	final public static function instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Init.
+	 */
+	public function init() {
+		add_filter( 'admin_body_class', array( $this, 'add_body_class' ) );
+	}
+
+	/**
+	 * Returns an array of filtered screen ids.
+	 */
+	public static function get_screen_ids() {
+		return apply_filters( 'woocommerce_navigation_screen_ids', self::$screen_ids );
+	}
+
+	/**
+	 * Returns an array of registered post types.
+	 */
+	public static function get_post_types() {
+		return apply_filters( 'woocommerce_navigation_post_types', self::$post_types );
+	}
+
+	/**
+	 * Check if we're on a WooCommerce page
+	 *
+	 * @return bool
+	 */
+	public static function is_woocommerce_page() {
+		global $pagenow;
+
+		// Get post type if on a post screen.
+		$post_type = '';
+		if ( in_array( $pagenow, array( 'edit.php', 'post.php', 'post-new.php' ), true ) ) {
+			if ( isset( $_GET['post'] ) ) { // phpcs:ignore CSRF ok.
+				$post_type = get_post_type( (int) $_GET['post'] ); // phpcs:ignore CSRF ok.
+			} elseif ( isset( $_GET['post_type'] ) ) { // phpcs:ignore CSRF ok.
+				$post_type = sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // phpcs:ignore CSRF ok.
+			}
+		}
+		$post_types = self::get_post_types();
+
+		// Get current screen ID.
+		$current_screen    = get_current_screen();
+		$screen_ids        = self::get_screen_ids();
+		$current_screen_id = $current_screen ? $current_screen->id : null;
+
+		if (
+			in_array( $post_type, $post_types, true ) ||
+			in_array( $current_screen_id, $screen_ids, true )
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Add navigation classes to body.
+	 *
+	 * @param string $classes Classes.
+	 * @return string
+	 */
+	public function add_body_class( $classes ) {
+		if ( self::is_woocommerce_page() ) {
+			$classes .= ' has-woocommerce-navigation';
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Adds a screen ID to the list of screens that use the navigtion.
+	 * Finds the parent if none is given to grab the correct screen ID.
+	 *
+	 * @param string      $callback Callback or URL for page.
+	 * @param string|null $parent   Parent screen ID.
+	 */
+	public static function add_screen( $callback, $parent = null ) {
+		global $submenu;
+
+		if ( ! $parent ) {
+			$parent = Menu::get_parent_key( $callback );
+		}
+
+		$screen_id = get_plugin_page_hookname( $callback, $parent );
+
+		// This screen has already been added.
+		if ( in_array( $screen_id, self::$screen_ids, true ) ) {
+			return;
+		}
+
+		self::$screen_ids[] = get_plugin_page_hookname( $callback, $parent );
+	}
+
+	/**
+	 * Register post type for use in WooCommerce Navigation screens.
+	 *
+	 * @param string $post_type Post type to add.
+	 * @param string $parent_id Parent menu item ID.
+	 */
+	public static function register_post_type( $post_type, $parent_id ) {
+		self::$post_types[] = $post_type;
+
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $post_type_object || ! $post_type_object->show_in_menu || ! $parent_id ) {
+			return;
+		}
+
+		Menu::add_item(
+			array(
+				'parent'     => $parent_id,
+				'title'      => esc_attr( $post_type_object->labels->menu_name ),
+				'capability' => $post_type_object->cap->edit_posts,
+				'id'         => $post_type,
+				'url'        => "edit.php?post_type={$post_type}",
+			)
+		);
+	}
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,6 +165,10 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
+		if ( 'navigation' === $feature && 'yes' !== get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
+			return false;
+		}
+
 		$features = self::get_features();
 		return in_array( $feature, $features, true );
 	}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -165,10 +165,6 @@ class Loader {
 	 * @return bool Returns true if the feature is enabled.
 	 */
 	public static function is_feature_enabled( $feature ) {
-		if ( 'navigation' === $feature && 'yes' !== get_option( 'woocommerce_navigation_enabled', 'no' ) ) {
-			return false;
-		}
-
 		$features = self::get_features();
 		return in_array( $feature, $features, true );
 	}


### PR DESCRIPTION
Depends on https://github.com/woocommerce/woocommerce-admin/pull/5292

This is pretty much a wholesale copy/paste from WC Navigation of `Menu`, `CoreMenu`, and `Screen`. I've also added a conditional on `Loader::is_feature_enabled( 'navigation' )` in `Navigation.php` to ensure Navigation doesn't work unless the feature flag is on AND the option is set to "yes".

### Detailed test instructions:

Since the JS isn't available, we can only test classes and root elements.

1. Run `composer install`
1. Set the `woocommerce_navigation_enabled` option to "yes".
2. Visit any WooCommerce page.
3. See the root element present for Navigation to hook onto: `document.getElementById('woocommerce-embedded-navigation')`.
4. See the proper class applied to the body: `document.body.classList.contains('has-woocommerce-navigation');`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

none: unreleased changes