### PR TITLE
New note: manage activity from home screen

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: update the content for the ChooseNiche note. #6048
 - Fix: Generate JSON translation chunks on plugin activation #6028
 - Dev: Update travis CI distribution. #6067
+- Add: Manage activity from home screen inbox message. #6072
 
 == 1.8.3 1/5/2021 ==
 

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -21,6 +21,7 @@ use \Automattic\WooCommerce\Admin\Notes\TestCheckout;
 use \Automattic\WooCommerce\Admin\Notes\SellingOnlineCourses;
 use \Automattic\WooCommerce\Admin\Notes\MerchantEmailNotifications\MerchantEmailNotifications;
 use \Automattic\WooCommerce\Admin\Notes\WelcomeToWooCommerceForStoreUsers;
+use \Automattic\WooCommerce\Admin\Notes\ManageStoreActivityFromHomeScreen;
 
 /**
  * Feature plugin main class.
@@ -193,6 +194,7 @@ class FeaturePlugin {
 		new SellingOnlineCourses();
 		new LearnMoreAboutVariableProducts();
 		new WelcomeToWooCommerceForStoreUsers();
+		new ManageStoreActivityFromHomeScreen();
 
 		// Initialize RemoteInboxNotificationsEngine.
 		RemoteInboxNotificationsEngine::init();

--- a/src/Install.php
+++ b/src/Install.php
@@ -137,7 +137,25 @@ class Install {
 		 */
 		if ( ! $version_option || $requires_update ) {
 			self::install();
+			/**
+			 * WooCommerce Admin has been installed or updated.
+			 */
 			do_action( 'woocommerce_admin_updated' );
+
+			if ( ! $version_option ) {
+				/**
+				 * WooCommerce Admin has been installed.
+				 */
+				do_action( 'woocommerce_admin_installed' );
+			}
+
+			if ( $requires_update ) {
+				/**
+				 * An existing installation of WooCommerce Admin has been
+				 * updated.
+				 */
+				do_action( 'woocommerce_admin_updated_existing' );
+			}
 		}
 
 		/*

--- a/src/Install.php
+++ b/src/Install.php
@@ -146,7 +146,7 @@ class Install {
 				/**
 				 * WooCommerce Admin has been installed.
 				 */
-				do_action( 'woocommerce_admin_installed' );
+				do_action( 'woocommerce_admin_newly_installed' );
 			}
 
 			if ( $requires_update ) {

--- a/src/Notes/ManageStoreActivityFromHomeScreen.php
+++ b/src/Notes/ManageStoreActivityFromHomeScreen.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * New! Manage your store activity from the Home screen.
+ */
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * New! Manage your store activity from the Home screen.
+ */
+class ManageStoreActivityFromHomeScreen {
+	/**
+	 * Note traits.
+	 */
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-admin-manage-store-activity-from-home-screen';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		add_action(
+			'woocommerce_admin_updated_existing',
+			array( $this, 'possibly_add_note' )
+		);
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Note|null
+	 */
+	public static function get_note() {
+		$installed_version = get_option( 'woocommerce_admin_version' );
+		if ( ! version_compare( $installed_version, '1.9.0-dev', '=' ) ) {
+			return;
+		}
+
+		$note = new Note();
+
+		$note->set_title( __( 'New! Manage your store activity from the Home screen', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Start your day knowing the next steps you need to take with your orders, products, and customer feedback.<br/><br/>Read more about how to use the activity panels on the Home screen.', 'woocommerce-admin' ) );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://docs.woocommerce.com/document/home-screen/?utm_source=inbox"',
+			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			true
+		);
+
+		return $note;
+	}
+}

--- a/src/Notes/ManageStoreActivityFromHomeScreen.php
+++ b/src/Notes/ManageStoreActivityFromHomeScreen.php
@@ -38,7 +38,7 @@ class ManageStoreActivityFromHomeScreen {
 	 */
 	public static function get_note() {
 		$installed_version = get_option( 'woocommerce_admin_version' );
-		if ( ! version_compare( $installed_version, '1.9.0-dev', '=' ) ) {
+		if ( ! version_compare( $installed_version, '1.9.0', '=' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #5957

This adds a new note that only triggers when updating to WooCommerce Admin 1.9.0.

### Screenshots
![image](https://user-images.githubusercontent.com/224531/104545039-d8e4cb00-5674-11eb-88cd-3cb8865be911.png)

### Detailed test instructions:

1. Go to the WooCommerce home screen. The notification should not be present.
2. `UPDATE wp_options SET option_value = '1.8.0' WHERE option_name = 'woocommerce_admin_version'`
3. In `ManageStoreActivityFromHomeScreen.php` set the version that is checked (line 41) to `1.9.0-dev` (or whatever the version you are using will update to).
4. Refresh home screen - this will trigger the update. Note should now be present.
