### PR TITLE
Prepare 2.1.4 Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,11 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Ensure production script asset names don't include .min suffix #6681
 - Fix: Improve AddFirstProduct email note contents. #6617
 
+
+== 2.1.4 3/29/2021  ==
+
+- Fix: Adding New Zealand and Ireland to selective bundle option, previously missed. #6649
+
 == 2.1.3 3/14/2021  ==
 
 - Feature: Increase target audience for business feature step. #6508


### PR DESCRIPTION
Adds changelog for 2.1.4. No testing instructions are necessary.

No changelog lint.