### PR TITLE
Task List: Match Stripe settings to mode of provided keys

### DIFF
--- a/client/task-list/tasks/payments/bacs.js
+++ b/client/task-list/tasks/payments/bacs.js
@@ -57,7 +57,7 @@ class Bacs extends Component {
 			createNotice(
 				'error',
 				__(
-					'There was a problem saving your payment setings',
+					'There was a problem saving your payment settings',
 					'woocommerce-admin'
 				)
 			);

--- a/client/task-list/tasks/payments/eway.js
+++ b/client/task-list/tasks/payments/eway.js
@@ -59,7 +59,7 @@ class EWay extends Component {
 			createNotice(
 				'error',
 				__(
-					'There was a problem saving your payment setings',
+					'There was a problem saving your payment settings',
 					'woocommerce-admin'
 				)
 			);

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -170,6 +170,15 @@ export function getPaymentMethods( {
 		} );
 	}
 
+	// Whether publishable and secret keys are filled for given mode.
+	const isStripeConfigured =
+		options.woocommerce_stripe_settings &&
+		( options.woocommerce_stripe_settings.testmode === 'no'
+			? options.woocommerce_stripe_settings.publishable_key &&
+			  options.woocommerce_stripe_settings.secret_key
+			: options.woocommerce_stripe_settings.test_publishable_key &&
+			  options.woocommerce_stripe_settings.test_secret_key );
+
 	methods.push(
 		{
 			key: 'stripe',
@@ -192,16 +201,7 @@ export function getPaymentMethods( {
 				! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
-			// Whether publishable and secret keys are filled for given mode.
-			isConfigured:
-				options.woocommerce_stripe_settings &&
-				( ( options.woocommerce_stripe_settings.testmode === 'no' &&
-					options.woocommerce_stripe_settings.publishable_key &&
-					options.woocommerce_stripe_settings.secret_key ) ||
-					( options.woocommerce_stripe_settings.testmode === 'yes' &&
-						options.woocommerce_stripe_settings
-							.test_publishable_key &&
-						options.woocommerce_stripe_settings.test_secret_key ) ),
+			isConfigured: isStripeConfigured,
 			isEnabled:
 				options.woocommerce_stripe_settings &&
 				options.woocommerce_stripe_settings.enabled === 'yes',

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -192,10 +192,16 @@ export function getPaymentMethods( {
 				! hasCbdIndustry,
 			plugins: [ 'woocommerce-gateway-stripe' ],
 			container: <Stripe />,
+			// Whether publishable and secret keys are filled for given mode.
 			isConfigured:
 				options.woocommerce_stripe_settings &&
-				options.woocommerce_stripe_settings.publishable_key &&
-				options.woocommerce_stripe_settings.secret_key,
+				( ( options.woocommerce_stripe_settings.testmode === 'no' &&
+					options.woocommerce_stripe_settings.publishable_key &&
+					options.woocommerce_stripe_settings.secret_key ) ||
+					( options.woocommerce_stripe_settings.testmode === 'yes' &&
+						options.woocommerce_stripe_settings
+							.test_publishable_key &&
+						options.woocommerce_stripe_settings.test_secret_key ) ),
 			isEnabled:
 				options.woocommerce_stripe_settings &&
 				options.woocommerce_stripe_settings.enabled === 'yes',

--- a/client/task-list/tasks/payments/payfast.js
+++ b/client/task-list/tasks/payments/payfast.js
@@ -71,7 +71,7 @@ class PayFast extends Component {
 			createNotice(
 				'error',
 				__(
-					'There was a problem saving your payment setings',
+					'There was a problem saving your payment settings',
 					'woocommerce-admin'
 				)
 			);

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -188,6 +188,14 @@ class Stripe extends Component {
 				'Please enter a valid secret key. Valid keys start with "sk_live", "sk_test", "rk_live or "rk_test".',
 				'woocommerce-admin'
 			);
+		} else if (
+			values.secret_key.slice( 3, 7 ) !==
+			values.publishable_key.slice( 3, 7 )
+		) {
+			errors.secret_key = __(
+				'Please enter a secret key in the same mode as the publishable key.',
+				'woocommerce-admin'
+			);
 		}
 
 		return errors;

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -154,7 +154,7 @@ class Stripe extends Component {
 			createNotice(
 				'error',
 				__(
-					'There was a problem saving your payment setings',
+					'There was a problem saving your payment settings',
 					'woocommerce-admin'
 				)
 			);

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -135,12 +135,15 @@ class Stripe extends Component {
 	async updateSettings( values ) {
 		const { updateOptions, stripeSettings, createNotice } = this.props;
 
+		const prefix = values.publishable_key.match( /^pk_live_/ )
+			? ''
+			: 'test_';
 		const update = await updateOptions( {
 			woocommerce_stripe_settings: {
 				...stripeSettings,
-				publishable_key: values.publishable_key,
-				secret_key: values.secret_key,
-				testmode: 'no',
+				[ prefix + 'publishable_key' ]: values.publishable_key,
+				[ prefix + 'secret_key' ]: values.secret_key,
+				testmode: prefix === 'test_' ? 'yes' : 'no',
 				enabled: 'yes',
 			},
 		} );

--- a/client/task-list/tasks/payments/stripe.js
+++ b/client/task-list/tasks/payments/stripe.js
@@ -176,7 +176,7 @@ class Stripe extends Component {
 			null
 		) {
 			errors.publishable_key = __(
-				'Please enter a valid publishable key. Valid keys start with "pk_live" or "pk_test".',
+				'Please enter a valid publishable key (starting with "pk_").',
 				'woocommerce-admin'
 			);
 		}
@@ -185,7 +185,7 @@ class Stripe extends Component {
 			null
 		) {
 			errors.secret_key = __(
-				'Please enter a valid secret key. Valid keys start with "sk_live", "sk_test", "rk_live or "rk_test".',
+				'Please enter a valid secret key (starting with "sk_" or "rk_").',
 				'woocommerce-admin'
 			);
 		} else if (


### PR DESCRIPTION
Addresses https://github.com/woocommerce/woocommerce-admin/pull/5201#issuecomment-704931521, primarily by configuring _test_ keys & mode when those are provided via the Stripe task.

### Detailed test instructions:

- Go to Task List » Payments » Stripe
- Verify that mismatched mode (e.g. `pk_live_****` with `sk_test_****`) results in a validation error
- Submit test keys
- Go to WooCommerce » Settings » Payments » Stripe, and verify that test mode and test keys are set

(Can test live mode case as well, and verify that test mode is not set and live keys are set.)