### PR TITLE
Update onboarding email marketing note title

### DIFF
--- a/src/Notes/OnboardingEmailMarketing.php
+++ b/src/Notes/OnboardingEmailMarketing.php
@@ -32,7 +32,7 @@ class OnboardingEmailMarketing {
 		$content = __( 'We\'re here for you - get tips, product updates and inspiration straight to your email box', 'woocommerce-admin' );
 
 		$note = new Note();
-		$note->set_title( __( 'Tips, product updates, and inspiration', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Sign up for tips, product updates, and inspiration', 'woocommerce-admin' ) );
 		$note->set_content( $content );
 		$note->set_content_data( (object) array() );
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );


### PR DESCRIPTION
Fixes #5919

Updates the note title.

### Detailed test instructions:

1. Delete the note if it exists.
2. Retrigger the note via `wc_admin_daily` cron event.
3. Note the note title.