### PR TITLE
Add width: 100% style to the container of the popover menu to expand …

### DIFF
--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -102,6 +102,10 @@
 	.components-popover:not(.is-mobile) .components-popover__content {
 		min-width: 180px;
 	}
+
+	.components-popover__content > div {
+		width: 100%;
+	}
 }
 
 .woocommerce-filters-advanced__fieldset {


### PR DESCRIPTION
Fixes #5191 

Added ```width: 100%``` style to the direct child of ```div.components-popover__content``` in order to give 100% width to the child ul element.
### Screenshots

**Before**
![before](https://user-images.githubusercontent.com/4723145/97937291-13f08700-1d33-11eb-8b9e-8415056055b5.jpg)

**After**
![after](https://user-images.githubusercontent.com/4723145/97937920-e60c4200-1d34-11eb-8db9-d8d5c3ba2a38.jpg)



### Detailed test instructions:

1. Navigate to Analytics -> Orders (or any other pages with Advanced Filters) 
2. Change **Show:** option to "Advanced Filters" from "All Orders"
3 Click "+ Add a Filter"
4. Hover over each menu item.
5. Note that the grey background (hover state) is fully extended to 100% width.