### PR TITLE
Fix shipping task smart defaults

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -94,12 +94,6 @@ export function getAllTasks( {
 		purchaseAndInstallText = sprintf( purchaseAndInstallFormat, itemName );
 	}
 
-	const shippingCompleted =
-		shippingZonesCount > 0 &&
-		isJetpackConnected &&
-		activePlugins.includes( 'woocommerce-services' ) &&
-		! [ 'AU', 'NZ', 'UK' ].includes( countryCode );
-
 	const tasks = [
 		{
 			key: 'store_details',
@@ -224,7 +218,7 @@ export function getAllTasks( {
 				} );
 				updateQueryString( { task: 'shipping' } );
 			},
-			completed: shippingCompleted,
+			completed: shippingZonesCount > 0,
 			visible:
 				( productTypes && productTypes.includes( 'physical' ) ) ||
 				hasPhysicalProducts,

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -25,6 +25,14 @@ class OnboardingSetUpShipping {
 				'on_onboarding_profile_completed',
 			)
 		);
+
+		add_action(
+			'jetpack_authorize_ending_authorized',
+			array(
+				__CLASS__,
+				'on_onboarding_profile_completed',
+			)
+		);
 	}
 
 	/**
@@ -36,6 +44,31 @@ class OnboardingSetUpShipping {
 		}
 
 		if ( self::has_existing_shipping_zones() ) {
+			return;
+		}
+
+		$country_code = WC()->countries->get_base_country();
+
+		// Corrolary to the logic in /client/task-list/tasks.js.
+		// Skip for countries we don't recommend WCS for.
+		if ( in_array( $country_code, array( 'AU', 'CA', 'GB' ), true ) ) {
+			return;
+		}
+
+		if (
+			! class_exists( '\Jetpack_Data' ) ||
+			! class_exists( '\WC_Connect_Loader' ) ||
+			! class_exists( '\WC_Connect_Options' )
+		) {
+			return;
+		}
+
+		$user_token        = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+		$jetpack_connected = isset( $user_token->external_user_id );
+		$wcs_version       = \WC_Connect_Loader::get_wcs_version();
+		$wcs_tos_accepted  = \WC_Connect_Options::get_option( 'tos_accepted' );
+
+		if ( ! $jetpack_connected || ! $wcs_version || ! $wcs_tos_accepted ) {
 			return;
 		}
 


### PR DESCRIPTION
Check for connected JP+WCS and non-ShipStation country for shipping defaults.

Fixes #5318. (Different approach from https://github.com/woocommerce/woocommerce-admin/pull/5319).

This PR checks the prerequisites for smart shipping defaults on the server side rather than on the display-only completion indicator on the TaskList component.

### Detailed test instructions:

- Use JN to set up a new site
- Complete profiler with a US address, opt in to JP+WCS
- Connect JP
- Verify shipping task is complete
- Use JN to set up a new site
- Complete profiler with a UK address, opt in to JP+WCS
- Connect JP
- Verify shipping task is NOT complete


<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
