### PR TITLE
Return countryInfo as an empty object if not in locale info

### DIFF
--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -113,10 +113,10 @@ const CurrencyFactory = ( currencySetting ) => {
 		localeInfo = {},
 		currencySymbols = {}
 	) {
-		const countryInfo = localeInfo[ countryCode ];
+		const countryInfo = localeInfo[ countryCode ] || {};
 		const symbol = currencySymbols[ countryInfo.currency_code ];
 
-		if ( ! symbol || ! countryInfo ) {
+		if ( ! symbol ) {
 			return {};
 		}
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/6155

Return `countryInfo` as an empty object if not in locale info


### Detailed test instructions:
<img width="510" alt="螢幕快照 2021-01-26 下午5 02 35" src="https://user-images.githubusercontent.com/56378160/105911652-64a51280-5ff8-11eb-8de7-dd81b175504a.png">

