### PR TITLE
Nav Docs: Fix syntax error

### DIFF
--- a/docs/page-controller.md
+++ b/docs/page-controller.md
@@ -138,7 +138,7 @@ Alternatively, register a regular page with the controller.
 
 ```php
 function add_extension_register_page() {
-    if ( ! function_exists( 'wc_admin_register_page' ) {
+    if ( ! function_exists( 'wc_admin_register_page' ) ) {
         return;
 	}
 


### PR DESCRIPTION
Left over from review of https://github.com/woocommerce/woocommerce-admin/pull/5844 that I didn't address before merging.
.A close parentheses was missing/

### Detailed test instructions:

Just check the syntax is correct.
