### PR TITLE
Fix Markdown formatting in page-controller.md

### DIFF
--- a/docs/page-controller.md
+++ b/docs/page-controller.md
@@ -70,10 +70,10 @@ WooCommerce Admin implements it's own version of `get_current_screen()` to allow
 
 Some screen ID formats that the function will generate are:
 
--   -   `{$current_screen->action}-{$current_screen->action}-tab-section`
--   -   `{$current_screen->action}-{$current_screen->action}-tab`
--   -   `{$current_screen->action}-{$current_screen->action}` if no tab is present
--   -   `{$current_screen->action}` if no action or tab is present
+- `{$current_screen->action}-{$current_screen->action}-tab-section`
+- `{$current_screen->action}-{$current_screen->action}-tab`
+- `{$current_screen->action}-{$current_screen->action}` if no tab is present
+- `{$current_screen->action}` if no action or tab is present
 
 WooCommerce Admin can recognize WooCommerce pages that have both tabs and sub sections. For example, `woocommerce_page_wc-settings-products-inventory` is the `WooCommerce > Settings > Products > Inventory` page.
 
@@ -94,9 +94,9 @@ Register pages with `wc_admin_register_page()` using these parameters:
 -   `capability` - User capability needed to access this page. Optional (defaults to `manage_options`).
 -   `icon` - Dashicons helper class or base64-encoded SVG. Include the entire dashicon class name, ie `dashicons-*`. This is optional and won't be included in WC Navigation.
 -   `position` - Menu item position for parent pages. Optional. See: `add_menu_page()`.
--   'nav_args` - Arguments for registering items in WooCommerce Navigation.
--   'nav_args[ 'order' ]` - Order number for presentation.
--   'nav_args[ 'parent' ]`- Menu for item to fall under.`woocommerce`,`woocommerce-settings`,`woocommerce-analytics`, or another category added by an extension are available.
+-   `nav_args` - Arguments for registering items in WooCommerce Navigation.
+-   `nav_args[ 'order' ]` - Order number for presentation.
+-   `nav_args[ 'parent' ]`- Menu for item to fall under.`woocommerce`,`woocommerce-settings`,`woocommerce-analytics`, or another category added by an extension are available.
 
 #### Example - Adding a New Analytics Report
 


### PR DESCRIPTION
Markdown formatting is of for [`page-controller.md`](https://github.com/woocommerce/woocommerce-admin/blob/main/docs/page-controller.md). 
- Some list items are double decorated.
- ' and ` are mismatched, making `code` elements created in the wrong places.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] I've tested using a screen reader
-   [n/a] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [n/a] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

#### Before 
![Screenshoot of double-decorated list items.](https://user-images.githubusercontent.com/17435/108112848-fa333f80-7096-11eb-99f6-a64047322168.png)

![Screenshoot of mismatched ' and `.](https://user-images.githubusercontent.com/17435/108112828-eee01400-7096-11eb-8163-b21e6eb7afd3.png)

#### After

![Screenshoot of fixed list item decorations.](https://user-images.githubusercontent.com/17435/108113131-601fc700-7097-11eb-91be-4fca10b7b1ea.png)

![Screenshot of fixed code elements.](https://user-images.githubusercontent.com/17435/108113176-775eb480-7097-11eb-87fc-44706430ad13.png)


### Detailed test instructions:

-  Preview https://github.com/woocommerce/woocommerce-admin/blob/0b97aa4792c5937dea41744cd3691d6dfdafef64/docs/page-controller.md
- Check if it's formatted correctly.



### Changelog note

I think it's not needed for such a cosmetic change.