### PR TITLE
Ensure script asset.php files are included in builds

### DIFF
--- a/bin/make-zip.sh
+++ b/bin/make-zip.sh
@@ -22,7 +22,7 @@ output 2 "Creating archive... 🎁"
 ZIP_FILE=$1
 
 build_files=$(find dist \( -name '*.js' -o -name '*.css' \))
-asset_files=$(find dist \( -name 'index.min.asset.php' \))
+asset_files=$(find dist \( -name '*.min.asset.php' \))
 
 zip -r "${ZIP_FILE}" \
 	woocommerce-admin.php \

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Introduce Typescript to Navigation utils #6477
 - Add: Paystack payment provider to several african countries. #6579
 - Dev: Payments task: include Mercado Pago #6572
+- Dev: Ensure script asset.php files are included in builds #6635
 
 == 2.1.3 3/14/2021  ==
 


### PR DESCRIPTION
Only dependency php files by the name of `index.min.asset.php` were getting included in builds. WC Admin scripts used a different pattern, `*.min.asset.php` for naming those files. This PR makes sure they are included as well.

### Detailed test instructions:

1. `npm run build` or if you have `npm start` already running that should be fine too.
2. Create a zip of the repo in its current state, `./bin/make-zip.sh test-assets`.
3. Open `tests-assets.zip` and navigate to `dist/wp-admin-scripts/`
4. Make sure js files have an associated `*.min.asset.php` file
