### PR TITLE
Add Google Analytics tracking to layout.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
 		font-size: 0.9em;
 	}
 	</style>
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
+	<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+
+	gtag('config', 'G-8KCYZ2CYMS');
+	</script>
 </head>
 <body>
 	<div id="app"></div>


### PR DESCRIPTION
There's not an associated issue for this PR, but it's partially related to [this issue](https://github.com/woocommerce/woocommerce-developer-advocacy/issues/92).

This PR adds a Google Analytics tracking tag to the base layout that will help us measure traffic and engagement for the pages in this resource.

### Accessibility

There were no changes to interactive elements.

### Screenshots

<img width="1280" alt="Screen Shot 2021-03-09 at 10 03 36 AM" src="https://user-images.githubusercontent.com/3477155/110490924-c314e480-80be-11eb-8a60-df3308f36e9c.png">


### Detailed test instructions:

-  Install dependencies (if necessary)
- Run `docsify serve`
-  Open http://localhost:3000 in a web browser.
-  Open your browser's web inspector and confirm that the Google Analytics tag appears in the `<HEAD>` section of the page
-  Browse to different pages in the documentation, and confirm that the GA tag data remains in the `<HEAD>` section.

<!--- Please add a Changelog note
Not sure if this change requires a Changelog note since it doesn't affect the package itself but rather the static site that lives independently on the `gh-pages` branch.  Let me know if we need an entry for this, and I can push another commit with the update in the `readme.txt` file.  :smiley:

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
