### PR TITLE
Apply IE fix for Array.flat

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,15 +1,18 @@
-const { babelConfig: e2eBabelConfig } = require( '@woocommerce/e2e-environment' );
+const {
+	babelConfig: e2eBabelConfig,
+} = require( '@woocommerce/e2e-environment' );
 
-module.exports = function( api ) {
+module.exports = function ( api ) {
 	api.cache( true );
 
 	return {
-        ...e2eBabelConfig,
-        presets: [
-              ...e2eBabelConfig.presets,
-              '@wordpress/babel-preset-default',
-        ],
-        plugins: [
+		...e2eBabelConfig,
+		presets: [
+			...e2eBabelConfig.presets,
+			'@wordpress/babel-preset-default',
+		],
+		sourceType: 'unambiguous',
+		plugins: [
 			/**
 			 * This allows arrow functions as class methods so that binding
 			 * methods to `this` in the constructor isn't required.

--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -51,7 +51,9 @@ export class TaskList extends Component {
 
 	getUngroupedTasks() {
 		const { tasks: groupedTasks } = this.props;
-		return Object.values( groupedTasks ).flat();
+		return Object.values( groupedTasks ).reduce( ( acc, task ) => {
+			return acc.concat( task );
+		}, [] );
 	}
 
 	getSpecificTasks() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,7 +117,7 @@ const webpackConfig = {
 			},
 			{
 				test: /\.js?$/,
-				exclude: /node_modules/,
+				exclude: /node_modules(\/|\\)(?!(debug))/,
 				use: {
 					loader: 'babel-loader',
 					options: {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/5968

This PR ports a solution that was applied to `release/1.8.3` in https://github.com/woocommerce/woocommerce-admin/pull/5987. Since we didn't get a more robust solution in place, this PR cherry-picked the commit and replaced usage of `Array.flat()` with an IE11 compatible solution.

### Detailed test instructions:

1. Fire up IE11 🔥 
2. Smoke test WCA pages.
3. Make sure things load.
4. Check other browsers to make sure no regressions have occurred.
