### PR TITLE
Adding history listener to update persisted queries for nav

### DIFF
--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -11,6 +11,7 @@ import {
 	getPersistedQuery,
 	getHistory,
 	getQueryExcludedScreens,
+	getScreenFromPath,
 } from '@woocommerce/navigation';
 import { Spinner } from '@woocommerce/components';
 
@@ -225,7 +226,7 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 		const search = last( item.href.split( '?' ) );
 		const query = parse( search );
 		const path = query.path || 'homescreen';
-		const screen = path.replace( '/analytics', '' ).replace( '/', '' );
+		const screen = getScreenFromPath( path );
 
 		const isExcludedScreen = excludedScreens.includes( screen );
 

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -10,6 +10,7 @@ import {
 	getNewPath,
 	getPersistedQuery,
 	getHistory,
+	getQueryExcludedScreens,
 } from '@woocommerce/navigation';
 import { Spinner } from '@woocommerce/components';
 
@@ -42,8 +43,6 @@ const MarketingOverview = lazy( () =>
 const ProfileWizard = lazy( () =>
 	import( /* webpackChunkName: "profile-wizard" */ '../profile-wizard' )
 );
-
-const TIME_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
 
 export const PAGES_FILTER = 'woocommerce_admin_pages_list';
 
@@ -248,13 +247,8 @@ export function updateLinkHref( item, nextQuery, excludedScreens ) {
 
 // Update's wc-admin links in wp-admin menu
 window.wpNavMenuUrlUpdate = function ( query ) {
-	const excludedScreens = applyFilters( TIME_EXCLUDED_SCREENS_FILTER, [
-		'stock',
-		'settings',
-		'customers',
-		'homescreen',
-	] );
 	const nextQuery = getPersistedQuery( query );
+	const excludedScreens = getQueryExcludedScreens();
 
 	Array.from(
 		document.querySelectorAll( '#adminmenu a' )

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -9,6 +9,7 @@ import {
 } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,8 +17,20 @@ import { __ } from '@wordpress/i18n';
 import getReports from '../analytics/report/get-reports';
 import { getPages } from './controller';
 import { isWCAdmin } from '../dashboard/utils';
+import { addHistoryListener } from '../navigation/utils';
 
 const NavigationPlugin = () => {
+	const [ persistedQuery, setPersistedQuery ] = useState(
+		getPersistedQuery()
+	);
+
+	// Update the persisted queries when history is updated
+	useEffect( () => {
+		return addHistoryListener( () => {
+			setTimeout( () => setPersistedQuery( getPersistedQuery() ), 0 );
+		} );
+	}, [] );
+
 	/**
 	 * If the current page is embedded, stay with the default urls
 	 * provided by Navigation because the router isn't present to
@@ -26,6 +39,7 @@ const NavigationPlugin = () => {
 	if ( ! isWCAdmin( window.location.href ) ) {
 		return null;
 	}
+
 	const reports = getReports().filter( ( item ) => item.navArgs );
 	const pages = getPages()
 		.filter( ( page ) => page.navArgs )
@@ -38,7 +52,7 @@ const NavigationPlugin = () => {
 			}
 			return page;
 		} );
-	const persistedQuery = getPersistedQuery( {} );
+
 	return (
 		<>
 			{ pages.map( ( page ) => (
@@ -77,4 +91,6 @@ const NavigationPlugin = () => {
 	);
 };
 
-registerPlugin( 'wc-admin-navigation', { render: NavigationPlugin } );
+registerPlugin( 'wc-admin-navigation', {
+	render: NavigationPlugin,
+} );

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -26,13 +26,14 @@ const NavigationPlugin = () => {
 		getPersistedQuery()
 	);
 
+	const pathIsExcluded = ( path ) =>
+		getQueryExcludedScreens().includes( getScreenFromPath( path ) );
+
 	// Update the persisted queries when history is updated
 	useEffect( () => {
 		return addHistoryListener( () => {
 			setTimeout( () => {
-				if (
-					getQueryExcludedScreens().includes( getScreenFromPath() )
-				) {
+				if ( pathIsExcluded() ) {
 					return;
 				}
 				setPersistedQuery( getPersistedQuery() );
@@ -49,12 +50,7 @@ const NavigationPlugin = () => {
 		return null;
 	}
 
-	const reports = getReports()
-		.filter( ( item ) => item.navArgs )
-		.map( ( item ) => ( {
-			...item,
-			excludePersisted: getQueryExcludedScreens().includes( item.report ),
-		} ) );
+	const reports = getReports().filter( ( item ) => item.navArgs );
 
 	const pages = getPages()
 		.filter( ( page ) => page.navArgs )
@@ -66,15 +62,6 @@ const NavigationPlugin = () => {
 				};
 			}
 			return page;
-		} )
-		.map( ( page ) => {
-			const path = page.path || 'homescreen';
-			return {
-				...page,
-				excludePersisted: getQueryExcludedScreens().includes(
-					path.replace( '/analytics', '' ).replace( '/', '' )
-				),
-			};
 		} );
 
 	return (
@@ -87,7 +74,7 @@ const NavigationPlugin = () => {
 					<Link
 						className="components-button"
 						href={ getNewPath(
-							page.excludePersisted ? {} : persistedQuery,
+							pathIsExcluded( page.path ) ? {} : persistedQuery,
 							page.path,
 							{}
 						) }
@@ -105,7 +92,7 @@ const NavigationPlugin = () => {
 					<Link
 						className="components-button"
 						href={ getNewPath(
-							item.excludePersisted ? {} : persistedQuery,
+							pathIsExcluded( item.report ) ? {} : persistedQuery,
 							`/analytics/${ item.report }`,
 							{}
 						) }

--- a/client/layout/navigation.js
+++ b/client/layout/navigation.js
@@ -7,6 +7,7 @@ import {
 	getNewPath,
 	getPersistedQuery,
 	getQueryExcludedScreens,
+	getScreenFromPath,
 } from '@woocommerce/navigation';
 import { Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
@@ -28,7 +29,14 @@ const NavigationPlugin = () => {
 	// Update the persisted queries when history is updated
 	useEffect( () => {
 		return addHistoryListener( () => {
-			setTimeout( () => setPersistedQuery( getPersistedQuery() ), 0 );
+			setTimeout( () => {
+				if (
+					getQueryExcludedScreens().includes( getScreenFromPath() )
+				) {
+					return;
+				}
+				setPersistedQuery( getPersistedQuery() );
+			}, 0 );
 		} );
 	}, [] );
 
@@ -41,16 +49,11 @@ const NavigationPlugin = () => {
 		return null;
 	}
 
-	const getExcludePersisted = ( screen ) => {
-		const excludedScreens = getQueryExcludedScreens();
-		return excludedScreens.includes( screen );
-	};
-
 	const reports = getReports()
 		.filter( ( item ) => item.navArgs )
 		.map( ( item ) => ( {
 			...item,
-			excludePersisted: getExcludePersisted( item.report ),
+			excludePersisted: getQueryExcludedScreens().includes( item.report ),
 		} ) );
 
 	const pages = getPages()
@@ -68,7 +71,7 @@ const NavigationPlugin = () => {
 			const path = page.path || 'homescreen';
 			return {
 				...page,
-				excludePersisted: getExcludePersisted(
+				excludePersisted: getQueryExcludedScreens().includes(
 					path.replace( '/analytics', '' ).replace( '/', '' )
 				),
 			};

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.3.0
+
+-   `getQueryExcludedScreens` Return a list of screens that should be excluded from persisted query logic.
+-   `getScreenFromPath` Given a path (defaulting to current), return simple screen "name"
+
 # 5.2.0
 
 -   Add slot/fill components WooNavigationItem, NavSlotFillProvider, and useNavSlot.

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -62,6 +62,18 @@ export const getQueryExcludedScreens = () =>
 	] );
 
 /**
+ * Retrieve a string 'name' representing the current screen
+ *
+ * @param {Object} path Path to resolve, default to current
+ * @return {string} Screen name
+ */
+export const getScreenFromPath = ( path = getPath() ) => {
+	return path === '/'
+		? 'homescreen'
+		: path.replace( '/analytics', '' ).replace( '/', '' );
+};
+
+/**
  * Get an array of IDs from a comma-separated query parameter.
  *
  * @param {string} queryString string value extracted from URL.

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -20,6 +20,8 @@ export { getHistory };
 // Export all filter utilities
 export * from './filters';
 
+const TIME_EXCLUDED_SCREENS_FILTER = 'woocommerce_admin_time_excluded_screens';
+
 /**
  * Get the current path from history.
  *
@@ -45,6 +47,19 @@ export const getPersistedQuery = ( query = navUtils.getQuery() ) => {
 	] );
 	return pick( query, params );
 };
+
+/**
+ * Get array of screens that should ignore persisted queries
+ *
+ * @return {Array} Array containing list of screens
+ */
+export const getQueryExcludedScreens = () =>
+	applyFilters( TIME_EXCLUDED_SCREENS_FILTER, [
+		'stock',
+		'settings',
+		'customers',
+		'homescreen',
+	] );
 
 /**
  * Get an array of IDs from a comma-separated query parameter.


### PR DESCRIPTION
Fixes #5684

The persisted queries haven't been persisting when using the new navigation. The logic to include this is already present, but there is nothing triggering a re-render in the plugin component when the history changes so the logic isn't utilized. 

This PR adds the history listener and triggers a state change when the persisted queries are updated.


### Detailed test instructions:

-  Check out branch
- Ensure that the new navigation is enabled.
- Go to an _Analytics_ report page and apply a different date range.
- Then navigate to a different report page (without a refresh), and ensure that the new date range persists.
- Disable the new navigation and do the same, ensuring that the old nav works as always.
