### PR TITLE
Display a "read blog" message

### DIFF
--- a/client/marketing/components/knowledge-base/ReadBlogMessage.js
+++ b/client/marketing/components/knowledge-base/ReadBlogMessage.js
@@ -1,36 +1,26 @@
 /**
  * External dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
+import { Link } from '@woocommerce/components';
+import interpolateComponents from 'interpolate-components';
 
 const ReadBlogMessage = () => {
-	const message1 = _x(
-		'Read ',
-		'Read <a href="https://woocommerce.com/blog/marketing/coupons/">the WooCommerce blog</a> for more tips on marketing your store',
-		'woocommerce-admin'
-	);
-
-	const message2 = _x(
-		'the WooCommerce blog',
-		'Read <a href="https://woocommerce.com/blog/marketing/coupons/">the WooCommerce blog</a> for more tips on marketing your store',
-		'woocommerce-admin'
-	);
-
-	const message3 = _x(
-		' for more tips on marketing your store',
-		'Read <a href="https://woocommerce.com/blog/marketing/coupons/">the WooCommerce blog</a> for more tips on marketing your store',
-		'woocommerce-admin'
-	);
-
-	return (
-		<>
-			{ message1 }
-			<a href="https://woocommerce.com/blog/marketing/coupons/">
-				{ message2 }
-			</a>
-			{ message3 }
-		</>
-	);
+	return interpolateComponents( {
+		mixedString: __(
+			'Read {{link}}the WooCommerce blog{{/link}} for more tips on marketing your store',
+			'woocommerce-admin'
+		),
+		components: {
+			link: (
+				<Link
+					type="external"
+					href="https://woocommerce.com/blog/marketing/coupons/"
+					target="_blank"
+				/>
+			),
+		},
+	} );
 };
 
 export default ReadBlogMessage;

--- a/client/marketing/components/knowledge-base/ReadBlogMessage.js
+++ b/client/marketing/components/knowledge-base/ReadBlogMessage.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+const ReadBlogMessage = () => {
+	const message1 = _x(
+		'Read ',
+		'Read <a href="https://woocommerce.com/blog/marketing/coupons/">the WooCommerce blog</a> for more tips on marketing your store',
+		'woocommerce-admin'
+	);
+
+	const message2 = _x(
+		'the WooCommerce blog',
+		'Read <a href="https://woocommerce.com/blog/marketing/coupons/">the WooCommerce blog</a> for more tips on marketing your store',
+		'woocommerce-admin'
+	);
+
+	const message3 = _x(
+		' for more tips on marketing your store',
+		'Read <a href="https://woocommerce.com/blog/marketing/coupons/">the WooCommerce blog</a> for more tips on marketing your store',
+		'woocommerce-admin'
+	);
+
+	return (
+		<>
+			{ message1 }
+			<a href="https://woocommerce.com/blog/marketing/coupons/">
+				{ message2 }
+			</a>
+			{ message3 }
+		</>
+	);
+};
+
+export default ReadBlogMessage;

--- a/client/marketing/components/knowledge-base/index.js
+++ b/client/marketing/components/knowledge-base/index.js
@@ -17,6 +17,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import './style.scss';
 import { Slider } from '../../components';
 import { STORE_KEY } from '../../data/constants';
+import ReadBlogMessage from './ReadBlogMessage';
 
 const KnowledgeBase = ( {
 	posts,
@@ -110,26 +111,29 @@ const KnowledgeBase = ( {
 	};
 
 	const renderEmpty = () => {
-		const emptyTitle = __(
-			'There are no knowledge base posts.',
-			'woocommerce-admin'
-		);
+		const emptyTitle = __( 'No posts yet', 'woocommerce-admin' );
 
 		return (
-			<EmptyContent title={ emptyTitle } illustration="" actionLabel="" />
+			<EmptyContent
+				title={ emptyTitle }
+				message={ <ReadBlogMessage /> }
+				illustration=""
+				actionLabel=""
+			/>
 		);
 	};
 
 	const renderError = () => {
-		const emptyTitle = __(
-			'There was an error loading knowledge base posts. Please check again later.',
+		const errorTitle = __(
+			"Oops, our posts aren't loading right now",
 			'woocommerce-admin'
 		);
 
 		return (
 			<EmptyContent
-				title={ emptyTitle }
-				illustrationWidth={ 250 }
+				title={ errorTitle }
+				message={ <ReadBlogMessage /> }
+				illustration=""
 				actionLabel=""
 			/>
 		);

--- a/client/marketing/components/knowledge-base/test/index.js
+++ b/client/marketing/components/knowledge-base/test/index.js
@@ -109,10 +109,11 @@ describe( 'Posts and not loading', () => {
 	it( 'should not display the empty content component', () => {
 		const { queryByText } = knowledgeBaseWrapper;
 
+		expect( queryByText( 'No posts yet' ) ).toBeNull();
+		expect( queryByText( /Read /i ) ).toBeNull();
+		expect( queryByText( 'the WooCommerce blog' ) ).toBeNull();
 		expect(
-			queryByText(
-				'There was an error loading knowledge base posts. Please check again later.'
-			)
+			queryByText( / for more tips on marketing your store/i )
 		).toBeNull();
 	} );
 
@@ -160,10 +161,11 @@ describe( 'No posts and loading', () => {
 	it( 'should not display the empty content component', () => {
 		const { queryByText } = knowledgeBaseWrapper;
 
+		expect( queryByText( 'No posts yet' ) ).toBeNull();
+		expect( queryByText( /Read /i ) ).toBeNull();
+		expect( queryByText( 'the WooCommerce blog' ) ).toBeNull();
 		expect(
-			queryByText(
-				'There was an error loading knowledge base posts. Please check again later.'
-			)
+			queryByText( / for more tips on marketing your store/i )
 		).toBeNull();
 	} );
 
@@ -215,9 +217,12 @@ describe( 'Error and not loading', () => {
 		const { getByText } = knowledgeBaseWrapper;
 
 		expect(
-			getByText(
-				'There was an error loading knowledge base posts. Please check again later.'
-			)
+			getByText( "Oops, our posts aren't loading right now" )
+		).toBeInTheDocument();
+		expect( getByText( /Read /i ) ).toBeInTheDocument();
+		expect( getByText( 'the WooCommerce blog' ) ).toBeInTheDocument();
+		expect(
+			getByText( / for more tips on marketing your store/i )
 		).toBeInTheDocument();
 	} );
 
@@ -265,8 +270,11 @@ describe( 'No posts and not loading', () => {
 	it( 'should display the empty content component', () => {
 		const { getByText } = knowledgeBaseWrapper;
 
+		expect( getByText( 'No posts yet' ) ).toBeInTheDocument();
+		expect( getByText( /Read /i ) ).toBeInTheDocument();
+		expect( getByText( 'the WooCommerce blog' ) ).toBeInTheDocument();
 		expect(
-			getByText( 'There are no knowledge base posts.' )
+			getByText( / for more tips on marketing your store/i )
 		).toBeInTheDocument();
 	} );
 

--- a/packages/components/src/empty-content/index.js
+++ b/packages/components/src/empty-content/index.js
@@ -131,7 +131,7 @@ EmptyContent.propTypes = {
 	/**
 	 * An additional message to be displayed.
 	 */
-	message: PropTypes.string,
+	message: PropTypes.node,
 	/**
 	 * The url string of an image path for img src.
 	 */


### PR DESCRIPTION
Fixes #4581 

Display a "read blog" message when there is an error in getting blog posts or there is no blog posts.

### Accessibility

Not applicable.

### Screenshots

![Screenshot on 2020-10-22 at 00-53-24](https://user-images.githubusercontent.com/417342/96756890-47fcab80-1407-11eb-92da-45b7d51a445f.png)

![Screenshot on 2020-10-22 at 01-40-32](https://user-images.githubusercontent.com/417342/96757129-9d38bd00-1407-11eb-865b-7db69a86c3ca.png)

### Detailed test instructions:

- Open pafe https://ganwp1.test/wp-admin/admin.php?page=wc-admin&path=%2Fmarketing
- Scroll to the bottom to see the UI.
- To simulate network failure, you can change the [line 45 in `client/marketing/data/resolvers.js`](https://github.com/woocommerce/woocommerce-admin/blob/7df2ee2dfe76636a32ff657c2d0962ee4a180391/client/marketing/data/resolvers.js#L45) to be:

  ```js
  path: `${ API_NAMESPACE }/knowledge-base-THIS-WILL-NOT-WORK${ categoryParam }`,  // simulate network failure.
  ```

- To simulate empty blog post content, modify [line 58 in `client/marketing/data/reducer.js`](https://github.com/woocommerce/woocommerce-admin/blob/7df2ee2dfe76636a32ff657c2d0962ee4a180391/client/marketing/data/reducer.js#L58) to be:

  ```js
  [ action.data.category ]: [], // empty array.
  ```

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Enhancement: Display a "read blog" message when there is an error in getting blog posts or there is no blog posts.
