### PR TITLE
Fix a syntax error in the phpcs script

### DIFF
--- a/bin/phpcs.sh
+++ b/bin/phpcs.sh
@@ -4,7 +4,7 @@ PHP_FILES_CHANGED=""
 for FILE in $(echo $CHANGED_FILES | tr ',' '\n')
 do
 	if [[ $FILE =~ ".php" ]]; then
-		PHP_FILES_CHANGED += "$FILE,"
+		$PHP_FILES_CHANGED += "$FILE,"
 	fi	
 done
 


### PR DESCRIPTION
Fixes #6704

I accidentally left a syntax error in this file and so php linting has not been running properly but has been reporting success. This fixes that.

To validate this works check the output of the lint GitHub action ("Lint the PHP") looks correct. There may be some lint errors that have slipped through, so we'll have to fix those in follow up PRs. (They won't get caught in this PR because no PHP files have changed.)

No changelog required