### PR TITLE
Fix wrong filter arguments & duplicate schema properties

### DIFF
--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -438,7 +438,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		 */
 		return apply_filters(
 			'woocommerce_report_downloads_prepare_export_item',
-			$export_item,
+			$export_columns,
 			$item
 		);
 	}

--- a/src/API/Reports/Downloads/Controller.php
+++ b/src/API/Reports/Downloads/Controller.php
@@ -204,12 +204,6 @@ class Controller extends ReportsController implements ExportableInterface {
 					'context'     => array( 'view', 'edit' ),
 					'description' => __( 'File URL.', 'woocommerce-admin' ),
 				),
-				'product_id'   => array(
-					'type'        => 'integer',
-					'readonly'    => true,
-					'context'     => array( 'view', 'edit' ),
-					'description' => __( 'Product ID.', 'woocommerce-admin' ),
-				),
 				'order_id'     => array(
 					'type'        => 'integer',
 					'readonly'    => true,


### PR DESCRIPTION
Fixes #

There were a couple of issues in Download Controller

- `woocommerce_report_downloads_prepare_export_item` filter was passing an unknown property instead of `$export_columns` 
- Same class was containing double `product_id` property in schema  