### PR TITLE
Added warning when WC-Admin is active but not being used

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Missing i18n in Welcome modal. #6456
 - Fix: Restore visual styles back to Analytics tabs. #5913
 - Add: Add a "rather not say" option to revenue in the profile wizard. #6475
+- Dev: Added warning when WC-Admin is active but not being used #6453
 
 == 2.1.0 ==
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -98,6 +98,31 @@ class Loader {
 		// Handler for WooCommerce and WooCommerce Admin plugin activation.
 		add_action( 'woocommerce_activated_plugin', array( __CLASS__, 'activated_plugin' ) );
 		add_action( 'activated_plugin', array( __CLASS__, 'activated_plugin' ) );
+		add_action( 'admin_init', array( __CLASS__, 'is_using_installed_wc_admin_plugin' ) );
+	}
+
+	/**
+	 * Verifies which plugin version is being used. If WooCommerce Admin is installed and activated but not in use
+	 * it will show a warning.
+	 */
+	public static function is_using_installed_wc_admin_plugin() {
+		if ( PluginsHelper::is_plugin_active( 'woocommerce-admin' ) ) {
+			$path = PluginsHelper::get_plugin_data( 'woocommerce-admin' );
+			if ( WC_ADMIN_VERSION_NUMBER !== $path['Version'] ) {
+				add_action(
+					'admin_notices',
+					function() {
+						echo '<div class="error"><p>';
+						printf(
+							/* translators: %s: is referring to the plugin's name. */
+							esc_html__( 'You have %s activated but it is not being used.', 'woocommerce-admin' ),
+							'<code>WooCommerce Admin</code>'
+						);
+						echo '</p></div>';
+					}
+				);
+			}
+		}
 	}
 
 	/**

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -115,7 +115,7 @@ class Loader {
 						echo '<div class="error"><p>';
 						printf(
 							/* translators: %s: is referring to the plugin's name. */
-							esc_html__( 'You have %s activated but it is not being used.', 'woocommerce-admin' ),
+							esc_html__( 'You have the %s plugin activated but it is not being used.', 'woocommerce-admin' ),
 							'<code>WooCommerce Admin</code>'
 						);
 						echo '</p></div>';


### PR DESCRIPTION
This PR adds a warning when WC-Admin is active but not being used.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2021 02 25-13_22_04](https://user-images.githubusercontent.com/1314156/109183318-9383e500-776c-11eb-90fe-6af95b969f4b.png)

### Detailed test instructions:

- We need to simulate that these modifications are present in the `WC-Admin` that `WooCommerce` is using. To do it we will copy [these lines](https://github.com/woocommerce/woocommerce-admin/blob/e60af23541577dff54bb7408eb913045a26252b7/src/Loader.php#L101-L125) into `Loader.php` in the WC-Admin that lives under `packages` in the `WooCommerce` plugin (`packages/woocommerce-admin/src/Loader.php`).
- So we will add into `Loader.php` the `action` in the constructor and the method `is_using_installed_wc_admin_plugin `
- After that go back to the `woocommerce-admin` repo and checkout an older release of the plugin (like 1.8.0) `git checkout release/1.8.0`.
- Run `composer update`.
- Go to the `status` page (`/wp-admin/admin.php?page=wc-status`).

![screenshot-one wordpress test-2021 02 25-14_31_06](https://user-images.githubusercontent.com/1314156/109192655-43aa1b80-7776-11eb-865d-d76c01270101.png)

- Verify that the `WooCommerce Admin package` used is under the `WooCommerce` plugin in the `packages` folder.
- Also the warning: `You have WooCommerce Admin activated but it is not being used.` should be visible.
- Checkout this branch (`git checkout add/poc-plugin-use-warning`) and run `composer update`.
- Now the warning shouldn't be visible anymore and the WC-Admin package used should show a path to this repo.


<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
