### PR TITLE
Update/5394 remove label printing mention for non us countries

### DIFF
--- a/src/Notes/ReviewShippingSettings.php
+++ b/src/Notes/ReviewShippingSettings.php
@@ -27,7 +27,7 @@ class ReviewShippingSettings {
 	public static function get_note() {
 		$note = new Note();
 
-		$note_lines = array(
+		$content_lines = array(
 			__(
 				"Based on the information that you provided we've configured some shipping rates and options for your store:<br/><br/>",
 				'woocommerce-admin'
@@ -37,13 +37,13 @@ class ReviewShippingSettings {
 		);
 
 		if ( 'US' === WC()->countries->get_base_country() ) {
-			array_push( $note_lines, __( 'Label printing: enabled', 'woocommerce-admin' ) );
+			array_push( $content_lines, __( 'Label printing: enabled', 'woocommerce-admin' ) );
 		}
 
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->set_title( __( 'Review your shipping settings', 'woocommerce-admin' ) );
-		$note->set_content( implode( '', $note_lines ) );
+		$note->set_content( implode( '', $content_lines ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 

--- a/src/Notes/ReviewShippingSettings.php
+++ b/src/Notes/ReviewShippingSettings.php
@@ -27,18 +27,23 @@ class ReviewShippingSettings {
 	public static function get_note() {
 		$note = new Note();
 
+		$note_lines = array(
+			__(
+				"Based on the information that you provided we've configured some shipping rates and options for your store:<br/><br/>",
+				'woocommerce-admin'
+			),
+			__( 'Domestic orders: free shipping<br/>', 'woocommerce-admin' ),
+			__( 'International orders: disabled<br/>', 'woocommerce-admin' ),
+		);
+
+		if ( 'US' === WC()->countries->get_base_country() ) {
+			array_push( $note_lines, __( 'Label printing: enabled', 'woocommerce-admin' ) );
+		}
+
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->set_title( __( 'Review your shipping settings', 'woocommerce-admin' ) );
-		$note->set_content(
-			__(
-				"Based on the information that you provided we've configured some shipping rates and options for your store:<br/><br/>
-				Domestic orders: free shipping<br/>
-				International orders: disabled<br/>
-				Label printing: enabled",
-				'woocommerce-admin'
-			)
-		);
+		$note->set_content( implode( '', $note_lines ) );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 

--- a/tests/features/class-onboarding-set-up-shipping.php
+++ b/tests/features/class-onboarding-set-up-shipping.php
@@ -6,6 +6,7 @@
  */
 
 use \Automattic\WooCommerce\Admin\Features\OnboardingSetUpShipping;
+use \Automattic\WooCommerce\Admin\Notes\ReviewShippingSettings;
 
 /**
  * Tests shipping set up during onboarding.
@@ -65,5 +66,37 @@ class WC_Tests_OnboardingShippingSetUp extends WC_Unit_Test_Case {
 	 */
 	public function get_empty_base_location() {
 		return null;
+	}
+
+	/**
+	 * Verify that the shipping note does not include label printing for non-us countries.
+	 * Related issue: https://github.com/woocommerce/woocommerce-admin/issues/5394.
+	 */
+	public function test_shipping_note_does_not_include_label_printing_for_non_us_countries() {
+		// Given AU:QLD as the default country.
+		update_option( 'woocommerce_default_country', 'AU:QLD' );
+
+		// When note is retrieved.
+		$note = ReviewShippingSettings::get_note()->get_content();
+
+		// Then it should not contain 'Label printing: enabled'.
+		$contains_string = strpos( $note, 'Label printing: enabled' );
+		$this->assertFalse( $contains_string );
+	}
+
+	/**
+	 * Verify that the shipping note includes label printing for US.
+	 * Related issue: https://github.com/woocommerce/woocommerce-admin/issues/5394.
+	 */
+	public function test_shipping_note_includes_label_printing_string_for_us() {
+		// Given US:CA as the default country.
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+		// When note is retrieved.
+		$note = ReviewShippingSettings::get_note()->get_content();
+
+		// Then it should contain 'Label printing: enabled'.
+		$contains_string = strpos( $note, 'Label printing: enabled' );
+		$this->assertNotFalse( $contains_string );
 	}
 }


### PR DESCRIPTION
Fixes #5394 

This PR removes `Label printing: enabled` string from the shipping admin note for non-US countries by checking the store's base country.

Dev note: The code assumes that the WooCommerce Shipping extension and its label printing feature are enabled. I think it would be better if we actually perform a check on the WooCommerce Shipping extension availability and its settings, but I think that's a separate issue and requires a new PR.


### Screenshots

United States (notice we still have `Label printing: enabled`)
![beforeth_](https://user-images.githubusercontent.com/4723145/98055225-d30b7780-1df1-11eb-9bdc-6df096c8da3f.jpg)

non-US countries:

![afterth_](https://user-images.githubusercontent.com/4723145/98055228-d6066800-1df1-11eb-8fdf-2fd03789dbe2.jpg)



### Detailed test instructions:

It's tricky to test the change locally as we need Jetpack connection. I would recommend using http://jurassic.ninja/ to create a publicly accessible WordPress installation.

1. Create a fresh installation of WordPress.
2. Navigate to Plugins and install WooCommerce
3. Navigate to Plugins and click [ Add New]. Upload the attached zip file.
[woocommerce-admin.zip](https://github.com/woocommerce/woocommerce-admin/files/5484838/woocommerce-admin.zip)

4. Navigate to Plugins -> Installed Plugins and activate both WooCommerce and WooCommerce Admin plugin.
5. Click "WooCommerce" from the left sidebar to kick off the setup wizard.

**Scenario 1** - United States
**Expectation**: We should still see `Label printing: enabled` string from the admin note after finishing up the wizard.

Continuing from the above steps,

1. Fill out the address form and make sure to choose "United States (US) --- :state" from the Country/Region dropdown on the "Store Details" step and click [ Continue ]
2. Check at least one industry from the "Industry" step and click [ Continue ]
3. Choose "Physical products" from the "Product Types" step.
4. Continue and finish the wizard.
5. Make sure to choose "Yes please!" when "Enhance your storewith WooCommece Shipping & Tax" option pops up.
6. Make sure to connect to Jetpack and approve your site.

**Scenario 2** - Non-US countries
**Expectation**: We should not see `Label printing: enabled` string from the admin note after finishing up the wizard.

Same steps as scenario 1, except that you need to choose a country that is not one of United States, Australia, Canada, or United Kingdom. The reason we include Australia, Canada, and United Kingdom is that the shipping onboarding process won't continue for those countries according to https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/OnboardingSetUpShipping.php#L54


