### PR TITLE
Navigation: Declare script dependencies

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -313,7 +313,7 @@ class Loader {
 		wp_register_script(
 			'wc-navigation',
 			self::get_url( 'navigation/index', 'js' ),
-			array( 'wp-url', 'wp-hooks' ),
+			array( 'wp-url', 'wp-hooks', 'wp-components' ),
 			$js_file_version,
 			true
 		);
@@ -403,6 +403,7 @@ class Loader {
 				'wp-date',
 				'wp-plugins',
 				'wc-tracks',
+				'wc-navigation',
 			),
 			$js_file_version,
 			true


### PR DESCRIPTION
When a 3rd party declares a dependency on `wc-navigation` wc-admin breaks. This is because plain luck has it that loading order works, but an outside influence can change that.

Note that the new Woo flavored Dependency extraction plugin needs to be used here to avoid such problems. Until then, here is a piecemeal fix. 

https://github.com/woocommerce/woocommerce-admin/tree/fix/nav-script-deps/packages/dependency-extraction-webpack-plugin

### Detailed test instructions:

1. Check that wc-admin depends on its own navigation script and that navigation depends on `wp-components` to review code changes.
2. Bonus: Add a plugin that depends on `@woocommerce/navigation`, for example: https://github.com/psealock/examples. See that including this plugin on `main` results in wc-admin breaking.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

none: unreleased change
