### PR TITLE
Redirect on WCPay inbox note install action on 1.6

### DIFF
--- a/client/header/activity-panel/panels/inbox/index.js
+++ b/client/header/activity-panel/panels/inbox/index.js
@@ -47,14 +47,6 @@ const renderNotes = ( { hasNotes, isBatchUpdating, lastRead, notes } ) => {
 	const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
 	return notesArray.map( ( note ) => {
-		if ( note.isUpdating ) {
-			return (
-				<InboxNotePlaceholder
-					className="banner message-is-unread"
-					key={ note.id }
-				/>
-			);
-		}
 		return (
 			<InboxNoteCard
 				key={ note.id }

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -37,7 +37,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 * Attach hooks.
 	 */
 	public function __construct() {
-		add_action( 'woocommerce_note_action_install-now', array( $this, 'install' ) );
+		add_action( 'init', array( $this, 'install_on_action' ) );
 		add_action( 'wc-admin-woocommerce-payments_add_note', array( $this, 'add_note' ) );
 	}
 
@@ -98,13 +98,22 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	public static function get_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Try the new way to get paid', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with WooCommerce Payments.', 'woocommerce-admin' ) );
+		$note->set_content(
+			__( 'Securely accept credit and debit cards on your site. Manage transactions without leaving your WordPress dashboard. Only with <strong>WooCommerce Payments</strong>.', 'woocommerce-admin' ) .
+			'<br><br>' .
+			sprintf(
+				/* translators: 1: opening link tag, 2: closing tag */
+				__( 'By clicking "Get started", you agree to our %1$sTerms of Service%2$s', 'woocommerce-admin' ),
+				'<a href="https://wordpress.com/tos/" target="_blank">',
+				'</a>'
+			)
+		);
 		$note->set_content_data( (object) array() );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action( 'learn-more', __( 'Learn more', 'woocommerce-admin' ), 'https://woocommerce.com/payments/', WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
-		$note->add_action( 'install-now', __( 'Install now', 'woocommerce-admin' ), false, WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+		$note->add_action( 'get-started', __( 'Get started', 'woocommerce-admin' ), wc_admin_url( '&action=setup-woocommerce-payments' ), WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED, true );
 
 		// Create the note as "actioned" if the plugin is already installed.
 		if ( self::is_installed() ) {
@@ -126,22 +135,58 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	}
 
 	/**
-	 * Install WooCommerce Payments when note is actioned.
+	 * Install and activate WooCommerce Payments.
 	 *
-	 * @param WC_Admin_Note $note Note being acted upon.
+	 * @return boolean Whether the plugin was successfully activated.
 	 */
-	public function install( $note ) {
-		if ( self::NOTE_NAME === $note->get_name() && current_user_can( 'install_plugins' ) ) {
-			$install_request = array( 'plugins' => self::PLUGIN_SLUG );
-			$installer       = new \Automattic\WooCommerce\Admin\API\Plugins();
-			$result          = $installer->install_plugins( $install_request );
-
-			if ( is_wp_error( $result ) ) {
-				return;
-			}
-
-			$activate_request = array( 'plugins' => self::PLUGIN_SLUG );
-			$installer->activate_plugins( $activate_request );
+	private function install_and_activate_wcpay() {
+		$install_request = array( 'plugins' => self::PLUGIN_SLUG );
+		$installer       = new \Automattic\WooCommerce\Admin\API\Plugins();
+		$result          = $installer->install_plugins( $install_request );
+		if ( is_wp_error( $result ) ) {
+			return false;
 		}
+
+		$activate_request = array( 'plugins' => self::PLUGIN_SLUG );
+		$result           = $installer->activate_plugins( $activate_request );
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Install & activate WooCommerce Payments plugin, and redirect to setup.
+	 */
+	public function install_on_action() {
+		// TODO: Need to validate this request more strictly since we're taking install actions directly?
+		/* phpcs:disable WordPress.Security.NonceVerification */
+		if (
+			! isset( $_GET['page'] ) ||
+			'wc-admin' !== $_GET['page'] ||
+			! isset( $_GET['action'] ) ||
+			'setup-woocommerce-payments' !== $_GET['action']
+		) {
+			return;
+		}
+		/* phpcs:enable */
+
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		$this->install_and_activate_wcpay();
+
+		// WooCommerce Payments is installed at this point, so link straight into the onboarding flow.
+		$connect_url = add_query_arg(
+			array(
+				'wcpay-connect' => '1',
+				'_wpnonce'      => wp_create_nonce( 'wcpay-connect' ),
+			),
+			admin_url()
+		);
+		wp_safe_redirect( $connect_url );
+		exit;
 	}
 }

--- a/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
+++ b/src/Notes/WC_Admin_Notes_WooCommerce_Payments.php
@@ -38,6 +38,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'install_on_action' ) );
+		add_action( 'woocommerce_note_action_install-now', array( $this, 'install_and_activate_wcpay' ) ); // Handle <1.6.3 note action.
 		add_action( 'wc-admin-woocommerce-payments_add_note', array( $this, 'add_note' ) );
 	}
 
@@ -139,7 +140,7 @@ class WC_Admin_Notes_WooCommerce_Payments {
 	 *
 	 * @return boolean Whether the plugin was successfully activated.
 	 */
-	private function install_and_activate_wcpay() {
+	public function install_and_activate_wcpay() {
 		$install_request = array( 'plugins' => self::PLUGIN_SLUG );
 		$installer       = new \Automattic\WooCommerce\Admin\API\Plugins();
 		$result          = $installer->install_plugins( $install_request );


### PR DESCRIPTION
Fixes #5412 **on 1.6.x** by redirecting into WooCommerce Payments setup flow from the relevant Inbox note action.

Addresses https://github.com/woocommerce/woocommerce-admin/pull/5413#issuecomment-714706612:
- https://github.com/woocommerce/woocommerce-admin/commit/bbba670fb221d12024c02e5a8301e23ff919a4a0 **applies the fix in https://github.com/woocommerce/woocommerce-admin/pull/5413** to the `release/1.6.3` base branch
  - Test using same instructions from that PR. ([This code snippet](https://cloudup.com/c7FvOGE0Tve) can be used to trigger the note.)
- https://github.com/woocommerce/woocommerce-admin/commit/3303b8c071922a08e3a30dd39468587758dc8c29 restores the handling for the note action from earlier versions
  - Can test by triggering the note to appear using an earlier version, upgrading to this version, and verifying that the behavior matches https://github.com/woocommerce/woocommerce-admin/issues/5412: WooCommerce Payments is activated but does not proceed to next step.

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

Fix: Proceed to next step after WCPay installation from Inbox note