### PR TITLE
Set default value to array when op is 'contains'

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -8,6 +8,16 @@
 2. Verifty the dropdown buttons (date range or filters) are now higher contrast.
 3. Verifty the text and chevron in the dropdown button turn blue on hover, and while active.
 
+### Set default value to array when op is `contains` #6622
+
+1. Clone and start https://github.com/Automattic/woocommerce.com
+2. Open `notifications.json.php` from woocommerce.com repository and find a rule that uses the `contains` operator and remove the `default` key. Please make a note of the option name.
+3. Open `src/RemoteInboxNotifications/DataSourcepoller.php` from your WooCommerce Admin repository and change the datasource to your local woocommerce.com (woocommerce.test)
+4. Make sure your local WooCommerce Admin database does not have the option from step #2
+5. Install and activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)
+6. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
+7. Check your debug log in `wp-content/debug.log`. You should see PHP error.
+
 ### Close activity panel tabs by default and track #6566
 
 1. Open your browser console and enter `localStorage.setItem( 'debug', 'wc-admin:tracks' );`.  Make sure the "Verbose" is selected under the levels shown.

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Tweak: Add default value for contains op #6622
 - Dev: Close activity panel tabs by default and track #6566
 - Dev: Update undefined task name properties for help panel tracks #6565
 - Fix: Allow the manager role to query certain options #6577

--- a/src/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -20,8 +20,9 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 	 * @return bool The result of the operation.
 	 */
 	public function process( $rule, $stored_state ) {
-		$default      = isset( $rule->default ) ? $rule->default : false;
-		$option_value = get_option( $rule->option_name, $default );
+		$default_value = 'contains' === $rule->operation ? array() : false;
+		$default       = isset( $rule->default ) ? $rule->default : $default_value;
+		$option_value  = get_option( $rule->option_name, $default );
 
 		return ComparisonOperation::compare(
 			$option_value,


### PR DESCRIPTION
Fixes #6618

This PR sets `array` as a default value when the specified op is `contains`. This essentially prevents an edge case where an option is missing and the default value is not set.


### Detailed test instructions:


1. Clone and start https://github.com/Automattic/woocommerce.com
2. Open `notifications.json.php` from woocommerce.com repository and find a rule that uses the `contains` operator and remove the `default` key. Please make a note of the option name.
3. Open `src/RemoteInboxNotifications/DataSourcepoller.php` from your WooCommerce Admin repository and change the datasource to your local woocommerce.com (woocommerce.test)
4. Make sure your local WooCommerce Admin database does not have the option from step #2
5. Install and activate [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/)
6. Navigate to Tools -> Cron Events and run `wc_admin_daily` job
7. Check your debug log in `wp-content/debug.log`. You should see PHP error.


