### PR TITLE
Dependency Extraction Webpack Plugin: bump version to 1.2

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.1.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.1.0"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.2.0"
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+-   Add WooCommerce Blocks Dependencies.
+
 # 1.1.0
 
 -   Fix: Handle irregular package names that don't conform to a pattern.

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2.0
 
--   Add WooCommerce Blocks Dependencies.
+-   Add WooCommerce Blocks Dependencies. #6228
 
 # 1.1.0
 

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
This PR bumps Dependency Extraction Webpack Plugin to 1.2 in preparation to make a release.

This is the only change since last release https://github.com/woocommerce/woocommerce-admin/pull/6228