### PR TITLE
Add CES feature toggle

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -5,6 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
+		"customer-effort-score": false,
 		"devdocs": false,
 		"marketing": true,
 		"onboarding": true,

--- a/config/development.json
+++ b/config/development.json
@@ -5,6 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
+		"customer-effort-score": true,
 		"devdocs": true,
 		"marketing": true,
 		"onboarding": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -5,6 +5,7 @@
 		"analytics-dashboard": true,
 		"analytics-dashboard/customizable": true,
 		"coupons": true,
+		"customer-effort-score": false,
 		"devdocs": false,
 		"marketing": true,
 		"onboarding": true,

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -9,8 +9,6 @@ namespace Automattic\WooCommerce\Admin\Features;
 
 defined( 'ABSPATH' ) || exit;
 
-use \Automattic\WooCommerce\Admin\Loader;
-
 /**
  * Triggers customer effort score on several different actions.
  */
@@ -37,10 +35,6 @@ class CustomerEffortScoreTracks {
 	 * Constructor. Sets up filters to hook into WooCommerce.
 	 */
 	public function __construct() {
-		if ( ! Loader::is_feature_enabled( 'customer-effort-score' ) ) {
-			return;
-		}
-
 		add_filter( 'add_meta_boxes_product', array( $this, 'add_meta_boxes_product' ) );
 	}
 

--- a/src/Features/CustomerEffortScoreTracks.php
+++ b/src/Features/CustomerEffortScoreTracks.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Admin\Features;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Admin\Loader;
+
 /**
  * Triggers customer effort score on several different actions.
  */
@@ -35,6 +37,10 @@ class CustomerEffortScoreTracks {
 	 * Constructor. Sets up filters to hook into WooCommerce.
 	 */
 	public function __construct() {
+		if ( ! Loader::is_feature_enabled( 'customer-effort-score' ) ) {
+			return;
+		}
+
 		add_filter( 'add_meta_boxes_product', array( $this, 'add_meta_boxes_product' ) );
 	}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -96,7 +96,9 @@ class Loader {
 		// Combine JSON translation files (from chunks) when language packs are updated.
 		add_action( 'upgrader_process_complete', array( __CLASS__, 'combine_translation_chunk_files' ), 10, 2 );
 
-		CustomerEffortScoreTracks::get_instance();
+		if ( ! self::is_feature_enabled( 'customer-effort-score' ) ) {
+			CustomerEffortScoreTracks::get_instance();
+		}
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -96,7 +96,7 @@ class Loader {
 		// Combine JSON translation files (from chunks) when language packs are updated.
 		add_action( 'upgrader_process_complete', array( __CLASS__, 'combine_translation_chunk_files' ), 10, 2 );
 
-		if ( ! self::is_feature_enabled( 'customer-effort-score' ) ) {
+		if ( self::is_feature_enabled( 'customer-effort-score' ) ) {
 			CustomerEffortScoreTracks::get_instance();
 		}
 	}


### PR DESCRIPTION
This adds a feature toggle so that the CES feature is only active in development.

This is so we can get the spiked feature into `main` and stop working against the spike branch.

### Detailed test instructions:

- Check out this branch
- `npm install && npm start` to apply the changes to the feature configuration
- Add a new product. The CES modal should be displayed, because you're in development and the feature is enabled in development.
- Add another product. The CES modal should not be displayed.

