### PR TITLE
Cache initial read time

### DIFF
--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { EmptyContent, Section } from '@woocommerce/components';
 import {
@@ -74,17 +74,15 @@ const renderNotes = ( { hasNotes, isBatchUpdating, lastRead, notes } ) => {
 const InboxPanel = ( props ) => {
 	const { isError, isResolving, isBatchUpdating, notes } = props;
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
-	const lastRead = userPrefs.activity_panel_inbox_last_read;
+	const [ lastRead ] = useState( userPrefs.activity_panel_inbox_last_read );
 
 	useEffect( () => {
 		const mountTime = Date.now();
 
-		return () => {
-			const userDataFields = {
-				activity_panel_inbox_last_read: mountTime,
-			};
-			updateUserPreferences( userDataFields );
+		const userDataFields = {
+			activity_panel_inbox_last_read: mountTime,
 		};
+		updateUserPreferences( userDataFields );
 	}, [] );
 
 	if ( isError ) {


### PR DESCRIPTION
Fixes #6160 

Cache initial read time


### Screenshots
Before refresh
<img width="200" alt="unread dot" src="https://user-images.githubusercontent.com/56378160/106619626-c9072b00-653e-11eb-922c-78402469b5a8.png">
After refresh
<img width="224" alt="read" src="https://user-images.githubusercontent.com/56378160/106619654-d02e3900-653e-11eb-8fed-b26fd291c8fe.png">
Before panel open
<img width="82" alt="inbox unread" src="https://user-images.githubusercontent.com/56378160/106619673-d45a5680-653e-11eb-84c5-25ff5eda0c99.png">
After panel close
<img width="60" alt="inbox read" src="https://user-images.githubusercontent.com/56378160/106619691-d6bcb080-653e-11eb-9767-0fc32fab29e5.png">


### Detailed test instructions:
- Go to your database -> usermeta -> change last read meta value to less than a note's timestamp
- Go to WC home, see that inbox messages render as unread messages
- Refresh and see that the unread indicator does not render
-----------------------------
- Go to your database -> usermeta -> change last read meta value to less than a note's timestamp
- Go to Orders and check that Inbox icon has the unread indicator
- Click Inbox, see that inbox messages render as unread messages
- Click outside of the panel and open the panel again, see that unread indicator does not render

