### PR TITLE
Move CES action dispatch to report filter configs.

### DIFF
--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -3,11 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getCategoryLabels } from '../../../lib/async-requests';
+import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 const CATEGORY_REPORT_CHARTS_FILTER =
 	'woocommerce_admin_categories_report_charts';
@@ -15,6 +17,8 @@ const CATEGORY_REPORT_FILTERS_FILTER =
 	'woocommerce_admin_categories_report_filters';
 const CATEGORY_REPORT_ADVANCED_FILTERS_FILTER =
 	'woocommerce_admin_category_report_advanced_filters';
+
+const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 
 export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
 	{
@@ -99,6 +103,7 @@ export const filters = applyFilters( CATEGORY_REPORT_FILTERS_FILTER, [
 						title: __( 'Compare Categories', 'woocommerce-admin' ),
 						update: __( 'Compare', 'woocommerce-admin' ),
 					},
+					onClick: addCesSurveyForAnalytics,
 				},
 			},
 		],

--- a/client/analytics/report/categories/index.js
+++ b/client/analytics/report/categories/index.js
@@ -4,7 +4,6 @@
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ import ReportChart from '../../components/report-chart';
 import ReportSummary from '../../components/report-summary';
 import ProductsReportTable from '../products/table';
 import ReportFilters from '../../components/report-filters';
-import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 class CategoriesReport extends Component {
 	getChartMeta() {
@@ -44,12 +42,7 @@ class CategoriesReport extends Component {
 	}
 
 	render() {
-		const {
-			isRequesting,
-			query,
-			path,
-			addCesSurveyForAnalytics,
-		} = this.props;
+		const { isRequesting, query, path } = this.props;
 		const { mode, itemsLabel, isSingleCategoryView } = this.getChartMeta();
 
 		const chartQuery = {
@@ -61,10 +54,6 @@ class CategoriesReport extends Component {
 				? 'product'
 				: 'category';
 		}
-
-		filters[ 0 ].filters.find(
-			( item ) => item.value === 'compare-categories'
-		).settings.onClick = addCesSurveyForAnalytics;
 
 		return (
 			<Fragment>
@@ -134,7 +123,4 @@ CategoriesReport.propTypes = {
 	path: PropTypes.string.isRequired,
 };
 
-export default withDispatch( ( dispatch ) => {
-	const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
-	return { addCesSurveyForAnalytics };
-} )( CategoriesReport );
+export default CategoriesReport;

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -3,16 +3,20 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getCouponLabels } from '../../../lib/async-requests';
+import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 const COUPON_REPORT_CHARTS_FILTER = 'woocommerce_admin_coupons_report_charts';
 const COUPON_REPORT_FILTERS_FILTER = 'woocommerce_admin_coupons_report_filters';
 const COUPON_REPORT_ADVANCED_FILTERS_FILTER =
 	'woocommerce_admin_coupon_report_advanced_filters';
+
+const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 
 export const charts = applyFilters( COUPON_REPORT_CHARTS_FILTER, [
 	{
@@ -85,6 +89,7 @@ export const filters = applyFilters( COUPON_REPORT_FILTERS_FILTER, [
 							'woocommerce-admin'
 						),
 					},
+					onClick: addCesSurveyForAnalytics,
 				},
 			},
 		],

--- a/client/analytics/report/coupons/index.js
+++ b/client/analytics/report/coupons/index.js
@@ -4,7 +4,6 @@
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,7 +14,6 @@ import getSelectedChart from '../../../lib/get-selected-chart';
 import ReportChart from '../../components/report-chart';
 import ReportSummary from '../../components/report-summary';
 import ReportFilters from '../../components/report-filters';
-import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 class CouponsReport extends Component {
 	getChartMeta() {
@@ -35,17 +33,8 @@ class CouponsReport extends Component {
 	}
 
 	render() {
-		const {
-			isRequesting,
-			query,
-			path,
-			addCesSurveyForAnalytics,
-		} = this.props;
+		const { isRequesting, query, path } = this.props;
 		const { mode, itemsLabel } = this.getChartMeta();
-
-		filters[ 0 ].filters.find(
-			( item ) => item.value === 'compare-coupons'
-		).settings.onClick = addCesSurveyForAnalytics;
 
 		const chartQuery = {
 			...query,
@@ -100,7 +89,4 @@ CouponsReport.propTypes = {
 	query: PropTypes.object.isRequired,
 };
 
-export default withDispatch( ( dispatch ) => {
-	const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
-	return { addCesSurveyForAnalytics };
-} )( CouponsReport );
+export default CouponsReport;

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import {
 	getProductLabels,
 	getVariationLabels,
 } from '../../../lib/async-requests';
+import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 const PRODUCTS_REPORT_CHARTS_FILTER =
 	'woocommerce_admin_products_report_charts';
@@ -18,6 +20,8 @@ const PRODUCTS_REPORT_FILTERS_FILTER =
 	'woocommerce_admin_products_report_filters';
 const PRODUCTS_REPORT_ADVANCED_FILTERS_FILTER =
 	'woocommerce_admin_products_report_advanced_filters';
+
+const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 
 export const charts = applyFilters( PRODUCTS_REPORT_CHARTS_FILTER, [
 	{
@@ -95,6 +99,7 @@ const filterConfig = {
 					title: __( 'Compare Products', 'woocommerce-admin' ),
 					update: __( 'Compare', 'woocommerce-admin' ),
 				},
+				onClick: addCesSurveyForAnalytics,
 			},
 		},
 	],

--- a/client/analytics/report/products/index.js
+++ b/client/analytics/report/products/index.js
@@ -6,7 +6,7 @@ import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { ITEMS_STORE_NAME } from '@woocommerce/data';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,7 +19,6 @@ import ReportError from '../../components/report-error';
 import ReportSummary from '../../components/report-summary';
 import VariationsReportTable from '../variations/table';
 import ReportFilters from '../../components/report-filters';
-import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 class ProductsReport extends Component {
 	getChartMeta() {
@@ -61,7 +60,6 @@ class ProductsReport extends Component {
 			isError,
 			isRequesting,
 			isSingleProductVariable,
-			addCesSurveyForAnalytics,
 		} = this.props;
 
 		if ( isError ) {
@@ -76,10 +74,6 @@ class ProductsReport extends Component {
 			chartQuery.segmentby =
 				compareObject === 'products' ? 'product' : 'variation';
 		}
-
-		filters[ 0 ].filters.find(
-			( item ) => item.value === 'compare-products'
-		).settings.onClick = addCesSurveyForAnalytics;
 
 		return (
 			<Fragment>
@@ -193,9 +187,5 @@ export default compose(
 			query,
 			isSingleProductView,
 		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
-		return { addCesSurveyForAnalytics };
 	} )
 )( ProductsReport );

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -4,17 +4,21 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import { NAMESPACE } from '@woocommerce/data';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { getRequestByIdString } from '../../../lib/async-requests';
 import { getTaxCode } from './utils';
+import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 const TAXES_REPORT_CHARTS_FILTER = 'woocommerce_admin_taxes_report_charts';
 const TAXES_REPORT_FILTERS_FILTER = 'woocommerce_admin_taxes_report_filters';
 const TAXES_REPORT_ADVANCED_FILTERS_FILTER =
 	'woocommerce_admin_taxes_report_advanced_filters';
+
+const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 
 export const charts = applyFilters( TAXES_REPORT_CHARTS_FILTER, [
 	{
@@ -82,6 +86,7 @@ export const filters = applyFilters( TAXES_REPORT_FILTERS_FILTER, [
 						title: __( 'Compare Tax Codes', 'woocommerce-admin' ),
 						update: __( 'Compare', 'woocommerce-admin' ),
 					},
+					onClick: addCesSurveyForAnalytics,
 				},
 			},
 		],

--- a/client/analytics/report/taxes/index.js
+++ b/client/analytics/report/taxes/index.js
@@ -4,7 +4,6 @@
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
-import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,7 +14,6 @@ import ReportChart from '../../components/report-chart';
 import ReportSummary from '../../components/report-summary';
 import TaxesReportTable from './table';
 import ReportFilters from '../../components/report-filters';
-import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 class TaxesReport extends Component {
 	getChartMeta() {
@@ -31,17 +29,8 @@ class TaxesReport extends Component {
 	}
 
 	render() {
-		const {
-			isRequesting,
-			query,
-			path,
-			addCesSurveyForAnalytics,
-		} = this.props;
+		const { isRequesting, query, path } = this.props;
 		const { mode, itemsLabel } = this.getChartMeta();
-
-		filters[ 0 ].filters.find(
-			( item ) => item.value === 'compare-taxes'
-		).settings.onClick = addCesSurveyForAnalytics;
 
 		const chartQuery = {
 			...query,
@@ -94,7 +83,4 @@ TaxesReport.propTypes = {
 	query: PropTypes.object.isRequired,
 };
 
-export default withDispatch( ( dispatch ) => {
-	const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
-	return { addCesSurveyForAnalytics };
-} )( TaxesReport );
+export default TaxesReport;

--- a/client/analytics/report/variations/config.js
+++ b/client/analytics/report/variations/config.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import {
 	getProductLabels,
 	getVariationLabels,
 } from '../../../lib/async-requests';
+import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 const VARIATIONS_REPORT_CHARTS_FILTER =
 	'woocommerce_admin_variations_report_charts';
@@ -19,6 +21,8 @@ const VARIATIONS_REPORT_FILTERS_FILTER =
 	'woocommerce_admin_variations_report_filters';
 const VARIATIONS_REPORT_ADVANCED_FILTERS_FILTER =
 	'woocommerce_admin_variations_report_advanced_filters';
+
+const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
 
 export const charts = applyFilters( VARIATIONS_REPORT_CHARTS_FILTER, [
 	{
@@ -102,6 +106,7 @@ export const filters = applyFilters( VARIATIONS_REPORT_FILTERS_FILTER, [
 						title: __( 'Compare Variations', 'woocommerce-admin' ),
 						update: __( 'Compare', 'woocommerce-admin' ),
 					},
+					onClick: addCesSurveyForAnalytics,
 				},
 			},
 			{

--- a/client/analytics/report/variations/index.js
+++ b/client/analytics/report/variations/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { withDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ import ReportError from '../../components/report-error';
 import ReportSummary from '../../components/report-summary';
 import VariationsReportTable from './table';
 import ReportFilters from '../../components/report-filters';
-import { STORE_KEY as CES_STORE_KEY } from '../../../customer-effort-score-tracks/data/constants';
 
 const getChartMeta = ( { query } ) => {
 	const isCompareView =
@@ -33,13 +31,7 @@ const getChartMeta = ( { query } ) => {
 
 const VariationsReport = ( props ) => {
 	const { itemsLabel, mode } = getChartMeta( props );
-	const {
-		path,
-		query,
-		isError,
-		isRequesting,
-		addCesSurveyForAnalytics,
-	} = props;
+	const { path, query, isError, isRequesting } = props;
 
 	if ( isError ) {
 		return <ReportError isError />;
@@ -52,10 +44,6 @@ const VariationsReport = ( props ) => {
 	if ( mode === 'item-comparison' ) {
 		chartQuery.segmentby = 'variation';
 	}
-
-	filters[ 0 ].filters.find(
-		( item ) => item.value === 'compare-variations'
-	).settings.onClick = addCesSurveyForAnalytics;
 
 	return (
 		<Fragment>
@@ -103,7 +91,4 @@ VariationsReport.propTypes = {
 	query: PropTypes.object.isRequired,
 };
 
-export default withDispatch( ( dispatch ) => {
-	const { addCesSurveyForAnalytics } = dispatch( CES_STORE_KEY );
-	return { addCesSurveyForAnalytics };
-} )( VariationsReport );
+export default VariationsReport;

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Missed DB version number updates causing unnecessary upgrades. #6818
 - Fix: Parsing bad JSON string data from user WooCommerce meta. #6819
 - Fix: Remove PayPal for India #6828
+- Fix: Report filters expecting specific ordering. #6847
 - Performance: Avoid updating customer info synchronously from the front end. #6765
 - Tweak: Add settings_section event prop for CES #6762
 - Tweak: Refactor payments to allow management of methods #6786


### PR DESCRIPTION
Fixes #6339.

This PR seeks to fix the reported bug and make the CES click handler attachment more resilient to 3PD filter usage.

The original PR (https://github.com/woocommerce/woocommerce-admin/pull/5649) used the following logic to add an `onClick` handler to the comparison filter:

https://github.com/woocommerce/woocommerce-admin/blob/087b9fad197c561119960def835650671e6f6e04/client/analytics/report/categories/index.js#L65-L67

This is problematic because it assumed that the comparison filter would always be in the first filter group, and that it would always be found. Anyone using the hook could alter that - and did.. that's how the original report occurred.

### Detailed test instructions:

- Download/build this extension https://github.com/Sidlegionair/filter-reports-by-vendor/
- Enable it
- Go to the Taxes Report
- Verify there are no console errors (specifically `TypeError: Cannot read property 'settings' of undefined`)
- Enable tracking (WooCommerce > Settings > Advanced > WooCommerce.com)
- For these reports: Categories, Coupons, Products, Taxes, Variations
  - Delete `woocommerce_ces_shown_for_actions` wp_option
  - Delete `woocommerce_ces_tracks_queue ` wp_option
  - Enter comparison mode using "Show" menu
  - Choose 2 or more items, click "compare"
  - Verify the CES snackbar is shown ("How easy was it to filter?")

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
