### PR TITLE
Dev/fix css lint

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -194,7 +194,6 @@ install_deps() {
  	composer self-update --1
 	cd "woocommerce"
  	composer install --no-dev
-	composer self-update --2
 
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"labels:sync": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels woocommerce/woocommerce-admin",
 		"lint": "npm run lint:js && npm run lint:css",
 		"lint:css": "stylelint '**/*.scss'",
-		"lint:css-fix": "stylelint '**/*.scss' --fix",
+		"lint:css-fix": "stylelint '**/*.scss' --fix --ip 'storybook/wordpress/*'",
 		"lint:js": "wp-scripts lint-js ./packages ./client",
 		"lint:js:packages": "wp-scripts lint-js ./packages",
 		"lint:js:client": "wp-scripts lint-js ./client",


### PR DESCRIPTION
Fixes #6133 

This adds an "ignore pattern" flag to the CSS lint so that it doesn't fail on files we gitignore from the storybook folder (specifically the scss downloaded from Wordpress). I didn't ignore the whole storybook folder because there is at least one top level scss file in there that we wrote.

### Detailed test instructions:

1. Checkout `main`. run `npm run storybook`, wait for it to finish. There should be a new folder in `storybook/wordpress`
2. Run `npm run lint:css-fix`, it *should show errors*
3. Now check out this branch and repeat step 1 & 2 and you should see no errors.
4. For bonus points, put an erroneous piece of scss in a file that *shouldn't* be ignored and repeat step 3. It *should* show errors.
