### PR TITLE
Remove importing the class-wc-install.php to allow local tests to run

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,9 +54,6 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';
 
-		// load the wc installer.
-		require_once $this->wc_core_dir . '/includes/class-wc-install.php';
-
 		// load WC.
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
 


### PR DESCRIPTION
Fixes #5656 

Removing the `class-wc-install.php` require as at this stage locally the `ABSPATH` is not defined and it exits the tests instead of running them.

### Detailed test instructions:

- Checkout this branch
- Try running the php unit tests using `composer test`
- It should successfully run all the tests
