### PR TITLE
Add navigation favorites tests

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 - Fix: Add check for navigating being enabled. #6462
 - Dev: Add a changelog lint check to PRs. #6414
+- Dev: Add navigation favorites tests #6409
 - Fix: Move the shipping input and text 1px lower. #6408
 - Dev: support use of Array.flat in client and packages. #6411
 - Fix: Correct the Klarna slug #6440

--- a/tests/navigation/class-wc-favorites.php
+++ b/tests/navigation/class-wc-favorites.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Favorites tests
+ *
+ * @package WooCommerce\Admin\Tests\Navigation
+ */
+
+use Automattic\WooCommerce\Admin\Features\Navigation\Favorites;
+
+
+/**
+ * Class WC_Tests_Navigation_Favorites
+ */
+class WC_Tests_Navigation_Favorites extends WC_Unit_Test_Case {
+
+	/**
+	 * @var Marketing
+	 */
+	private $instance;
+
+	/**
+	 * setUp
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Favorites();
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test that errors are given when no user is provided or logged in.
+	 */
+	public function test_favorites_without_user() {
+		$result = $this->instance->add_item( 'menu-item' );
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		$result = $this->instance->remove_item( 'menu-item' );
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		$result = $this->instance->get_all();
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Test that favorites can be added.
+	 */
+	public function test_add_favorites() {
+		wp_set_current_user( $this->user );
+
+		$result = $this->instance->add_item( 'menu-item' );
+		$this->assertTrue( $result );
+		$result = $this->instance->add_item( 'menu-item2' );
+		$this->assertTrue( $result );
+
+		$favorites = $this->instance->get_all();
+		$this->assertContains( 'menu-item', $favorites );
+		$this->assertContains( 'menu-item2', $favorites );
+	}
+
+	/**
+	 * Test that favorites can be removed.
+	 */
+	public function test_remove_favorites() {
+		wp_set_current_user( $this->user );
+
+		$result = $this->instance->add_item( 'item-to-remove' );
+		$this->assertTrue( $result );
+
+		$favorites = $this->instance->get_all();
+		$this->assertContains( 'item-to-remove', $favorites );
+
+		$result    = $this->instance->remove_item( 'item-to-remove' );
+		$favorites = $this->instance->get_all();
+		$this->assertNotContains( 'item-to-remove', $favorites );
+	}
+
+	/**
+	 * Test that favorites can be added.
+	 */
+	public function test_add_previously_added_favorite() {
+		wp_set_current_user( $this->user );
+
+		$result = $this->instance->add_item( 'duplicate-item' );
+		$this->assertTrue( $result );
+
+		$result = $this->instance->add_item( 'duplicate-item' );
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * Test removing a favorite that does not exist.
+	 */
+	public function test_remove_invalid_favorite() {
+		wp_set_current_user( $this->user );
+
+		$result = $this->instance->remove_item( 'does-not-exist' );
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+}

--- a/tests/navigation/class-wc-favorites.php
+++ b/tests/navigation/class-wc-favorites.php
@@ -79,7 +79,7 @@ class WC_Tests_Navigation_Favorites extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that favorites can be added.
+	 * Test that existing favorites can not be added again.
 	 */
 	public function test_add_previously_added_favorite() {
 		wp_set_current_user( $this->user );

--- a/tests/navigation/class-wc-favorites.php
+++ b/tests/navigation/class-wc-favorites.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\Admin\Features\Navigation\Favorites;
 class WC_Tests_Navigation_Favorites extends WC_Unit_Test_Case {
 
 	/**
-	 * @var Marketing
+	 * @var Favorites
 	 */
 	private $instance;
 


### PR DESCRIPTION
Fixes #6406 

Adds some unit tests around the Favorites class.

### Detailed test instructions:

1. Check that tests pass ✅ 

`npm run test:php -- --filter=WC_Tests_Navigation_Favorites`