### PR TITLE
Set `$collate` to an empty string in case a database backend doesn't support collation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Fix: Undefined $collate variable when database does not have collation capability. #5992
 - Tweak: Remove visit_count from track, and update task count logic. #5996
 - Fix: Moved certified owner label for review to title. ##5877
 - Fix: Move collapsible config to panels object, to allow for more control. #5855

--- a/src/Install.php
+++ b/src/Install.php
@@ -188,9 +188,7 @@ class Install {
 	protected static function get_schema() {
 		global $wpdb;
 
-		if ( $wpdb->has_cap( 'collation' ) ) {
-			$collate = $wpdb->get_charset_collate();
-		}
+		$collate = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
 
 		// Max DB index length. See wp_get_db_schema().
 		$max_index_length = 191;


### PR DESCRIPTION
Fixes #


`$collate` variable is undefined while trying to install Woocommerce

### Screenshots

![image](https://user-images.githubusercontent.com/5086322/103509742-a935f780-4e18-11eb-9355-0a684c73986e.png)


### Detailed test instructions:

- Copy this file https://github.com/aaemnnosttv/wp-sqlite-db/blob/master/src/db.php into `wp-content`
- Copy `wp-config-sample.php` to `wp-config.php`. Use this file as an example:  https://github.com/aaemnnosttv/wp-sqlite-db/blob/master/tests/wp-config.php
- Install Woocommerce


I would really appreciate some feedback on mysterious Travis CI errors and suggestions on how to add a simple test to test this change! Thanks!

PS I also grepped for `$wpdb->has_cap( 'collation' )` and this seems to be the only unhandled occurrence. 