### PR TITLE
Allow for larger result sets of attribute terms

### DIFF
--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -91,7 +91,7 @@ const AttributeFilter = ( props ) => {
 			value[ 0 ]
 		) {
 			apiFetch( {
-				path: `/wc-analytics/products/attributes/${ value[ 0 ] }`,
+				path: `/wc-analytics/products/attributes/${ value[ 0 ] }?per_page=-1`,
 			} )
 				.then( ( { id, name } ) => [
 					{
@@ -112,7 +112,7 @@ const AttributeFilter = ( props ) => {
 		}
 		setAttributeTerms( false );
 		apiFetch( {
-			path: `/wc-analytics/products/attributes/${ selectedAttribute[ 0 ].key }/terms`,
+			path: `/wc-analytics/products/attributes/${ selectedAttribute[ 0 ].key }/terms?per_page=-1`,
 		} )
 			.then( ( terms ) =>
 				terms.map( ( { id, name } ) => ( {

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -91,7 +91,7 @@ const AttributeFilter = ( props ) => {
 			value[ 0 ]
 		) {
 			apiFetch( {
-				path: `/wc-analytics/products/attributes/${ value[ 0 ] }?per_page=-1`,
+				path: `/wc-analytics/products/attributes/${ value[ 0 ] }`,
 			} )
 				.then( ( { id, name } ) => [
 					{

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -112,7 +112,7 @@ const AttributeFilter = ( props ) => {
 		}
 		setAttributeTerms( false );
 		apiFetch( {
-			path: `/wc-analytics/products/attributes/${ selectedAttribute[ 0 ].key }/terms?per_page=-1`,
+			path: `/wc-analytics/products/attributes/${ selectedAttribute[ 0 ].key }/terms?per_page=100`,
 		} )
 			.then( ( terms ) =>
 				terms.map( ( { id, name } ) => ( {

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,10 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 2. Activity Panels
 3. Analytics
 
+== Unreleased ==
+
+- Fix: allow for more terms to be shown for product attributes in the Analytics orders report.
+
 == Changelog ==
 
 == 1.9.0 1/15/2021 ==


### PR DESCRIPTION
At least in part this fixes #5868 

The issue is that attributes and attribute terms work quite differently in the search at the moment.

Attributes will not show anything until you start typing, at which point it does a `search` request with what you've typed and limits it to 10 results. This makes sense and works.

Attribute terms however does not do this, first it requests all the terms for the attribute selected, *but* without a per page limit this only returns 10 results, causing the confusion we saw in #5868. However my solution of a per_page limit of `-1` will still limit results to 100. 

A more extensive solution to this (in the case where an attribute has more than 100 terms), would be to ensure that they're all fetched up front and then text search the entire result set, or if possible do a search on the entered text like we do for attributes.

I'm suggesting this as an interim fix that at least makes it more usable for a majority of users.

### Detailed test instructions:

1. Create a product attribute
2. Give the attribute more than 10 terms
3. Go to Analytics -> Orders
4. Add an attribute filter to the list, choose your attribute.
5. Go to the second input field and click on it, a result set of all your terms should appear
