### PR TITLE
Navigation: Change default location and add Product category items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
 				"config": "^3.2.4",
 				"eslint": "6.7.2",
 				"jest": "^24.9.0",
+				"prettier": "npm:wp-prettier@1.19.1",
 				"puppeteer": "^2.0.0"
 			},
 			"dependencies": {
@@ -103,6 +104,11 @@
 							}
 						}
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@1.19.1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 				}
 			}
 		},
@@ -14865,6 +14871,15 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"optional": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bl": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -20394,6 +20409,12 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
+		},
 		"filelist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
@@ -25565,6 +25586,7 @@
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}
@@ -26677,6 +26699,15 @@
 			"requires": {
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
+			}
+		},
+		"locutus": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+			"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.2.5"
 			}
 		},
 		"lodash": {
@@ -37759,6 +37790,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}

--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -134,10 +134,11 @@ class CoreMenu {
 				'order'  => 20,
 			)
 		);
-		$coupon_items      = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'woocommerce-marketing' ) );
-		$setting_items     = self::get_setting_items();
-		$wca_items         = array();
-		$wca_pages         = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_pages();
+
+		$coupon_items  = Menu::get_post_type_items( 'shop_coupon', array( 'parent' => 'woocommerce-marketing' ) );
+		$setting_items = self::get_setting_items();
+		$wca_items     = array();
+		$wca_pages     = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_pages();
 
 		foreach ( $wca_pages as $page ) {
 			if ( ! isset( $page['nav_args'] ) ) {

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -543,9 +543,7 @@ class Menu {
 
 				if ( isset( $query['taxonomy'] ) ) {
 					Screen::register_taxonomy( $query['taxonomy'] );
-				}
-
-				if ( isset( $query['post_type'] ) ) {
+				} elseif ( isset( $query['post_type'] ) ) {
 					Screen::register_post_type( $query['post_type'] );
 				}
 			}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -490,11 +490,13 @@ class Menu {
 	public function migrate_core_child_items( $menu ) {
 		global $submenu;
 
-		if ( ! isset( $submenu['woocommerce'] ) ) {
+		if ( ! isset( $submenu['woocommerce'] ) || ! isset( $submenu['edit.php?post_type=product'] ) ) {
 			return;
 		}
 
-		foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
+		$submenu_items = array_merge( $submenu['woocommerce'], $submenu['edit.php?post_type=product'] );
+
+		foreach ( $submenu_items as $key => $menu_item ) {
 			if ( in_array( $menu_item[2], CoreMenu::get_excluded_items(), true ) ) {
 				// phpcs:disable
 				if ( ! isset( $menu_item[ self::CSS_CLASSES ] ) ) {
@@ -508,7 +510,11 @@ class Menu {
 
 			// Don't add already added items.
 			$callbacks = self::get_callbacks();
-			if ( array_key_exists( $menu_item[2], $callbacks ) ) {
+			if ( array_key_exists( htmlspecialchars_decode( $menu_item[2] ), $callbacks ) ) {
+				continue;
+			}
+
+			if ( in_array( $menu_item[2], array( 'product_importer', 'product_exporter', 'product_attributes' ), true ) ) {
 				continue;
 			}
 

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -523,11 +523,12 @@ class Menu {
 
 			self::add_item(
 				array(
-					'parent'     => 'woocommerce-settings',
+					'parent'     => 'woocommerce',
 					'title'      => $menu_item[0],
 					'capability' => $menu_item[1],
 					'id'         => sanitize_title( $menu_item[0] ),
 					'url'        => $menu_item[2],
+					'menuId'     => 'plugins',
 				)
 			);
 		}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -521,14 +521,12 @@ class Menu {
 				continue;
 			}
 
-			self::add_item(
+			self::add_plugin_item(
 				array(
-					'parent'     => 'woocommerce',
 					'title'      => $menu_item[0],
 					'capability' => $menu_item[1],
 					'id'         => sanitize_title( $menu_item[0] ),
 					'url'        => $menu_item[2],
-					'menuId'     => 'plugins',
 				)
 			);
 		}

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -519,6 +519,7 @@ class Menu {
 				continue;
 			}
 
+			// Don't add these Product submenus because they are added elsewhere.
 			if ( in_array( $menu_item[2], array( 'product_importer', 'product_exporter', 'product_attributes' ), true ) ) {
 				continue;
 			}
@@ -531,6 +532,23 @@ class Menu {
 					'url'        => $menu_item[2],
 				)
 			);
+
+			// Determine if migrated items are a taxonomy or post_type. If they are, register them.
+			$parsed_url   = wp_parse_url( $menu_item[2] );
+			$query_string = isset( $parsed_url['query'] ) ? $parsed_url['query'] : false;
+
+			if ( $query_string ) {
+				$query = array();
+				parse_str( $query_string, $query );
+
+				if ( isset( $query['taxonomy'] ) ) {
+					Screen::register_taxonomy( $query['taxonomy'] );
+				}
+
+				if ( isset( $query['post_type'] ) ) {
+					Screen::register_post_type( $query['post_type'] );
+				}
+			}
 		}
 
 		return $menu;

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -511,9 +511,11 @@ class Menu {
 				continue;
 			}
 
+			$menu_item[2] = htmlspecialchars_decode( $menu_item[2] );
+
 			// Don't add already added items.
 			$callbacks = self::get_callbacks();
-			if ( array_key_exists( htmlspecialchars_decode( $menu_item[2] ), $callbacks ) ) {
+			if ( array_key_exists( $menu_item[2], $callbacks ) ) {
 				continue;
 			}
 

--- a/src/Features/Navigation/Menu.php
+++ b/src/Features/Navigation/Menu.php
@@ -490,11 +490,14 @@ class Menu {
 	public function migrate_core_child_items( $menu ) {
 		global $submenu;
 
-		if ( ! isset( $submenu['woocommerce'] ) || ! isset( $submenu['edit.php?post_type=product'] ) ) {
+		if ( ! isset( $submenu['woocommerce'] ) && ! isset( $submenu['edit.php?post_type=product'] ) ) {
 			return;
 		}
 
-		$submenu_items = array_merge( $submenu['woocommerce'], $submenu['edit.php?post_type=product'] );
+		$submenu_items = array_merge(
+			isset( $submenu['woocommerce'] ) ? $submenu['woocommerce'] : array(),
+			isset( $submenu['edit.php?post_type=product'] ) ? $submenu['edit.php?post_type=product'] : array()
+		);
 
 		foreach ( $submenu_items as $key => $menu_item ) {
 			if ( in_array( $menu_item[2], CoreMenu::get_excluded_items(), true ) ) {

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -213,7 +213,9 @@ class Screen {
 	 * @param string $post_type Post type to add.
 	 */
 	public static function register_post_type( $post_type ) {
-		self::$post_types[] = $post_type;
+		if ( ! in_array( $post_type, self::$post_types, true ) ) {
+			self::$post_types[] = $post_type;
+		}
 	}
 
 	/**
@@ -222,6 +224,8 @@ class Screen {
 	 * @param string $taxonomy Taxonomy to add.
 	 */
 	public static function register_taxonomy( $taxonomy ) {
-		self::$taxonomies[] = $taxonomy;
+		if ( ! in_array( $taxonomy, self::$taxonomies, true ) ) {
+			self::$taxonomies[] = $taxonomy;
+		}
 	}
 }

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -131,7 +131,7 @@ class Screen {
 	 * @return bool
 	 */
 	public static function is_woocommerce_core_taxonomy( $taxonomy ) {
-		if ( in_array( $taxonomy, array( 'product_cat', 'product_tag' ), true ) ) {
+		if ( in_array( $taxonomy, array( 'product_cat', 'product_tag', 'product_brand' ), true ) ) {
 			return true;
 		}
 

--- a/src/Features/Navigation/Screen.php
+++ b/src/Features/Navigation/Screen.php
@@ -131,7 +131,7 @@ class Screen {
 	 * @return bool
 	 */
 	public static function is_woocommerce_core_taxonomy( $taxonomy ) {
-		if ( in_array( $taxonomy, array( 'product_cat', 'product_tag', 'product_brand' ), true ) ) {
+		if ( in_array( $taxonomy, array( 'product_cat', 'product_tag' ), true ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/49234

[Early Navigation feedback](https://wp.me/p7DVsv-ae2) points to users being unable to find plugins. This PR changes the default from "Settings" to "Extensions".

Also in this PR is the automatic inclusion of extension items that were under "Products" in the old navigation. They are registered by default in the same way those that fell under "WooCommerce" category.

### Screenshots

<img width="265" alt="Screen Shot 2021-01-26 at 10 40 41 AM" src="https://user-images.githubusercontent.com/1922453/105770452-19710c80-5fc4-11eb-935f-84014da3db6e.png">

## Problem

Clicking on `Brands` leads to the correct url, but the screen is not registered so the Nav isn't activated for that route. I tried using `Screen::add_screen` without much luck.

### Detailed test instructions:

1. Install MailChimp
2. Install a plugin that registered in the old nav under "Products". [WooCommerce Brands](https://github.com/woocommerce/woocommerce-brands), for example.
3. See MailChimp (previously under Settings) now located under "Extensions"
4. See Brands appear under "Extensions"

