### PR TITLE
Fix note class name.

### DIFF
--- a/src/Notes/ConfirmTaxSettings.php
+++ b/src/Notes/ConfirmTaxSettings.php
@@ -30,7 +30,7 @@ class Confirm_Tax_Settings {
 	 * @return Note
 	 */
 	public static function get_note() {
-		$note = new Note();
+		$note = new WC_Admin_Note();
 
 		$note->set_title( __( 'Confirm tax settings', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Automated tax calculations are enabled on your store through WooCommerce Shipping & Tax. Learn more about automated taxes <a href="https://docs.woocommerce.com/document/woocommerce-services/#section-12">here</a>.', 'woocommerce-admin' ) );


### PR DESCRIPTION
Missed in https://github.com/woocommerce/woocommerce-admin/pull/5314.
