### PR TITLE
Version bump to 1.9.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "1.8.0-dev",
+	"version": "1.9.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "1.8.0-dev",
+	"version": "1.9.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -8488,7 +8488,8 @@
 			"requires": {
 				"@babel/runtime-corejs2": "7.12.5",
 				"@woocommerce/number": "2.0.0",
-				"@wordpress/deprecated": "^2.9.0"
+				"@wordpress/deprecated": "^2.9.0",
+				"@wordpress/html-entities": "2.7.0"
 			},
 			"dependencies": {
 				"@woocommerce/number": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "1.8.0-dev",
+	"version": "1.9.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.6.0
 Requires PHP: 5.6.20
-Stable tag: 1.8.0-dev
+Stable tag: 1.9.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -24,7 +24,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.8.0-dev';
+	const VERSION = '1.9.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -152,7 +152,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '1.8.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '1.9.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 1.8.0-dev
+ * Version: 1.9.0-dev
  * Requires at least: 5.3
  * Requires PHP: 5.6.20
  *


### PR DESCRIPTION
Bump the version on `main` so that composer uses it instead of 1.8.2 for those of us on the latest WooCommerce Core `master` branch.

This code was done by using the script `npm run bump-version`.