### PR TITLE
Import @wordpress/base-styles/default-custom-properties to get --wp-admin-theme-color

### DIFF
--- a/client/stylesheets/abstracts/_variables.scss
+++ b/client/stylesheets/abstracts/_variables.scss
@@ -7,6 +7,7 @@
 @import 'node_modules/@wordpress/base-styles/breakpoints';
 @import 'node_modules/@wordpress/base-styles/animations';
 @import 'node_modules/@wordpress/base-styles/z-index';
+@import 'node_modules/@wordpress/base-styles/default-custom-properties';
 
 @include wordpress-admin-schemes;
 


### PR DESCRIPTION
This is to get the root admin scheme color, so that we can use `--wp-admin-theme-color` in CSS.

Fixes #5449. Specifically, see [this comment](https://github.com/woocommerce/woocommerce-admin/issues/5449#issuecomment-718051052) for the root cause of the issue.

### Accessibility

Not applicable.

### Screenshots

The icons should show up correctly like below:

![Screenshot on 2020-10-29 at 00-40-39](https://user-images.githubusercontent.com/417342/97467682-691d4900-197f-11eb-9eec-38264a6c66d1.png)

### Detailed test instructions:

- Make sure your WooCommerce-Admin package has a higher version number than the WooCommerce package.
- Checkout the code, run `npm install` and `npm run build`.
- Visit the coupon page: https://example.test/wp-admin/edit.php?post_type=shop_coupon
- Make sure the icons shows up okay when you hover over them, as shown in the screenshot above.
- Open up dev tools and make sure that you have this file loaded:

![Screenshot on 2020-10-29 at 00-45-59](https://user-images.githubusercontent.com/417342/97468420-3889df00-1980-11eb-95ae-3697d9030824.png)

- Open up the file in a new tab, use the search command with the keyword ":root" and make sure you see the following code exists in the file (https://example.test/wp-content/plugins/woocommerce-admin/dist/marketing-coupons/style.css?ver=1602685252): 

```css
:root{--wp-admin-theme-color:#007cba;--wp-admin-theme-color-darker-10:#006ba1;--wp-admin-theme-color-darker-20:#005a87}
```

### Changelog Note:

Fix: Import @wordpress/base-styles/default-custom-properties in CSS file, so that we can use --wp-admin-theme-color in CSS.
