### PR TITLE
Pass prop role to MenuGroup

### DIFF
--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -179,6 +179,7 @@ export class SearchListControl extends Component {
 			<MenuGroup
 				label={ messages.list }
 				className="woocommerce-search-list__list"
+				role="menu"
 			>
 				{ this.renderList( list ) }
 			</MenuGroup>


### PR DESCRIPTION
Fixes #3642

Pass prop role to MenuGroup

### Detailed test instructions:
1. Check out the GB PR https://github.com/WordPress/gutenberg/pull/28053
2. Build the GB packages
3. `npm link` inside the `packages/components` directory
4. `npm link @wordpress/components` in WooCommerce Admin.
5. Run storybook.
6. Check that the container has a role of `menu`.

