### PR TITLE
Fix 1.8.x Navigation requirements

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -10,7 +10,7 @@
 		"marketing": true,
 		"minified-js": false,
 		"mobile-app-banner": true,
-		"navigation": true,
+		"navigation": false,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -10,7 +10,7 @@
 		"marketing": true,
 		"minified-js": true,
 		"mobile-app-banner": true,
-		"navigation": true,
+		"navigation": false,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
 		"shipping-label-banner": true,

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -241,52 +241,6 @@ class Loader {
 	}
 
 	/**
-	 * Adds the Features section to the advanced tab of WooCommerce Settings
-	 *
-	 * @param array $sections Sections.
-	 * @return array
-	 */
-	public static function add_features_section( $sections ) {
-		$sections['features'] = __( 'Features', 'woocommerce-admin' );
-		return $sections;
-	}
-
-	/**
-	 * Adds the Features settings.
-	 *
-	 * @param array  $settings Settings.
-	 * @param string $current_section Current section slug.
-	 * @return array
-	 */
-	public static function add_features_settings( $settings, $current_section ) {
-		if ( 'features' !== $current_section ) {
-			return $settings;
-		}
-
-		return apply_filters(
-			'woocommerce_settings_features',
-			array(
-				array(
-					'title' => __( 'Features', 'woocommerce-admin' ),
-					'type'  => 'title',
-					'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' ),
-					'id'    => 'features_options',
-				),
-				array(
-					'title' => __( 'Navigation', 'woocommerce-admin' ),
-					'desc'  => __( 'Adds the new WooCommerce navigation experience to the dashboard', 'woocommerce-admin' ),
-					'id'    => 'woocommerce_navigation_enabled',
-					'type'  => 'checkbox',
-				),
-				array(
-					'type' => 'sectionend',
-					'id'   => 'features_options',
-				),
-			)
-		);
-	}
-
-	/**
 	 * Connects existing WooCommerce pages.
 	 *
 	 * @todo The entry point for the embed needs moved to this class as well.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -61,8 +61,6 @@ class Loader {
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		// Load feature before WooCommerce update hooks.
 		add_action( 'init', array( __CLASS__, 'load_features' ), 4 );
-		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ) );
-		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'add_features_settings' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_scripts' ), 15 );


### PR DESCRIPTION
Fixes issues relating to 1.8.1 release that enabled Navigation when it should not have. More info in pbIJXs-vY-p2

* Turn off feature flags for Plugin and Core
* Leave feature flag for Development
* Remove Advanced Feature setting section that contained toggle to turn Navigation on/off. Note that this code will be moved to wc-calypso-bridge.

### Detailed test instructions:

1. In Dev environments, make sure the feature toggle section is no longer visible.
2. Double check that the feature flags were correctly turned off for Plugin and Core.
