### PR TITLE
Wrong class name for querying Categories Report

### DIFF
--- a/src/API/Reports/Categories/Query.php
+++ b/src/API/Reports/Categories/Query.php
@@ -10,7 +10,7 @@
  *          'order'        => 'desc',
  *          'orderby'      => 'items_sold',
  *         );
- * $report = new \Automattic\WooCommerce\Admin\API\Reports\Query( $args );
+ * $report = new \Automattic\WooCommerce\Admin\API\Reports\Categories\Query( $args );
  * $mydata = $report->get_data();
  */
 


### PR DESCRIPTION
The inline docs example for querying Categories Report is missing `\Categories` in class name.