### PR TITLE
Add a Basic test for FilterPicker.

### DIFF
--- a/packages/components/src/filter-picker/index.js
+++ b/packages/components/src/filter-picker/index.js
@@ -162,7 +162,7 @@ class FilterPicker extends Component {
 
 	renderButton( filter, onClose, config ) {
 		if ( filter.component ) {
-			const { type, labels } = filter.settings;
+			const { type, labels, autocompleter } = filter.settings;
 			const persistedFilter = this.getFilter();
 			const selectedTag =
 				persistedFilter.value === filter.value
@@ -171,6 +171,7 @@ class FilterPicker extends Component {
 
 			return (
 				<Search
+					autocompleter={ autocompleter }
 					className="woocommerce-filters-filter__search"
 					type={ type }
 					placeholder={ labels.placeholder }

--- a/packages/components/src/filter-picker/stories/index.js
+++ b/packages/components/src/filter-picker/stories/index.js
@@ -3,7 +3,6 @@
  */
 import { FilterPicker } from '@woocommerce/components';
 
-const path = new URL( document.location ).searchParams.get( 'path' );
 const query = {
 	meal: 'breakfast',
 };
@@ -50,9 +49,11 @@ const config = {
 	],
 };
 
-export const Basic = () => (
-	<FilterPicker config={ config } path={ path } query={ query } />
-);
+export const Basic = ( {
+	path = new URL( document.location ).searchParams.get( 'path' ),
+} ) => {
+	return <FilterPicker config={ config } path={ path } query={ query } />;
+};
 
 export default {
 	title: 'WooCommerce Admin/components/FilterPicker',

--- a/packages/components/src/filter-picker/test/index.js
+++ b/packages/components/src/filter-picker/test/index.js
@@ -2,19 +2,101 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import { Basic } from '../stories/index';
+import FilterPicker from '../index';
+import Search from '../../search';
+import productAutocompleter from '../../search/autocompleters/product';
+// Due to Jest implementation we cannot mock it only for specific tests.
+// If your test requires non-mocked Search, move them to another test file.
+jest.mock( '../../search' );
 
 describe( 'FilterPicker', () => {
-	it( 'should render the example from the sotrybook', async () => {
+	let config;
+	beforeEach( () => {
+		config = {
+			label: 'Show',
+			staticParams: [],
+			param: 'product_filter',
+			showFilters: () => true,
+			filters: [
+				{ label: 'All Products', value: 'all' },
+				{
+					component: 'Search',
+					value: 'select_product',
+					chartMode: 'item-comparison',
+					path: 'select_product',
+					settings: {
+						type: 'products',
+						param: 'products',
+						labels: {
+							placeholder: 'Type to search for a product',
+							button: 'Single Product',
+						},
+					},
+				},
+			],
+		};
+	} );
+	it( 'should render the example from the storybook', async () => {
 		// Jest and its JSDOM does not allow making extensive use of searchParams used by Basic example.
 		const path = '/story/woocommerce-admin-components-filterpicker--basic';
 
 		expect( function () {
 			render( <Basic path={ path } /> );
 		} ).not.toThrow();
+	} );
+	describe( "when a config is given with a filter with `component: 'Search'`", () => {
+		it( 'should render the Search component', async () => {
+			const path = '/foo/bar';
+
+			const { queryAllByRole } = render(
+				<FilterPicker path={ path } type="custom" config={ config } />
+			);
+
+			// Emulate filter dropdown being opened.
+			// The main dropdown does not have its role defined, so we need to dig deeper into actual internals.
+			userEvent.click( queryAllByRole( 'button' )[ 0 ] );
+
+			// Check that the given component was rendered, without checking its behavior/internals/implementation details.
+			//
+			// In vanilla HTML, we would check
+			// expect( filterPicker.querySelector('woo-search') ).to.be.not.null();
+			// expect( filterPicker.querySelector('woo-search') ).to.be.an.instanceof( Search );
+			//
+			// Following will check if it was rendered, not neceserily being visible now.
+			expect( Search ).toHaveBeenCalled();
+		} );
+		it( "for a `'custom'` type should forward autocompleter config the Search component", async () => {
+			const path = '/foo/bar';
+
+			const customFilterSettings = config.filters[ 1 ].settings;
+			customFilterSettings.type = 'custom';
+			customFilterSettings.autocompleter = productAutocompleter;
+
+			const { queryAllByRole } = render(
+				<FilterPicker path={ path } type="custom" config={ config } />
+			);
+
+			// Emulate filter dropdown being opened.
+			// The main dropdown does not have its role defined, so we need to dig deeper into actual internals.
+			userEvent.click( queryAllByRole( 'button' )[ 0 ] );
+
+			// Check that the given component was rendered, without checking its behavior/internals/implementation details.
+			//
+			// In vanilla HTML, we would check
+			// expect( filterPicker.querySelector('woo-search') ).to.have.a.property( 'autocompleter', autocompleter );
+			//
+			// Following will check if it was rendered with given props, not neceserily being visible now.
+			const lastCallArgs = Search.mock.calls.slice( -1 )[ 0 ];
+			expect( lastCallArgs[ 0 ] ).toHaveProperty(
+				'autocompleter',
+				productAutocompleter
+			);
+		} );
 	} );
 } );

--- a/packages/components/src/filter-picker/test/index.js
+++ b/packages/components/src/filter-picker/test/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Basic } from '../stories/index';
+
+describe( 'FilterPicker', () => {
+	it( 'should render the example from the sotrybook', async () => {
+		// Jest and its JSDOM does not allow making extensive use of searchParams used by Basic example.
+		const path = '/story/woocommerce-admin-components-filterpicker--basic';
+
+		expect( function () {
+			render( <Basic path={ path } /> );
+		} ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
- Forward `autocompleter` prop from `FilterPicker` to `Search`. (35c5253)
Allow, to use the `custom` type of search, previously it was complaining about lack of `autocompleter`, even though it was provided.


- Move `path` in Storybooks example to a parameter, to allow setting it in unit tests.
- Add few tests for FilterPicker. 
	- it renders the basic storybook example without throwing an error (e5ed7d4)
	- it renders `Search` when `component: 'Search'` is given (35c5253)
	- it forwards `autocompleter` prop when `type: 'custom'` is given (35c5253)

Fixes: #6062.
Needed for:242-gh-woocommerce/google-listings-and-ads

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] I've tested using a screen reader

No new texts or animations were introduced, existing ones behave as before.
-   [n/a] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [n/a] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

-   Create `<FilterPicker>` with a config that contains 
	```js
	...
	component: 'Search',
	settings: {
		type: 'custom',
		autocompleter: {...} // Even the one copied from exiting ones.
	``` 
-   Check for errors.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->