### PR TITLE
Make the stat titles more specific to remove ambiguity

### DIFF
--- a/src/API/Reports/Products/Stats/Controller.php
+++ b/src/API/Reports/Products/Stats/Controller.php
@@ -156,8 +156,8 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
-				'title'       => __( 'Items Sold', 'woocommerce-admin' ),
-				'description' => __( 'Number of items sold.', 'woocommerce-admin' ),
+				'title'       => __( 'Product Items Sold', 'woocommerce-admin' ),
+				'description' => __( 'Number of product items sold.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/src/API/Reports/Products/Stats/Controller.php
+++ b/src/API/Reports/Products/Stats/Controller.php
@@ -156,7 +156,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
-				'title'       => __( 'Product Items Sold', 'woocommerce-admin' ),
+				'title'       => __( 'Products Sold', 'woocommerce-admin' ),
 				'description' => __( 'Number of product items sold.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),

--- a/src/API/Reports/Variations/Stats/Controller.php
+++ b/src/API/Reports/Variations/Stats/Controller.php
@@ -153,8 +153,8 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
-				'title'       => __( 'Items Sold', 'woocommerce-admin' ),
-				'description' => __( 'Number of items sold.', 'woocommerce-admin' ),
+				'title'       => __( 'Variation Items Sold', 'woocommerce-admin' ),
+				'description' => __( 'Number of variation items sold.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,

--- a/src/API/Reports/Variations/Stats/Controller.php
+++ b/src/API/Reports/Variations/Stats/Controller.php
@@ -153,7 +153,7 @@ class Controller extends \WC_REST_Reports_Controller {
 	public function get_item_schema() {
 		$data_values = array(
 			'items_sold'   => array(
-				'title'       => __( 'Variation Items Sold', 'woocommerce-admin' ),
+				'title'       => __( 'Variations Sold', 'woocommerce-admin' ),
 				'description' => __( 'Number of variation items sold.', 'woocommerce-admin' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),


### PR DESCRIPTION
Fixes #6915 

The problem described in #6915 is that 2 stats are displayed in the analytics overview for "items sold". Some digging revealed that these are individual stats for products and variations that have the same title so its confusing in the UI what these stats are for.

I've updated them to be more specific. I think we're moving to sentence case in titles, but I have opted not to make that change here because it would be inconsistent unless we changed all the headings.

To test this, simply visit the analytics overview screen, and you should see 2 different stats displayed in the dropdown and also the performance indicators, with unique names.

Screenshots:

<img width="2330" alt="Screenshot 2021-05-05 at 10 47 24 AM" src="https://user-images.githubusercontent.com/1281828/117079145-54d36200-ad8f-11eb-8ff8-fa6ceb018992.png">

<img width="238" alt="Screenshot 2021-05-05 at 10 47 34 AM" src="https://user-images.githubusercontent.com/1281828/117079154-59981600-ad8f-11eb-9a70-dfe177639982.png">


@jeffstieler you're familiar with this area, just wanted to check you approve of solving it this way.

No changelog required