### PR TITLE
Dates: Account for leat year in `getLastPeriod`

### DIFF
--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Take into account leap year in calculating `getLastPeriod`.
+
 # 2.1.0
 
 -   Update to @wordpress/eslint coding standards.

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -148,6 +148,7 @@ export function getLastPeriod( period, compare ) {
 			secondaryEnd = secondaryStart.clone().endOf( period );
 		} else {
 			// Otherwise, use days in primary period to figure out how far to go back
+			// This is necessary for calculating weeks instead of using `endOf`.
 			const daysDiff = primaryEnd.diff( primaryStart, 'days' );
 			secondaryEnd = primaryStart.clone().subtract( 1, 'days' );
 			secondaryStart = secondaryEnd.clone().subtract( daysDiff, 'days' );
@@ -156,6 +157,12 @@ export function getLastPeriod( period, compare ) {
 		secondaryStart = primaryStart.clone().subtract( 1, 'years' );
 		secondaryEnd = primaryEnd.clone().subtract( 1, 'years' );
 	}
+
+	// When the period is month, be sure to force end of month to take into account leap year
+	if ( period === 'month' ) {
+		secondaryEnd = secondaryEnd.clone().endOf( 'month' );
+	}
+
 	return {
 		primaryStart,
 		primaryEnd,

--- a/packages/date/test/index.js
+++ b/packages/date/test/index.js
@@ -552,7 +552,7 @@ describe( 'getLastPeriod', () => {
 			).toBe( true );
 		} );
 
-		it.skip( 'should return correct values for previous_year', () => {
+		it( 'should return correct values for previous_year', () => {
 			const dateValue = getLastPeriod( 'month', 'previous_year' );
 
 			const lastMonthkLastYearStart = lastMonthStart
@@ -561,7 +561,6 @@ describe( 'getLastPeriod', () => {
 			const lastMonthkLastYearEnd = lastMonthkLastYearStart
 				.clone()
 				.endOf( 'month' );
-
 			expect(
 				lastMonthkLastYearStart.isSame(
 					dateValue.secondaryStart,


### PR DESCRIPTION
Unit tests weren't passing because `getLastPeriod` wasn't taking into account leap year. This PR makes sure that calculating the last period (ie, last week, last month, last year) always uses `moment().endOf` to calculate the previous period when looking at months.

### Detailed test instructions:

Take a look at Revenue report for last month against previous year and previous period. Make sure nothing bad happens. Note that the UI looks the exact same because the primary period is used to create the chart's X-axis. Making that accomodate one extra day for the previous period is out of scope of this PR. You can, however, check the requests for data and see that 29th day's data where previously there wasn't.

<img width="1196" alt="Screen Shot 2021-03-01 at 3 58 31 PM" src="https://user-images.githubusercontent.com/1922453/109449074-66a53a00-7aac-11eb-8228-78bef7a8b3d4.png">

<img width="599" alt="Screen Shot 2021-03-01 at 4 28 05 PM" src="https://user-images.githubusercontent.com/1922453/109449080-6a38c100-7aac-11eb-910b-f4a91e10eccb.png">



<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
