### PR TITLE
Change `import-wp-css-storybook.sh`'s shebang to portable bash.

### DIFF
--- a/bin/import-wp-css-storybook.sh
+++ b/bin/import-wp-css-storybook.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 STORYBOOK_WORDPRESS_DIR="$DIR/../storybook/wordpress";
 STORY_BOOK_CSS_PATH="$DIR/../storybook/wordpress/css";

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 
 == Unreleased ==
 
+- Dev: Fixed storybook build script #6875
 - Add: Add plugin installer to allow installation of plugins via URL #6805
 - Add: Optional children prop to SummaryNumber component #6748
 - Dev: Add data source filter to remote inbox notification system #6794


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/6874

Changes `./bin/import-wp-css-storybook.sh` shabang from sh to bash.

### Accessibility

n/a

### Screenshots

![image](https://user-images.githubusercontent.com/17435/115911683-ac5bfe80-a46e-11eb-8e16-817b20d62592.png)


### Detailed test instructions:

```sh
npm install
npm run build
npm run storybook
```


<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
