### PR TITLE
Dependency Extraction Webpack Plugin: Add Woo Blocks packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ woocommerce-admin.zip
 includes/feature-config.php
 storybook/wordpress
 storybook-static/
-packages/dependency-extraction-webpack-plugin/assets
 
 # Directories/files that may appear in your environment
 .DS_Store

--- a/bin/packages/build.js
+++ b/bin/packages/build.js
@@ -217,44 +217,12 @@ async function buildPackage( packagePath ) {
 	process.stdout.write( `${ DONE }\n` );
 }
 
-/**
- * Build array of packages for consumption for Dependency Extraction
- */
-function buildDependencyExtractionAssets() {
-	const packages = getPackages();
-	const packageNames = packages.map( ( packagePath ) => {
-		return `\n\t'@woocommerce/${ path.basename( packagePath ) }'`;
-	} );
-	const contents = `module.exports = [${ packageNames },\n];\n`;
-	const DEPENDENCY_EXTRACTION_ASSETS = path.join(
-		path.resolve(
-			__dirname,
-			'../../packages/dependency-extraction-webpack-plugin'
-		),
-		'assets'
-	);
-
-	try {
-		rimraf( DEPENDENCY_EXTRACTION_ASSETS, () => {
-			mkdirp.sync( DEPENDENCY_EXTRACTION_ASSETS );
-			fs.writeFileSync(
-				path.join( DEPENDENCY_EXTRACTION_ASSETS, 'packages.js' ),
-				contents
-			);
-		} );
-	} catch ( err ) {
-		console.log( err );
-		exit( 1 );
-	}
-}
-
 const files = process.argv.slice( 2 );
 
 if ( files.length ) {
 	buildFiles( files );
 } else {
 	process.stdout.write( chalk.inverse( '>> Building packages \n' ) );
-	buildDependencyExtractionAssets();
 	getPackages()
 		.filter(
 			( package ) =>

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,23 +2,22 @@
 
 Currently we have a small set of public-facing packages that can be dowloaded from [npm](https://www.npmjs.com/org/woocommerce) and used in external applications.
 
-- `@woocommerce/components`: A library of components that can be used to create pages in the WooCommerce dashboard and reports pages.
-- `@woocommerce/csv-export`: A set of functions to convert data into CSV values, and enable a browser download of the CSV data.
-- `@woocommerce/currency`: A class to display and work with currency values.
-- `@woocommerce/date`: A collection of utilities to display and work with date values.
-- `@woocommerce/navigation`: A collection of navigation-related functions for handling query parameter objects, serializing query parameters, updating query parameters, and triggering path changes.
-- `@woocommerce/tracks`: User event tracking utility functions for Automattic based projects.
-
+-   `@woocommerce/components`: A library of components that can be used to create pages in the WooCommerce dashboard and reports pages.
+-   `@woocommerce/csv-export`: A set of functions to convert data into CSV values, and enable a browser download of the CSV data.
+-   `@woocommerce/currency`: A class to display and work with currency values.
+-   `@woocommerce/date`: A collection of utilities to display and work with date values.
+-   `@woocommerce/navigation`: A collection of navigation-related functions for handling query parameter objects, serializing query parameters, updating query parameters, and triggering path changes.
+-   `@woocommerce/tracks`: User event tracking utility functions for Automattic based projects.
 
 ## Working with existing packages
 
-- You can make changes to packages files as normal, and running `npm start` will compile and watch both app files and packages.
-- :warning: Make sure any dependencies you add to a package are also added to that package's `package.json`, not just the woocommerce-admin package.json
-- :warning: Make sure you're not importing from any woocommerce-admin files outside of the package (you can import from other packages, just use the `import from @woocommerce/package` syntax).
-- Add your change to the CHANGELOG for that package under the next version number, creating one if necessary (we use semantic versioning for packages, [see these guidelines](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md#maintaining-changelogs)).
-- Don't change the version in `package.json`.
-- Label your PR with the `Packages` label.
-- Once merged, you can wait for the next package release roundup, or you can publish a release now (see below, "Publishing packages").
+-   You can make changes to packages files as normal, and running `npm start` will compile and watch both app files and packages.
+-   :warning: Make sure any dependencies you add to a package are also added to that package's `package.json`, not just the woocommerce-admin package.json
+-   :warning: Make sure you're not importing from any woocommerce-admin files outside of the package (you can import from other packages, just use the `import from @woocommerce/package` syntax).
+-   Add your change to the CHANGELOG for that package under the next version number, creating one if necessary (we use semantic versioning for packages, [see these guidelines](https://github.com/WordPress/gutenberg/blob/master/CONTRIBUTING.md#maintaining-changelogs)).
+-   Don't change the version in `package.json`.
+-   Label your PR with the `Packages` label.
+-   Once merged, you can wait for the next package release roundup, or you can publish a release now (see below, "Publishing packages").
 
 ---
 
@@ -29,56 +28,55 @@ Most of this is pulled [from the Gutenberg workflow](https://github.com/WordPres
 To create a new package, add a new folder to `/packages`, containing…
 
 1. `package.json` based on the template:
-	```json
-	{
-		"name": "@woocommerce/package-name",
-		"version": "1.0.0-beta.0",
-		"description": "Package description.",
-		"author": "Automattic",
-		"license": "GPL-2.0-or-later",
-		"keywords": [
-			"wordpress",
-			"woocommerce"
-		],
-		"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/[_YOUR_PACKAGE_]/README.md",
-		"repository": {
-			"type": "git",
-			"url": "https://github.com/woocommerce/woocommerce-admin.git"
-		},
-		"bugs": {
-			"url": "https://github.com/woocommerce/woocommerce-admin/issues"
-		},
-		"main": "build/index.js",
-		"module": "build-module/index.js",
-		"react-native": "src/index",
-		"dependencies": {
-			"@babel/runtime-corejs2": "7.1.5"
-		},
-		"publishConfig": {
-			"access": "public"
-		}
-	}
-	```
+    ```json
+    {
+    	"name": "@woocommerce/package-name",
+    	"version": "1.0.0-beta.0",
+    	"description": "Package description.",
+    	"author": "Automattic",
+    	"license": "GPL-2.0-or-later",
+    	"keywords": [ "wordpress", "woocommerce" ],
+    	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/[_YOUR_PACKAGE_]/README.md",
+    	"repository": {
+    		"type": "git",
+    		"url": "https://github.com/woocommerce/woocommerce-admin.git"
+    	},
+    	"bugs": {
+    		"url": "https://github.com/woocommerce/woocommerce-admin/issues"
+    	},
+    	"main": "build/index.js",
+    	"module": "build-module/index.js",
+    	"react-native": "src/index",
+    	"dependencies": {
+    		"@babel/runtime-corejs2": "7.1.5"
+    	},
+    	"publishConfig": {
+    		"access": "public"
+    	}
+    }
+    ```
 2. `.npmrc` file which disables creating `package-lock.json` file for the package:
-	```
-	package-lock=false
-	```
+    ```
+    package-lock=false
+    ```
 3. `README.md` file containing at least:
-	- Package name
-	- Package description
-	- Installation details
-	- Usage example
+    - Package name
+    - Package description
+    - Installation details
+    - Usage example
 4. A `src` directory for the source of your module, which will be built by default using the `npm run build:packages` command. Note that you'll want an `index.js` file that exports the package contents, see other packages for examples.
+
+5. Add the new package name to `packages/dependency-extraction-webpack-plugin/assets/packages.js` so that users of that plugin will also be able to use the new package without enqueuing it.
 
 ---
 
 ## Publishing packages
 
-- Run `npm run publish-packages:check` to see which packages will be published
-- Create a PR with a CHANGELOG for each updated package (or try to add to the CHANGELOG with any PR editing `packages/`)
-- Run `npm run publish-packages:prod` to publish the package
-- _OR_ Run `npm run publish-packages:dev` to publish "next" releases (installed as `npm i @woocommerce/package@next`). Only use `:dev` if you have a reason to.
-- Both commands will run `build:packages` before the lerna task, just to catch any last updates.
+-   Run `npm run publish-packages:check` to see which packages will be published
+-   Create a PR with a CHANGELOG for each updated package (or try to add to the CHANGELOG with any PR editing `packages/`)
+-   Run `npm run publish-packages:prod` to publish the package
+-   _OR_ Run `npm run publish-packages:dev` to publish "next" releases (installed as `npm i @woocommerce/package@next`). Only use `:dev` if you have a reason to.
+-   Both commands will run `build:packages` before the lerna task, just to catch any last updates.
 
 It will confirm with you once more before publishing:
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -31,4 +31,5 @@ Additional module requests on top of Wordpress [Dependency Extraction Webpack Pl
 | `@woocommerce/data`            | `wc['data']`             | `wc-store-data`      |
 | `@woocommerce/csv-export`      | `wc['csvExport']`        | `wc-csv`             |
 | `@woocommerce/blocks-registry` | `wc['wcBlocksRegistry']` | `wc-blocks-registry` |
+| `@woocommerce/blocks-settings` | `wc['wcSettings']`       | `wc-blocks-settings` |
 | `@woocommerce/*`               | `wc['*']`                | `wc-*`               |

--- a/packages/dependency-extraction-webpack-plugin/assets/packages.js
+++ b/packages/dependency-extraction-webpack-plugin/assets/packages.js
@@ -16,5 +16,5 @@ module.exports = [
 	// wc-blocks packages
 	'@woocommerce/blocks-checkout',
 	'@woocommerce/blocks-registry',
-	'@woocommerce/block-settings',
+	'@woocommerce/blocks-settings',
 ];

--- a/packages/dependency-extraction-webpack-plugin/assets/packages.js
+++ b/packages/dependency-extraction-webpack-plugin/assets/packages.js
@@ -1,0 +1,20 @@
+module.exports = [
+	// wc-admin packages
+	'@woocommerce/components',
+	'@woocommerce/csv-export',
+	'@woocommerce/currency',
+	'@woocommerce/customer-effort-score',
+	'@woocommerce/data',
+	'@woocommerce/date',
+	'@woocommerce/dependency-extraction-webpack-plugin',
+	'@woocommerce/eslint-plugin',
+	'@woocommerce/experimental',
+	'@woocommerce/navigation',
+	'@woocommerce/notices',
+	'@woocommerce/number',
+	'@woocommerce/tracks',
+	// wc-blocks packages
+	'@woocommerce/blocks-checkout',
+	'@woocommerce/blocks-registry',
+	'@woocommerce/block-settings',
+];

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -22,7 +22,7 @@ const wooRequestToExternal = ( request ) => {
 		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
 		const irregularExternalMap = {
 			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
-			'block-settings': [ 'wc', 'wcSettings' ],
+			'blocks-settings': [ 'wc', 'wcSettings' ],
 		};
 
 		const excludedExternals = [ 'experimental' ];

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -22,6 +22,7 @@ const wooRequestToExternal = ( request ) => {
 		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
 		const irregularExternalMap = {
 			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
+			'block-settings': [ 'wc', 'wcSettings' ],
 		};
 
 		const excludedExternals = [ 'experimental' ];

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -22,7 +22,7 @@ const wooRequestToExternal = ( request ) => {
 		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
 		const irregularExternalMap = {
 			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
-			'blocks-settings': [ 'wc', 'wcSettings' ],
+			'blocks-settings': [ 'wcSettings' ],
 		};
 
 		const excludedExternals = [ 'experimental' ];


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/6025

A list of packages was being compiled at build from this repo. The resulting list did not include any packages from https://github.com/woocommerce/woocommerce-gutenberg-products-block so this PR exchanges the automation in favour of a hard coded list.

### Detailed test instructions:

1. `npm run build`
2. `npm run create-wc-extension` and give the plugin a name
3. `cd packages/dependency-extraction-webpack-plugin`
4. `npm link`
5. `cd ../../../<plugin name>`
6. `npm install`
7. `npm link @woocommerce/dependency-extraction-webpack-plugin`
8. `npm start`
9. In your plugins `scr/index.js` file add this code:
```js
import { flag } from '@woocommerce/components';
import { ShippingRatesControl } from '@woocommerce/blocks-checkout';
import { SITE_TITLE } from '@woocommerce/blocks-settings';

console.log( flag, ShippingRatesControl, SITE_TITLE );
```
10. Check the new plugin's `build/index.asset.php` file and check the array of dependencies to make sure its correct.
11. Visit `build/index.js` to make sure the aliases are correct. For example, see `@woocommerce/components` alias correctly to `window.wc.components`:
```js
/***/ "@woocommerce/components":
/*!*********************************************!*\
  !*** external {"this":["wc","components"]} ***!
  \*********************************************/
/*! no static exports found */
/***/ (function(module, exports) {

(function() { module.exports = this["wc"]["components"]; }());
```


<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
