### PR TITLE
Center the activity panel

### DIFF
--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -8,7 +8,8 @@
 	height: $header-height;
 
 	@include breakpoint( '<782px' ) {
-		position: relative;
+		position: absolute;
+		top: 60px;
 		background: $studio-white;
 		margin: 0;
 		padding: 0;

--- a/client/header/activity-panel/style.scss
+++ b/client/header/activity-panel/style.scss
@@ -2,20 +2,18 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	position: fixed;
-	right: 0;
-	top: 32px;
 	height: $header-height;
 
 	@include breakpoint( '<782px' ) {
 		position: absolute;
-		top: 60px;
+		top: 100%;
 		background: $studio-white;
 		margin: 0;
 		padding: 0;
 		width: 100vw;
 		display: none;
 		flex: 1 100%;
+		right: 0;
 	}
 
 	@include breakpoint( '782px-960px' ) {
@@ -187,12 +185,10 @@
 .woocommerce-layout__activity-panel-mobile-toggle {
 	margin-right: 10px;
 	max-width: 48px;
-	height: $header-height;
-	position: absolute;
-	right: 0;
-	bottom: 0;
+
 	@include breakpoint( '>782px' ) {
 		display: none;
+		height: 100%;
 	}
 }
 
@@ -295,8 +291,4 @@
 
 .woocommerce-layout__notice-list-hide {
 	display: none;
-}
-
-.has-woocommerce-navigation .woocommerce-layout__activity-panel {
-	top: 0;
 }

--- a/client/header/style.scss
+++ b/client/header/style.scss
@@ -2,9 +2,8 @@
 	background: $studio-white;
 	box-sizing: border-box;
 	padding: 0;
-	min-height: $header-height;
 	position: fixed;
-	width: 100%;
+	width: calc(100% - 160px);
 	top: $adminbar-height;
 	z-index: 1001; /* on top of #wp-content-editor-tools */
 
@@ -14,11 +13,18 @@
 
 	.woocommerce-layout__header-wrapper {
 		display: flex;
+		align-items: center;
+		min-height: $header-height;
 	}
 
 	@include breakpoint( '<782px' ) {
 		flex-flow: row wrap;
 		top: $adminbar-height-mobile;
+		width: 100%;
+	}
+
+	@include breakpoint( '782px-960px' ) {
+		width: calc(100% - 36px);
 	}
 
 	.woocommerce-layout__header-breadcrumbs-wrapper {
@@ -34,7 +40,6 @@
 		padding: 0 0 0 $gutter-large;
 		flex: 1 auto;
 		height: $header-height;
-		line-height: $header-height;
 		background: $studio-white;
 		font-weight: 600;
 		font-size: 14px;
@@ -45,6 +50,7 @@
 .has-woocommerce-navigation .woocommerce-layout__header {
 	top: 0;
 	left: 0;
+	width: 100%;
 }
 
 .woocommerce-page {

--- a/client/stylesheets/shared/_embed.scss
+++ b/client/stylesheets/shared/_embed.scss
@@ -104,12 +104,6 @@
 		}
 	}
 
-	.woocommerce-layout__activity-panel-mobile-toggle {
-		@include breakpoint( '>782px' ) {
-			display: none;
-		}
-	}
-
 	.woocommerce-activity-card__actions {
 		a.components-button:not(.is-primary) {
 			color: $gray-text;


### PR DESCRIPTION
Fixes #6199 

Center the activity panel

### Screenshots
Beofre
<img width="425" alt="螢幕快照 2021-02-08 下午1 45 58" src="https://user-images.githubusercontent.com/56378160/107267604-21459d80-6a15-11eb-9ac3-d4839f8353fc.png">
After
<img width="428" alt="螢幕快照 2021-02-08 下午1 45 23" src="https://user-images.githubusercontent.com/56378160/107267606-21de3400-6a15-11eb-8e55-cd33c2297e82.png">


### Detailed test instructions:
- Narrow your screen to <782px
- Go to WooCommerce home and orders page
- Click on 'w' button, see that the activity panel renders as expected.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

