### PR TITLE
Fix count bubble alignment in SearchListItem with latest @wordpress/components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 -   Change styling of `<ProductImage />`
 -   Add new `<Accordion>` component.
--   Removed the `showCount` prop from `<SearchListItem>`. Count will always be displayed if any of those props is not undefined/null: `countLabel` and `item.count`.
+-   Remove the `showCount` prop from `<SearchListItem>`. Count will always be displayed if any of those props is not undefined/null: `countLabel` and `item.count`.
+-   Fix alignment of `<SearchListItem>` count bubble in newest versions of `@wordpress/components`.
 
 # 5.1.2
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 -   Change styling of `<ProductImage />`
 -   Add new `<Accordion>` component.
+-   Removed the `showCount` prop from `<SearchListItem>`. Count will always be displayed if any of those props is not undefined/null: `countLabel` and `item.count`.
 
 # 5.1.2
 

--- a/packages/components/src/search-list-control/README.md
+++ b/packages/components/src/search-list-control/README.md
@@ -63,11 +63,10 @@ Used implicitly by `SearchListControl` when the `renderItem` prop is omitted.
 Name | Type | Default | Description
 --- | --- | --- | ---
 `className` | String | `null` | Additional CSS classes
-`countLabel` | ReactNode | `null` | Label to display if `showCount` is set to true. If undefined, it will use `item.count`
+`countLabel` | ReactNode | `null` | Label to display in the count bubble. Takes preference over `item.count`.
 `depth` | Number | `0` | Depth, non-zero if the list is hierarchical
 `item` | Object | `null` | Current item to display
 `isSelected` | Boolean | `null` | Whether this item is selected
 `isSingle` | Boolean | `null` | Whether this should only display a single item (controls radio vs checkbox icon)
 `onSelect` | Function | `null` | Callback for selecting the item
 `search` | String | `''` | Search string, used to highlight the substring in the item name
-`showCount` | Boolean | `false` | Toggles the "count" bubble on/off

--- a/packages/components/src/search-list-control/item.js
+++ b/packages/components/src/search-list-control/item.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { escapeRegExp, first, last } from 'lodash';
+import { escapeRegExp, first, last, isNil } from 'lodash';
 import { MenuItem } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -50,13 +50,16 @@ const SearchListItem = ( {
 	isSingle,
 	onSelect,
 	search = '',
-	showCount = false,
 	...props
 } ) => {
+	const showCount = ! isNil( countLabel ) || ! isNil( item.count );
 	const classes = [ className, 'woocommerce-search-list__item' ];
 	classes.push( `depth-${ depth }` );
 	if ( isSingle ) {
 		classes.push( 'is-radio-button' );
+	}
+	if ( showCount ) {
+		classes.push( 'has-count' );
 	}
 	const hasBreadcrumbs = item.breadcrumbs && item.breadcrumbs.length;
 
@@ -128,10 +131,6 @@ SearchListItem.propTypes = {
 	 * Search string, used to highlight the substring in the item name.
 	 */
 	search: PropTypes.string,
-	/**
-	 * Toggles the "count" bubble on/off.
-	 */
-	showCount: PropTypes.bool,
 };
 
 export default SearchListItem;

--- a/packages/components/src/search-list-control/item.js
+++ b/packages/components/src/search-list-control/item.js
@@ -104,7 +104,7 @@ SearchListItem.propTypes = {
 	 */
 	className: PropTypes.string,
 	/**
-	 * Label to display if `showCount` is set to true. If undefined, it will use `item.count`.
+	 * Label to display in the count bubble. Takes preference over `item.count`.
 	 */
 	countLabel: PropTypes.node,
 	/**

--- a/packages/components/src/search-list-control/stories/index.js
+++ b/packages/components/src/search-list-control/stories/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { boolean } from '@storybook/addon-knobs';
 import { SearchListControl } from '@woocommerce/components';
 import { withState } from '@wordpress/compose';
 
@@ -8,7 +9,8 @@ const SearchListControlExample = withState( {
 	selected: [],
 	loading: true,
 } )( ( { selected, loading, setState } ) => {
-	const list = [
+	const showCount = boolean( 'Show count', false );
+	let list = [
 		{ id: 1, name: 'Apricots' },
 		{ id: 2, name: 'Clementine' },
 		{ id: 3, name: 'Elderberry' },
@@ -16,6 +18,11 @@ const SearchListControlExample = withState( {
 		{ id: 5, name: 'Lychee' },
 		{ id: 6, name: 'Mulberry' },
 	];
+	const counts = [ 3, 1, 1, 5, 2, 0 ];
+
+	if ( showCount ) {
+		list = list.map( ( item, i ) => ( { ...item, count: counts[ i ] } ) );
+	}
 
 	return (
 		<div>

--- a/packages/components/src/search-list-control/style.scss
+++ b/packages/components/src/search-list-control/style.scss
@@ -182,6 +182,12 @@
 			}
 		}
 
+		&.has-count {
+			> .components-menu-item__item {
+				width: 100%;
+			}
+		}
+
 		.woocommerce-search-list__item-count {
 			flex: 0 1 auto;
 			padding: $gap-smallest/2 $gap-smaller;


### PR DESCRIPTION
Fixes #5806.

This PR:
* Removes the `showCount` prop from `SearchListItem`. Instead, it checks if `countLabel` or `item.count` are defined to decide whether the count bubble should be displayed or not.
* Updates the `SearchListControl` story so it's possible to enable count bubbles.
* Fixes #5806 by making `.components-menu-item__item` full-width. This is a [new `<span>` element](https://github.com/WordPress/gutenberg/blob/master/packages/components/src/menu-item/index.js#L77) that wraps `MenuItem` children that was making the bubble not to be properly aligned (see screenshots below).

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/101039308-1afdf580-357c-11eb-833d-db7225a3a6be.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/101039122-0de10680-357c-11eb-9ecb-280cdbef6601.png)

### Detailed test instructions:

Some code changes are needed to reproduce the issue because the bug is only reproducible in dev versions of Gutenberg, but I wanted to get this PR up so we can start reviewing it. Since it's a low-risk change (adding a CSS selector), I think it's fine getting this merged before updating `@wordpress/components`.

1.   Make this change in `item.js` to simulate the changes coming to `@wordpress/components`:
```diff
<MenuItem { ... }>
+	<span
+		className="components-menu-item__item"
+		style={ {
+			whiteSpace: 'nowrap',
+			marginRight: 'auto',
+			display: 'inline-flex',
+			alignItems: 'center',
+		} }
+	>
		{ ... }
+	</span>
</MenuItem>
```
2.   Run `npm run storybook` and check the `SearchListControl` story.
3.   Check the _Show count_ checkbox and toggle the loading state.
4.   Verify the count bubble is aligned to the right (see screenshots above).
5.   Undo the changes from step 1 and repeat the other steps to verify there are no regressions with the current version of `@wordpress/components`.

Dev: Fix alignment of `<SearchListItem>` count bubble in newest versions of `@wordpress/components`.
