### PR TITLE
Hide tooltip in welcome modal

### DIFF
--- a/client/homescreen/welcome-modal/style.scss
+++ b/client/homescreen/welcome-modal/style.scss
@@ -8,11 +8,6 @@
 
 		.components-button {
 			color: $white;
-
-			// @todo Remove this after https://github.com/WordPress/gutenberg/issues/28311 is fixed
-			span {
-				display: none;
-			}
 		}
 	}
 

--- a/client/homescreen/welcome-modal/style.scss
+++ b/client/homescreen/welcome-modal/style.scss
@@ -8,6 +8,10 @@
 
 		.components-button {
 			color: $white;
+
+			span {
+				display: none;
+			}
 		}
 	}
 

--- a/client/homescreen/welcome-modal/style.scss
+++ b/client/homescreen/welcome-modal/style.scss
@@ -9,6 +9,7 @@
 		.components-button {
 			color: $white;
 
+			// @todo Remove this after https://github.com/WordPress/gutenberg/issues/28311 is fixed
 			span {
 				display: none;
 			}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -158,6 +158,11 @@
 	}
 }
 
+// @todo Remove this after https://github.com/WordPress/gutenberg/issues/28311 is fixed
+.components-modal__header .components-button svg + span {
+	display: none;
+}
+
 .components-modal__frame.woocommerce-usage-modal {
 	width: 600px;
 	max-width: 100%;


### PR DESCRIPTION
Fixes #6125 

Hide tooltip in welcome modal.

This is a temporary fix, it can be removed after https://github.com/WordPress/gutenberg/issues/28311 is fixed.

### Screenshots
<img width="528" alt="before" src="https://user-images.githubusercontent.com/56378160/105407676-03e29800-5bfc-11eb-90b2-0a5ae77e8f04.png">

<img width="539" alt="after" src="https://user-images.githubusercontent.com/56378160/105407683-07761f00-5bfc-11eb-8314-d16ca00ef08e.png">

### Detailed test instructions:
-  Test via Firefox
-   Find welcome-modal file -> layout
-   Replace `shouldShowWelcomeModal` with `true` to keep the modal open
-   Hover over the close button and check that the tooltip does not render and scrollbar does not show

