### PR TITLE
Fix/5318 shipping default exclusions

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -98,7 +98,7 @@ export function getAllTasks( {
 		shippingZonesCount > 0 &&
 		isJetpackConnected &&
 		activePlugins.includes( 'woocommerce-services' ) &&
-		! [ 'AU', 'CA', 'UK' ].includes( countryCode );
+		! [ 'AU', 'CA', 'GB' ].includes( countryCode );
 
 	const tasks = [
 		{

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -39,6 +39,14 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
+		$country_code = WC()->countries->get_base_country();
+
+		// Corrolary to the logic in /client/task-list/tasks.js.
+		// Skip for countries we don't recommend WCS for.
+		if ( in_array( $country_code, array( 'AU', 'CA', 'GB' ), true ) ) {
+			return;
+		}
+
 		self::set_up_free_local_shipping();
 		WC_Admin_Notes_Review_Shipping_Settings::possibly_add_note();
 		wc_admin_record_tracks_event( 'shipping_automatically_set_up' );
@@ -78,18 +86,13 @@ class OnboardingSetUpShipping {
 	 * Set up free local shipping.
 	 */
 	public static function set_up_free_local_shipping() {
-		$default_country = apply_filters(
-			'woocommerce_get_base_location',
-			get_option( 'woocommerce_default_country' )
-		);
+		$country_code = WC()->countries->get_base_country();
 
-		if ( ! $default_country ) {
+		if ( ! $country_code ) {
 			return;
 		}
 
-		$country_code = explode( ':', $default_country )[0];
-		$zone         = new \WC_Shipping_Zone();
-
+		$zone = new \WC_Shipping_Zone();
 		$zone->add_location( $country_code, 'country' );
 
 		$countries_service = new \WC_Countries();


### PR DESCRIPTION
Fixes #5318 

Apply the shipping country exclusions to the post-OBW setup and fix the UK's country code (it's GB).

### Detailed test instructions:

- Create a new store with wcadmin 1.6 installed
- Complete store details with UK as location, including the JP and WCS connection step
- See the shipping task marked as incomplete
- Note the lack of a shipping inbox notice

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
