### PR TITLE
Fix a bug where welcome modal would briefly display even when dismissed.

### DIFF
--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -144,18 +144,21 @@ Layout.propTypes = {
 export default compose(
 	withSelect( ( select ) => {
 		const { isNotesRequesting } = select( NOTES_STORE_NAME );
-		const { getOption, isResolving } = select( OPTIONS_STORE_NAME );
+		const { getOption, isResolving, hasFinishedResolution } = select(
+			OPTIONS_STORE_NAME
+		);
 
 		const welcomeModalDismissed =
 			getOption( 'woocommerce_task_list_welcome_modal_dismissed' ) ===
 			'yes';
 
-		const welcomeModalDismissedIsResolving = isResolving( 'getOption', [
-			'woocommerce_task_list_welcome_modal_dismissed',
-		] );
+		const welcomeModalDismissedHasResolved = hasFinishedResolution(
+			'getOption',
+			[ 'woocommerce_task_list_welcome_modal_dismissed' ]
+		);
 
 		const shouldShowWelcomeModal =
-			! welcomeModalDismissedIsResolving && ! welcomeModalDismissed;
+			welcomeModalDismissedHasResolved && ! welcomeModalDismissed;
 
 		const defaultHomescreenLayout =
 			getOption( 'woocommerce_default_homepage_layout' ) ||


### PR DESCRIPTION
Fixes #5555 

An explanation of what happens currently:

1. we call `getOption`
2. straight after that we call `isResolving` to check if that option is loading.

I had assumed that the way `@wordpress/data` works is, that calling a selector would mean that `isResolving` for the backing resolver is immediately and synchronously `true`, but debugging the code this is not the case. Instead `isResolving` is false for a short while.

The simplest way to fix this was to use `hasFinishedResolution` instead. This will only return true once the option is actually loaded. 

**As a side note, we use this pattern a lot in our code base so it might be a good time to look at fixing that.

I have [raised a discussion about this](p1604982087129300-slack-C0926NEBC). If this is indeed an anti-pattern I'll raise an issue to fix it throughout the code base.**

### Detailed test instructions:

@timmyc had reproduced this in a JN site, and I'm not sure exactly how I triggered it locally, but I had the following setup:

1. Gutenberg installed
2. Woocommerce 4.8.0 dev installed
3. Complete OBW so you can view homescreen, dismiss the welcome modal. (testing that the welcome modal still displays as normal is important here too!)
4. refresh the homescreen page
5. the modal should **not** flicker briefly on screen.

### Changelog Note:

Fix: a bug where the welcome modal briefly displays when loading the home screen.