### PR TITLE
Update WC Payments plugin copy

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,9 +2,7 @@
 
 ## Unreleased
 
-
 ### Fix varation bug with Products reports #6647
-
 
 1. Add two variable products. You want to have at least one variable for each product. 
 
@@ -20,6 +18,12 @@ Product B - size:medium
 5. Confirm that the "Variations" table shows the correct variations. If you searched for the 'Product A', then you should see color:black and color:white.
 
 In case the report shows "no data", please reimport historical data by following the guide on [here](https://docs.woocommerce.com/document/woocommerce-analytics/#analytics-settings__import-historical-data)
+
+### Update WC Payments plugin copy #6734
+
+1. Install WooCommerce with WooCommerce Payments
+2. Clone this branch and run npm start (only needed if you are using dev version)
+3. Navigate to WooCommerce -> Home and observe the copy change.
 
 ### Check active plugins before getting the PayPal onboarding status #6625
 

--- a/client/task-list/tasks.js
+++ b/client/task-list/tasks.js
@@ -150,7 +150,10 @@ export function getAllTasks( {
 		},
 		{
 			key: 'woocommerce-payments',
-			title: __( 'Set up WooCommerce Payments', 'woocommerce-admin' ),
+			title: __(
+				'Get paid with WooCommerce Payments',
+				'woocommerce-admin'
+			),
 			container: <Fragment />,
 			completed: wcPayIsConnected,
 			onClick: async ( e ) => {

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Update folded header style #6724
 - Fix: Fix unreleated variations showing up in the Products reports #6647
 - Tweak: Add tracking data for the preview site btn #6623
+- Tweak: Update WC Payments copy on the task list #6734
 - Tweak: Add check to see if value for contains is array, show warning if not. #6645
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Check active plugins before getting the PayPal onboarding status #6625


### PR DESCRIPTION
Fixes #6690 

This PR updates the WC Payments plugin copy on the task list.

### Screenshots

Before:

![Screen Shot 2021-04-01 at 1 31 14 PM](https://user-images.githubusercontent.com/4723145/113350619-8f5c6180-92ee-11eb-8670-d374e51f3050.jpg)

After:

![Screen Shot 2021-04-01 at 1 27 31 PM](https://user-images.githubusercontent.com/4723145/113350630-92efe880-92ee-11eb-852d-dc0b481ed9c7.jpg)

#### Test Instructions

1. Install WooCommerce with WooCommerce Payments
2. Clone this branch and run `npm start`
3. Navigate to WooCommerce -> Home and observe the copy change.