### PR TITLE
Allow filtering the list of settings pages returned by CoreMenu::get_setting_items()

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -64,7 +64,7 @@ class CoreMenu {
 			);
 		}
 
-		return $menu_items;
+		return apply_filters( 'woocommerce_navigation_setting_items', $menu_items, $settings );
 	}
 
 	/**


### PR DESCRIPTION
This PR is to assist WooCommerce Subscriptions with WC Admin navigation compatibility. To read more details on the issue please see 3910-gh-woocommerce/woocommerce-subscriptions

In short, the WooCommerce Subscriptions setting link is missing from the new Navigation under WooCommerce > Settings:

![](https://camo.githubusercontent.com/d834ac33c84dc2eb3b05127a06dec4a5093e4a40c0022e83cf5419c407767fbe/68747470733a2f2f642e70722f692f636c677055472b)

The menu items in the settings navigation bar are populated using the list of setting pages returned by `WC_Admin_Settings::get_settings_pages()` and the reason subscriptions isn't appearing in this list is because we register our settings page a little differently 😅  We use the [`woocommerce_settings_tabs_array` filter to add the Subscriptions tab and then add the settings page by hooking onto `woocommerce_settings_subscriptions`](https://github.com/woocommerce/woocommerce-subscriptions/blob/3155e0cb23b9d8c296e325878a1301cab0e932bb/includes/admin/class-wc-subscriptions-admin.php#L97-L99).


### Detailed test instructions:

1. Install the latest subscriptions trunk and latest WC Admin.
1. Enable the navigation feature (WooCommerce > Settings > Advanced > features)
1. Visit WooCommerce > Settings with the new navigation
1. Notice Subscriptions doesn't appear in the list of setting pages in navigation

To test the filter here's the code I used in Subscriptions (class `WCS_WC_Admin_Manager`):

```
/**
 * Register the settings navigation items in the WooCommerce navigation.
 *
 * @since 3.0.12
 */
public static function register_subscription_setting_item( $menu_items, $settings ) {
	$menu_items[] = (
		array(
			'parent'     => 'settings',
			'title'      => 'Subscriptions',
			'capability' => 'manage_woocommerce',
			'id'         => 'subscriptions',
			'url'        => 'admin.php?page=wc-settings&tab=subscriptions',
			'order'      => 96,
		)
	);

	return $menu_items;
}

add_filter( 'woocommerce_navigation_setting_items', array( __CLASS__, 'register_subscription_setting_item' ), 10, 2 );
```

**Result:**

![](https://d.pr/i/fqfzyF+)

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->