### PR TITLE
Add content grouping for Google Analytics.

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
 	function gtag(){dataLayer.push(arguments);}
 	gtag('js', new Date());
 
-	gtag('config', 'G-8KCYZ2CYMS');
+	gtag('config', 'G-8KCYZ2CYMS', {
+		'content_group' : 'WooCommerce Admin Docs',
+	});
 	</script>
 </head>
 <body>


### PR DESCRIPTION
This PR is a follow-up to #6544 that adds a bit of additional configuration to our Google Analytics tracking tag so that we can segment traffic on GitHub Pages traffic more easily.

### Detailed test instructions:

- Install dependencies (if necessary)
- Launch the local server via `docsify serve`
- Browse to http://localhost:3000
- Confirm that the `content_group` configuration value is visible in the the page's Global site tag section (in the page `<HEAD>` tag)
