### PR TITLE
WC core is on composer 2 now so no need to downgrade in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,10 @@ matrix:
         php: 7.3
         env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress RUN_RANDOM=1 COMPOSER_DEV=1
 
+# Composer 2.0.7 introduced a change that broke the jetpack autoloader in PHP 7.0 - 7.3.
 before_install:
     - nvm install 'lts/*'
+    - composer self-update 2.0.6
 
 before_script:
     - phpenv config-rm xdebug.ini

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -192,7 +192,12 @@ install_deps() {
 
 	# Bring in WooCommerce Core dependencies
 	cd "woocommerce"
- 	composer install --no-dev
+	composer --version
+	if [[ "$COMPOSER_DEV" == "1" ]]; then
+		composer install
+	else
+		composer install --no-dev
+	fi
 
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -191,10 +191,8 @@ install_deps() {
 	git clone --depth 1 --branch $LATEST_WC_TAG https://github.com/woocommerce/woocommerce.git
 
 	# Bring in WooCommerce Core dependencies
- 	composer self-update --1
 	cd "woocommerce"
  	composer install --no-dev
-	composer self-update --2
 
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce


### PR DESCRIPTION
The builds are currently broken, I suspect this is because wc core has gone to composer 2 now so autoloader generation fails for us with our downgrade of composer in place.

If this build passes my suspicion is correct 😄 