### PR TITLE
Allow setting Jetpack connection when JETPACK_MASTER_USER isn't available

### DIFF
--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -63,8 +63,13 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		$user_token        = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-		$jetpack_connected = isset( $user_token->external_user_id );
+		if ( defined('JETPACK_MASTER_USER') ) {
+			$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+			$jetpack_connected = isset( $user_token->external_user_id );
+		} else {
+			$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false);
+		}
+
 		$wcs_version       = \WC_Connect_Loader::get_wcs_version();
 		$wcs_tos_accepted  = \WC_Connect_Options::get_option( 'tos_accepted' );
 

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -63,7 +63,7 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		if ( defined('JETPACK_MASTER_USER' ) ) {
+		if ( defined( 'JETPACK_MASTER_USER' ) ) {
 			$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 			$jetpack_connected = isset( $user_token->external_user_id );
 		} else {

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -63,11 +63,11 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		if ( defined('JETPACK_MASTER_USER') ) {
+		if ( defined('JETPACK_MASTER_USER' ) ) {
 			$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 			$jetpack_connected = isset( $user_token->external_user_id );
 		} else {
-			$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false);
+			$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false );
 		}
 
 		$wcs_version       = \WC_Connect_Loader::get_wcs_version();

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -67,6 +67,11 @@ class OnboardingSetUpShipping {
 			$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 			$jetpack_connected = isset( $user_token->external_user_id );
 		} else {
+			/**
+			 * Filter allowing to set the status of the jetpack connection wiuthout setting constant `JETPACK_MASTER_USER`
+			 *
+			 * @param bool $is_connected False.
+			 */
 			$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false );
 		}
 

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -59,9 +59,14 @@ class ShippingLabelBanner {
 			$wcs_tos_accepted  = null;
 
 			if ( class_exists( '\Jetpack_Data' ) ) {
-				$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 
-				$jetpack_connected = isset( $user_token->external_user_id );
+				if ( defined('JETPACK_MASTER_USER') ) {
+					$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
+					$jetpack_connected = isset( $user_token->external_user_id );
+				} else {
+					$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false );
+				}
+
 				$jetpack_version   = JETPACK__VERSION;
 			}
 

--- a/src/Features/ShippingLabelBanner.php
+++ b/src/Features/ShippingLabelBanner.php
@@ -60,7 +60,7 @@ class ShippingLabelBanner {
 
 			if ( class_exists( '\Jetpack_Data' ) ) {
 
-				if ( defined('JETPACK_MASTER_USER') ) {
+				if ( defined( 'JETPACK_MASTER_USER' ) ) {
 					$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
 					$jetpack_connected = isset( $user_token->external_user_id );
 				} else {


### PR DESCRIPTION
### A bit of background

With [gold team](https://timgoldp2.wordpress.com/), we are integrating WOO on WPCOM, which comes with its challenges.
One of them is the use of `JETPACK_MASTER_USER`, which we would like not to define on WPCOM, therefore I created this PR that should allow more flexibility without having to add another constant on the global scope.

Let me kown your thoughts or how it can be eventually improved. Also happy to add some tests if needed...

### After merging

I will need to have to wait for this to be merged and deployed to WPCOM before committing my `D54286` patch 

