### PR TITLE
Dependency Extraction Webpack Plugin: Add @woocommerce/settings to list of packages

### DIFF
--- a/bin/starter-pack/_package.json
+++ b/bin/starter-pack/_package.json
@@ -22,6 +22,6 @@
 	"devDependencies": {
 		"@wordpress/scripts": "^12.2.1",
 		"@woocommerce/eslint-plugin": "1.1.0",
-		"@woocommerce/dependency-extraction-webpack-plugin": "1.3.0"
+		"@woocommerce/dependency-extraction-webpack-plugin": "1.4.0"
 	}
 }

--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -1,7 +1,12 @@
+# 1.4.0
+
+-   Add `@woocommerce/settings` to list of packages.
+
 # 1.3.0
 
--  Remove `@woocommerce/block-settings` from internal maps and use `@woocommerce/settings` instead. This external exposes the `getSetting` API interface which encourages read only use of the global.
--  Remove explicitly scoping externals to `this`. The plugin compiler will take care of scoping the external to the correct context and `this` is not correct in some contexts consuming this package.
+-   Remove `@woocommerce/block-settings` from internal maps and use `@woocommerce/settings` instead. This external exposes the `getSetting` API interface which encourages read only use of the global.
+-   Remove explicitly scoping externals to `this`. The plugin compiler will take care of scoping the external to the correct context and `this` is not correct in some contexts consuming this package.
+
 # 1.2.0
 
 -   Add WooCommerce Blocks Dependencies. #6228

--- a/packages/dependency-extraction-webpack-plugin/assets/packages.js
+++ b/packages/dependency-extraction-webpack-plugin/assets/packages.js
@@ -16,5 +16,5 @@ module.exports = [
 	// wc-blocks packages
 	'@woocommerce/blocks-checkout',
 	'@woocommerce/blocks-registry',
-	'@woocommerce/blocks-settings',
+	'@woocommerce/settings',
 ];

--- a/packages/dependency-extraction-webpack-plugin/package.json
+++ b/packages/dependency-extraction-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/dependency-extraction-webpack-plugin",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "WooCommerce Dependency Extraction Webpack Plugin",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Discovered in https://github.com/woocommerce/woocommerce-admin/pull/6295#issuecomment-776659446, `@woocommerce/settings` was not in the list of accepted packages.

### Screenshots

### Detailed test instructions:

See https://github.com/woocommerce/woocommerce-admin/pull/6295#issuecomment-776659446 and make sure the changes make sense, as well as the version bump.

