### PR TITLE
Disabling wc-admin: Remove filter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Store profiler - Added MailPoet to Business Details step  #6503
 - Dev: Store profiler - Added MailPoet to new Business Details step  #6515
 - Dev: Add tilde (~) to represent client root directory for imports. #6517
+- Dev: Remove ability to disable wc-admin. #6568
 
 == 2.1.0 3/10/2021  ==
 

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -60,15 +60,6 @@ class FeaturePlugin {
 	 * Init the feature plugin, only if we can detect both Gutenberg and WooCommerce.
 	 */
 	public function init() {
-		/**
-		 * Filter allowing WooCommerce Admin to be disabled.
-		 *
-		 * @param bool $disabled False.
-		 */
-		if ( apply_filters( 'woocommerce_admin_disabled', false ) ) {
-			return;
-		}
-
 		$this->define_constants();
 
 		require_once WC_ADMIN_ABSPATH . '/src/Notes/DeprecatedNotes.php';


### PR DESCRIPTION
Removes the ability to turn off wc-admin.

Now that wc-admin is in Core, more and more functionality is baked into the plugin, and extensions build off its functionality, it makes less and less sense to allow users or plugins to disable it.

This PR removes the ability to disable the plugin and will be a good space to discuss the ramifications.