### PR TITLE
Add a new revenue option, 'rather not say'

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -11,11 +11,24 @@
 
 ### Deprecate Onboarding::has_woocommerce_support #6401
 
-- Clear existing site transients. For example, by using the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin, and pressing the "Delete all transients" button it provides.
-- Add any new theme to WordPress but **DO NOT** activate it.
-- Initialize the Onboarding Wizard.
-- See that the Themes step loads fast 😎 
-- See that the new theme is listed in the Themes step.
+-   Clear existing site transients. For example, by using the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin, and pressing the "Delete all transients" button it provides.
+-   Add any new theme to WordPress but **DO NOT** activate it.
+-   Initialize the Onboarding Wizard.
+-   See that the Themes step loads fast 😎
+-   See that the new theme is listed in the Themes step.
+
+### Set up tasks can now navigate back to the home screen #6397
+
+1. With a fresh install of wc-admin and woocommerce, go to the home screen
+2. Going to the homescreen redirects to the profile setup wizard, click "Skip setup store details" to return to the home screen
+3. On the home screen you will see the setup task list. It has the heading "Get ready to start selling"
+
+For each task in that list apart from "Store details":
+
+1. Click the item
+2. You should land on the setup task page
+3. A title in the top left should reflect the original task name from the task list. e.g. "Add tax rates"
+4. Clicking the chevron to the left of the title should take you back to the home screen
 
 ## 2.1.0
 
@@ -58,9 +71,9 @@ wp option delete 'woocommerce_merchant_email_notifications';
 ```
 
 -   Run the cron job `wc_admin_daily` (this tool can help [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)).
-    - Go to **Tools > Cron Events** and scroll down to the `wc_admin_daily`.
-    -  Hover over the item and click `Edit` change the **Next Run** to `Now` and click `Update Event`.
-    - It will redirect you to the cron event list, and `wc_admin_daily` should be near the top, if you wait 10 seconds and refresh the page the `wc_admin_daily` should be near the bottom again, this means it has been run, and scheduled again to run tomorrow.
+    -   Go to **Tools > Cron Events** and scroll down to the `wc_admin_daily`.
+    -   Hover over the item and click `Edit` change the **Next Run** to `Now` and click `Update Event`.
+    -   It will redirect you to the cron event list, and `wc_admin_daily` should be near the top, if you wait 10 seconds and refresh the page the `wc_admin_daily` should be near the bottom again, this means it has been run, and scheduled again to run tomorrow.
 -   You should have not received an email note.
 -   Verify the note `wc-admin-add-first-product-note` was added in the DB and its `status` is `unactioned`. You can use a statement like this:
 
@@ -269,6 +282,14 @@ localStorage.setItem( 'debug', 'wc-admin:tracks' );
         -   The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
 
 Once everything is configured and enabled do a client test
+<<<<<<< HEAD
+
+-   Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
+-   Navigate to one of the products and add it to the cart
+-   Click **go to checkout**
+-   Paypal should be one of the options to pay
+-   Filling in your billing/shipping info then click pay with **Paypal**
+-   # The paypal pay window should pop up correctly without errors.
 
 -   Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
 -   Navigate to one of the products and add it to the cart
@@ -276,3 +297,4 @@ Once everything is configured and enabled do a client test
 -   Paypal should be one of the options to pay
 -   Filling in your billing/shipping info then click pay with **Paypal**
 -   The paypal pay window should pop up correctly without errors.
+    > > > > > > > origin/main

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+### Fix double prefixing of navigation URLs #6460
+
+1. Register a navigation menu item with a full URL or admin link.
+```
+	\Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item(
+		array(
+			'id'         => 'my-page,
+			'title'      => 'My Page,
+			'capability' => 'manage_woocommerce',
+			'url'        => admin_url( 'my-page '),
+		)
+	);
+```
+2. Enable the navigation.
+3. Check that the menu item is marked active when visiting that page.
+4. Make sure old menu items are still correctly marked active.
+
+### Fix summary number style regression on analytics reports #5913
+
+- Go to Analytics
+- See that the active (selected) tab is white, with a highlight above the tab.
+- See that inactive tabs are a lighter shade of grey.
+
+### Update payment card style on mobile #6413
+
+- Using a small size screen, go to your WooCommerce -> Home -> Choose payment methods.
+- See that the text descriptions for payment methods have a margin between them and the edge of the screen.
+
 ### Navigation: Correct error thrown when enabling #6462
 
 1. Create a fresh store
@@ -11,24 +39,11 @@
 
 ### Deprecate Onboarding::has_woocommerce_support #6401
 
--   Clear existing site transients. For example, by using the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin, and pressing the "Delete all transients" button it provides.
--   Add any new theme to WordPress but **DO NOT** activate it.
--   Initialize the Onboarding Wizard.
--   See that the Themes step loads fast 😎
--   See that the new theme is listed in the Themes step.
-
-### Set up tasks can now navigate back to the home screen #6397
-
-1. With a fresh install of wc-admin and woocommerce, go to the home screen
-2. Going to the homescreen redirects to the profile setup wizard, click "Skip setup store details" to return to the home screen
-3. On the home screen you will see the setup task list. It has the heading "Get ready to start selling"
-
-For each task in that list apart from "Store details":
-
-1. Click the item
-2. You should land on the setup task page
-3. A title in the top left should reflect the original task name from the task list. e.g. "Add tax rates"
-4. Clicking the chevron to the left of the title should take you back to the home screen
+- Clear existing site transients. For example, by using the [Transients Manager](https://wordpress.org/plugins/transients-manager/) plugin, and pressing the "Delete all transients" button it provides.
+- Add any new theme to WordPress but **DO NOT** activate it.
+- Initialize the Onboarding Wizard.
+- See that the Themes step loads fast 😎 
+- See that the new theme is listed in the Themes step.
 
 ## 2.1.0
 
@@ -71,9 +86,9 @@ wp option delete 'woocommerce_merchant_email_notifications';
 ```
 
 -   Run the cron job `wc_admin_daily` (this tool can help [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)).
-    -   Go to **Tools > Cron Events** and scroll down to the `wc_admin_daily`.
-    -   Hover over the item and click `Edit` change the **Next Run** to `Now` and click `Update Event`.
-    -   It will redirect you to the cron event list, and `wc_admin_daily` should be near the top, if you wait 10 seconds and refresh the page the `wc_admin_daily` should be near the bottom again, this means it has been run, and scheduled again to run tomorrow.
+    - Go to **Tools > Cron Events** and scroll down to the `wc_admin_daily`.
+    -  Hover over the item and click `Edit` change the **Next Run** to `Now` and click `Update Event`.
+    - It will redirect you to the cron event list, and `wc_admin_daily` should be near the top, if you wait 10 seconds and refresh the page the `wc_admin_daily` should be near the bottom again, this means it has been run, and scheduled again to run tomorrow.
 -   You should have not received an email note.
 -   Verify the note `wc-admin-add-first-product-note` was added in the DB and its `status` is `unactioned`. You can use a statement like this:
 
@@ -282,14 +297,6 @@ localStorage.setItem( 'debug', 'wc-admin:tracks' );
         -   The enable/disable button should be correctly reflected in the Woocommerce payment settings screen as well.
 
 Once everything is configured and enabled do a client test
-<<<<<<< HEAD
-
--   Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
--   Navigate to one of the products and add it to the cart
--   Click **go to checkout**
--   Paypal should be one of the options to pay
--   Filling in your billing/shipping info then click pay with **Paypal**
--   # The paypal pay window should pop up correctly without errors.
 
 -   Make sure you have added a product and store homescreen (Finish the **Personalize my store** task)
 -   Navigate to one of the products and add it to the cart
@@ -297,4 +304,3 @@ Once everything is configured and enabled do a client test
 -   Paypal should be one of the options to pay
 -   Filling in your billing/shipping info then click pay with **Paypal**
 -   The paypal pay window should pop up correctly without errors.
-    > > > > > > > origin/main

--- a/client/profile-wizard/steps/business-details/data/revenue-options.js
+++ b/client/profile-wizard/steps/business-details/data/revenue-options.js
@@ -97,4 +97,8 @@ export const getRevenueOptions = ( numberConfig, country ) => [
 			formatAmount( convertCurrency( 250000, country ) )
 		),
 	},
+	{
+		key: 'rather-not-say',
+		label: __( "I'd rather not say", 'woocommerce-admin' ),
+	},
 ];

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Deprecate Onboarding::has_woocommerce_support. #6401
 - Fix: Broken link anchors to online documentation. #6455
 - Dev: Add Dependency Extraction Webpack Plugin #5762
+- Add: Add a "rather not say" option to revenue in the profile wizard. #6475
 
 == 2.1.0 ==
 

--- a/src/API/OnboardingProfile.php
+++ b/src/API/OnboardingProfile.php
@@ -315,6 +315,7 @@ class OnboardingProfile extends \WC_REST_Data_Controller {
 					'10000-50000',
 					'50000-250000',
 					'more-than-250000',
+					'rather-not-say',
 				),
 			),
 			'other_platform'      => array(


### PR DESCRIPTION
Fixes #6459 

Reasoning outlined in the ticket, I think this is a great addition to the profile wizard. I did a thorough check around the use of `revenue` and the value is not checked or relied on anywhere that I can see, but I would appreciate any second opinions on this.

### Accessibility

n/a

### Detailed test instructions:

-   Run through the onboarding wizard up to the business details step
-   For "currently selling" choose "yes, on another platform"
-   The revenue dropdown should appear, open it and confirm the "I'd rather not say" option is present.
-  Choose that option and any others needed for the form to be valid and click continue
-  Confirm no errors are reported. go back from previous section to business details and confirm the option was persisted.

The value stored for this is `rather-not-say`

This feels a bit too minor to worry about testing instructions? Happy to hear other opinions on that.