### PR TITLE
Fix Failure to Set Up Free Local Shipping

### DIFF
--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -64,6 +64,7 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
+		// Check Jetpack connection.
 		if ( class_exists( Jetpack_Connection_Manager::class ) ) {
  			$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
  		} else {

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -58,8 +58,8 @@ class OnboardingSetUpShipping {
 
 		// Check Jetpack connection.
 		if ( class_exists( Jetpack_Connection_Manager::class ) ) {
- 			$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
- 		} else {
+			$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
+		} else {
 			$jetpack_connected = false;
 		}
 

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -56,19 +56,16 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		if (
-			! class_exists( '\Jetpack_Data' ) ||
-			! class_exists( '\WC_Connect_Loader' ) ||
-			! class_exists( '\WC_Connect_Options' )
-		) {
-			return;
-		}
-
 		// Check Jetpack connection.
 		if ( class_exists( Jetpack_Connection_Manager::class ) ) {
  			$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
  		} else {
 			$jetpack_connected = false;
+		}
+
+		// Check WooCommerce Shipping & Tax plugin classes.
+		if ( ! class_exists( '\WC_Connect_Loader' ) || ! class_exists( '\WC_Connect_Options' ) ) {
+			return;
 		}
 
 		$wcs_version       = \WC_Connect_Loader::get_wcs_version();

--- a/src/Features/OnboardingSetUpShipping.php
+++ b/src/Features/OnboardingSetUpShipping.php
@@ -9,6 +9,7 @@ namespace Automattic\WooCommerce\Admin\Features;
 
 use \Automattic\WooCommerce\Admin\PluginsHelper;
 use \Automattic\WooCommerce\Admin\Notes\ReviewShippingSettings;
+use \Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 
 /**
  * This contains logic for setting up shipping when the profiler completes.
@@ -63,16 +64,10 @@ class OnboardingSetUpShipping {
 			return;
 		}
 
-		if ( defined( 'JETPACK_MASTER_USER' ) ) {
-			$user_token = \Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-			$jetpack_connected = isset( $user_token->external_user_id );
-		} else {
-			/**
-			 * Filter allowing to set the status of the jetpack connection wiuthout setting constant `JETPACK_MASTER_USER`
-			 *
-			 * @param bool $is_connected False.
-			 */
-			$jetpack_connected = apply_filters( 'woocommerce_admin_is_jetpack_connected', false );
+		if ( class_exists( Jetpack_Connection_Manager::class ) ) {
+ 			$jetpack_connected = ( new Jetpack_Connection_Manager() )->is_active();
+ 		} else {
+			$jetpack_connected = false;
 		}
 
 		$wcs_version       = \WC_Connect_Loader::get_wcs_version();


### PR DESCRIPTION
This PR fixes a bug preventing free local shipping being set up when onboarding is completed.

At the end of the onboarding process, free local shipping should be set up when certain conditions are met, including that the Jetpack plugin is installed and connected. However the logic determining whether a site is connected to Jetpack was failing due to deprecated usage of Jetpack code. As such, the conditions to create free local shipping are never met and it fails to be set up in onboarding.

The following deprecate usage has been updated:

- The [`JETPACK_MASTER_USER`](https://github.com/Automattic/jetpack/blob/2b2103a4bf3f6767703f92f64e293751729b57bc/jetpack.php#L21-L27) constant.
- The [`Jetpack_Data`](https://github.com/Automattic/jetpack/blob/2b2103a4bf3f6767703f92f64e293751729b57bc/class.jetpack-data.php#L5-L8) class.

This has been replaced with [`Manager::is_active`,](https://github.com/Automattic/jetpack/blob/2b2103a4bf3f6767703f92f64e293751729b57bc/packages/connection/src/class-manager.php#L524) which was recommended by Jetpack developers. This provides[ compatibility with Jetpack back to version `7.5`](https://plugins.svn.wordpress.org/jetpack/tags/7.5/vendor/automattic/jetpack-connection/src/). 

Additionally, the `woocommerce_admin_is_jetpack_connected` filter has been removed because its use-case is no longer needed with usage of `JETPACK_MASTER_USER` removed, per https://github.com/woocommerce/woocommerce-admin/pull/5880#issuecomment-747925876. This filter has not made it into a release yet so I don't think there are backwards-compatibility concerns.

### Detailed test instructions:

With a clean installation of WC Admin:

-   Complete the onboarding wizard, using the following configuration:
    - US location
    - Store contains physical products
    - Install and connect Jetpack when prompted
    - Install WooCommerce Shipping & Tax when prompted
-  Confirm that a US shipping zone is automatically added in the WooCommerce Shipping settings.

![Screen Shot 2020-12-23 at 3 17 15 pm](https://user-images.githubusercontent.com/9312929/102975395-f671b980-453a-11eb-8a19-9606cee63810.png)


<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->