### PR TITLE
Add the bundle size check workflow.

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,18 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+    build:
+        name: Check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 1
+            - uses: preactjs/compressed-size-action@v2.0.1
+              with:
+                  repo-token: '${{ secrets.GITHUB_TOKEN }}'
+                  pattern: '{dist/**/*.min.{js,css},packages/**/build/**/*.{js,css}}'
+                  exclude: '{*.map, node_modules}'
+                  minimum-change-threshold: 100


### PR DESCRIPTION
This adds the bundle size check workflow to all PRs. It will report changes but it won't block PRs. The hope is that this informational feedback will help inform reviewers.

This is branched from a branch that makes some fixes to the package-lock to allow the PR to pass. The reason for this is that the action runs `npm ci` which fails right now due to some misconfiguration of dependencies.