### PR TITLE
Fallback to empty object when window.wcNavigation is not defined

### DIFF
--- a/client/navigation/utils.js
+++ b/client/navigation/utils.js
@@ -68,6 +68,8 @@ export const getDefaultMatchExpression = ( url ) => {
  * @return {Function} Function to remove listeners.
  */
 export const addHistoryListener = ( listener ) => {
+	window.wcNavigation = window.wcNavigation || {};
+
 	// Monkey patch pushState to allow trigger the pushstate event listener.
 	if ( ! window.wcNavigation.historyPatched ) {
 		( ( history ) => {


### PR DESCRIPTION
Function `addHistoryListener` uses global `window.wcNavigation` object. In latest (5.1.0) version of WooCommerce `window.wcNavigation` seems to be undefined. It's something which blocks the WP editor and user cannot do anything. The easiest thing to do there is to initialize it with empty object when `window.wcNavigation` is undefined.

```javascript
TypeError: Cannot read property 'historyPatched' of undefined
    at u (https://localhost/wp-content/plugins/woocommerce/packages/woocommerce-admin/dist/app/index.js?ver=2.0.2:2:146001)
    at https://localhost/wp-content/plugins/woocommerce/packages/woocommerce-admin/dist/app/index.js?ver=2.0.2:2:54908
    at Bh (https://localhost/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:126:456)
    at Dj (https://localhost/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:162:476)
    at unstable_runWithPriority (https://localhost/wp-includes/js/dist/vendor/react.min.js?ver=16.13.1:25:260)
    at Da (https://localhost/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:60:280)
    at xb (https://localhost/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:162:231)
    at Te (https://localhost/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:146:79)
    at https://localhost/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:61:68
    at unstable_runWithPriority (https://localhost/wp-includes/js/dist/vendor/react.min.js?ver=16.13.1:25:260)
``` 
