### PR TITLE
Avoid updating customer info synchronously when "last active" is modified.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Event tracking for merchant email notes #6616
 - Fix: Check active plugins before getting the PayPal onboarding status #6625
 - Dev: Add support for running php unit tests in PHP 8. #6678
+- Performance: Avoid updating customer info synchronously from the front end. #6765
 
 == 2.2.0 3/30/2021 ==
 

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -84,22 +84,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 */
 	public static function init() {
 		add_action( 'edit_user_profile_update', array( __CLASS__, 'update_registered_customer' ) );
-		add_action( 'updated_user_meta', array( __CLASS__, 'update_registered_customer_via_last_active' ), 10, 3 );
 		add_action( 'woocommerce_analytics_delete_order_stats', array( __CLASS__, 'sync_on_order_delete' ), 15, 2 );
-	}
-
-	/**
-	 * Trigger a customer update if their "last active" meta value was changed.
-	 * Function expects to be hooked into the `updated_user_meta` action.
-	 *
-	 * @param int    $meta_id ID of updated metadata entry.
-	 * @param int    $user_id ID of the user being updated.
-	 * @param string $meta_key Meta key being updated.
-	 */
-	public static function update_registered_customer_via_last_active( $meta_id, $user_id, $meta_key ) {
-		if ( 'wc_last_active' === $meta_key ) {
-			self::update_registered_customer( $user_id );
-		}
 	}
 
 	/**

--- a/src/Schedulers/CustomersScheduler.php
+++ b/src/Schedulers/CustomersScheduler.php
@@ -28,6 +28,7 @@ class CustomersScheduler extends ImportScheduler {
 	public static function init() {
 		add_action( 'woocommerce_new_customer', array( __CLASS__, 'schedule_import' ) );
 		add_action( 'woocommerce_update_customer', array( __CLASS__, 'schedule_import' ) );
+		add_action( 'updated_user_meta', array( __CLASS__, 'schedule_import_via_last_active' ), 10, 3 );
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( __CLASS__, 'schedule_anonymize' ) );
 		add_action( 'delete_user', array( __CLASS__, 'schedule_user_delete' ) );
 		add_action( 'remove_user_from_blog', array( __CLASS__, 'schedule_user_delete' ) );
@@ -135,6 +136,20 @@ class CustomersScheduler extends ImportScheduler {
 	 */
 	public static function schedule_import( $user_id ) {
 		self::schedule_action( 'import', array( $user_id ) );
+	}
+
+	/**
+	 * Schedule an import if the "last active" meta value was changed.
+	 * Function expects to be hooked into the `updated_user_meta` action.
+	 *
+	 * @param int    $meta_id ID of updated metadata entry.
+	 * @param int    $user_id ID of the user being updated.
+	 * @param string $meta_key Meta key being updated.
+	 */
+	public static function schedule_import_via_last_active( $meta_id, $user_id, $meta_key ) {
+		if ( 'wc_last_active' === $meta_key ) {
+			self::schedule_import( $user_id );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6570.

This PR seeks to utilize action scheduler to process customer updates in the background when the `wc_last_active` user meta is updated. Prior to these changes, front end page loads (that updated the `wc_last_active` meta) would trigger a full customer sync.

The issue also called for auditing the other hooks:

> Seems like we should revisit all of the hooks being used in the customers data store and shift those tasks to jobs.

The other hooks used are `edit_user_profile_update` and `woocommerce_analytics_delete_order_stats`. The former is only fired from the backend user profile edit page, and the latter is internal to WC Admin and fires when orders are deleted (another backend - or admin-only flow).

### Detailed test instructions:

- Log in to your test store as a customer user that already exists (has a record in the Customers Report)
- Check in Tools > Scheduled Actions that a job was queued for updating that user ID

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

Performance: Avoid updating customer info synchronously from the front end.
