### PR TITLE
TRY Attempt a fix to the task list which was not hiding when completed.

### DIFF
--- a/client/task-list/list.js
+++ b/client/task-list/list.js
@@ -52,20 +52,26 @@ export class TaskList extends Component {
 	possiblyCompleteTaskList() {
 		const { isComplete, name = 'task_list', updateOptions } = this.props;
 		const taskListVariableName = `woocommerce_${ name }_complete`;
-		const taskListToComplete = isComplete
-			? { [ taskListVariableName ]: 'no' }
-			: { [ taskListVariableName ]: 'yes' };
-		if ( name === 'task_list' ) {
-			taskListToComplete.woocommerce_default_homepage_layout =
-				'two_columns';
-		}
+		const remainingIncompleteTasks = !! this.getIncompleteTasks().length;
 
 		if (
-			( ! this.getIncompleteTasks().length && ! isComplete ) ||
-			( this.getIncompleteTasks().length && isComplete )
+			( remainingIncompleteTasks && isComplete ) ||
+			( ! remainingIncompleteTasks && ! isComplete )
 		) {
+			const layoutUpdate =
+				name === 'task_list'
+					? { woocommerce_default_homepage_layout: 'two_columns' }
+					: {};
+
+			const taskListHiddenUpdate =
+				name === 'task_list' && isComplete
+					? { woocommerce_task_list_hidden: 'yes' }
+					: {};
+
 			updateOptions( {
-				...taskListToComplete,
+				[ taskListVariableName ]: isComplete ? 'yes' : 'no',
+				...layoutUpdate,
+				...taskListHiddenUpdate,
 			} );
 		}
 	}


### PR DESCRIPTION
Fixes #6592 

The task list was not hiding and the store management links were not appearing.

@octaedro Could you please review this, I'm not sure about the fix.

I think this broke with the slew of updates we've seen trying to fix this, and unfortunately its really hard to tell the intent of these components any more, this latest fix feels like a hack to solve a confusing component/options relationship here that we should fix as soon as possible. This is not anyone's fault, its just the way its evolved I think.

I think the core issue here (I think?) is that `woocommerce_task_list_hidden` is relied on alongside `woocommerce_task_list_complete` to render things properly, so it needs to be set as well when marking as complete.