### PR TITLE
Fix a bug in useSettings that causes an infinite loop.

### DIFF
--- a/packages/data/src/settings/use-settings.js
+++ b/packages/data/src/settings/use-settings.js
@@ -30,7 +30,7 @@ export const useSettings = ( group, settingsKeys = [] ) => {
 				isDirty: getIsDirty( group, settingsKeys ),
 			};
 		},
-		[ group, ...settingsKeys ]
+		[ group, ...settingsKeys.sort() ]
 	);
 	const {
 		persistSettingsForGroup,

--- a/packages/data/src/settings/use-settings.js
+++ b/packages/data/src/settings/use-settings.js
@@ -30,7 +30,7 @@ export const useSettings = ( group, settingsKeys = [] ) => {
 				isDirty: getIsDirty( group, settingsKeys ),
 			};
 		},
-		[ group, settingsKeys ]
+		[ group, ...settingsKeys ]
 	);
 	const {
 		persistSettingsForGroup,

--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Remove Mollie promo note on install #6510
 - Add: Remote Inbox Notifications rule to trigger when WooCommerce Admin is upgraded. #6040
 - Feature: Increase target audience for business feature step. #6508
+- Fix: Crash of Analytics > Settings page when Gutenberg is installed. #6540
 
 == 2.1.0 ==
 


### PR DESCRIPTION
Fixes #5728 

In #5728 when Gutenberg is installed and you visit Analytics > Settings, the page crashes. This turns out to be an infinite loop that is started in the `Settings` component.

I traced this down to a bug in `wc/data` where we create a new array reference every time the `useSettings` hook is called due to a fresh array being created when its empty. This exceeds the maximum call depth and crashes the app.

To fix this, I use a commonly used approach of spreading the array arguments (which are strings) into the dependency list. This should also make `useSetting` more efficient wherever it is used currently.

### Accessibility

n/a

### Screenshots

n/a

### Detailed test instructions:

1. Install latest gutenberg plugin
2. Visit the Analytics > Settings page.
3. It should not crash, smoke test the page elements.
<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->