### PR TITLE
Fix undefined index error

### DIFF
--- a/src/API/Products.php
+++ b/src/API/Products.php
@@ -157,7 +157,9 @@ class Products extends \WC_REST_Products_Controller {
 				$data->data['last_order_date'] = wc_rest_prepare_date_response( $this->last_order_dates[ $product_id ] );
 			}
 		}
-		$data->data['name'] = wp_strip_all_tags( $data->data['name'] );
+		if ( isset( $data->data['name'] ) ) {
+			$data->data['name'] = wp_strip_all_tags( $data->data['name'] );
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
The WooCommerce admin page triggers a call to the following URI:
/wp-json/wc-analytics/products?page=1&per_page=1&low_in_stock=true&status=publish&_fields%5B0%5D=id&_locale=user

This currently throws the following error for each product returned as the code assumes that "name" is included in the response (It's a similar issue #5989). 

This PR fixes this issue by only attempting to call `wp_strip_all_tags` on the name if it is present. 

Changelog note:
Fix: Undefined index error thrown on WooCommerce admin page for each low stock item
