### PR TITLE
fix 404 URL in image tag

### DIFF
--- a/examples/activity-panel-inbox.md
+++ b/examples/activity-panel-inbox.md
@@ -19,7 +19,7 @@ But unlike today’s notices, this part of the UI will be reserved for “priori
 
 The second category is what we’re focusing on in this example - and what we expect the vast majority of extension developers will want to extend - we call it the “Activity Panel Inbox.” It will look something like this:
 
-<img src="images/activity-panel-inbox.png" width="400" title="Activity Panel Inbox" alt="Activity Panel Inbox" />
+![Activity Panel Inbox](images/activity-panel-inbox.png)
 
 This section is dedicated to informational content coming from multiple sources such as WooCommerce core, WooCommerce.com Subscription management, extensions activity and store achievements. This section was also envisioned to display more insightful content in the future, e.g. content that could help with the day to day tasks of managing and optimizing a store.
 


### PR DESCRIPTION
fix [broken image](https://woocommerce.github.io/woocommerce-admin/#/examples/activity-panel-inbox?id=category-2-activity-panel-inbox) in the Github Pages hosted docs