### PR TITLE
Update Stale Action with Ascending Order

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,3 +23,4 @@ jobs:
                   exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
                   debug-only: true
                   operations-per-run: 500
+                  ascending: true


### PR DESCRIPTION
This ensures the oldest issues/PRs are processed first.