### PR TITLE
Dependency Extraction Webpack Plugin: Handle irregular dependency names

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.0.0-beta.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.0.1"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.1.0"
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0
+
+-   Fix: Handle csv-export and data packages as they don't conform to a pattern.
+
 # 1.0.1
 
 -   Fix: Avoid tanspiling packaged code.

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.1.0
 
--   Fix: Handle csv-export and data packages as they don't conform to a pattern.
+-   Fix: Handle irregular package names that don't conform to a pattern.
 
 # 1.0.1
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -26,6 +26,8 @@ module.exports = {
 
 Additional module requests on top of Wordpress [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin) are:
 
-| Request          | Global    | Script handle |
-| ---------------- | --------- | ------------- |
-| `@woocommerce/*` | `wc['*']` | `wc-*`        |
+| Request                   | Global            | Script handle   |
+| ------------------------- | ----------------- | --------------- |
+| `@woocommerce/data`       | `wc['data']`      | `wc-store-data` |
+| `@woocommerce/csv-export` | `wc['csvExport']` | `wc-csv`        |
+| `@woocommerce/*`          | `wc['*']`         | `wc-*`          |

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -26,8 +26,9 @@ module.exports = {
 
 Additional module requests on top of Wordpress [Dependency Extraction Webpack Plugin](https://github.com/WordPress/gutenberg/tree/master/packages/dependency-extraction-webpack-plugin) are:
 
-| Request                   | Global            | Script handle   |
-| ------------------------- | ----------------- | --------------- |
-| `@woocommerce/data`       | `wc['data']`      | `wc-store-data` |
-| `@woocommerce/csv-export` | `wc['csvExport']` | `wc-csv`        |
-| `@woocommerce/*`          | `wc['*']`         | `wc-*`          |
+| Request                        | Global                   | Script handle        |
+| ------------------------------ | ------------------------ | -------------------- |
+| `@woocommerce/data`            | `wc['data']`             | `wc-store-data`      |
+| `@woocommerce/csv-export`      | `wc['csvExport']`        | `wc-csv`             |
+| `@woocommerce/blocks-registry` | `wc['wcBlocksRegistry']` | `wc-blocks-registry` |
+| `@woocommerce/*`               | `wc['*']`                | `wc-*`               |

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -28,7 +28,17 @@ const wooRequestToExternal = ( request ) => {
 
 const wooRequestToHandle = ( request ) => {
 	if ( packages.includes( request ) ) {
-		return 'wc-' + request.substring( WOOCOMMERCE_NAMESPACE.length );
+		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
+		const irregularHandleMap = {
+			data: 'wc-store-data',
+			'csv-export': 'wc-csv',
+		};
+
+		if ( irregularHandleMap[ handle ] ) {
+			return irregularHandleMap[ handle ];
+		}
+
+		return 'wc-' + handle;
 	}
 };
 

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -19,10 +19,16 @@ function camelCaseDash( string ) {
 
 const wooRequestToExternal = ( request ) => {
 	if ( packages.includes( request ) ) {
-		return [
-			'wc',
-			camelCaseDash( request.substring( WOOCOMMERCE_NAMESPACE.length ) ),
-		];
+		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
+		const irregularExternalMap = {
+			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
+		};
+
+		if ( irregularExternalMap[ handle ] ) {
+			return irregularExternalMap[ handle ];
+		}
+
+		return [ 'wc', camelCaseDash( handle ) ];
 	}
 };
 


### PR DESCRIPTION
I noticed in https://github.com/woocommerce/woocommerce-admin/pull/5762 while adding Dependency Extraction Webpack Plugin that `csvExport` and `data` packages don't follow the normal convention. This PR handles those and readies the packgage for another release.

### Detailed test instructions:

1. See the names of scripts registered 
https://github.com/woocommerce/woocommerce-admin/blob/6fba36c4082a915cb4ef4af49caa6ec6313aa504/src/Loader.php#L350
2. Make sure that csv and data are the only packages that don't translate `@woocommerce/<package>` to `wc-<package>`.
3. Make sure the code makes sense.
