### PR TITLE
Revert the work to sort the task list by completion in #5001

### DIFF
--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -242,13 +242,7 @@ export function getAllTasks( {
 
 	return applyFilters(
 		'woocommerce_admin_onboarding_task_list',
-		tasks.sort( ( a, b ) => {
-			if ( a.completed === b.completed ) {
-				return 0;
-			}
-
-			return a.completed ? 1 : -1;
-		} ),
+		tasks,
 		query
 	);
 }


### PR DESCRIPTION
#5602 highlights some issues with payment analytics, and it's been determined that the only path forward here is to revert 2 pieces of work: the smart tax defaults and the reordering of the task list to group items completed.

This PR reverts the work to group the task list by completion

### Detailed test instructions:

1. Complete the OBW so that the task list displays on homescreen
2. Complete a couple of tasks that do not render next to each other
3. confirm they are not grouped/sorted together, but remain in their existing order

### Changelog Note:

Dev: Revert the #5001 work to order tasks by completion.