### PR TITLE
Remove hardcoded dependencies from examples.

### DIFF
--- a/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
+++ b/docs/examples/extensions/add-navigation-items/woocommerce-admin-add-navigation-items-example.php
@@ -13,17 +13,12 @@ function add_navigation_items_register_script() {
 		return;
 	}
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'add-navigation-items',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-			'wp-element',
-			'wp-i18n',
-			'wc-components',
-			'wp-plugins',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 

--- a/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
+++ b/docs/examples/extensions/add-report/woocommerce-admin-add-report-example.php
@@ -14,16 +14,12 @@ function add_report_register_script() {
 		return;
 	}
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'add-report',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-			'wp-element',
-			'wp-i18n',
-			'wc-components',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -88,7 +88,7 @@ addFilter(
 				additionalInfo: __( 'Additional info here', 'woocommerce-admin' ),
 				time: __( '2 minutes', 'woocommerce-admin' ),
 				isDismissable: true,
-				onDismiss: () => console.log( "The task was dismissed" ),
+				onDismiss: () => console.log( 'The task was dismissed' ),
 			},
 		];
 	}

--- a/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
+++ b/docs/examples/extensions/add-task/woocommerce-admin-add-task-example.php
@@ -20,16 +20,12 @@ function add_task_register_script() {
 		return;
 	}
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'add-task',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-			'wp-element',
-			'wp-i18n',
-			'wc-components',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 

--- a/docs/examples/extensions/dashboard-section/woocommerce-admin-dashboard-section.php
+++ b/docs/examples/extensions/dashboard-section/woocommerce-admin-dashboard-section.php
@@ -14,16 +14,12 @@ function dashboard_section_register_script() {
 		return;
 	}
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'dashboard_section',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-			'wp-element',
-			'wp-i18n',
-			'wc-components',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 

--- a/docs/examples/extensions/examples.config.js
+++ b/docs/examples/extensions/examples.config.js
@@ -23,6 +23,8 @@ if ( ! fs.existsSync( extensionPath ) ) {
 	throw new Error( 'Extension example does not exist.' );
 }
 
+const WooCommerceDependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extraction-webpack-plugin' );
+
 const webpackConfig = {
 	mode: 'development',
 	entry: {
@@ -100,6 +102,7 @@ const webpackConfig = {
 		new MiniCssExtractPlugin( {
 			filename: '[name]/dist/style.css',
 		} ),
+		new WooCommerceDependencyExtractionWebpackPlugin(),
 	],
 };
 

--- a/docs/examples/extensions/important-admin-notice/woocommerce-admin-important-admin-notice-example.php
+++ b/docs/examples/extensions/important-admin-notice/woocommerce-admin-important-admin-notice-example.php
@@ -20,13 +20,12 @@ function wc_admin_important_notice_register_script() {
 		return;
 	}
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'wc-admin-important-notice',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 

--- a/docs/examples/extensions/important-admin-notice/woocommerce-admin-important-admin-notice-example.php
+++ b/docs/examples/extensions/important-admin-notice/woocommerce-admin-important-admin-notice-example.php
@@ -42,7 +42,7 @@ function wc_admin_add_important_notice() {
 		<p class="notice-text">Important notice targeted by inspecting DOM.</p>
 	</div>
 	<div class="updated woocommerce-admin woocommerce-message">
-		<p>Impotant notice targeted by class.</p>
+		<p>Important notice targeted by class.</p>
 	</div>
 	<div class="updated woocommerce-admin woocommerce-message ok-to-hide">
 		<p>Notice excluded from importance clause targeted by class.</p>

--- a/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
+++ b/docs/examples/extensions/sql-modification/woocommerce-admin-sql-modification.php
@@ -75,18 +75,12 @@ function add_report_register_script() {
 
 	add_currency_settings();
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'sql-modification',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-			'wp-element',
-			'wp-i18n',
-			'wp-plugins',
-			'wc-components',
-			'wc-settings',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 
@@ -104,9 +98,11 @@ add_action( 'admin_enqueue_scripts', 'add_report_register_script' );
 function apply_currency_arg( $args ) {
 	$currency = 'USD';
 
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['currency'] ) ) {
 		$currency = sanitize_text_field( wp_unslash( $_GET['currency'] ) );
 	}
+	// phpcs:enable
 
 	$args['currency'] = $currency;
 
@@ -170,9 +166,11 @@ add_filter( 'woocommerce_analytics_clauses_join_taxes_stats_interval', 'add_join
 function add_where_subquery( $clauses ) {
 	$currency = 'USD';
 
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_GET['currency'] ) ) {
 		$currency = sanitize_text_field( wp_unslash( $_GET['currency'] ) );
 	}
+	// phpcs:enable
 
 	$clauses[] = "AND currency_postmeta.meta_key = '_order_currency' AND currency_postmeta.meta_value = '{$currency}'";
 

--- a/docs/examples/extensions/table-column/woocommerce-admin-table-column.php
+++ b/docs/examples/extensions/table-column/woocommerce-admin-table-column.php
@@ -14,16 +14,12 @@ function table_column_register_script() {
 		return;
 	}
 
+	$asset_file = require __DIR__ . '/dist/index.asset.php';
 	wp_register_script(
 		'table_column',
 		plugins_url( '/dist/index.js', __FILE__ ),
-		array(
-			'wp-hooks',
-			'wp-element',
-			'wp-i18n',
-			'wc-components',
-		),
-		filemtime( dirname( __FILE__ ) . '/dist/index.js' ),
+		$asset_file['dependencies'],
+		$asset_file['version'],
 		true
 	);
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
 		"@woocommerce/customer-effort-score": "file:packages/customer-effort-score",
 		"@woocommerce/data": "file:packages/data",
 		"@woocommerce/date": "file:packages/date",
-		"@woocommerce/dependency-extraction-webpack-plugin": "^1.4.0",
+		"@woocommerce/dependency-extraction-webpack-plugin": "file:packages/dependency-extraction-webpack-plugin",
 		"@woocommerce/eslint-plugin": "file:packages/eslint-plugin",
 		"@woocommerce/experimental": "file:packages/experimental",
 		"@woocommerce/navigation": "file:packages/navigation",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
 		"@woocommerce/customer-effort-score": "file:packages/customer-effort-score",
 		"@woocommerce/data": "file:packages/data",
 		"@woocommerce/date": "file:packages/date",
+		"@woocommerce/dependency-extraction-webpack-plugin": "^1.4.0",
 		"@woocommerce/eslint-plugin": "file:packages/eslint-plugin",
 		"@woocommerce/experimental": "file:packages/experimental",
 		"@woocommerce/navigation": "file:packages/navigation",


### PR DESCRIPTION
Following on from #6482, it was identified that the code examples under [`docs/examples/extensions`](https://github.com/woocommerce/woocommerce-admin/tree/main/docs/examples/extensions) all hardcode the Javascript dependencies, which is suboptimal, and can lead to odd bugs due to missing dependencies. 

This PR:

- Adds the WooCommerce Dependency Extraction webpack plugin
- Uses it during the build for `npm run example`
- Updates examples to use the generated `foo.asset.php` files rather than hardcoding dependencies

I'm not a webpack guru, so please check that everything in that section of the PR has been done sensibly. 

Also of note is that I had to add two sets of PHPCS exclusions relating to lack of nonce checks in `/sql-modification/woocommerce-admin-sql-modification.php` to be able to commit the asset file changes - although this seems to be a pre-existing issue unrelated to this PR. 

No changelog required