### PR TITLE
Add tracks event for WooCommerce Payments install via tasklist and inbox note

### DIFF
--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -10,6 +10,7 @@ import {
 } from '@woocommerce/wc-admin-settings';
 import { Link } from '@woocommerce/components';
 import { WC_ADMIN_NAMESPACE } from '@woocommerce/data';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -58,7 +59,13 @@ export function installActivateAndConnectWcpay(
 	};
 
 	installAndActivatePlugins( [ 'woocommerce-payments' ] )
-		.then( () => connect() )
+		.then( () => {
+			recordEvent( 'woocommerce_payments_install', {
+				context: 'tasklist',
+			} );
+
+			connect();
+		} )
 		.catch( ( error ) => {
 			createNoticesFromResponse( error );
 			reject();

--- a/src/Notes/WooCommercePayments.php
+++ b/src/Notes/WooCommercePayments.php
@@ -149,6 +149,8 @@ class WooCommercePayments {
 			return false;
 		}
 
+		wc_admin_record_tracks_event( 'woocommerce_payments_install', array( 'context' => 'inbox' ) );
+
 		$activate_request = array( 'plugins' => self::PLUGIN_SLUG );
 		$result           = $installer->activate_plugins( $activate_request );
 		if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
This adds a tracks event fired after WooCommerce Payments is installed
via the tasklist.

See p1612278892009000-slack-C0144BMA170 for more details.

### Detailed test instructions:

1. With a new store, go initiate the payment task in the onboarding task list.
2. Select the Set up button for WooCommerce Payments.
3. After 5-10 minutes check tracks live view for a `wcadmin_woocommerce_payments_install` event with the context prop of `tasklist`.

Note this event is also implemented in https://github.com/woocommerce/woocommerce/pull/29052 with the context of `extensions`

### Changelog

> Tweak: Track the number of installations of WooCommerce Payments via that task list for stores that have opted into tracking.
