### PR TITLE
Turn stale bot on

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,5 @@ jobs:
                   close-pr-message: 'This PR was automatically closed due to being stale.'
                   stale-pr-label: 'status: stale'
                   stale-issue-label: 'status: stale'
-                  debug-only: true
-                  operations-per-run: 500
                   exempt-issue-labels: 'cooldown period,priority: high,priority: critical'
                   ascending: true


### PR DESCRIPTION
After looking at some dry runs such as: https://github.com/woocommerce/woocommerce-admin/runs/1747054049?check_suite_focus=true I'm confident the stale bot is conservative enough. This PR will switch it on to run 30 ops maximum every hour.