### PR TITLE
packages: bump version Dep Ext Webpack plugin

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.0.0-beta.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.0.0"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.0.1"
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+-   Fix: Avoid tanspiling packaged code.
+
 # 1.0.0
 
 -   Released package

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Prep for release of Dependency Extraction Webpack Plugin with patch version bump. Also point starter pack to latest version. This is needed due to changes in https://github.com/woocommerce/woocommerce-admin/pull/5598.

### Detailed test instructions:

Just ensure version bumps and changelog make sense

### Changelog Note:

none
