### PR TITLE
Starter Pack: expand scope to all admin pages

### DIFF
--- a/bin/starter-pack/_main.php
+++ b/bin/starter-pack/_main.php
@@ -9,11 +9,6 @@
  * Register the JS.
  */
 function add_extension_register_script() {
-
-	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_page() ) {
-		return;
-	}
-
 	$script_path       = '/build/index.js';
 	$script_asset_path = dirname( __FILE__ ) . '/build/index.asset.php';
 	$script_asset      = file_exists( $script_asset_path )

--- a/bin/starter-pack/_main.php
+++ b/bin/starter-pack/_main.php
@@ -9,6 +9,10 @@
  * Register the JS.
  */
 function add_extension_register_script() {
+	if ( ! is_admin() ) {
+		return;
+	}
+	
 	$script_path       = '/build/index.js';
 	$script_asset_path = dirname( __FILE__ ) . '/build/index.asset.php';
 	$script_asset      = file_exists( $script_asset_path )

--- a/bin/starter-pack/_main.php
+++ b/bin/starter-pack/_main.php
@@ -9,7 +9,7 @@
  * Register the JS.
  */
 function add_extension_register_script() {
-	if ( ! is_admin() ) {
+	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Loader' ) || ! \Automattic\WooCommerce\Admin\Loader::is_admin_or_embed_page() ) {
 		return;
 	}
 	


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5608

SlotFill wasn't working with my example because the script was never loaded outside wc-admin pages, but should be loaded on all admin pages. This PR changes that to prevent future headache for extensions using the starter pack to hook into the Nav.

### Detailed test instructions:

1. Just make sure the change makes sense. Any extension using the starter pack will have their scripts load on all admin pages, not just wc-admin. This is important because the new Nav operates outside of just wc-admin pages.

<!--- Note: When displaying information based on sample data, such as SwaggerHub, 
be sure to detail parts affected in Release Notes --->

### Changelog Note:

- tweak: Expand default script loading in Create Extension to all admin pages
