### PR TITLE
Add event recording to start of gateway connections

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Add event recording to start of gateway connections #6801
+
+-   Enable debug messages inside browser devtools, you can do it by running `localStorage.setItem( 'debug', 'wc-admin:*' );` in your browser console. And don't forget to enable all log levels.
+-   Create a new store with event tracking enabled.
+-   Select `United States` or `UK` as the store country.
+-   Visit the Payments task and click to setup `Stripe` and `PayPal`.
+-   Verify the event `wcadmin_payments_task_stepper_view` with the right `payment_method was recorded correctly.
+-   Press `Proceed` and verify the event `wcadmin_tasklist_payment_connect_start` with the right `payment_method` was recorded.
+-   Verify that the event `wcadmin_tasklist_payment_connect_start` also is recorded for the payment gateways: Square, eWAY (for AU and NZ) and generic gateways like PayFast (for ZA) and PayStack (for ZA, GH, and NG).
+
 ### Retain persisted queries when navigating to Homescreen #6614
 
 1. Go to Analytics Report.

--- a/client/task-list/tasks/payments/components/PaymentSetup.js
+++ b/client/task-list/tasks/payments/components/PaymentSetup.js
@@ -14,7 +14,12 @@ import { useSelect } from '@wordpress/data';
  */
 import { createNoticesFromResponse } from '~/lib/notices';
 
-export const PaymentSetup = ( { method, markConfigured, query } ) => {
+export const PaymentSetup = ( {
+	method,
+	markConfigured,
+	query,
+	recordConnectStartEvent,
+} ) => {
 	const { activePlugins } = useSelect( ( select ) => {
 		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 
@@ -73,6 +78,7 @@ export const PaymentSetup = ( { method, markConfigured, query } ) => {
 					query,
 					installStep,
 					markConfigured,
+					recordConnectStartEvent,
 					hasCbdIndustry: method.hasCbdIndustry,
 				} ) }
 			</CardBody>

--- a/client/task-list/tasks/payments/components/PaymentSetup.js
+++ b/client/task-list/tasks/payments/components/PaymentSetup.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody } from '@wordpress/components';
-import { cloneElement, useMemo } from '@wordpress/element';
+import { cloneElement, useEffect, useMemo } from '@wordpress/element';
 import { Plugins } from '@woocommerce/components';
 import { PLUGINS_STORE_NAME, pluginNames } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
@@ -20,6 +20,12 @@ export const PaymentSetup = ( {
 	query,
 	recordConnectStartEvent,
 } ) => {
+	useEffect( () => {
+		recordEvent( 'payments_task_stepper_view', {
+			payment_method: method.key,
+		} );
+	}, [] );
+
 	const { activePlugins } = useSelect( ( select ) => {
 		const { getActivePlugins } = select( PLUGINS_STORE_NAME );
 

--- a/client/task-list/tasks/payments/generic-payment-step.js
+++ b/client/task-list/tasks/payments/generic-payment-step.js
@@ -12,6 +12,7 @@ export function GenericPaymentStep( {
 	installStep,
 	markConfigured,
 	methodConfig,
+	recordConnectStartEvent,
 } ) {
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 	const { createNotice } = useDispatch( 'core/notices' );
@@ -129,7 +130,10 @@ export function GenericPaymentStep( {
 							<Button
 								isPrimary
 								isBusy={ isOptionsRequesting }
-								onClick={ handleSubmit }
+								onClick={ ( event ) => {
+									handleSubmit( event );
+									recordConnectStartEvent( methodConfig.key );
+								} }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
 							</Button>

--- a/client/task-list/tasks/payments/generic-payment-step.js
+++ b/client/task-list/tasks/payments/generic-payment-step.js
@@ -131,8 +131,8 @@ export function GenericPaymentStep( {
 								isPrimary
 								isBusy={ isOptionsRequesting }
 								onClick={ ( event ) => {
-									handleSubmit( event );
 									recordConnectStartEvent( methodConfig.key );
+									handleSubmit( event );
 								} }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -172,6 +172,12 @@ export const Payments = ( { query } ) => {
 		);
 	};
 
+	const recordConnectStartEvent = ( methodName ) => {
+		recordEvent( 'tasklist_payment_connect_start', {
+			payment_method: methodName,
+		} );
+	};
+
 	const currentMethod = useMemo( () => {
 		if ( ! query.method ) {
 			return null;
@@ -198,6 +204,7 @@ export const Payments = ( { query } ) => {
 			<PaymentSetup
 				method={ currentMethod }
 				markConfigured={ markConfigured }
+				recordConnectStartEvent={ recordConnectStartEvent }
 			/>
 		);
 	}

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -138,18 +138,6 @@ export const Payments = ( { query } ) => {
 		return method.key;
 	}, [ methods ] );
 
-	// const recommendedMethod = useMemo( () => {
-	// 	const method = methods.find(
-	// 		( m ) =>
-	// 			( m.key === 'wcpay' && m.visible ) ||
-	// 			( m.key === 'mercadopago' && m.visible )
-	// 	);
-	// 	if ( ! method ) {
-	// 		return 'stripe';
-	// 	}
-	// 	return method.key;
-	// }, [ methods ] );
-
 	const markConfigured = async ( methodKey, queryParams = {} ) => {
 		const method = methods.find( ( option ) => option.key === methodKey );
 
@@ -200,10 +188,6 @@ export const Payments = ( { query } ) => {
 		if ( ! method ) {
 			throw `Current method ${ query.method } not found in available methods list`;
 		}
-
-		recordEvent( 'payments_task_stepper_view', {
-			payment_method: method.key,
-		} );
 
 		return method;
 	}, [ query ] );

--- a/client/task-list/tasks/payments/index.js
+++ b/client/task-list/tasks/payments/index.js
@@ -138,6 +138,18 @@ export const Payments = ( { query } ) => {
 		return method.key;
 	}, [ methods ] );
 
+	// const recommendedMethod = useMemo( () => {
+	// 	const method = methods.find(
+	// 		( m ) =>
+	// 			( m.key === 'wcpay' && m.visible ) ||
+	// 			( m.key === 'mercadopago' && m.visible )
+	// 	);
+	// 	if ( ! method ) {
+	// 		return 'stripe';
+	// 	}
+	// 	return method.key;
+	// }, [ methods ] );
+
 	const markConfigured = async ( methodKey, queryParams = {} ) => {
 		const method = methods.find( ( option ) => option.key === methodKey );
 
@@ -188,6 +200,10 @@ export const Payments = ( { query } ) => {
 		if ( ! method ) {
 			throw `Current method ${ query.method } not found in available methods list`;
 		}
+
+		recordEvent( 'payments_task_stepper_view', {
+			payment_method: method.key,
+		} );
 
 		return method;
 	}, [ query ] );

--- a/client/task-list/tasks/payments/methods/eway.js
+++ b/client/task-list/tasks/payments/methods/eway.js
@@ -67,7 +67,7 @@ class EWay extends Component {
 	};
 
 	renderConnectStep() {
-		const { isOptionsRequesting } = this.props;
+		const { isOptionsRequesting, recordConnectStartEvent } = this.props;
 		const helpText = interpolateComponents( {
 			mixedString: __(
 				'Your API details can be obtained from your {{link}}eWAY account{{/link}}',
@@ -112,7 +112,10 @@ class EWay extends Component {
 							<Button
 								isPrimary
 								isBusy={ isOptionsRequesting }
-								onClick={ handleSubmit }
+								onClick={ ( event ) => {
+									handleSubmit( event );
+									recordConnectStartEvent( 'eway' );
+								} }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
 							</Button>

--- a/client/task-list/tasks/payments/methods/eway.js
+++ b/client/task-list/tasks/payments/methods/eway.js
@@ -113,8 +113,8 @@ class EWay extends Component {
 								isPrimary
 								isBusy={ isOptionsRequesting }
 								onClick={ ( event ) => {
-									handleSubmit( event );
 									recordConnectStartEvent( 'eway' );
+									handleSubmit( event );
 								} }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }

--- a/client/task-list/tasks/payments/methods/paypal.js
+++ b/client/task-list/tasks/payments/methods/paypal.js
@@ -43,7 +43,7 @@ function loadOnboardingScript( url, data, onLoad ) {
 	}
 }
 
-function PaypalConnectButton( { connectUrl } ) {
+function PaypalConnectButton( { connectUrl, recordConnectStartEvent } ) {
 	useEffect( () => {
 		// eslint-disable-next-line camelcase
 		if ( ppcp_onboarding ) {
@@ -61,6 +61,7 @@ function PaypalConnectButton( { connectUrl } ) {
 			data-paypal-onboard-button="true"
 			data-paypal-button="true"
 			data-paypal-onboard-complete="ppcp_onboarding_productionCallback"
+			onClick={ () => recordConnectStartEvent( 'paypal' ) }
 		>
 			{ __( 'Connect', 'woocommerce-admin' ) }
 		</a>
@@ -438,11 +439,15 @@ class PayPal extends Component {
 
 	renderConnectFields() {
 		const { autoConnectFailed, connectURL } = this.state;
+		const { recordConnectStartEvent } = this.props;
 
 		if ( ! autoConnectFailed && connectURL ) {
 			return (
 				<>
-					<PaypalConnectButton connectUrl={ connectURL } />
+					<PaypalConnectButton
+						connectUrl={ connectURL }
+						recordConnectStartEvent={ recordConnectStartEvent }
+					/>
 					<p>
 						{ __(
 							'You will be redirected to the PayPal website to create the connection.',

--- a/client/task-list/tasks/payments/methods/square.js
+++ b/client/task-list/tasks/payments/methods/square.js
@@ -43,6 +43,7 @@ class Square extends Component {
 			createNotice,
 			hasCbdIndustry,
 			options,
+			recordConnectStartEvent,
 			updateOptions,
 		} = this.props;
 		this.setState( { isPending: true } );
@@ -58,6 +59,8 @@ class Square extends Component {
 			'There was an error connecting to Square. Please try again or skip to connect later in store settings.',
 			'woocommerce-admin'
 		);
+
+		recordConnectStartEvent( 'square' );
 
 		try {
 			let newWindow = null;

--- a/client/task-list/tasks/payments/methods/stripe.js
+++ b/client/task-list/tasks/payments/methods/stripe.js
@@ -192,7 +192,7 @@ class Stripe extends Component {
 	}
 
 	renderManualConfig() {
-		const { isOptionsUpdating } = this.props;
+		const { isOptionsUpdating, recordConnectStartEvent } = this.props;
 		const stripeHelp = interpolateComponents( {
 			mixedString: __(
 				'Your API details can be obtained from your {{docsLink}}Stripe account{{/docsLink}}. Don’t have a Stripe account? {{registerLink}}Create one.{{/registerLink}}',
@@ -245,7 +245,10 @@ class Stripe extends Component {
 							<Button
 								isPrimary
 								isBusy={ isOptionsUpdating }
-								onClick={ handleSubmit }
+								onClick={ ( event ) => {
+									handleSubmit( event );
+									recordConnectStartEvent( 'stripe' );
+								} }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }
 							</Button>
@@ -259,6 +262,7 @@ class Stripe extends Component {
 	}
 
 	renderOauthConfig() {
+		const { recordConnectStartEvent } = this.props;
 		const tosPrompt = interpolateComponents( {
 			mixedString: __(
 				'By clicking "Connect," you agree to the {{tosLink}}Terms of Service{{/tosLink}}. Or {{manualConfigLink}}manually enter your Stripe API details{{/manualConfigLink}} instead.',
@@ -279,6 +283,7 @@ class Stripe extends Component {
 							this.setState( {
 								connectURL: null,
 							} );
+							recordConnectStartEvent( 'stripe' );
 						} }
 					/>
 				),

--- a/client/task-list/tasks/payments/methods/stripe.js
+++ b/client/task-list/tasks/payments/methods/stripe.js
@@ -246,8 +246,8 @@ class Stripe extends Component {
 								isPrimary
 								isBusy={ isOptionsUpdating }
 								onClick={ ( event ) => {
-									handleSubmit( event );
 									recordConnectStartEvent( 'stripe' );
+									handleSubmit( event );
 								} }
 							>
 								{ __( 'Proceed', 'woocommerce-admin' ) }

--- a/readme.txt
+++ b/readme.txt
@@ -101,7 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin #6710
 - Fix: Pause inbox message "GivingFeedbackNotes" #6802
 - Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
-- Dev: Add PayPal and Stripe start connection tracking #6801
+- Dev: Add event recording to start of gateway connections #6801
 
 == 2.2.0 3/30/2021 ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin #6710
 - Fix: Pause inbox message "GivingFeedbackNotes" #6802
 - Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
+- Dev: Add PayPal and Stripe start connection tracking #6801
 
 == 2.2.0 3/30/2021 ==
 


### PR DESCRIPTION
Fixes #6727

This PR adds event recording to the start of gateway connections for Stripe, Square, PayPal, eWAY, and generic payment gateways.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![screenshot-one wordpress test-2021 04 14-12_03_56](https://user-images.githubusercontent.com/1314156/114733214-8a99a380-9d19-11eb-88df-a5f86e4ae9ca.png)


### Detailed test instructions:

-   Enable debug messages inside browser devtools, you can do it by running `localStorage.setItem( 'debug', 'wc-admin:*' );` in your browser console. And don't forget to enable all log levels
![image](https://user-images.githubusercontent.com/1314156/114731683-52de2c00-9d18-11eb-970b-279b1f4f33ba.png)
-   Create a new store with event tracking enabled
-   Select `United States` or `UK` as the store country
-   Visit the Payments task and click to setup `Stripe` and `PayPal`
-   Verify the event `wcadmin_payments_task_stepper_view` with the right `payment_method was recorded correctly

![Captura de Pantalla 2021-04-15 a la(s) 16 31 51](https://user-images.githubusercontent.com/1314156/114928086-8d26f680-9e08-11eb-972e-d04ea3121348.png)

-   Press `Proceed` and verify the event `wcadmin_tasklist_payment_connect_start` with the right `payment_method` was recorded

![Captura de Pantalla 2021-04-15 a la(s) 16 32 09](https://user-images.githubusercontent.com/1314156/114928121-9adc7c00-9e08-11eb-9de3-087eb459c5de.png)

-   Verify that the event `wcadmin_tasklist_payment_connect_start` also is recorded for the payment gateways: Square, eWAY (for AU and NZ) and generic gateways like PayFast (for ZA) and PayStack (for ZA, GH, and NG).

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
