### PR TITLE
Navigation: Introduce wc-admin registration client side navArgs

### DIFF
--- a/client/analytics/report/README.md
+++ b/client/analytics/report/README.md
@@ -40,17 +40,21 @@ addFilter(
 				report: 'example',
 				title: 'My Example Extension',
 				component: Report,
+				navArgs: {
+					id: 'my-example-report',
+				},
 			},
 		];
 	}
 );
 ```
 
-Each report is defined by an object containing `report`, `title`, `component`.
+Each report is defined by an object containing `report`, `title`, `component`, and optionally `navArgs`.
 
 -   `report` (string): The path used to show the report, ex: `/analytics/example`
 -   `title` (string): The title shown in the breadcrumbs & document title.
 -   `component` (react component): The component containing the report content- everything on the page under the breadcrumbs header.
+-   `navArgs` (object): Supply an id which is the same id as the server side registration.
 
 The component will get the following props:
 

--- a/client/analytics/report/README.md
+++ b/client/analytics/report/README.md
@@ -54,7 +54,7 @@ Each report is defined by an object containing `report`, `title`, `component`, a
 -   `report` (string): The path used to show the report, ex: `/analytics/example`
 -   `title` (string): The title shown in the breadcrumbs & document title.
 -   `component` (react component): The component containing the report content- everything on the page under the breadcrumbs header.
--   `navArgs` (object): Supply an id which is the same id as the server side registration.
+-   `navArgs` (object): Arguments used for the new navigation experience, typically used to supply a matching ID for server-side registered menu items.
 
 The component will get the following props:
 

--- a/client/analytics/report/get-reports.js
+++ b/client/analytics/report/get-reports.js
@@ -57,42 +57,66 @@ export default () => {
 			report: 'revenue',
 			title: __( 'Revenue', 'woocommerce-admin' ),
 			component: RevenueReport,
+			navArgs: {
+				id: 'woocommerce-analytics-revenue',
+			},
 		},
 		{
 			report: 'products',
 			title: __( 'Products', 'woocommerce-admin' ),
 			component: ProductsReport,
+			navArgs: {
+				id: 'woocommerce-analytics-products',
+			},
 		},
 		{
 			report: 'variations',
 			title: __( 'Variations', 'woocommerce-admin' ),
 			component: VariationsReport,
+			navArgs: {
+				id: 'woocommerce-analytics-variations',
+			},
 		},
 		{
 			report: 'orders',
 			title: __( 'Orders', 'woocommerce-admin' ),
 			component: OrdersReport,
+			navArgs: {
+				id: 'woocommerce-analytics-orders',
+			},
 		},
 		{
 			report: 'categories',
 			title: __( 'Categories', 'woocommerce-admin' ),
 			component: CategoriesReport,
+			navArgs: {
+				id: 'woocommerce-analytics-categories',
+			},
 		},
 		{
 			report: 'coupons',
 			title: __( 'Coupons', 'woocommerce-admin' ),
 			component: CouponsReport,
+			navArgs: {
+				id: 'woocommerce-analytics-coupons',
+			},
 		},
 		{
 			report: 'taxes',
 			title: __( 'Taxes', 'woocommerce-admin' ),
 			component: TaxesReport,
+			navArgs: {
+				id: 'woocommerce-analytics-taxes',
+			},
 		},
 		manageStock === 'yes'
 			? {
 					report: 'stock',
 					title: __( 'Stock', 'woocommerce-admin' ),
 					component: StockReport,
+					navArgs: {
+						id: 'woocommerce-analytics-stock',
+					},
 			  }
 			: null,
 		{
@@ -105,6 +129,9 @@ export default () => {
 			report: 'downloads',
 			title: __( 'Downloads', 'woocommerce-admin' ),
 			component: DownloadsReport,
+			navArgs: {
+				id: 'woocommerce-analytics-downloads',
+			},
 		},
 	].filter( Boolean );
 

--- a/client/analytics/report/get-reports.js
+++ b/client/analytics/report/get-reports.js
@@ -123,7 +123,6 @@ export default () => {
 			report: 'customers',
 			title: __( 'Customers', 'woocommerce-admin' ),
 			component: CustomersReport,
-			id: null,
 		},
 		{
 			report: 'downloads',

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -59,6 +59,9 @@ export const getPages = () => {
 			__( 'Home', 'woocommerce-admin' ),
 		],
 		wpOpenMenu: 'toplevel_page_woocommerce',
+		navArgs: {
+			id: 'woocommerce-home',
+		},
 	} );
 
 	if ( window.wcAdminFeatures.analytics ) {
@@ -74,6 +77,9 @@ export const getPages = () => {
 				__( 'Overview', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
+			navArgs: {
+				id: 'woocommerce-analytics-overview',
+			},
 		} );
 		pages.push( {
 			container: AnalyticsSettings,
@@ -87,6 +93,9 @@ export const getPages = () => {
 				__( 'Settings', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_wc-admin-path--analytics-overview',
+			navArgs: {
+				id: 'woocommerce-analytics-settings',
+			},
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -96,6 +105,9 @@ export const getPages = () => {
 				__( 'Customers', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce',
+			navArgs: {
+				id: 'woocommerce-analytics-customers',
+			},
 		} );
 		pages.push( {
 			container: AnalyticsReport,
@@ -130,6 +142,9 @@ export const getPages = () => {
 				__( 'Overview', 'woocommerce-admin' ),
 			],
 			wpOpenMenu: 'toplevel_page_woocommerce-marketing',
+			navArgs: {
+				id: 'woocommerce-marketing-overview',
+			},
 		} );
 	}
 

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -26,28 +26,26 @@ const NavigationPlugin = () => {
 	if ( ! isWCAdmin( window.location.href ) ) {
 		return null;
 	}
-	const pagesWithoutNavigation = [ '/analytics/:report', '/setup-wizard' ];
-	const reports = getReports();
+	const reports = getReports().filter( ( item ) => item.navArgs );
 	const pages = getPages()
-		.filter( ( page ) => ! pagesWithoutNavigation.includes( page.path ) )
+		.filter( ( page ) => page.navArgs )
 		.map( ( page ) => {
-			const pageWithId = {
-				...page,
-				id: `wc_admin-wc-admin&path=${ page.path }`,
-			};
-			if ( pageWithId.path === '/analytics/settings' ) {
+			if ( page.path === '/analytics/settings' ) {
 				return {
-					...pageWithId,
+					...page,
 					breadcrumbs: [ __( 'Analytics', 'woocommerce-admin' ) ],
 				};
 			}
-			return pageWithId;
+			return page;
 		} );
 	const persistedQuery = getPersistedQuery( {} );
 	return (
 		<>
 			{ pages.map( ( page ) => (
-				<WooNavigationItem item={ page.id } key={ page.id }>
+				<WooNavigationItem
+					item={ page.navArgs.id }
+					key={ page.navArgs.id }
+				>
 					<Link
 						className="components-button"
 						href={ getNewPath( persistedQuery, page.path, {} ) }
@@ -57,24 +55,24 @@ const NavigationPlugin = () => {
 					</Link>
 				</WooNavigationItem>
 			) ) }
-			{ reports.map( ( item ) => {
-				const id = `wc_admin-wc-admin&path=/analytics/${ item.report }`;
-				return (
-					<WooNavigationItem item={ id } key={ id }>
-						<Link
-							className="components-button"
-							href={ getNewPath(
-								persistedQuery,
-								`/analytics/${ item.report }`,
-								{}
-							) }
-							type="wc-admin"
-						>
-							{ item.title }
-						</Link>
-					</WooNavigationItem>
-				);
-			} ) }
+			{ reports.map( ( item ) => (
+				<WooNavigationItem
+					item={ item.navArgs.id }
+					key={ item.navArgs.id }
+				>
+					<Link
+						className="components-button"
+						href={ getNewPath(
+							persistedQuery,
+							`/analytics/${ item.report }`,
+							{}
+						) }
+						type="wc-admin"
+					>
+						{ item.title }
+					</Link>
+				</WooNavigationItem>
+			) ) }
 		</>
 	);
 };

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -137,7 +137,7 @@ class CoreMenu {
 			$path = isset( $page['path'] ) ? $page['path'] : null;
 			$item = array_merge(
 				array(
-					'id'         => 'wc_admin-' . $path,
+					'id'         => $page['id'],
 					'url'        => $path,
 					'title'      => $page['title'][0],
 					'capability' => isset( $page['capability'] ) ? $page['capability'] : 'manage_woocommerce',
@@ -156,7 +156,7 @@ class CoreMenu {
 		$home_item = array();
 		if ( defined( '\Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG' ) ) {
 			$home_item = array(
-				'id'    => 'wc_admin-wc-admin&path=/',
+				'id'    => 'woocommerce-home',
 				'title' => __( 'Home', 'woocommerce-admin' ),
 				'url'   => \Automattic\WooCommerce\Admin\Features\AnalyticsDashboard::MENU_SLUG,
 				'order' => 0,


### PR DESCRIPTION
While reviewing https://github.com/Automattic/woocommerce-payments/pull/1067 I noticed a problem with using the `path` as an id: When designating a `parent`, you'd have to supply the correctly computed `path` parameter of the parent or wc-admin would need to calculate that on behalf of the extension. Consider the following child item:

```php
			wc_admin_register_page(
				[
					'id'       => 'wc-payments-transactions',
					'title'    => __( 'Transactions', 'woocommerce-payments' ),
					'parent'   => 'wc-payments',
					'path'     => '/payments/transactions',
					'nav_args' => [
						'parent' => 'wc-payments',
						'order'  => 20,
					],
				]
			);
```
The parent would actually need to be `wc_admin-wc-admin&path=/payments/deposits`. So I was thinking that since we need to ask wc-admin extensions to supply `nav_args` in PHP, why not be explicit and ask them to also supply `navArgs` on the client?

This PR makes that change to filters `woocommerce_admin_pages_list` and `woocommerce_admin_reports_list` to accept `navArgs`. Similar to PHP, slotFill does not function if `navArgs` are not supplied.

### Detailed test instructions:

Same as https://github.com/woocommerce/woocommerce-admin/pull/5665

1. Ensure all wc-admin pages can navigate without refreshing the page, including Home, Settings > Analytics, and Customers.
2. Ensure Settings > Products is a functioning Nav item. 

### Note

The base is `update/simplify-wca-nav-registration` for easy testing of https://github.com/Automattic/woocommerce-payments/pull/1067