### PR TITLE
Add missing translation call.

### DIFF
--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -98,7 +98,7 @@ class Analytics {
 			'button'   => __( 'Clear', 'woocommerce-admin' ),
 			'desc'     => sprintf(
 				/* translators: 1: opening link tag, 2: closing tag */
-				'This tool will reset the cached values used in WooCommerce Analytics. If numbers still look off, try %1$sReimporting Historical Data%2$s.',
+				__( 'This tool will reset the cached values used in WooCommerce Analytics. If numbers still look off, try %1$sReimporting Historical Data%2$s.', 'woocommerce-admin' ),
 				'<a href="' . esc_url( $settings_url ) . '">',
 				'</a>'
 			),


### PR DESCRIPTION
Fixes #5115 

This PR adds a missing call to `__()` to the description of the Analytics Cache clearing tool.

### Detailed test instructions:

- Go to WooCommerce > Status > Tools
- Verify the text for the analytics cache clear renders

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->

N/A - probably minor enough to not mention.
