### PR TITLE
Dep Ext Webpack Plugin: Map wc-navigation to wc-admin

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.0.0-beta.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.0.1"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.1.0"
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+-   Fix: Map wc-navigation to wc-admin-app
+
 # 1.0.1
 
 -   Fix: Avoid tanspiling packaged code.

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -27,6 +27,12 @@ const wooRequestToExternal = ( request ) => {
 };
 
 const wooRequestToHandle = ( request ) => {
+	// Dependencies on `@woocommerce/navigation` must depend on `wc-admin-app`,
+	// which has a dependency on `wc-navigation` itself.
+	if ( request === '@woocommerce/navigation' ) {
+		return 'wc-admin-app';
+	}
+
 	if ( packages.includes( request ) ) {
 		return 'wc-' + request.substring( WOOCOMMERCE_NAMESPACE.length );
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5559

When using SlotFill from `@woocommerce/navigation` a dependency on `wc-admin-app` must be declared. This PR does that which will ultimately also bring in a dependency on `wc-navigation`.

https://github.com/woocommerce/woocommerce-admin/blob/62501ce94073a9646e560bfea7222309a3c5b04f/src/Loader.php#L481-L494

See discussion in https://github.com/WordPress/gutenberg/pull/27020 for previous attempts to solve this one.

### Detailed test instructions:

1. `npm run build`.
2. `cd packages/dependency-extraction-webpack-plugin`.
3. `npm link`
4. `cd ../..`
5. `npm run create-wc-extension`
6. Follow the instructions and name your new app.
7. `cd ../<new app name>`
8. `npm install`
9. `npm link @woocommerce/dependency-extraction-webpack-plugin`
10. `npm start`
11. Add this code to `src/index.js`
```js
import { Table } from '@woocommerce/components';
import { WooNavigationItem } from '@woocommerce/navigation';

console.log( Button, Table, WooNavigationItem );
```
12. Check that `build/index.assets.php` correctly indicates dependencies on `wc-admin-app` and `wc-components`

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

<!--- Optional: Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance:. If no note is entered, one will be constructed from the title and labels. --->
