### PR TITLE
Update Minimum version in docs and test configs

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -12,7 +12,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ['7.1', '7.2', '7.3']
-                wordpress: ['5.3', '5.6']
+                wordpress: ['5.4', '5.6']
                 woocommerce: ['4.8.0', '4.9.1']
                 phpunit: ['7.5.20']
                 composer: ['2.0.6']

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[WordPress 5.3 or greater](https://wordpress.org/download/) and [WooCommerce 3.6.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.4 or greater](https://wordpress.org/download/) and [WooCommerce 4.8.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 
@@ -12,41 +12,51 @@ For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', tru
 
 After cloning the repo, install dependencies:
 
- - `npm install` to install JavaScript dependencies.
- - `composer install` to gather PHP dependencies.
+-   `npm install` to install JavaScript dependencies.
+-   `composer install` to gather PHP dependencies.
 
 Now you can build the files using one of these commands:
 
- - `npm run build` : Build a production version
- - `npm run dev` : Build a development version
- - `npm start` : Build a development version, watch files for changes
- - `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
+-   `npm run build` : Build a production version
+-   `npm run dev` : Build a development version
+-   `npm start` : Build a development version, watch files for changes
+-   `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
 
 For more helper scripts [see here](./CONTRIBUTING.md#helper-scripts)
 
 For some debugging tools/help [see here](./CONTRIBUTING.md#debugging)
 
 ### Testing
+
 #### End-to-end tests
+
 Tests live in `./tests/e2e`. An existing build is required prior running, please refer to the section above for steps. E2E tests have their own Docker container to run the WordPress server. Start
 the server using:
+
 ```
 npm run docker:up
 ```
+
 Run tests using:
+
 ```
 npm run test:e2e-dev
 ```
+
 or in headless mode:
+
 ```
 npm run test:e2e
 ```
+
 Run a single test by adding the file name:
+
 ```
 npm run test:e2e-dev complete-onboarding-wizard.test.js
 ```
 
 ## Common Issues
+
 If you're encountering any issue setting things up, chances are we have been there too. Please have a look at our [wiki](https://github.com/woocommerce/woocommerce-admin/wiki/Common-Issues) for a list of common problems.
 
 ## Privacy

--- a/docker/wc-admin-php-test-suite/docker-compose.yml
+++ b/docker/wc-admin-php-test-suite/docker-compose.yml
@@ -9,8 +9,8 @@ services:
             - '../../:/app'
         environment:
             - WC_CORE_DIR=/tmp/wordpress/wp-content/plugins/woocommerce
-            - WC_VERSION=${WC_VERSION:-5.0.0}
-            - WP_VERSION=${WP_VERSION:-5.6}
+            - WC_VERSION=${WC_VERSION:-4.8.0}
+            - WP_VERSION=${WP_VERSION:-5.4}
             - DB_USER=root
             - DB_PASS=password
             - DB_NAME=wordpress_test

--- a/docker/wc-admin-php-test-suite/docker-compose.yml
+++ b/docker/wc-admin-php-test-suite/docker-compose.yml
@@ -1,33 +1,43 @@
-version: "3"
+version: '3'
 
 services:
-  phpunit:
-    build: "."
-    image: wc-admin-php-test-suite-phpunit:1.2.1
-    volumes:
-      - "test-suite:/tmp"
-      - "../../:/app"
-    environment:
-      - WC_CORE_DIR=/tmp/wordpress/wp-content/plugins/woocommerce
-      - WC_VERSION=${WC_VERSION:-4.5.0}
-      - WP_VERSION=${WP_VERSION:-5.3}
-      - DB_USER=root
-      - DB_PASS=password
-      - DB_NAME=wordpress_test
-      - DB_HOST=phpunit-db
-    depends_on:
-      - phpunit-db
+    phpunit:
+        build: '.'
+        image: wc-admin-php-test-suite-phpunit:1.2.1
+        volumes:
+            - 'test-suite:/tmp'
+            - '../../:/app'
+        environment:
+            - WC_CORE_DIR=/tmp/wordpress/wp-content/plugins/woocommerce
+            - WC_VERSION=${WC_VERSION:-5.0.0}
+            - WP_VERSION=${WP_VERSION:-5.6}
+            - DB_USER=root
+            - DB_PASS=password
+            - DB_NAME=wordpress_test
+            - DB_HOST=phpunit-db
+        depends_on:
+            - phpunit-db
 
-  phpunit-db:
-    image: mysql:5.7
-    hostname: "phpunit-db"
-    environment:
-      MYSQL_DATABASE: "wordpress_test"
-      MYSQL_ROOT_PASSWORD: "password"
-    healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", '-u', 'root', '-ppassword' ]
-      interval: 10s
-      timeout: 5s
+    phpunit-db:
+        image: mysql:5.7
+        hostname: 'phpunit-db'
+        environment:
+            MYSQL_DATABASE: 'wordpress_test'
+            MYSQL_ROOT_PASSWORD: 'password'
+        healthcheck:
+            test:
+                [
+                    'CMD',
+                    'mysqladmin',
+                    'ping',
+                    '-h',
+                    'localhost',
+                    '-u',
+                    'root',
+                    '-ppassword',
+                ]
+            interval: 10s
+            timeout: 5s
 
 volumes:
-  test-suite: {}
+    test-suite: {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This is a feature plugin for a modern, javascript-driven WooCommerce Admin exper
 
 ## Prerequisites
 
-[WordPress 5.3 or greater](https://wordpress.org/download/) and [WooCommerce 3.6.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
+[WordPress 5.4 or greater](https://wordpress.org/download/) and [WooCommerce 4.8.0 or greater](https://wordpress.org/plugins/woocommerce/) should be installed prior to activating the WooCommerce Admin feature plugin.
 
 For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', true );` to your wp-config. This will load the unminified version of all libraries, and specifically the development build of React.
 
@@ -12,15 +12,15 @@ For better debugging, it's also recommended you add `define( 'SCRIPT_DEBUG', tru
 
 After cloning the repo, install dependencies:
 
- - `npm install` to install JavaScript dependencies.
- - `composer install` to gather PHP dependencies.
+-   `npm install` to install JavaScript dependencies.
+-   `composer install` to gather PHP dependencies.
 
 Now you can build the files using one of these commands:
 
- - `npm run build` : Build a production version
- - `npm run dev` : Build a development version
- - `npm start` : Build a development version, watch files for changes
- - `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
+-   `npm run build` : Build a production version
+-   `npm run dev` : Build a development version
+-   `npm start` : Build a development version, watch files for changes
+-   `npm run build:release` : Build a WordPress plugin ZIP file (`woocommerce-admin.zip` will be created in the repository root)
 
 For more helper scripts [see here](./CONTRIBUTING.md#helper-scripts)
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,7 +37,7 @@ WooCommerce Admin also allows store owners to customize a new dashboard screen w
 = Minimum Requirements =
 
 * WordPress 5.3
-* WooCommerce 4.5 or greater
+* WooCommerce 4.8 or greater
 * PHP version 7.0 or greater. PHP 7.2 or greater is recommended
 * MySQL version 5.0 or greater. MySQL 5.6 or greater is recommended
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ WooCommerce Admin also allows store owners to customize a new dashboard screen w
 
 = Minimum Requirements =
 
-* WordPress 5.3
+* WordPress 5.4
 * WooCommerce 4.8 or greater
 * PHP version 7.0 or greater. PHP 7.2 or greater is recommended
 * MySQL version 5.0 or greater. MySQL 5.6 or greater is recommended

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -220,8 +220,8 @@ class FeaturePlugin {
 	protected function get_dependency_errors() {
 		$errors                      = array();
 		$wordpress_version           = get_bloginfo( 'version' );
-		$minimum_wordpress_version   = '5.3';
-		$minimum_woocommerce_version = '3.6';
+		$minimum_wordpress_version   = '5.4';
+		$minimum_woocommerce_version = '4.8';
 		$wordpress_minimum_met       = version_compare( $wordpress_version, $minimum_wordpress_version, '>=' );
 		$woocommerce_minimum_met     = class_exists( 'WooCommerce' ) && version_compare( WC_VERSION, $minimum_woocommerce_version, '>=' );
 

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -11,8 +11,8 @@
  * Requires at least: 5.4
  * Requires PHP: 5.6.20
  *
- * WC requires at least: 4.5.0
- * WC tested up to: 4.7.0
+ * WC requires at least: 4.8.0
+ * WC tested up to: 5.0.0
  *
  * @package WooCommerce\Admin
  */

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -9,7 +9,7 @@
  * Domain Path: /languages
  * Version: 2.1.0-dev
  * Requires at least: 5.4
- * Requires PHP: 5.6.20
+ * Requires PHP: 7.0
  *
  * WC requires at least: 4.8.0
  * WC tested up to: 5.0.0


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-admin/pull/6330 the minimum version of WP was bumped to 5.4, but docs and testing configs weren't updated, so this PR handles that. Minimum WooCommerce version is also bumped to 4.8

### To Test

* See that changes make sense
* See CI tests passing