### PR TITLE
TRY: Fixing site errors being concealed by new navigation (dynamic margin on body)

### DIFF
--- a/client/header/index.js
+++ b/client/header/index.js
@@ -94,26 +94,26 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 		window.addEventListener( 'resize', updateBodyMargin );
 		return () => {
 			window.removeEventListener( 'resize', updateBodyMargin );
-			const wpBody = document.querySelector( '#wpbody' );
+			const bodyEl = document.querySelector( 'body' );
 
-			if ( ! wpBody ) {
+			if ( ! bodyEl ) {
 				return;
 			}
 
-			wpBody.style.marginTop = null;
+			bodyEl.style.marginTop = null;
 		};
 	}, [ isModalDismissed ] );
 
 	const updateBodyMargin = () => {
 		clearTimeout( debounceTimer );
 		debounceTimer = setTimeout( function () {
-			const wpBody = document.querySelector( '#wpbody' );
+			const bodyEl = document.querySelector( 'body' );
 
-			if ( ! wpBody || ! headerElement.current ) {
+			if ( ! bodyEl || ! headerElement.current ) {
 				return;
 			}
 
-			wpBody.style.marginTop = `${ headerElement.current.offsetHeight }px`;
+			bodyEl.style.marginTop = `${ headerElement.current.offsetHeight }px`;
 		}, 200 );
 	};
 

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -38,7 +38,9 @@ body.is-wc-nav-expanded {
 		height: 100%;
 	}
 
-	font > .xe-notice {
+	font > .xe-notice,
+	font > .xdebug-error,
+	font > .xe-warning {
 		margin-left: calc(#{$navigation-width} + #{$gap});
 	}
 }
@@ -131,10 +133,6 @@ body.is-wc-nav-folded {
 	&:not(.is-wp-toolbar-disabled) {
 		#wpbody-content {
 			margin-top: $adminbar-height;
-		}
-
-		font > .xe-notice {
-			margin-top: $header-height;
 		}
 	}
 }

--- a/client/navigation/style.scss
+++ b/client/navigation/style.scss
@@ -37,6 +37,10 @@ body.is-wc-nav-expanded {
 		width: $navigation-width;
 		height: 100%;
 	}
+
+	font > .xe-notice {
+		margin-left: calc(#{$navigation-width} + #{$gap});
+	}
 }
 
 body.is-wc-nav-folded {
@@ -127,6 +131,10 @@ body.is-wc-nav-folded {
 	&:not(.is-wp-toolbar-disabled) {
 		#wpbody-content {
 			margin-top: $adminbar-height;
+		}
+
+		font > .xe-notice {
+			margin-top: $header-height;
 		}
 	}
 }

--- a/client/stylesheets/shared/_reset.scss
+++ b/client/stylesheets/shared/_reset.scss
@@ -48,6 +48,9 @@
 	width: 100%;
 	box-sizing: border-box;
 	padding-top: 0;
+}
+
+body {
 	margin-top: $header-height;
 }
 


### PR DESCRIPTION
Fixes #5859

Certain site errors are displayed in a way that they are covered up by the new site navigation. This PR amends this to apply appropriate margins to the errors only when the new navigation is enabled and expanded.

_Notes:_
- This is an alternative to https://github.com/woocommerce/woocommerce-admin/pull/6337
- Known issue:
When Woo Nav is disabled, the side navigation responds to the margin in a bad way
![image](https://user-images.githubusercontent.com/444632/110186376-e7747680-7dc9-11eb-8817-29699a66e90c.png)


### Screenshots

![image](https://user-images.githubusercontent.com/444632/107830247-510be280-6d40-11eb-9bba-3b01b13d7af5.png)

### Detailed test instructions:

-   Checkout branch
- Ensure the new navigation is enabled
- Navigate to a WC-Admin page (such as Homescreen)
-   Make a quick code change to cause an error. I did so by changing a variable name in `Screen.php`.
- Confirm that the resulting error(s) display as they do in the screenshot, and are not covered up by the side navigation.