### PR TITLE
Update the checked input radio button margin style

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -760,7 +760,6 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 2. Go to `Analytics` > `Orders`
 3. Set the `Date Range` filter in order to cover the refunded order date.
 4. Verify that now the associated order number and the related products are visible.
-=======
 
 ### Remove CES actions for adding and editing a product and editing an order #6355
 

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -32,6 +32,11 @@
 1. Visit any admin page with the params `plugin_action` (`install`, `activate`, or `install-activate`) and `plugins` (list of comma separated plugins). `wp-admin/admin.php?page=wc-admin&plugin_action=install&plugins=jetpack`
 2. If visiting this URL from a link, make sure you are sent back to the referer.
 3. Check that the plugins provided are installed, activated, or both depending on your query.
+### Update the checked input radio button margin style #6701
+1. Go to Home.
+2. Click on 'Add my products'.
+3. Select 'Start with a template'.
+4. Click on the input radio button and see that render as expected.
 
 ### Retain persisted queries when navigating to Homescreen #6614
 
@@ -755,6 +760,7 @@ wp db query 'SELECT status FROM wp_wc_admin_notes WHERE name = "wc-admin-add-fir
 2. Go to `Analytics` > `Orders`
 3. Set the `Date Range` filter in order to cover the refunded order date.
 4. Verify that now the associated order number and the related products are visible.
+=======
 
 ### Remove CES actions for adding and editing a product and editing an order #6355
 

--- a/client/task-list/tasks/products/product-template-modal.js
+++ b/client/task-list/tasks/products/product-template-modal.js
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, RadioControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
 import { ITEMS_STORE_NAME } from '@woocommerce/data';
 import { getAdminLink } from '@woocommerce/wc-admin-settings';
 import { recordEvent } from '@woocommerce/tracks';
-import { List } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -48,7 +47,7 @@ const PRODUCT_TEMPLATES = [
 ];
 
 export default function ProductTemplateModal( { onClose } ) {
-	const [ selectedTemplate, setSelectedTemplate ] = useState();
+	const [ selectedTemplate, setSelectedTemplate ] = useState( null );
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const { createProductFromTemplate } = useDispatch( ITEMS_STORE_NAME );
 
@@ -85,11 +84,6 @@ export default function ProductTemplateModal( { onClose } ) {
 		}
 	};
 
-	const onSelectTemplateClick = ( event ) => {
-		const val = event.target && event.target.value;
-		setSelectedTemplate( val );
-	};
-
 	const templates = applyFilters(
 		ONBOARDING_PRODUCT_TEMPLATES_FILTER,
 		PRODUCT_TEMPLATES
@@ -104,36 +98,25 @@ export default function ProductTemplateModal( { onClose } ) {
 		>
 			<div className="woocommerce-product-template-modal__wrapper">
 				<div className="woocommerce-product-template-modal__list">
-					<List items={ templates }>
-						{ ( item, index ) => (
-							<div className="woocommerce-list__item-inner">
-								<input
-									id={ `product-templates-${
-										item.key || index
-									}` }
-									className="components-radio-control__input"
-									type="radio"
-									name="product-template-options"
-									value={ item.key }
-									onChange={ onSelectTemplateClick }
-									checked={ item.key === selectedTemplate }
-								/>
-								<label
-									className="woocommerce-list__item-text"
-									htmlFor={ `product-templates-${
-										item.key || index
-									}` }
-								>
-									<div className="woocommerce-list__item-label">
-										{ item.title }
-									</div>
-									<div className="woocommerce-list__item-subtitle">
-										{ item.subtitle }
-									</div>
-								</label>
-							</div>
-						) }
-					</List>
+					<RadioControl
+						selected={ selectedTemplate }
+						options={ templates.map( ( item ) => {
+							return {
+								label: (
+									<>
+										<div className="woocommerce-list__item-label">
+											{ item.title }
+										</div>
+										<div className="woocommerce-list__item-subtitle">
+											{ item.subtitle }
+										</div>
+									</>
+								),
+								value: item.key,
+							};
+						} ) }
+						onChange={ setSelectedTemplate }
+					/>
 				</div>
 				<div className="woocommerce-product-template-modal__actions">
 					<Button

--- a/client/task-list/tasks/products/product-template-modal.js
+++ b/client/task-list/tasks/products/product-template-modal.js
@@ -104,12 +104,12 @@ export default function ProductTemplateModal( { onClose } ) {
 							return {
 								label: (
 									<>
-										<div className="woocommerce-list__item-label">
+										<span className="woocommerce-product-template-modal__list-title">
 											{ item.title }
-										</div>
-										<div className="woocommerce-list__item-subtitle">
+										</span>
+										<span className="woocommerce-product-template-modal__list-subtitle">
 											{ item.subtitle }
-										</div>
+										</span>
 									</>
 								),
 								value: item.key,

--- a/client/task-list/tasks/products/product-template-modal.scss
+++ b/client/task-list/tasks/products/product-template-modal.scss
@@ -1,7 +1,9 @@
 $border-color: $gray-100;
 
 .woocommerce-product-template-modal {
-	min-width: 565px;
+	@include breakpoint( '>600px' ) {
+		min-width: 565px;
+	}
 
 	.woocommerce-product-template-modal__actions {
 		padding-top: $gap-large;

--- a/client/task-list/tasks/products/product-template-modal.scss
+++ b/client/task-list/tasks/products/product-template-modal.scss
@@ -19,7 +19,7 @@ $border-color: $gray-100;
 			height: 20px;
 			margin-right: $gap;
 			&:checked::before {
-				margin: 1px 0 0 1px;
+				margin: -5px 0 0 -5px;
 				width: 10px;
 				height: 10px;
 				background: var(--wp-admin-theme-color);

--- a/client/task-list/tasks/products/product-template-modal.scss
+++ b/client/task-list/tasks/products/product-template-modal.scss
@@ -27,6 +27,7 @@ $border-color: $gray-100;
 				}
 				.components-radio-control__input {
 					margin-right: $gap;
+					flex: none;
 					&:checked::before {
 						box-sizing: border-box;
 					}

--- a/client/task-list/tasks/products/product-template-modal.scss
+++ b/client/task-list/tasks/products/product-template-modal.scss
@@ -25,9 +25,6 @@ $border-color: $gray-100;
 				}
 				.components-radio-control__input {
 					margin-right: $gap;
-					width: 20px;
-					height: 20px;
-					margin-right: $gap;
 					&:checked::before {
 						box-sizing: border-box;
 					}
@@ -38,12 +35,14 @@ $border-color: $gray-100;
 			}
 		}
 	}
-	.woocommerce-list__item-label {
+	.woocommerce-product-template-modal__list-title {
 		color: $gray-900;
+		display: block;
 	}
-	.woocommerce-list__item-subtitle {
+	.woocommerce-product-template-modal__list-subtitle {
 		color: $gray-700;
 		margin-top: 4px;
+		display: block;
 	}
 }
 .woocommerce-product-template-modal__actions {

--- a/client/task-list/tasks/products/product-template-modal.scss
+++ b/client/task-list/tasks/products/product-template-modal.scss
@@ -8,24 +8,33 @@ $border-color: $gray-100;
 	}
 }
 .woocommerce-product-template-modal__list {
-	.woocommerce-list {
-		margin: 0 #{-1 * $gap-large};
-		border-bottom: 1px solid $border-color;
-		border-top: 1px solid $border-color;
-	}
-	.woocommerce-list__item-inner {
-		.components-radio-control__input {
-			width: 20px;
-			height: 20px;
-			margin-right: $gap;
-			&:checked::before {
-				margin: -5px 0 0 -5px;
-				width: 10px;
-				height: 10px;
-				background: var(--wp-admin-theme-color);
-			}
-			&:focus {
-				box-shadow: none;
+	.components-base-control {
+		margin: 0 -#{$gap-large};
+		.components-base-control__field {
+			.components-radio-control__option {
+				display: flex;
+				text-decoration: none;
+				width: 100%;
+				align-items: center;
+				padding: $gap $gap-large;
+				margin-bottom: 0;
+				box-sizing: border-box;
+				border-bottom: 1px solid $gray-100;
+				&:first-child {
+					border-top: 1px solid $gray-100;
+				}
+				.components-radio-control__input {
+					margin-right: $gap;
+					width: 20px;
+					height: 20px;
+					margin-right: $gap;
+					&:checked::before {
+						box-sizing: border-box;
+					}
+					&:focus {
+						box-shadow: none;
+					}
+				}
 			}
 		}
 	}
@@ -35,9 +44,6 @@ $border-color: $gray-100;
 	.woocommerce-list__item-subtitle {
 		color: $gray-700;
 		margin-top: 4px;
-	}
-	.woocommerce-list__item:hover {
-		background: none;
 	}
 }
 .woocommerce-product-template-modal__actions {

--- a/readme.txt
+++ b/readme.txt
@@ -261,7 +261,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == 2.0.2 25/05/2021 ==
 
 - Fix: Correct the Klarna slug #6440
-=======
 
 == 2.0.0 02/05/2021 ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add event recording to start of gateway connections #6801
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Use the store timezone to make time data requests #6632
+- Fix: Update the checked input radio button margin style #6701
 - Fix: Make pagination buttons height and width consistent #6725
 - Fix: Retain persisted queries when navigating to Homescreen #6614
 - Fix: Update folded header style #6724
@@ -260,6 +261,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == 2.0.2 25/05/2021 ==
 
 - Fix: Correct the Klarna slug #6440
+=======
 
 == 2.0.0 02/05/2021 ==
 


### PR DESCRIPTION
Fixes #6651 

Update the checked input radio button margin style.

### Screenshots
Before
<img width="378" alt="before" src="https://user-images.githubusercontent.com/56378160/112911900-5a6cc680-90c4-11eb-805f-50618d427512.png">

After
<img width="389" alt="after" src="https://user-images.githubusercontent.com/56378160/112911903-5e98e400-90c4-11eb-8638-e2ba21352b6c.png">


### Detailed test instructions:

- Go to Home
- Click on 'Add my products'
- Select 'Start with a template'
- Click on the input radio button and see that render as expected

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
