### PR TITLE
add dewps request table

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -23,3 +23,9 @@ module.exports = {
 	plugins: [ new WooCommerceDependencyExtractionWebpackPlugin() ],
 };
 ```
+
+Additional module requests on top of Wordpress [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin) are:
+
+| Request          | Global    | Script handle |
+| ---------------- | --------- | ------------- |
+| `@woocommerce/*` | `wc['*']` | `wc-*`        |


### PR DESCRIPTION
The WP [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin) has a table that explains what modules are mapped. I thought it would be a good idea to add what extra modules are mapped with this extended version of the plugin.

### Detailed test instructions:

1. Read changes to make sure they make sense
