### PR TITLE
Update experimental package path, and bump patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
 				"config": "^3.2.4",
 				"eslint": "6.7.2",
 				"jest": "^24.9.0",
-				"prettier": "npm:wp-prettier@1.19.1",
 				"puppeteer": "^2.0.0"
 			},
 			"dependencies": {
@@ -135,11 +134,6 @@
 							}
 						}
 					}
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@1.19.1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 				}
 			}
 		},
@@ -1374,24 +1368,6 @@
 			"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"@babel/runtime-corejs2": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
-			"integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -9132,12 +9108,6 @@
 			"version": "file:packages/components",
 			"dev": true,
 			"requires": {
-				"@woocommerce/csv-export": "1.3.0",
-				"@woocommerce/currency": "3.0.0",
-				"@woocommerce/data": "1.1.1",
-				"@woocommerce/date": "2.1.0",
-				"@woocommerce/experimental": "1.0.0",
-				"@woocommerce/navigation": "5.2.0",
 				"@wordpress/api-fetch": "^3.21.5",
 				"@wordpress/components": "10.2.0",
 				"@wordpress/compose": "3.23.1",
@@ -9158,11 +9128,9 @@
 				"d3-selection": "1.4.2",
 				"d3-shape": "1.3.7",
 				"d3-time-format": "2.3.0",
-				"dompurify": "2.2.7",
 				"emoji-flags": "1.3.0",
 				"gridicons": "3.3.1",
 				"interpolate-components": "1.1.1",
-				"md5": "2.3.0",
 				"memoize-one": "5.1.1",
 				"moment": "2.29.1",
 				"prop-types": "15.7.2",
@@ -9172,185 +9140,6 @@
 				"react-transition-group": "4.4.1"
 			},
 			"dependencies": {
-				"@woocommerce/csv-export": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.3.0.tgz",
-					"integrity": "sha512-++JfLjhmK+B++5ogy1f0OB2lLoqDSY0lZ2oKc/b3S7BvYQWcRP5N1u5D+AYcoQMUWJLI+EH52Bkp+ivwVeUAJQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.10.5",
-						"browser-filesaver": "1.1.1",
-						"moment": "2.27.0"
-					},
-					"dependencies": {
-						"moment": {
-							"version": "2.27.0",
-							"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-							"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-							"dev": true
-						}
-					}
-				},
-				"@woocommerce/currency": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-3.0.0.tgz",
-					"integrity": "sha512-uNck3JUgGo1RGoWJ/3qm1mhpikNAeTtVCgR0qb3/jti5Mm7pTM6WInGqQV8uP63PMDlPq2dnuhbvmXEER04jBQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.10.5",
-						"@woocommerce/number": "2.0.0",
-						"@wordpress/deprecated": "^2.9.0"
-					}
-				},
-				"@woocommerce/data": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.1.1.tgz",
-					"integrity": "sha512-grmCllxDV/0PB8Mc+w9TQFJkAzO/yjjdDmaOzNk2ICuoz2ZhUGiFXnvZmWLyZr9BDtoYK+/jBIsM2ezr34b3ww==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.11.2"
-					},
-					"dependencies": {
-						"@babel/runtime-corejs2": {
-							"version": "7.11.2",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
-							"integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
-							"dev": true,
-							"requires": {
-								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.4"
-							}
-						},
-						"core-js": {
-							"version": "2.6.12",
-							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-							"dev": true
-						}
-					}
-				},
-				"@woocommerce/date": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.1.0.tgz",
-					"integrity": "sha512-gZutoGaeKtalq5DQFc1751CyyMDIDVahfp+f2NAuafeWC8q/5KjqjdAPFDl3qSQGe+yZmdYiQHSwMPFOjfzSEg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.10.5",
-						"@wordpress/date": "3.9.0",
-						"@wordpress/i18n": "3.11.0",
-						"lodash": "4.17.15",
-						"moment": "2.27.0"
-					},
-					"dependencies": {
-						"@wordpress/date": {
-							"version": "3.9.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.9.0.tgz",
-							"integrity": "sha512-V4+k6Ipkm/JX1TzRcwo96v0Lk1m1NGAHwO9JsnUCCXlG1Qxgl+MxRkWpgmUwgdCDjVvevS/4bU+LvndDWQIzVA==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"moment": "^2.22.1",
-								"moment-timezone": "^0.5.16"
-							}
-						},
-						"@wordpress/i18n": {
-							"version": "3.11.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
-							"integrity": "sha512-wcu8NBxaSu8b4Bj+Nt4dMQvziQrfdgTeEGSRy9GzJChTVpFdyZT88zAaPbK+W8yqFaX3zMSf4rHpZSP6QvWkQg==",
-							"dev": true,
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"gettext-parser": "^1.3.1",
-								"lodash": "^4.17.15",
-								"memize": "^1.1.0",
-								"sprintf-js": "^1.1.1",
-								"tannin": "^1.2.0"
-							}
-						},
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						},
-						"moment": {
-							"version": "2.27.0",
-							"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-							"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-							"dev": true
-						}
-					}
-				},
-				"@woocommerce/navigation": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-5.2.0.tgz",
-					"integrity": "sha512-tDtDZjqqw5LtSqHhx3PDGx/kt4l45qzRNJ0sZZwJMbM/If2Y8WfRr7ceXVGuuypH0vLC7T9TGHnEcMK1iXKXqw==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.12.5",
-						"history": "4.10.1",
-						"lodash": "4.17.15",
-						"qs": "6.9.4"
-					},
-					"dependencies": {
-						"@babel/runtime-corejs2": {
-							"version": "7.12.5",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
-							"integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
-							"dev": true,
-							"requires": {
-								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.4"
-							}
-						},
-						"core-js": {
-							"version": "2.6.12",
-							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-							"dev": true
-						},
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						},
-						"qs": {
-							"version": "6.9.4",
-							"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-							"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-							"dev": true
-						}
-					}
-				},
-				"@woocommerce/number": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
-					"integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.7.4",
-						"locutus": "2.0.11"
-					},
-					"dependencies": {
-						"@babel/runtime-corejs2": {
-							"version": "7.7.4",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-							"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
-							"dev": true,
-							"requires": {
-								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.2"
-							}
-						},
-						"core-js": {
-							"version": "2.6.12",
-							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-							"dev": true
-						}
-					}
-				},
 				"@wordpress/api-fetch": {
 					"version": "3.23.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.0.tgz",
@@ -9516,15 +9305,6 @@
 						"lodash": "^4.17.19"
 					}
 				},
-				"locutus": {
-					"version": "2.0.11",
-					"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
-					"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
-					"dev": true,
-					"requires": {
-						"es6-promise": "^4.2.5"
-					}
-				},
 				"uuid": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
@@ -9545,30 +9325,8 @@
 			"version": "file:packages/currency",
 			"dev": true,
 			"requires": {
-				"@woocommerce/number": "2.1.0",
 				"@wordpress/deprecated": "^2.9.0",
 				"@wordpress/html-entities": "2.10.0"
-			},
-			"dependencies": {
-				"@woocommerce/number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.1.0.tgz",
-					"integrity": "sha512-3junwiGMZ9u096EqYkeAJQlEstQl1TW79hENJLNwxYBvIGkmby5oF8AOIT81+/mwphKuszUL9fNcY22RTCbA4w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.10.5",
-						"locutus": "2.0.11"
-					}
-				},
-				"locutus": {
-					"version": "2.0.11",
-					"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
-					"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
-					"dev": true,
-					"requires": {
-						"es6-promise": "^4.2.5"
-					}
-				}
 			}
 		},
 		"@woocommerce/customer-effort-score": {
@@ -9652,97 +9410,7 @@
 			"version": "file:packages/data",
 			"dev": true,
 			"requires": {
-				"@woocommerce/date": "2.1.0",
-				"@woocommerce/navigation": "5.2.0",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@woocommerce/date": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.1.0.tgz",
-					"integrity": "sha512-gZutoGaeKtalq5DQFc1751CyyMDIDVahfp+f2NAuafeWC8q/5KjqjdAPFDl3qSQGe+yZmdYiQHSwMPFOjfzSEg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.10.5",
-						"@wordpress/date": "3.9.0",
-						"@wordpress/i18n": "3.11.0",
-						"lodash": "4.17.15",
-						"moment": "2.27.0"
-					}
-				},
-				"@woocommerce/navigation": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-5.2.0.tgz",
-					"integrity": "sha512-tDtDZjqqw5LtSqHhx3PDGx/kt4l45qzRNJ0sZZwJMbM/If2Y8WfRr7ceXVGuuypH0vLC7T9TGHnEcMK1iXKXqw==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime-corejs2": "7.12.5",
-						"history": "4.10.1",
-						"lodash": "4.17.15",
-						"qs": "6.9.4"
-					},
-					"dependencies": {
-						"@babel/runtime-corejs2": {
-							"version": "7.12.5",
-							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
-							"integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
-							"dev": true,
-							"requires": {
-								"core-js": "^2.6.5",
-								"regenerator-runtime": "^0.13.4"
-							}
-						}
-					}
-				},
-				"@wordpress/date": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.9.0.tgz",
-					"integrity": "sha512-V4+k6Ipkm/JX1TzRcwo96v0Lk1m1NGAHwO9JsnUCCXlG1Qxgl+MxRkWpgmUwgdCDjVvevS/4bU+LvndDWQIzVA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
-					"integrity": "sha512-wcu8NBxaSu8b4Bj+Nt4dMQvziQrfdgTeEGSRy9GzJChTVpFdyZT88zAaPbK+W8yqFaX3zMSf4rHpZSP6QvWkQg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.1.0",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.2.0"
-					}
-				},
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
-				"moment": {
-					"version": "2.27.0",
-					"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-					"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.9.4",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-					"dev": true
-				}
 			}
 		},
 		"@woocommerce/date": {
@@ -15630,15 +15298,6 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"optional": true
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
 		"bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -21482,12 +21141,6 @@
 				}
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"optional": true
-		},
 		"filelist": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -27005,7 +26658,6 @@
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}
@@ -39365,7 +39017,6 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
 				"config": "^3.2.4",
 				"eslint": "6.7.2",
 				"jest": "^24.9.0",
+				"prettier": "npm:wp-prettier@1.19.1",
 				"puppeteer": "^2.0.0"
 			},
 			"dependencies": {
@@ -134,6 +135,11 @@
 							}
 						}
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@1.19.1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 				}
 			}
 		},
@@ -1368,6 +1374,24 @@
 			"integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/runtime-corejs2": {
+			"version": "7.10.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
+			"integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -9108,6 +9132,12 @@
 			"version": "file:packages/components",
 			"dev": true,
 			"requires": {
+				"@woocommerce/csv-export": "1.3.0",
+				"@woocommerce/currency": "3.0.0",
+				"@woocommerce/data": "1.1.1",
+				"@woocommerce/date": "2.1.0",
+				"@woocommerce/experimental": "1.0.0",
+				"@woocommerce/navigation": "5.2.0",
 				"@wordpress/api-fetch": "^3.21.5",
 				"@wordpress/components": "10.2.0",
 				"@wordpress/compose": "3.23.1",
@@ -9128,9 +9158,11 @@
 				"d3-selection": "1.4.2",
 				"d3-shape": "1.3.7",
 				"d3-time-format": "2.3.0",
+				"dompurify": "2.2.7",
 				"emoji-flags": "1.3.0",
 				"gridicons": "3.3.1",
 				"interpolate-components": "1.1.1",
+				"md5": "2.3.0",
 				"memoize-one": "5.1.1",
 				"moment": "2.29.1",
 				"prop-types": "15.7.2",
@@ -9140,6 +9172,185 @@
 				"react-transition-group": "4.4.1"
 			},
 			"dependencies": {
+				"@woocommerce/csv-export": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.3.0.tgz",
+					"integrity": "sha512-++JfLjhmK+B++5ogy1f0OB2lLoqDSY0lZ2oKc/b3S7BvYQWcRP5N1u5D+AYcoQMUWJLI+EH52Bkp+ivwVeUAJQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.10.5",
+						"browser-filesaver": "1.1.1",
+						"moment": "2.27.0"
+					},
+					"dependencies": {
+						"moment": {
+							"version": "2.27.0",
+							"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+							"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+							"dev": true
+						}
+					}
+				},
+				"@woocommerce/currency": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-3.0.0.tgz",
+					"integrity": "sha512-uNck3JUgGo1RGoWJ/3qm1mhpikNAeTtVCgR0qb3/jti5Mm7pTM6WInGqQV8uP63PMDlPq2dnuhbvmXEER04jBQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.10.5",
+						"@woocommerce/number": "2.0.0",
+						"@wordpress/deprecated": "^2.9.0"
+					}
+				},
+				"@woocommerce/data": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.1.1.tgz",
+					"integrity": "sha512-grmCllxDV/0PB8Mc+w9TQFJkAzO/yjjdDmaOzNk2ICuoz2ZhUGiFXnvZmWLyZr9BDtoYK+/jBIsM2ezr34b3ww==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.11.2"
+					},
+					"dependencies": {
+						"@babel/runtime-corejs2": {
+							"version": "7.11.2",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
+							"integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+							"dev": true,
+							"requires": {
+								"core-js": "^2.6.5",
+								"regenerator-runtime": "^0.13.4"
+							}
+						},
+						"core-js": {
+							"version": "2.6.12",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+							"dev": true
+						}
+					}
+				},
+				"@woocommerce/date": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.1.0.tgz",
+					"integrity": "sha512-gZutoGaeKtalq5DQFc1751CyyMDIDVahfp+f2NAuafeWC8q/5KjqjdAPFDl3qSQGe+yZmdYiQHSwMPFOjfzSEg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.10.5",
+						"@wordpress/date": "3.9.0",
+						"@wordpress/i18n": "3.11.0",
+						"lodash": "4.17.15",
+						"moment": "2.27.0"
+					},
+					"dependencies": {
+						"@wordpress/date": {
+							"version": "3.9.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.9.0.tgz",
+							"integrity": "sha512-V4+k6Ipkm/JX1TzRcwo96v0Lk1m1NGAHwO9JsnUCCXlG1Qxgl+MxRkWpgmUwgdCDjVvevS/4bU+LvndDWQIzVA==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.9.2",
+								"moment": "^2.22.1",
+								"moment-timezone": "^0.5.16"
+							}
+						},
+						"@wordpress/i18n": {
+							"version": "3.11.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
+							"integrity": "sha512-wcu8NBxaSu8b4Bj+Nt4dMQvziQrfdgTeEGSRy9GzJChTVpFdyZT88zAaPbK+W8yqFaX3zMSf4rHpZSP6QvWkQg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.9.2",
+								"gettext-parser": "^1.3.1",
+								"lodash": "^4.17.15",
+								"memize": "^1.1.0",
+								"sprintf-js": "^1.1.1",
+								"tannin": "^1.2.0"
+							}
+						},
+						"lodash": {
+							"version": "4.17.15",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+							"dev": true
+						},
+						"moment": {
+							"version": "2.27.0",
+							"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+							"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+							"dev": true
+						}
+					}
+				},
+				"@woocommerce/navigation": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-5.2.0.tgz",
+					"integrity": "sha512-tDtDZjqqw5LtSqHhx3PDGx/kt4l45qzRNJ0sZZwJMbM/If2Y8WfRr7ceXVGuuypH0vLC7T9TGHnEcMK1iXKXqw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.12.5",
+						"history": "4.10.1",
+						"lodash": "4.17.15",
+						"qs": "6.9.4"
+					},
+					"dependencies": {
+						"@babel/runtime-corejs2": {
+							"version": "7.12.5",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+							"integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
+							"dev": true,
+							"requires": {
+								"core-js": "^2.6.5",
+								"regenerator-runtime": "^0.13.4"
+							}
+						},
+						"core-js": {
+							"version": "2.6.12",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+							"dev": true
+						},
+						"lodash": {
+							"version": "4.17.15",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+							"dev": true
+						},
+						"qs": {
+							"version": "6.9.4",
+							"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+							"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+							"dev": true
+						}
+					}
+				},
+				"@woocommerce/number": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
+					"integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.7.4",
+						"locutus": "2.0.11"
+					},
+					"dependencies": {
+						"@babel/runtime-corejs2": {
+							"version": "7.7.4",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
+							"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+							"dev": true,
+							"requires": {
+								"core-js": "^2.6.5",
+								"regenerator-runtime": "^0.13.2"
+							}
+						},
+						"core-js": {
+							"version": "2.6.12",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+							"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+							"dev": true
+						}
+					}
+				},
 				"@wordpress/api-fetch": {
 					"version": "3.23.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.0.tgz",
@@ -9305,6 +9516,15 @@
 						"lodash": "^4.17.19"
 					}
 				},
+				"locutus": {
+					"version": "2.0.11",
+					"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+					"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+					"dev": true,
+					"requires": {
+						"es6-promise": "^4.2.5"
+					}
+				},
 				"uuid": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
@@ -9325,8 +9545,30 @@
 			"version": "file:packages/currency",
 			"dev": true,
 			"requires": {
+				"@woocommerce/number": "2.1.0",
 				"@wordpress/deprecated": "^2.9.0",
 				"@wordpress/html-entities": "2.10.0"
+			},
+			"dependencies": {
+				"@woocommerce/number": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.1.0.tgz",
+					"integrity": "sha512-3junwiGMZ9u096EqYkeAJQlEstQl1TW79hENJLNwxYBvIGkmby5oF8AOIT81+/mwphKuszUL9fNcY22RTCbA4w==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.10.5",
+						"locutus": "2.0.11"
+					}
+				},
+				"locutus": {
+					"version": "2.0.11",
+					"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+					"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+					"dev": true,
+					"requires": {
+						"es6-promise": "^4.2.5"
+					}
+				}
 			}
 		},
 		"@woocommerce/customer-effort-score": {
@@ -9410,7 +9652,97 @@
 			"version": "file:packages/data",
 			"dev": true,
 			"requires": {
+				"@woocommerce/date": "2.1.0",
+				"@woocommerce/navigation": "5.2.0",
 				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@woocommerce/date": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.1.0.tgz",
+					"integrity": "sha512-gZutoGaeKtalq5DQFc1751CyyMDIDVahfp+f2NAuafeWC8q/5KjqjdAPFDl3qSQGe+yZmdYiQHSwMPFOjfzSEg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.10.5",
+						"@wordpress/date": "3.9.0",
+						"@wordpress/i18n": "3.11.0",
+						"lodash": "4.17.15",
+						"moment": "2.27.0"
+					}
+				},
+				"@woocommerce/navigation": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-5.2.0.tgz",
+					"integrity": "sha512-tDtDZjqqw5LtSqHhx3PDGx/kt4l45qzRNJ0sZZwJMbM/If2Y8WfRr7ceXVGuuypH0vLC7T9TGHnEcMK1iXKXqw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime-corejs2": "7.12.5",
+						"history": "4.10.1",
+						"lodash": "4.17.15",
+						"qs": "6.9.4"
+					},
+					"dependencies": {
+						"@babel/runtime-corejs2": {
+							"version": "7.12.5",
+							"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.12.5.tgz",
+							"integrity": "sha512-kt5YpZ7F5A05LOgQuaMXXmcxakK/qttf5C/E1BJPA3Kf5PanbjPzDoXN+PIslUnjUxpuKblCsXyP0QfMiqyKqA==",
+							"dev": true,
+							"requires": {
+								"core-js": "^2.6.5",
+								"regenerator-runtime": "^0.13.4"
+							}
+						}
+					}
+				},
+				"@wordpress/date": {
+					"version": "3.9.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.9.0.tgz",
+					"integrity": "sha512-V4+k6Ipkm/JX1TzRcwo96v0Lk1m1NGAHwO9JsnUCCXlG1Qxgl+MxRkWpgmUwgdCDjVvevS/4bU+LvndDWQIzVA==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"moment": "^2.22.1",
+						"moment-timezone": "^0.5.16"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.11.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
+					"integrity": "sha512-wcu8NBxaSu8b4Bj+Nt4dMQvziQrfdgTeEGSRy9GzJChTVpFdyZT88zAaPbK+W8yqFaX3zMSf4rHpZSP6QvWkQg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.15",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"moment": {
+					"version": "2.27.0",
+					"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+					"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.9.4",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+					"integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+					"dev": true
+				}
 			}
 		},
 		"@woocommerce/date": {
@@ -15298,6 +15630,15 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"optional": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -21141,6 +21482,12 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
+		},
 		"filelist": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -26658,6 +27005,7 @@
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}
@@ -39017,6 +39365,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.1.1
+
+-   Update dependencies.
+
 # 6.1.0
 
 -   Make pagination buttons height and width consistent. #6725

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "6.1.0",
+	"version": "6.1.1",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",
@@ -25,7 +25,7 @@
 		"@woocommerce/currency": "3.0.0",
 		"@woocommerce/data": "1.1.1",
 		"@woocommerce/date": "2.1.0",
-		"@woocommerce/experimental": "1.0.0",
+		"@woocommerce/experimental": "file:../experimental",
 		"@woocommerce/navigation": "5.2.0",
 		"@wordpress/api-fetch": "^3.21.5",
 		"@wordpress/components": "10.2.0",


### PR DESCRIPTION
Updates the experimental package to a local path to fix a npm release, and bump package version to 6.1.1

No changelog necessary

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
