### PR TITLE
New Settings: Turn off in dev mode

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -13,7 +13,7 @@
 		"navigation": true,
 		"onboarding": true,
 		"remote-inbox-notifications": true,
-		"settings": true,
+		"settings": false,
 		"shipping-label-banner": true,
 		"store-alerts": true,
 		"wcpay": true


### PR DESCRIPTION
Since there currently isn't a way to disable the new Settings from the UI. This turns off Settings from development mode because it difficult to get out of for those without easy CLI access.

cc @joshuatf because I know you are still tinkering in this area.