### PR TITLE
Check current user's install plugin capability before rendering

### DIFF
--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -99,7 +99,8 @@ export const InstallJetpackCTA = () => {
 				isBusy: busyState,
 				jetpackInstallState: installState,
 				canUserInstallPlugins:
-					currentUser.allcaps && currentUser.allcaps.install_plugins,
+					currentUser.capabilities &&
+					currentUser.capabilities.install_plugins,
 			};
 		}
 	);

--- a/client/homescreen/stats-overview/install-jetpack-cta.js
+++ b/client/homescreen/stats-overview/install-jetpack-cta.js
@@ -4,7 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PLUGINS_STORE_NAME, useUserPreferences } from '@woocommerce/data';
+import {
+	PLUGINS_STORE_NAME,
+	useUserPreferences,
+	USER_STORE_NAME,
+} from '@woocommerce/data';
 import { H } from '@woocommerce/components';
 import { recordEvent } from '@woocommerce/tracks';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
@@ -78,23 +82,33 @@ export const JetpackCTA = ( {
 
 export const InstallJetpackCTA = () => {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
-	const { jetpackInstallState, isBusy } = useSelect( ( select ) => {
-		const { getPluginInstallState, isPluginsRequesting } = select(
-			PLUGINS_STORE_NAME
-		);
-		const installState = getPluginInstallState( 'jetpack' );
-		const busyState =
-			isPluginsRequesting( 'getJetpackConnectUrl' ) ||
-			isPluginsRequesting( 'installPlugins' ) ||
-			isPluginsRequesting( 'activatePlugins' );
+	const { canUserInstallPlugins, jetpackInstallState, isBusy } = useSelect(
+		( select ) => {
+			const { getPluginInstallState, isPluginsRequesting } = select(
+				PLUGINS_STORE_NAME
+			);
+			const installState = getPluginInstallState( 'jetpack' );
+			const busyState =
+				isPluginsRequesting( 'getJetpackConnectUrl' ) ||
+				isPluginsRequesting( 'installPlugins' ) ||
+				isPluginsRequesting( 'activatePlugins' );
+			const { getCurrentUser } = select( USER_STORE_NAME );
+			const currentUser = getCurrentUser() || {};
 
-		return {
-			isBusy: busyState,
-			jetpackInstallState: installState,
-		};
-	} );
+			return {
+				isBusy: busyState,
+				jetpackInstallState: installState,
+				canUserInstallPlugins:
+					currentUser.allcaps && currentUser.allcaps.install_plugins,
+			};
+		}
+	);
 
 	const { installJetpackAndConnect } = useDispatch( PLUGINS_STORE_NAME );
+
+	if ( ! canUserInstallPlugins ) {
+		return null;
+	}
 
 	const onClickInstall = () => {
 		installJetpackAndConnect( createErrorNotice, getAdminLink );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1085,9 +1085,9 @@ class Loader {
 			}
 		}
 
-		$user_controller   = new \WP_REST_Users_Controller();
-		$user_response     = $user_controller->get_current_item( new \WP_REST_Request() );
-		$current_user_data = is_wp_error( $user_response ) ? (object) array() : $user_response->get_data();
+		$current_user_data                     = (array) get_userdata( get_current_user_id() );
+		$woocommerce_meta                      = self::get_user_data_values( array( 'id' => get_current_user_id() ) );
+		$current_user_data['woocommerce_meta'] = $woocommerce_meta;
 
 		$settings['currentUserData']      = $current_user_data;
 		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1085,9 +1085,11 @@ class Loader {
 			}
 		}
 
-		$current_user_data                     = (array) get_userdata( get_current_user_id() );
-		$woocommerce_meta                      = self::get_user_data_values( array( 'id' => get_current_user_id() ) );
-		$current_user_data['woocommerce_meta'] = $woocommerce_meta;
+		$user_controller = new \WP_REST_Users_Controller();
+		$request         = new \WP_REST_Request();
+		$request->set_query_params( array( 'context' => 'edit' ) );
+		$user_response     = $user_controller->get_current_item( $request );
+		$current_user_data = is_wp_error( $user_response ) ? (object) array() : $user_response->get_data();
 
 		$settings['currentUserData']      = $current_user_data;
 		$settings['reviewsEnabled']       = get_option( 'woocommerce_enable_reviews' );


### PR DESCRIPTION
Fixes #6124 

Check current user's install plugin capability before rendering.

### Screenshots
1. Admin
<img width="525" alt="admin" src="https://user-images.githubusercontent.com/56378160/105567562-c9165800-5d00-11eb-9c9f-f7533218fa5e.png">

2. Editor
<img width="528" alt="editor" src="https://user-images.githubusercontent.com/56378160/105567567-d0d5fc80-5d00-11eb-8caa-61e0de757d12.png">

### Detailed test instructions:
1. Add a role that can see WooCommerce reports, but not install plugins (for example, use Members by Memberpress and add the `manage_woocommerce` and `view_woocommerce_reports` capabilities, but not `install_plugins` to the "Editor" role.
2. Create a user with that role
3. Check that the user can see the report, but not the install Jetpack CTA
4. Check that admin users can still see the CTA.

