### PR TITLE
Fixes for @woocommerce/dependency-extraction-webpack-plugin

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.1.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.2.0"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.3.0"
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+-  Remove `@woocommerce/block-settings` from internal maps and use `@woocommerce/settings` instead. This external exposes the `getSetting` API interface which encourages read only use of the global.
+-  Remove explicitly scoping externals to `this`. The plugin compiler will take care of scoping the external to the correct context and `this` is not correct in some contexts consuming this package.
 # 1.2.0
 
 -   Add WooCommerce Blocks Dependencies. #6228
@@ -8,7 +12,7 @@
 
 # 1.0.1
 
--   Fix: Avoid tanspiling packaged code.
+-   Fix: Avoid transpiling packaged code.
 
 # 1.0.0
 

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -31,5 +31,5 @@ Additional module requests on top of Wordpress [Dependency Extraction Webpack Pl
 | `@woocommerce/data`            | `wc['data']`             | `wc-store-data`      |
 | `@woocommerce/csv-export`      | `wc['csvExport']`        | `wc-csv`             |
 | `@woocommerce/blocks-registry` | `wc['wcBlocksRegistry']` | `wc-blocks-registry` |
-| `@woocommerce/settings`        | `wc['wcSettings']`       | `wc-settings` |
+| `@woocommerce/settings`        | `wc['wcSettings']`       | `wc-settings`        |
 | `@woocommerce/*`               | `wc['*']`                | `wc-*`               |

--- a/packages/dependency-extraction-webpack-plugin/README.md
+++ b/packages/dependency-extraction-webpack-plugin/README.md
@@ -31,5 +31,5 @@ Additional module requests on top of Wordpress [Dependency Extraction Webpack Pl
 | `@woocommerce/data`            | `wc['data']`             | `wc-store-data`      |
 | `@woocommerce/csv-export`      | `wc['csvExport']`        | `wc-csv`             |
 | `@woocommerce/blocks-registry` | `wc['wcBlocksRegistry']` | `wc-blocks-registry` |
-| `@woocommerce/blocks-settings` | `wc['wcSettings']`       | `wc-blocks-settings` |
+| `@woocommerce/settings`        | `wc['wcSettings']`       | `wc-settings` |
 | `@woocommerce/*`               | `wc['*']`                | `wc-*`               |

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -22,7 +22,7 @@ const wooRequestToExternal = ( request ) => {
 		const handle = request.substring( WOOCOMMERCE_NAMESPACE.length );
 		const irregularExternalMap = {
 			'blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
-			'blocks-settings': [ 'wcSettings' ],
+			settings: [ 'wc', 'wcSettings' ],
 		};
 
 		const excludedExternals = [ 'experimental' ];

--- a/packages/dependency-extraction-webpack-plugin/src/index.js
+++ b/packages/dependency-extraction-webpack-plugin/src/index.js
@@ -74,7 +74,7 @@ class DependencyExtractionWebpackPlugin extends WPDependencyExtractionWebpackPlu
 		if ( externalRequest ) {
 			this.externalizedDeps.add( request );
 
-			return callback( null, { this: externalRequest } );
+			return callback( null, externalRequest );
 		}
 
 		// Fall back to the WP method


### PR DESCRIPTION
While working on the Stripe cart and checkout blocks integration migration to the Stripe extension, I tried using the `@woocommerce/dependency-extraction-webpack-plugin` (including the latest 1.2.0 release) but it didn't work because it was compiling various `@woocommerce/*` aliases to the wrong scope resulting in something like this in the built file:

```js
/***/ "@woocommerce/blocks-registry":
/*!*********************************************!*\
  !*** external {"this":["wc","wcBlocksRegistry"]} ***!
  \*********************************************/
/*! no static exports found */
/***/ (function(module, exports) {
(function() { module.exports = window[undefined]; }());
```

The above was generated with this webpack config:


```js
const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
const DependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );

module.exports = {
	...defaultConfig,
	plugins: [
		...defaultConfig.plugins.filter(
			( plugin ) =>
				plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
		),
		new DependencyExtractionWebpackPlugin(),
	],
};
```

Besides this issue, `block-settings` shouldn't really be exposed as an external and instead we should expose `@woocommerce/settings` as `@woocommerce/block-settings` is really just something we have specific to the blocks project builds. The "official" interface we should expose for "settings" coming from the server is on the `wc.wcSettings` global which in turn exposes the [`getSetting` function](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/settings/shared/get-setting.js) thus encouraging _read only_ usage of values from the global. So I've made the correct adjustments for that too.

## To Test

* [x] It doesn't look like wc-admin is using this plugin in your webpack config so no impact there.
* [x] I tested this with the Stripe integration work I'm doing (by just directly copying changes into the node_modules install of the Webpack plugin, and the files are built correctly with these changes and the above webpack configuration.
