### PR TITLE
Hook reference: Add SlotFill support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
 		'@wordpress/valid-sprintf': 'warn',
 		'jsdoc/check-tag-names': [
 			'error',
-			{ definedTags: [ 'jest-environment', 'hook' ] },
+			{ definedTags: [ 'jest-environment', 'hook', 'slotFill' ] },
 		],
 		'import/no-extraneous-dependencies': 'warn',
 		'import/no-unresolved': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
 		'@wordpress/valid-sprintf': 'warn',
 		'jsdoc/check-tag-names': [
 			'error',
-			{ definedTags: [ 'jest-environment', 'hook', 'slotFill' ] },
+			{ definedTags: [ 'jest-environment', 'filter', 'slotFill' ] },
 		],
 		'import/no-extraneous-dependencies': 'warn',
 		'import/no-unresolved': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,14 @@ module.exports = {
 		'@wordpress/valid-sprintf': 'warn',
 		'jsdoc/check-tag-names': [
 			'error',
-			{ definedTags: [ 'jest-environment', 'filter', 'slotFill' ] },
+			{
+				definedTags: [
+					'jest-environment',
+					'filter',
+					'action',
+					'slotFill',
+				],
+			},
 		],
 		'import/no-extraneous-dependencies': 'warn',
 		'import/no-unresolved': 'warn',

--- a/bin/hook-reference/data.js
+++ b/bin/hook-reference/data.js
@@ -4,9 +4,11 @@ const { parse } = require( 'comment-parser/lib' );
 const { relative, resolve } = require( 'path' );
 const chalk = require( 'chalk' );
 
+const dataTypes = [ 'hook', 'slotFill' ];
+
 const getHooks = ( parsedData ) =>
 	parsedData.filter( ( docBlock ) =>
-		docBlock.tags.some( ( tag ) => tag.tag === 'hook' )
+		docBlock.tags.some( ( tag ) => dataTypes.includes( tag.tag ) )
 	);
 
 const getSourceFile = ( file, commit, { source } ) => {
@@ -17,7 +19,7 @@ const getSourceFile = ( file, commit, { source } ) => {
 };
 
 const logProgress = ( fileName, { tags } ) => {
-	const hook = tags.find( ( tag ) => tag.tag === 'hook' );
+	const hook = tags.find( ( tag ) => dataTypes.includes( tag.tag ) );
 	console.log(
 		chalk.cyan( `${ hook.name } ` ) +
 			chalk.yellow( 'generated in ' ) +
@@ -51,7 +53,7 @@ const makeDocObjects = async ( path ) => {
 	const hooks = await prepareHooks( path );
 	return hooks.map( ( { description, tags, sourceFile } ) => {
 		const example = tags.find( ( tag ) => tag.tag === 'example' );
-		const hook = tags.find( ( tag ) => tag.tag === 'hook' );
+		const hook = tags.find( ( tag ) => dataTypes.includes( tag.tag ) );
 		return {
 			description,
 			sourceFile,

--- a/bin/hook-reference/data.js
+++ b/bin/hook-reference/data.js
@@ -4,7 +4,7 @@ const { parse } = require( 'comment-parser/lib' );
 const { relative, resolve } = require( 'path' );
 const chalk = require( 'chalk' );
 
-const dataTypes = [ 'hook', 'slotFill' ];
+const dataTypes = [ 'filter', 'slotFill' ];
 
 const getHooks = ( parsedData ) =>
 	parsedData.filter( ( docBlock ) =>

--- a/bin/hook-reference/data.js
+++ b/bin/hook-reference/data.js
@@ -53,12 +53,14 @@ const makeDocObjects = async ( path ) => {
 	const hooks = await prepareHooks( path );
 	return hooks.map( ( { description, tags, sourceFile } ) => {
 		const example = tags.find( ( tag ) => tag.tag === 'example' );
-		const hook = tags.find( ( tag ) => dataTypes.includes( tag.tag ) );
+		const tag = tags.find( ( tag ) => dataTypes.includes( tag.tag ) );
+
 		return {
 			description,
 			sourceFile,
-			name: hook ? hook.name : '',
+			name: tag ? tag.name : '',
 			example: example ? example.description : '',
+			type: tag.tag,
 		};
 	} );
 };

--- a/bin/hook-reference/data.js
+++ b/bin/hook-reference/data.js
@@ -4,7 +4,7 @@ const { parse } = require( 'comment-parser/lib' );
 const { relative, resolve } = require( 'path' );
 const chalk = require( 'chalk' );
 
-const dataTypes = [ 'filter', 'slotFill' ];
+const dataTypes = [ 'action', 'filter', 'slotFill' ];
 
 const getHooks = ( parsedData ) =>
 	parsedData.filter( ( docBlock ) =>

--- a/bin/hook-reference/data.js
+++ b/bin/hook-reference/data.js
@@ -21,7 +21,8 @@ const getSourceFile = ( file, commit, { source } ) => {
 const logProgress = ( fileName, { tags } ) => {
 	const hook = tags.find( ( tag ) => dataTypes.includes( tag.tag ) );
 	console.log(
-		chalk.cyan( `${ hook.name } ` ) +
+		chalk.green( `@${ hook.tag } ` ) +
+			chalk.cyan( `${ hook.name } ` ) +
 			chalk.yellow( 'generated in ' ) +
 			chalk.yellow.underline( fileName )
 	);

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,14 +1,16 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/e706cd8a12f6f2da49f340dc2ff61c7174cec291/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0b8079ea98a6b7291adb7f345954e16cfa0b1c7b/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
-        "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );"
+        "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );",
+        "type": "hook"
     },
     {
         "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/e706cd8a12f6f2da49f340dc2ff61c7174cec291/packages/navigation/src/index.js#L252-L268",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0b8079ea98a6b7291adb7f345954e16cfa0b1c7b/packages/navigation/src/index.js#L252-L268",
         "name": "WooNavigationItem",
-        "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );"
+        "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );",
+        "type": "slotFill"
     }
 ]

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,14 +1,14 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0b8079ea98a6b7291adb7f345954e16cfa0b1c7b/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/8db53a7ae136925c10f3bdacd30e1a5bd04ca548/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
         "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );",
         "type": "hook"
     },
     {
         "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0b8079ea98a6b7291adb7f345954e16cfa0b1c7b/packages/navigation/src/index.js#L252-L268",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/8db53a7ae136925c10f3bdacd30e1a5bd04ca548/packages/navigation/src/index.js#L252-L268",
         "name": "WooNavigationItem",
         "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );",
         "type": "slotFill"

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,14 +1,14 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/8db53a7ae136925c10f3bdacd30e1a5bd04ca548/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/3cddd6d9d8ea1fde9445554944c2d93e2b9ff514/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
         "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );",
-        "type": "hook"
+        "type": "filter"
     },
     {
         "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/8db53a7ae136925c10f3bdacd30e1a5bd04ca548/packages/navigation/src/index.js#L252-L268",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/3cddd6d9d8ea1fde9445554944c2d93e2b9ff514/packages/navigation/src/index.js#L252-L268",
         "name": "WooNavigationItem",
         "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );",
         "type": "slotFill"

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,8 +1,14 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/ff1a3cb2f3857cfa759fb3c93cedfe630dbd5510/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/e706cd8a12f6f2da49f340dc2ff61c7174cec291/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
         "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );"
+    },
+    {
+        "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/e706cd8a12f6f2da49f340dc2ff61c7174cec291/packages/navigation/src/index.js#L252-L268",
+        "name": "WooNavigationItem",
+        "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );"
     }
 ]

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,14 +1,14 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/3cddd6d9d8ea1fde9445554944c2d93e2b9ff514/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/bdf8c90efcbdde5de667c7d039407630d6ab1fc3/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
         "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );",
         "type": "filter"
     },
     {
         "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/3cddd6d9d8ea1fde9445554944c2d93e2b9ff514/packages/navigation/src/index.js#L252-L268",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/bdf8c90efcbdde5de667c7d039407630d6ab1fc3/packages/navigation/src/index.js#L252-L268",
         "name": "WooNavigationItem",
         "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );",
         "type": "slotFill"

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,14 +1,14 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0518766447af1bcfe0f78f955f15853da5d36d58/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/6889e695d6bbeff1e0fb607339f83cce18ca6e59/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
         "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );",
         "type": "filter"
     },
     {
         "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0518766447af1bcfe0f78f955f15853da5d36d58/packages/navigation/src/index.js#L254-L270",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/6889e695d6bbeff1e0fb607339f83cce18ca6e59/packages/navigation/src/index.js#L254-L270",
         "name": "WooNavigationItem",
         "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );",
         "type": "slotFill"

--- a/bin/hook-reference/data.json
+++ b/bin/hook-reference/data.json
@@ -1,14 +1,14 @@
 [
     {
         "description": "List of homepage stats enabled by default",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/bdf8c90efcbdde5de667c7d039407630d6ab1fc3/client/homescreen/stats-overview/defaults.js#L5-L16",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0518766447af1bcfe0f78f955f15853da5d36d58/client/homescreen/stats-overview/defaults.js#L5-L16",
         "name": "woocommerce_admin_homepage_default_stats",
         "example": "addFilter( 'woocommerce_admin_homepage_default_stats', 'plugin-domain', ( defaultStats ) => defaultStats.filter( ( stat ) => stat !== 'jetpack/stats/views' ) );",
         "type": "filter"
     },
     {
         "description": "Create a Fill for extensions to add client facing custom Navigation Items.",
-        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/bdf8c90efcbdde5de667c7d039407630d6ab1fc3/packages/navigation/src/index.js#L252-L268",
+        "sourceFile": "https://github.com/woocommerce/woocommerce-admin/blob/0518766447af1bcfe0f78f955f15853da5d36d58/packages/navigation/src/index.js#L254-L270",
         "name": "WooNavigationItem",
         "example": "const MyExtenstionNavItem = () => ( <WooNavigationItem item=\"my-extension\">My Extension</WooNavigationItem> ); registerPlugin( 'my-extension', { render: MyExtenstionNavItem, scope: 'woocommerce-admin', } );",
         "type": "slotFill"

--- a/bin/hook-reference/index.js
+++ b/bin/hook-reference/index.js
@@ -17,6 +17,16 @@ async function getFilePaths( dir ) {
 	return files.reduce( ( a, f ) => a.concat( f ), [] );
 }
 
+async function getAllFilePaths( paths ) {
+	const allFiles = await Promise.all(
+		paths.map( async ( path ) => {
+			return await getFilePaths( path );
+		} )
+	);
+
+	return allFiles.reduce( ( a, f ) => a.concat( f ), [] );
+}
+
 const writeJSONFile = async ( data ) => {
 	const fileName = 'bin/hook-reference/data.json';
 	const stringifiedData = JSON.stringify( data, null, 4 );
@@ -33,7 +43,7 @@ const writeJSONFile = async ( data ) => {
 console.log( chalk.green( 'Preparing Hook Reference data file' ) );
 console.log( '\n' );
 
-getFilePaths( 'client' )
+getAllFilePaths( [ 'client', 'packages/navigation/src' ] )
 	.then( ( paths ) => createData( paths ) )
 	.then( ( data ) => writeJSONFile( data ) )
 	.catch( ( e ) => console.error( e ) );

--- a/bin/hook-reference/index.js
+++ b/bin/hook-reference/index.js
@@ -1,4 +1,3 @@
-const fs = require( 'fs' );
 const { stat, readdir, writeFile } = require( 'fs' ).promises;
 const { resolve } = require( 'path' );
 const createData = require( './data' );
@@ -9,12 +8,22 @@ async function getFilePaths( dir ) {
 	const files = await Promise.all(
 		subdirs.map( async ( subdir ) => {
 			const res = resolve( dir, subdir );
-			return ( await stat( res ) ).isDirectory()
-				? getFilePaths( res )
-				: res;
+			const _stat = await stat( res );
+			const isDir = _stat.isDirectory();
+			const isNotSourceDir =
+				isDir &&
+				/\/(build|build-module|build-style|node_modules)$/g.test( res );
+
+			if ( isNotSourceDir ) {
+				return;
+			}
+
+			return isDir ? getFilePaths( res ) : res;
 		} )
 	);
-	return files.reduce( ( a, f ) => a.concat( f ), [] );
+	return files
+		.filter( ( f ) => !! f )
+		.reduce( ( a, f ) => a.concat( f ), [] );
 }
 
 async function getAllFilePaths( paths ) {
@@ -43,7 +52,7 @@ const writeJSONFile = async ( data ) => {
 console.log( chalk.green( 'Preparing Hook Reference data file' ) );
 console.log( '\n' );
 
-getAllFilePaths( [ 'client', 'packages/navigation/src' ] )
+getAllFilePaths( [ 'client', 'packages' ] )
 	.then( ( paths ) => createData( paths ) )
 	.then( ( data ) => writeJSONFile( data ) )
 	.catch( ( e ) => console.error( e ) );

--- a/client/homescreen/stats-overview/defaults.js
+++ b/client/homescreen/stats-overview/defaults.js
@@ -5,7 +5,7 @@ import { applyFilters } from '@wordpress/hooks';
 /**
  * List of homepage stats enabled by default
  *
- * @hook woocommerce_admin_homepage_default_stats
+ * @filter woocommerce_admin_homepage_default_stats
  * @example
  * addFilter(
  *	'woocommerce_admin_homepage_default_stats',

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -254,6 +254,16 @@ export const addHistoryListener = ( listener ) => {
 /**
  * Create a Fill for extensions to add client facing custom Navigation Items.
  *
+ * @slotFill WooNavigationItem
+ * @example
+ * const MyExtenstionNavItem = () => (
+ * 	<WooNavigationItem item="my-extension">My Extension</WooNavigationItem>
+ * );
+ *
+ * registerPlugin( 'my-extension', {
+ * 	render: MyExtenstionNavItem,
+ * 	scope: 'woocommerce-admin',
+ * } );
  * @param {Object} param0
  * @param {Array} param0.children - Node children.
  * @param {string} param0.item - Navigation item slug.

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Add payment gateway suggestion unit tests #7142
 - Add: Feature toggle to disable Analytics UI #7168
 - Add: SlotFill to Abbreviated Notification panel #7091
+- Add: Hook reference slotFill support #6833
 - Dev: Add `woocommerce_admin_export_id` filter for customizing the export file name #7178
 - Dev: Remove old payment gateway task components #7224
 - Fix: Currency display on Orders activity card on homescreen #7181

--- a/readme.txt
+++ b/readme.txt
@@ -269,6 +269,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: UI updates to Payment Task screen #6766
 - Update: Update payment gateway suggestions semantics to be more consistent #7130
 - Update: Adding setup required icon for non-configured payment methods #6811
+- Update: Add SlotFill support in hook reference script #6833
 
 == 2.2.6 5/7/2021 ==
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/6778

The hook reference script needs to include SlotFill so we can document all the ways extensions can add custom code to WC Admin, not just filters. This PR adds support for documenting slotFills and renames hooks -> filters because its more specific.

### Detailed test instructions:

Run `npm run create-hook-reference` and see the `bin/hook-reference/data.json` file created, now with an entry for the added slotFill docBlock. See also the `type` property added to each data point.

