### PR TITLE
Spike - WC Payments decouple

### DIFF
--- a/config/core.json
+++ b/config/core.json
@@ -17,6 +17,7 @@
 		"shipping-label-banner": true,
 		"store-alerts": true,
 		"wcpay": true,
-		"wcpay/support-international-countries": true
+		"wcpay/support-international-countries": true,
+		"wcpay/stepper-flow": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -17,6 +17,7 @@
 		"shipping-label-banner": true,
 		"store-alerts": true,
 		"wcpay": true,
-		"wcpay/support-international-countries": true
+		"wcpay/support-international-countries": true,
+		"wcpay/stepper-flow": true
 	}
 }

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -17,6 +17,7 @@
 		"shipping-label-banner": true,
 		"store-alerts": true,
 		"wcpay": true,
-		"wcpay/support-international-countries": true
+		"wcpay/support-international-countries": true,
+		"wcpay/stepper-flow": false
 	}
 }


### PR DESCRIPTION
This is a spike/poc of how we can decouple WC Payments configuration/setup from WC Admin.

**DO NOT MERGE ME** I am a proof of concept only

Things of note:

- there's a stub of where an a/b test can be added
- there's a `wcpay/stepper-flow` feature toggle which can be used to ship this before it has been implemented in WC Payments
- it falls back to the existing flow if the stepper flow is disabled or if the a/b test doesn't indicate the stepper flow
- it uses a filter (`@woocommerce/hooks`) to get the steps configuration from WC Payments - this is where the decoupling happens. This configuration will then be used to hydrate a `Stepper` component.