### PR TITLE
Never skip changelog labelling, default to remove label.

### DIFF
--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -30,9 +30,7 @@ jobs:
               shell: bash
             - name: Add a reminder label to the PR
               uses: ./.github/actions/pr-labeler
-              if: github.event.pull_request.user.login != 'renovate[bot]' && !steps.skip-workflow.outputs.skip && always()
               with:
                   access_token: ${{ github.token }}
-                  label: ${{ env.label }}
-                  action: ${{ env.label_action }}
-
+                  label: ${{ env.label || 'needs changelog entry' }}
+                  action: ${{ env.label_action || 'remove' }}

--- a/.github/workflows/lint-changelog.yml
+++ b/.github/workflows/lint-changelog.yml
@@ -30,6 +30,7 @@ jobs:
               shell: bash
             - name: Add a reminder label to the PR
               uses: ./.github/actions/pr-labeler
+              if: github.event.pull_request.user.login != 'renovate[bot]' && always()
               with:
                   access_token: ${{ github.token }}
                   label: ${{ env.label || 'needs changelog entry' }}


### PR DESCRIPTION
Rather than skip labelling action this defaults to always remove it, so unless the lint explicitly asked for the changelog label to be added it will be removed.

no changelog