### PR TITLE
Increase makes ops per run for the stale action to audit what will be closed

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,3 +22,4 @@ jobs:
                   stale-issue-label: 'status: stale'
                   exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
                   debug-only: true
+                  operations-per-run: 500


### PR DESCRIPTION
This will be removed when we go to switch it off debug mode.