### PR TITLE
Go to v3 of stale action to support the arguments we're using

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ jobs:
     stale:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v3.0.14
+            - uses: actions/stale@v3
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   days-before-issue-stale: 90


### PR DESCRIPTION
It's quite hard to test actions in isolation, so I didn't realise that the *latest* version of stale action does not support some of the arguments we're using.

This down-bumps stale to use v3 which still supports these extra flags we're using. I'm not sure why they were removed, and I suspect it may have been accidental. I've raised an issue: https://github.com/actions/stale/issues/287