### PR TITLE
Detect missed DB version number updates and fix them.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Load the page controller functions file first to prevent fatal errors when disabling WooCommerce Admin #6710
 - Fix: Pause inbox message "GivingFeedbackNotes" #6802
 - Tweak: Sort the extension task list by completion status and allow toggling visibility. #6792
+- Fix: Missed DB version number updates causing unnecessary upgrades. #6818
 
 == 2.2.0 3/30/2021 ==
 


### PR DESCRIPTION
Fixes #5058.

This PR seeks to identify cases where for some reason (race condition / concurrency issues cited by the reported) the DB version is out-of-sync with the performed updates.

The method used to make this determination is to see if all the update callbacks have been "completed" for version numbers greater than the option value. In these cases, the option value is then updated to those versions.

With this fix In practice (and how I structured the tests), if a store has run all the update callbacks, but the option holds `1.6.0` as the value, the new detection will see that all of the `1.7.0` callbacks are complete and will update the option to `1.7.0`. The next run of the update check will see that no version callbacks remain and will update the option to `WC_ADMIN_VERSION_NUMBER`.

### Detailed test instructions:

- Check out `main`
- Force your store version option (`woocommerce_admin_version`) back to `1.6.0` or earlier.
- Verify that the option is never updated (all callbacks have completed and won't get rescheduled)
- Check out this branch
- Verify that the option gets updated to the current version number

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
