### PR TITLE
Task List: Show Stripe task in Brazil

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -313,7 +313,7 @@ class OnboardingTasks {
 			'AT',
 			'BE',
 			'BG',
-			// 'BR', // Preview, requires invite.
+			'BR',
 			'CA',
 			'CY',
 			'CZ',
@@ -324,7 +324,7 @@ class OnboardingTasks {
 			'DE',
 			'GR',
 			'HK',
-			'IN', // Preview.
+			'IN',
 			'IE',
 			'IT',
 			'JP',


### PR DESCRIPTION
Addresses country inclusion from https://github.com/woocommerce/woocommerce-admin/issues/5209

Adds Brazil to the set of countries that see the Stripe task, as the country is now out of preview and fully available.

### Detailed test instructions:

- Set store country to Brazil
- Verify that Stripe appears in Task List » Set up payments