### PR TITLE
This fix fixes the bug: "Undefined index: id"

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1077,11 +1077,14 @@ class Loader {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
 				$group_settings   = $setting_options->get_group_settings( $group );
-				$preload_settings = [];
-				foreach ( $group_settings as $option ) {
-					$preload_settings[ $option['id'] ] = $option['value'];
-				}
-				$settings['preloadSettings'][ $group ] = $preload_settings;
+
+				if (!is_wp_error($group_settings)){
+                    $preload_settings = [];
+                    foreach ( $group_settings as $option ) {
+                        $preload_settings[ $option['id'] ] = $option['value'];
+                    }
+                    $settings['preloadSettings'][ $group ] = $preload_settings;
+                }
 			}
 		}
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1077,7 +1077,6 @@ class Loader {
 			$setting_options = new \WC_REST_Setting_Options_V2_Controller();
 			foreach ( $preload_settings as $group ) {
 				$group_settings   = $setting_options->get_group_settings( $group );
-
 				if (!is_wp_error($group_settings)){
                     $preload_settings = [];
                     foreach ( $group_settings as $option ) {


### PR DESCRIPTION
PHP Notice:  Undefined index: id in .../plugins/woocommerce/packages/woocommerce-admin/src/Loader.php on line 1046
ErrorException: Undefined index: value in .../plugins/woocommerce/packages/woocommerce-admin/src/Loader.php:1046
Stack trace:
#0 .../plugins/woocommerce/packages/woocommerce-admin/src/Loader.php(1046): {closure}()
#1 .../wp-includes/class-wp-hook.php(287): Automattic\WooCommerce\Admin\Loader::add_component_settings()
#2 .../wp-includes/plugin.php(212): WP_Hook->apply_filters()
#3 .../plugins/woocommerce/packages/woocommerce-blocks/src/Assets/AssetDataRegistry.php(132): apply_filters()
#4 .../plugins/woocommerce/packages/woocommerce-blocks/src/Assets/AssetDataRegistry.php(223): Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry->initialize_core_data()
#5 .../wp-includes/class-wp-hook.php(287): Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry->enqueue_asset_data()
#6 .../wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters()
#7 .../wp-includes/plugin.php(484): WP_Hook->do_action()
#8 .../wp-admin/admin-footer.php(95): do_action()
#9 .../wp-admin/post.php(369): require_once('/var/www/stagin...')
#10 {main}

Fixes #

_Replace this with a good description of your changes & reasoning._

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

-   Ex: Open page `url`
-   Click XYZ…

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
