### PR TITLE
Restrict beta features to only those that have opted into tracking, adding modal for navigation feature

### DIFF
--- a/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -2,12 +2,29 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { Button, Modal, CheckboxControl } from '@wordpress/components';
 
 export const BetaFeaturesTrackingContainer = () => {
-	const [ isModalOpen, setIsModalOpen ] = useState( true );
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ isChecked, setIsChecked ] = useState( false );
+
+	useEffect( () => {
+		const enableNavigationCheckbox = document.querySelector(
+			'#woocommerce_navigation_enabled'
+		);
+
+		enableNavigationCheckbox.addEventListener(
+			'change',
+			( e ) => {
+				if ( e.target.checked ) {
+					e.target.checked = false;
+					setIsModalOpen( true );
+				}
+			},
+			false
+		);
+	}, [] );
 
 	if ( ! isModalOpen ) {
 		return null;
@@ -40,10 +57,7 @@ export const BetaFeaturesTrackingContainer = () => {
 				/>
 			</div>
 			<div className="woocommerce-beta-features-tracking-modal__actions">
-				<Button
-					isPrimary
-					onClick={ () => this.setState( { isModalOpen: false } ) }
-				>
+				<Button isPrimary onClick={ () => setIsModalOpen( false ) }>
 					{ __( 'Save', 'woocommerce-admin' ) }
 				</Button>
 			</div>

--- a/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { Button, Modal, CheckboxControl } from '@wordpress/components';
+
+export const BetaFeaturesTrackingContainer = () => {
+	const [ isModalOpen, setIsModalOpen ] = useState( true );
+	const [ isChecked, setIsChecked ] = useState( false );
+
+	if ( ! isModalOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ __( 'Build a Better WooCommerce', 'woocommerce-admin' ) }
+			onRequestClose={ () => setIsModalOpen( false ) }
+			className="woocommerce-beta-features-tracking-modal"
+		>
+			<p>
+				{ __(
+					'Testing new features requires sharing non-sensitive data via ',
+					'woocommerce-admin'
+				) }
+				<a href="https://woocommerce.com/usage-tracking">
+					{ __( 'usage tracking', 'woocommerce-admin' ) }
+				</a>
+				{ __(
+					'. Gathering usage data allows us to make WooCommerce better — your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. No personal data is tracked or stored and you can opt-out at any time.',
+					'woocommerce-admin'
+				) }
+			</p>
+			<div className="woocommerce-beta-features-tracking-modal__checkbox">
+				<CheckboxControl
+					label="Enable usage tracking"
+					onChange={ setIsChecked }
+					checked={ isChecked }
+				/>
+			</div>
+			<div className="woocommerce-beta-features-tracking-modal__actions">
+				<Button
+					isPrimary
+					onClick={ () => this.setState( { isModalOpen: false } ) }
+				>
+					{ __( 'Save', 'woocommerce-admin' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};

--- a/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -30,6 +30,9 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 	};
 
 	useEffect( () => {
+		if ( ! enableNavigationCheckbox.current ) {
+			return;
+		}
 		const listener = ( e ) => {
 			if ( e.target.checked ) {
 				e.target.checked = false;
@@ -43,6 +46,10 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 
 		return () => checkbox.removeEventListener( 'change', listener );
 	}, [] );
+
+	if ( ! enableNavigationCheckbox.current ) {
+		return null;
+	}
 
 	if ( ! isModalOpen ) {
 		return null;

--- a/client/wp-admin-scripts/beta-features-tracking-modal/container.js
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/container.js
@@ -7,6 +7,7 @@ import { Button, Modal, CheckboxControl } from '@wordpress/components';
 import { withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { OPTIONS_STORE_NAME } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -22,6 +23,10 @@ const BetaFeaturesTrackingModal = ( { updateOptions } ) => {
 			} else {
 				window.wcTracks.isEnabled = false;
 			}
+		}
+
+		if ( allow ) {
+			recordEvent( 'settings_features_tracking_enabled' );
 		}
 
 		return updateOptions( {

--- a/client/wp-admin-scripts/beta-features-tracking-modal/index.js
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/index.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { BetaFeaturesTrackingContainer } from './container';
+import './style.scss';
+
+const betaFeaturesRoot = document.createElement( 'div' );
+betaFeaturesRoot.setAttribute( 'id', 'beta-features-tracking' );
+
+render(
+	<BetaFeaturesTrackingContainer />,
+	document.body.appendChild( betaFeaturesRoot )
+);

--- a/client/wp-admin-scripts/beta-features-tracking-modal/style.scss
+++ b/client/wp-admin-scripts/beta-features-tracking-modal/style.scss
@@ -1,0 +1,12 @@
+.woocommerce-beta-features-tracking-modal__actions {
+	text-align: right;
+	margin-top: $gap-large;
+
+	.components-button.is-primary {
+		margin-left: $gap;
+	}
+}
+
+.woocommerce-beta-features-tracking-modal__checkbox {
+	padding: $gap 0;
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -281,12 +281,28 @@ class Loader {
 			return $settings;
 		}
 
+		$rtl = is_rtl() ? '.rtl' : '';
+		wp_enqueue_style(
+			'wc-admin-beta-features-tracking-modal',
+			self::get_url( "beta-features-tracking-modal/style{$rtl}", 'css' ),
+			array( 'wp-components' ),
+			self::get_file_version( 'css' )
+		);
+
+		wp_enqueue_script(
+			'wc-admin-beta-features-tracking-modal',
+			self::get_url( 'wp-admin-scripts/beta-features-tracking-modal', 'js' ),
+			array( 'wp-i18n', 'wp-element', WC_ADMIN_APP ),
+			self::get_file_version( 'js' ),
+			true
+		);
+
 		return array_merge(
 			array(
 				array(
 					'title' => __( 'Features', 'woocommerce-admin' ),
 					'type'  => 'title',
-					'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce-admin' ),
+					'desc'  => __( 'Test new features to improve the store management experience. These features might be included in future versions of WooCommerce. <a href="https://href.li/?https://woocommerce.com/usage-tracking/">Requires usage tracking.</a>', 'woocommerce-admin' ),
 					'id'    => 'features_options',
 				),
 			),

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -63,6 +63,7 @@ class Loader {
 		add_action( 'init', array( __CLASS__, 'load_features' ), 4 );
 		add_filter( 'woocommerce_get_sections_advanced', array( __CLASS__, 'add_features_section' ) );
 		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'add_features_settings' ), 10, 2 );
+		add_filter( 'woocommerce_get_settings_advanced', array( __CLASS__, 'maybe_load_beta_features_modal' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'inject_wc_settings_dependencies' ), 14 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'load_scripts' ), 15 );
@@ -261,6 +262,39 @@ class Loader {
 	}
 
 	/**
+	 * Conditionally loads the beta features tracking modal.
+	 *
+	 * @param array $settings Settings.
+	 * @return array
+	 */
+	public static function maybe_load_beta_features_modal( $settings ) {
+		$tracking_enabled = get_option( 'woocommerce_allow_tracking', 'no' );
+
+		if ( 'yes' === $tracking_enabled ) {
+			return $settings;
+		}
+
+		$rtl = is_rtl() ? '.rtl' : '';
+
+		wp_enqueue_style(
+			'wc-admin-beta-features-tracking-modal',
+			self::get_url( "beta-features-tracking-modal/style{$rtl}", 'css' ),
+			array( 'wp-components' ),
+			self::get_file_version( 'css' )
+		);
+
+		wp_enqueue_script(
+			'wc-admin-beta-features-tracking-modal',
+			self::get_url( 'wp-admin-scripts/beta-features-tracking-modal', 'js' ),
+			array( 'wp-i18n', 'wp-element', WC_ADMIN_APP ),
+			self::get_file_version( 'js' ),
+			true
+		);
+
+		return $settings;
+	}
+
+	/**
 	 * Adds the Features settings.
 	 *
 	 * @param array  $settings Settings.
@@ -280,22 +314,6 @@ class Loader {
 		if ( empty( $features ) ) {
 			return $settings;
 		}
-
-		$rtl = is_rtl() ? '.rtl' : '';
-		wp_enqueue_style(
-			'wc-admin-beta-features-tracking-modal',
-			self::get_url( "beta-features-tracking-modal/style{$rtl}", 'css' ),
-			array( 'wp-components' ),
-			self::get_file_version( 'css' )
-		);
-
-		wp_enqueue_script(
-			'wc-admin-beta-features-tracking-modal',
-			self::get_url( 'wp-admin-scripts/beta-features-tracking-modal', 'js' ),
-			array( 'wp-i18n', 'wp-element', WC_ADMIN_APP ),
-			self::get_file_version( 'js' ),
-			true
-		);
 
 		return array_merge(
 			array(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,6 +78,7 @@ const wpAdminScripts = [
 	'onboarding-product-import-notice',
 	'onboarding-tax-notice',
 	'print-shipping-label-banner',
+	'beta-features-tracking-modal',
 ];
 wpAdminScripts.forEach( ( name ) => {
 	entryPoints[ name ] = `./client/wp-admin-scripts/${ name }`;

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Admin (ADD beta features tracked)
+ * Plugin Name: WooCommerce Admin
  * Plugin URI: https://github.com/woocommerce/woocommerce-admin
  * Description: A new JavaScript-driven interface for managing your store. The plugin includes new and improved reports, and a dashboard to monitor all the important key metrics of your site.
  * Author: WooCommerce

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Admin
+ * Plugin Name: WooCommerce Admin (ADD beta features tracked)
  * Plugin URI: https://github.com/woocommerce/woocommerce-admin
  * Description: A new JavaScript-driven interface for managing your store. The plugin includes new and improved reports, and a dashboard to monitor all the important key metrics of your site.
  * Author: WooCommerce


### PR DESCRIPTION
Fixes #5930

This PR implements the flow to be triggered when a user attempts to opt into the new navigation feature, detailed in the originating issue. These beta features will be restricted exclusively to those opted into tracking. 

_Possible Concerns_
- The modal is fairly tightly coupled to the navigation feature checkbox at the moment. I'm not sure of the likelihood or timeline if when we may want to use the modal elsewhere, but it will require some minor changes. I'm not sure if that's something we want to tackle in this PR, or leave it until the issue arises.
- I'm using a filter to conditionally load the modal script in `Loader.php` right now. It would be best to factor some of this logic into another file at some point (as mentioned by @joshuatf ) since this file has become a catch-all.
- I'm also using a `filter` instead of an `action` simply because this filter only triggers on the _Settings_ screen, and I wasn't aware of a comparable `action`. Just let me know if one exists.
- There is an async operation to change the option when hitting the _Save_ button, but no loading/etc indicator. I didn't see anything like that used elsewhere, but I'm glad to add it if it's suggested. 

### Screenshots

![image](https://user-images.githubusercontent.com/444632/104390957-b8d9ce00-54f3-11eb-9e89-e86fdeb9b9c8.png)


### Detailed test instructions:

-   Check out branch
-   Ensure tracking is disabled, either removing `woocommerce_allow_tracking` option or settings to "no," and the new navigation is disabled.
-   Navigate to `Settings -> Advanced -> Features` and click the checkbox to enable the new navigation.
- The modal should appear.
- If you check the "Enable usage tracking" checkbox and click "Save," the option `woocommerce_allow_tracking` should change to "yes" and the nav feature checkbox should be checked.
- If you exit in any other way, the nav feature checkbox should remain unchecked.

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
