### PR TITLE
Make stale bot use 60 days for PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,5 +20,6 @@ jobs:
                   stale-pr-label: 'status: stale'
                   stale-issue-label: 'status: stale'
                   debug-only: true
+                  operations-per-run: 500
                   exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
                   ascending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,4 @@ jobs:
                   stale-pr-label: 'status: stale'
                   stale-issue-label: 'status: stale'
                   exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
-                  debug-only: true
-                  operations-per-run: 500
                   ascending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,8 +11,7 @@ jobs:
             - uses: actions/stale@v3
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  days-before-issue-stale: 90
-                  days-before-pr-stale: 30
+                  days-before-stale: 60
                   days-before-close: 5
                   stale-issue-message: 'This issue has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
                   stale-pr-message: 'This PR has been automatically marked as stale because it has not had any recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
@@ -20,5 +19,6 @@ jobs:
                   close-pr-message: 'This PR was automatically closed due to being stale.'
                   stale-pr-label: 'status: stale'
                   stale-issue-label: 'status: stale'
+                  debug-only: true
                   exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
                   ascending: true


### PR DESCRIPTION
Stale bot doesn't yet support differentiating pr and issue close time I don't think. So I've moved it to a blanket value of 60. We'll assess the dry runs and see how it goes.