### PR TITLE
Make ids unique in SearchListControlItem

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 -   Add new (experimental) list, and add depreciation notice for the current list. #6787
+-   Force `<SearchListItem>` form elements id to be unique. #6871
+-   Add `controlId` and `name` props to `<SearchListItem>`. #6871
+-   Minor styling tweaks and fixes to `<SearchListcontrol>`. #6871
 
 # 6.1.2
 

--- a/packages/components/src/search-list-control/index.js
+++ b/packages/components/src/search-list-control/index.js
@@ -121,7 +121,7 @@ export class SearchListControl extends Component {
 	}
 
 	renderList( list, depth = 0 ) {
-		const { isSingle, search } = this.props;
+		const { isSingle, search, instanceId } = this.props;
 		const renderItem = this.props.renderItem || this.defaultRenderItem;
 		if ( ! list ) {
 			return null;
@@ -137,6 +137,7 @@ export class SearchListControl extends Component {
 						isSingle,
 						search,
 						depth,
+						controlId: instanceId,
 					} ) }
 				</li>
 				{ this.renderList( item.children, depth + 1 ) }

--- a/packages/components/src/search-list-control/item.js
+++ b/packages/components/src/search-list-control/item.js
@@ -39,6 +39,7 @@ const SearchListItem = ( {
 	countLabel,
 	className,
 	depth = 0,
+	controlId = '',
 	item,
 	isSelected,
 	isSingle,
@@ -56,14 +57,16 @@ const SearchListItem = ( {
 		classes.push( 'has-count' );
 	}
 	const hasBreadcrumbs = item.breadcrumbs && item.breadcrumbs.length;
+	const name = props.name || `search-list-item-${ controlId }`;
+	const id = `${ name }-${ item.id }`;
 
 	return (
-		<label htmlFor={ item.id } className={ classes.join( ' ' ) }>
+		<label htmlFor={ id } className={ classes.join( ' ' ) }>
 			{ isSingle ? (
 				<input
 					type="radio"
-					id={ item.id }
-					name={ item.name }
+					id={ id }
+					name={ name }
 					value={ item.value }
 					onChange={ onSelect( item ) }
 					checked={ isSelected }
@@ -73,8 +76,8 @@ const SearchListItem = ( {
 			) : (
 				<input
 					type="checkbox"
-					id={ item.id }
-					name={ item.name }
+					id={ id }
+					name={ name }
 					value={ item.value }
 					onChange={ onSelect( item ) }
 					checked={ isSelected }
@@ -113,6 +116,10 @@ SearchListItem.propTypes = {
 	 */
 	countLabel: PropTypes.node,
 	/**
+	 * Unique id of the parent control.
+	 */
+	controlId: PropTypes.node,
+	/**
 	 * Depth, non-zero if the list is hierarchical.
 	 */
 	depth: PropTypes.number,
@@ -120,6 +127,12 @@ SearchListItem.propTypes = {
 	 * Current item to display.
 	 */
 	item: PropTypes.object,
+	/**
+	 * Name of the inputs. Used to group input controls together. See:
+	 * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-name
+	 * If not provided, a default name will be generated using the controlId.
+	 */
+	name: PropTypes.string,
 	/**
 	 * Whether this item is selected.
 	 */

--- a/packages/components/src/search-list-control/stories/index.js
+++ b/packages/components/src/search-list-control/stories/index.js
@@ -7,7 +7,7 @@ import { withState } from '@wordpress/compose';
 
 const SearchListControlExample = withState( {
 	selected: [],
-	loading: true,
+	loading: false,
 } )( ( { selected, loading, setState } ) => {
 	const showCount = boolean( 'Show count', false );
 	const isCompact = boolean( 'Compact', false );

--- a/packages/components/src/search-list-control/style.scss
+++ b/packages/components/src/search-list-control/style.scss
@@ -43,7 +43,7 @@
 }
 
 .woocommerce-search-list__list {
-	border: 1px solid $gray-100;
+	border: 1px solid $gray-200;
 	padding: 0;
 	max-height: 17em;
 	overflow-x: hidden;
@@ -100,7 +100,7 @@
 		padding: $gap-small $gap;
 		background: $studio-white;
 		// !important to keep the border around on hover
-		border-bottom: 1px solid $gray-100 !important;
+		border-bottom: 1px solid $gray-100;
 		color: $gray-700;
 
 		@include hover-state {
@@ -110,10 +110,6 @@
 		&:active,
 		&:focus {
 			box-shadow: none;
-		}
-
-		&:last-child {
-			border-bottom: none !important;
 		}
 
 		.woocommerce-search-list__item-input {
@@ -204,6 +200,10 @@
 			background: $studio-white;
 			white-space: nowrap;
 		}
+	}
+
+	li:last-child .woocommerce-search-list__item {
+		border-bottom: none;
 	}
 }
 

--- a/packages/components/src/search-list-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/search-list-control/test/__snapshots__/index.js.snap
@@ -45,13 +45,13 @@ exports[`SearchListControl should render a search box and list of hierarchical o
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={1}
+        htmlFor="search-list-item-1-1"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={1}
-          name="Apricots"
+          id="search-list-item-1-1"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -69,13 +69,13 @@ exports[`SearchListControl should render a search box and list of hierarchical o
     <li>
       <label
         className=" woocommerce-search-list__item depth-1"
-        htmlFor={2}
+        htmlFor="search-list-item-1-2"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={2}
-          name="Clementine"
+          id="search-list-item-1-2"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -98,13 +98,13 @@ exports[`SearchListControl should render a search box and list of hierarchical o
     <li>
       <label
         className=" woocommerce-search-list__item depth-1"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -127,13 +127,13 @@ exports[`SearchListControl should render a search box and list of hierarchical o
     <li>
       <label
         className=" woocommerce-search-list__item depth-2"
-        htmlFor={4}
+        htmlFor="search-list-item-1-4"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={4}
-          name="Guava"
+          id="search-list-item-1-4"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -156,13 +156,13 @@ exports[`SearchListControl should render a search box and list of hierarchical o
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={5}
+        htmlFor="search-list-item-1-5"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={5}
-          name="Lychee"
+          id="search-list-item-1-5"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -180,13 +180,13 @@ exports[`SearchListControl should render a search box and list of hierarchical o
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -250,13 +250,13 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={1}
+        htmlFor="search-list-item-1-1"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={1}
-          name="Apricots"
+          id="search-list-item-1-1"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -274,13 +274,13 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={2}
+        htmlFor="search-list-item-1-2"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={2}
-          name="Clementine"
+          id="search-list-item-1-2"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -298,13 +298,13 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -322,13 +322,13 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={4}
+        htmlFor="search-list-item-1-4"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={4}
-          name="Guava"
+          id="search-list-item-1-4"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -346,13 +346,13 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={5}
+        htmlFor="search-list-item-1-5"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={5}
-          name="Lychee"
+          id="search-list-item-1-5"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -370,13 +370,13 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -440,13 +440,13 @@ exports[`SearchListControl should render a search box and list of options with a
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={1}
+        htmlFor="search-list-item-1-1"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={1}
-          name="Apricots"
+          id="search-list-item-1-1"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -464,13 +464,13 @@ exports[`SearchListControl should render a search box and list of options with a
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={2}
+        htmlFor="search-list-item-1-2"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={2}
-          name="Clementine"
+          id="search-list-item-1-2"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -488,13 +488,13 @@ exports[`SearchListControl should render a search box and list of options with a
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -512,13 +512,13 @@ exports[`SearchListControl should render a search box and list of options with a
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={4}
+        htmlFor="search-list-item-1-4"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={4}
-          name="Guava"
+          id="search-list-item-1-4"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -536,13 +536,13 @@ exports[`SearchListControl should render a search box and list of options with a
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={5}
+        htmlFor="search-list-item-1-5"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={5}
-          name="Lychee"
+          id="search-list-item-1-5"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -560,13 +560,13 @@ exports[`SearchListControl should render a search box and list of options with a
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -712,13 +712,13 @@ exports[`SearchListControl should render a search box and list of options, with 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={1}
+        htmlFor="search-list-item-1-1"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={1}
-          name="Apricots"
+          id="search-list-item-1-1"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -736,13 +736,13 @@ exports[`SearchListControl should render a search box and list of options, with 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={2}
+        htmlFor="search-list-item-1-2"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={2}
-          name="Clementine"
+          id="search-list-item-1-2"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -760,13 +760,13 @@ exports[`SearchListControl should render a search box and list of options, with 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -784,13 +784,13 @@ exports[`SearchListControl should render a search box and list of options, with 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={4}
+        htmlFor="search-list-item-1-4"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={4}
-          name="Guava"
+          id="search-list-item-1-4"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -808,13 +808,13 @@ exports[`SearchListControl should render a search box and list of options, with 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={5}
+        htmlFor="search-list-item-1-5"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={5}
-          name="Lychee"
+          id="search-list-item-1-5"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -832,13 +832,13 @@ exports[`SearchListControl should render a search box and list of options, with 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1046,13 +1046,13 @@ exports[`SearchListControl should render a search box with a search term, and on
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1074,13 +1074,13 @@ exports[`SearchListControl should render a search box with a search term, and on
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1149,13 +1149,13 @@ exports[`SearchListControl should render a search box with a search term, and on
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1177,13 +1177,13 @@ exports[`SearchListControl should render a search box with a search term, and on
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1304,13 +1304,13 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={1}
+        htmlFor="search-list-item-1-1"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={1}
-          name="Apricots"
+          id="search-list-item-1-1"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1328,13 +1328,13 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={2}
+        htmlFor="search-list-item-1-2"
       >
         <input
           checked={true}
           className="woocommerce-search-list__item-input"
-          id={2}
-          name="Clementine"
+          id="search-list-item-1-2"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1352,13 +1352,13 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1376,13 +1376,13 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={4}
+        htmlFor="search-list-item-1-4"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={4}
-          name="Guava"
+          id="search-list-item-1-4"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1400,13 +1400,13 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={5}
+        htmlFor="search-list-item-1-5"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={5}
-          name="Lychee"
+          id="search-list-item-1-5"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1424,13 +1424,13 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1590,13 +1590,13 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={1}
+        htmlFor="search-list-item-1-1"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={1}
-          name="Apricots"
+          id="search-list-item-1-1"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1614,13 +1614,13 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={2}
+        htmlFor="search-list-item-1-2"
       >
         <input
           checked={true}
           className="woocommerce-search-list__item-input"
-          id={2}
-          name="Clementine"
+          id="search-list-item-1-2"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1638,13 +1638,13 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={3}
+        htmlFor="search-list-item-1-3"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={3}
-          name="Elderberry"
+          id="search-list-item-1-3"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1662,13 +1662,13 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={4}
+        htmlFor="search-list-item-1-4"
       >
         <input
           checked={true}
           className="woocommerce-search-list__item-input"
-          id={4}
-          name="Guava"
+          id="search-list-item-1-4"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1686,13 +1686,13 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={5}
+        htmlFor="search-list-item-1-5"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={5}
-          name="Lychee"
+          id="search-list-item-1-5"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />
@@ -1710,13 +1710,13 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
     <li>
       <label
         className=" woocommerce-search-list__item depth-0"
-        htmlFor={6}
+        htmlFor="search-list-item-1-6"
       >
         <input
           checked={false}
           className="woocommerce-search-list__item-input"
-          id={6}
-          name="Mulberry"
+          id="search-list-item-1-6"
+          name="search-list-item-1"
           onChange={[Function]}
           type="checkbox"
         />


### PR DESCRIPTION
This PR makes some enhancements to `SearchListControl` that I found when updating `@woocommerce/components` in WC Blocks.

* Make `SearchListControlItem` ids unique: if two `SearchListControls` were displaying the same list of elements, the ids of the form elements would be duplicated, so clicking the label of one item in one control might cause the input of the other control to be checked. In this PR we pass down `instanceId` from `SearchListControl` to each individual item so they can generate ids which are unique to each control.
* Control items will share the same `name` attribute: if a list of checkboxes or radios are related to each other, they should have the same `name`. Instead, we were setting a unique name for each input/radio.
* I added a `name` prop to `SearchListControlItem` so we can overwrite it if needed (this will be helpful in WC Blocks because we have expandable list items).
* Style fixes: fixed the bottom border of each individual item not being displayed, removed an `!important` rule which doesn't seem to be necessary anymore and set the box border a bit darker, which seems to be closer to how it was in previous iterations.
* Set the `loading` default state in the story to `false`. It was really annoying to have to toggle it every time. :smile: 

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/115863297-8e25dc80-a435-11eb-9809-8dda72cb8ecf.png)

### Detailed test instructions:

In WC Admin repo, `SearchListControl` can only be tested in storybook.
-   Run `npm run storybook`.
-   Go to the `SearchListControl` page.
- Verify:
  - You can select items in the default mode and the single mode.
  - You can search items.
  - Styles look ok.
  - Smoke test in general.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

No changelog.