### PR TITLE
Revert "Add Ireland to Square payment method (#6559)"

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -360,16 +360,6 @@ For each task in that list apart from "Store details":
 3. A title in the top left should reflect the original task name from the task list. e.g. "Add tax rates"
 4. Clicking the chevron to the left of the title should take you back to the home screen
 
-### Add Ireland to Square payment method #6559
-
-1. Go to the store setup wizard `/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard`
-1. Set up your store with Ireland as its country, and proceed until the `Business Details` step
-1. In "Currently selling anywhere?" dropdown, select either:
-    - Yes, in person at physical stores and/or events
-    - Yes, on another platform and in person at physical stores and/or events
-1. Finish the setup wizard, and go to payments task `/wp-admin/admin.php?page=wc-admin&task=payments`
-1. Observe Square as a payment method option
-
 ### Add CES survey for search product, order, customer #6420
 - Make sure tracking is enabled in settings.
 - Delete the option `woocommerce_ces_shown_for_actions` to make sure CES prompt triggers when updating settings.
@@ -482,7 +472,6 @@ Scenario #2
 7. The task list should show the **Choose payment methods** task, and the **Set up additional payment providers** inbox card should not be present.
 8. Click on the **Choose payment methods** task, it should not be displaying the **Woocommerce Payments** option.
 9. Go to **Plugins > installed Plugins**, check if the selected plugin features selected in step 4 are installed and activated.
-
 
 ## 2.1.2
 

--- a/client/task-list/tasks/payments/methods.js
+++ b/client/task-list/tasks/payments/methods.js
@@ -386,9 +386,7 @@ export function getPaymentMethods( {
 				( [ 'brick-mortar', 'brick-mortar-other' ].includes(
 					profileItems.selling_venues
 				) &&
-					[ 'US', 'CA', 'JP', 'GB', 'AU', 'IE' ].includes(
-						countryCode
-					) ),
+					[ 'US', 'CA', 'JP', 'GB', 'AU' ].includes( countryCode ) ),
 			plugins: [ 'woocommerce-square' ],
 			container: <Square />,
 			isConfigured:

--- a/readme.txt
+++ b/readme.txt
@@ -124,7 +124,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Store profiler - Added MailPoet to new Business Details step  #6515
 - Dev: Add tilde (~) to represent client root directory for imports. #6517
 - Fix: Fix issue where Loader::is_admin_page() would error if WooCommerce admin is disabled. #6563
-- Add: Add Ireland to Square payment method #6559
 - Add: CES survey for search product, order, customer #6420
 - Add: CES survey for importing products #6419
 - Add: CES survey for adding product categories, tags, and attributes #6418


### PR DESCRIPTION
 #### DO NOT MERGE TO MAIN. THIS PR IS MEANT FOR 2.2.* MILESTONE ONLY

This reverts commit 61009a9166dbc0c655430ded52c3307644115268.

As mentioned [here](https://github.com/woocommerce/woocommerce-admin/issues/6481#issuecomment-804683791), Square launch in Ireland is only going to happen after the 5.3 release, so we should only include it in 5.4. This PR removes #6559 from 2.2.0 milestone.

No changelog required