### PR TITLE
Update Loader.php

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1091,7 +1091,9 @@ class Loader {
 				$group_settings   = $setting_options->get_group_settings( $group );
 				$preload_settings = [];
 				foreach ( $group_settings as $option ) {
-					$preload_settings[ $option['id'] ] = $option['value'];
+					if (isset($option['id'])){
+						$preload_settings[ $option['id'] ] = $option['value'];
+					}
 				}
 				$settings['preloadSettings'][ $group ] = $preload_settings;
 			}


### PR DESCRIPTION
Added a tweek to handle a UI error.  Shouldn't affect anything else.. I think it conflicts with a few other plugins?

Fixes #

I was getting a UI error after latest version, this eliminated the error.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

-   Ex: Open page `url`
-   Click XYZ…

<!--- Please add a Changelog note

Handle a few other plugins interactions with preloading, by checking for an id first.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
