### PR TITLE
Support transformers in remote inbox notifications

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Add remote payment gateway recommendations initial docs #6962
 - Add: Note date range logic for GivingFeedback, and InsightFirstSale note. #6969
 - Add: Add transient notices feature #6809
+- Add: Add transformers in remote inbox notifications #6948
 - Dev: Add data source filter to remote inbox notification system #6794
 - Dev: Add A/A test #6669
 - Dev: Add support for nonces in note actions #6726

--- a/src/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -41,6 +41,10 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 			$option_value = array();
 		}
 
+		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
+			$option_value = TransformerService::apply( $option_value, $rule->transformers );
+		}
+
 		return ComparisonOperation::compare(
 			$option_value,
 			$rule->value,

--- a/src/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -72,6 +72,13 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 			return false;
 		}
 
+		foreach ( $rule->transformers as $transform_args ) {
+			$transformer = TransformerService::create_transformer( $transform_args->use );
+			if ( ! $transformer->validate( $transform_args->arguments ) ) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 }

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -426,6 +426,64 @@ This passes when the option value matches the value using the operation.
 
 `option_name`, `value`, and `operation` are all required. `default` is not required and allows a default value to be used if the option does not exist.
 
+#### Option Transformer
+
+This transforms the given option value into a different value by a series of transformers.
+
+Example option value:
+
+```
+Array
+(
+    [setup_client] => 
+    [industry] => Array
+        (
+            [0] => Array
+                (
+                    [slug] => food-drink
+                )
+
+            [1] => Array
+                (
+                    [slug] => fashion-apparel-accessories
+                )
+        )
+)
+```
+If you want to ensure that the industry array contains `fashion-apparel-accessories`, you can use the following Option definition with transformers.
+
+```
+{
+	"type": "option",
+	"transformers": [
+	    {
+	        "use": "dot_notation",
+	        "arguments": {
+	            "path": "industry"
+	        }
+	    },
+	    {
+	        "use": "array_column",
+	        "arguments": {
+	            "key": "slug"
+	        }
+	    },
+	    {
+	        "use": "array_search",
+	        "arguments": {
+	            "value": "fashion-apparel-accessories"
+	        }
+	    }
+	],
+	"option_name": "woocommerce_onboarding_profile",
+	"value": "fashion-apparel-accessories",
+	"default": "USD",
+	"operation": "="
+}
+```
+
+You can find a list of transformers and examples in the transformer [README](./Transformers/README.md).
+
 ### WCA updated
 This passes when WooCommerce Admin has just been updated. The specs will be run
 on update. Note that this doesn't provide a way to check the version number as

--- a/src/RemoteInboxNotifications/TransformerInterface.php
+++ b/src/RemoteInboxNotifications/TransformerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+use stdClass;
+
+/**
+ * An interface to define a transformer.
+ *
+ * Interface TransformerInterface
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications
+ */
+interface TransformerInterface {
+	/**
+	 * TransformerInterface constructor.
+	 *
+	 * Argument validation should be done in the constructor.
+	 *
+	 * @param stdClass|null $arguments required arguments.
+	 */
+	public function __construct( stdClass $arguments = null);
+
+	/**
+	 * Transform given value to a different value.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed|null
+	 */
+	public function transform( $value);
+}

--- a/src/RemoteInboxNotifications/TransformerInterface.php
+++ b/src/RemoteInboxNotifications/TransformerInterface.php
@@ -13,20 +13,12 @@ use stdClass;
  */
 interface TransformerInterface {
 	/**
-	 * TransformerInterface constructor.
-	 *
-	 * Argument validation should be done in the constructor.
-	 *
-	 * @param stdClass|null $arguments required arguments.
-	 */
-	public function __construct( stdClass $arguments = null);
-
-	/**
 	 * Transform given value to a different value.
 	 *
-	 * @param mixed $value a value to transform.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments arguments.
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value);
+	public function transform( $value, stdClass $arguments = null);
 }

--- a/src/RemoteInboxNotifications/TransformerInterface.php
+++ b/src/RemoteInboxNotifications/TransformerInterface.php
@@ -21,4 +21,13 @@ interface TransformerInterface {
 	 * @return mixed|null
 	 */
 	public function transform( $value, stdClass $arguments = null);
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null );
 }

--- a/src/RemoteInboxNotifications/TransformerService.php
+++ b/src/RemoteInboxNotifications/TransformerService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * A simple service class for the Transformer classes.
+ *
+ * Class TransformerService
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications
+ */
+class TransformerService {
+	/**
+	 * Create a transformer object by name.
+	 *
+	 * @param string        $name name of the transformer.
+	 * @param stdClass|null $arguments required arguments.
+	 *
+	 * @return TransformerInterface|null
+	 */
+	public static function create_transformer( $name, stdClass $arguments = null ) {
+		$camel_cased = lcfirst( str_replace( ' ', '', ucwords( str_replace( '_', ' ', $name ) ) ) );
+
+		$classname = __NAMESPACE__ . '\\Transformers\\' . $camel_cased;
+		if ( ! class_exists( $classname ) ) {
+			return null;
+		}
+
+		return new $classname( $arguments );
+	}
+
+	/**
+	 * Apply transformers to the given value.
+	 *
+	 * @param mixed $target_value a value to transform.
+	 * @param array $transformer_configs transform configuration.
+	 *
+	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
+	 * @return mixed|null
+	 */
+	public static function apply( $target_value, array $transformer_configs ) {
+		foreach ( $transformer_configs as $transformer_config ) {
+			if ( ! isset( $transformer_config->use ) ) {
+				throw new InvalidArgumentException( 'Missing required config value: use' );
+			}
+
+			if ( ! isset( $transformer_config->arguments ) ) {
+				$transformer_config->arguments = null;
+			}
+
+			$transformer = self::create_transformer( $transformer_config->use, $transformer_config->arguments );
+			if ( null === $transformer ) {
+				throw new InvalidArgumentException( "Unable to find a transformer by name: {$transformer_config->use}" );
+			}
+
+			$transformed_value = $transformer->transform( $target_value );
+			// if the transformer returns null, then return the previously transformed value.
+			if ( null === $transformed_value ) {
+				return $target_value;
+			}
+
+			$target_value = $transformed_value;
+		}
+
+		return $target_value;
+	}
+}

--- a/src/RemoteInboxNotifications/TransformerService.php
+++ b/src/RemoteInboxNotifications/TransformerService.php
@@ -16,12 +16,11 @@ class TransformerService {
 	/**
 	 * Create a transformer object by name.
 	 *
-	 * @param string        $name name of the transformer.
-	 * @param stdClass|null $arguments required arguments.
+	 * @param string $name name of the transformer.
 	 *
 	 * @return TransformerInterface|null
 	 */
-	public static function create_transformer( $name, stdClass $arguments = null ) {
+	public static function create_transformer( $name ) {
 		$camel_cased = lcfirst( str_replace( ' ', '', ucwords( str_replace( '_', ' ', $name ) ) ) );
 
 		$classname = __NAMESPACE__ . '\\Transformers\\' . $camel_cased;
@@ -29,7 +28,7 @@ class TransformerService {
 			return null;
 		}
 
-		return new $classname( $arguments );
+		return new $classname();
 	}
 
 	/**
@@ -51,12 +50,12 @@ class TransformerService {
 				$transformer_config->arguments = null;
 			}
 
-			$transformer = self::create_transformer( $transformer_config->use, $transformer_config->arguments );
+			$transformer = self::create_transformer( $transformer_config->use );
 			if ( null === $transformer ) {
 				throw new InvalidArgumentException( "Unable to find a transformer by name: {$transformer_config->use}" );
 			}
 
-			$transformed_value = $transformer->transform( $target_value );
+			$transformed_value = $transformer->transform( $target_value, $transformer_config->arguments );
 			// if the transformer returns null, then return the previously transformed value.
 			if ( null === $transformed_value ) {
 				return $target_value;

--- a/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
@@ -23,10 +23,21 @@ class ArrayColumn implements TransformerInterface {
 	 * @return mixed
 	 */
 	public function transform( $value, stdClass $arguments = null ) {
+		return array_column( $value, $arguments->key );
+	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
 		if ( ! isset( $arguments->key ) ) {
-			throw new InvalidArgumentException( "ArrayColumn: Missing required argument 'key'" );
+			return false;
 		}
 
-		return array_column( $value, $arguments->key );
+		return true;
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
@@ -13,33 +13,20 @@ use stdClass;
  */
 class ArrayColumn implements TransformerInterface {
 	/**
-	 * Array key to search.
-	 *
-	 * @var string $key array key to search.
-	 */
-	private $key;
-
-	/**
-	 * ArrayColumn constructor.
-	 *
-	 * @param stdClass|null $arguments required arguments.
-	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
-	 */
-	public function __construct( stdClass $arguments = null ) {
-		if ( ! isset( $arguments->key ) ) {
-			throw new InvalidArgumentException( "ArrayColumn: Missing required argument 'key'" );
-		}
-		$this->key = $arguments->key;
-	}
-
-	/**
 	 * Search array value by one of its key.
 	 *
-	 * @param mixed $value a value to transform.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments required arguments 'key'.
+	 *
+	 * @throws InvalidArgumentException Throws when the required argument 'key' is missing.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value ) {
-		return array_column( $value, $this->key );
+	public function transform( $value, stdClass $arguments = null ) {
+		if ( ! isset( $arguments->key ) ) {
+			throw new InvalidArgumentException( "ArrayColumn: Missing required argument 'key'" );
+		}
+
+		return array_column( $value, $arguments->key );
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * Search array value by one of its key.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class ArrayColumn implements TransformerInterface {
+	/**
+	 * Array key to search.
+	 *
+	 * @var string $key array key to search.
+	 */
+	private $key;
+
+	/**
+	 * ArrayColumn constructor.
+	 *
+	 * @param stdClass|null $arguments required arguments.
+	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
+	 */
+	public function __construct( stdClass $arguments = null ) {
+		if ( ! isset( $arguments->key ) ) {
+			throw new InvalidArgumentException( "ArrayColumn: Missing required argument 'key'" );
+		}
+		$this->key = $arguments->key;
+	}
+
+	/**
+	 * Search array value by one of its key.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed
+	 */
+	public function transform( $value ) {
+		return array_column( $value, $this->key );
+	}
+}

--- a/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
@@ -3,7 +3,6 @@
 namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
-use InvalidArgumentException;
 use stdClass;
 
 /**
@@ -13,19 +12,14 @@ use stdClass;
  */
 class ArrayFlatten implements TransformerInterface {
 	/**
-	 * ArrayFlatten constructor.
-	 *
-	 * @param stdClass|null $arguments required arguments.
-	 */
-	public function __construct( stdClass $arguments = null ) {}
-	/**
 	 * Search a given value in the array.
 	 *
-	 * @param mixed $value a value to transform.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments arguments.
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value ) {
+	public function transform( $value, stdClass $arguments = null ) {
 		if ( ! is_array( $value ) ) {
 			return null;
 		}

--- a/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
@@ -20,10 +20,6 @@ class ArrayFlatten implements TransformerInterface {
 	 * @return mixed|null
 	 */
 	public function transform( $value, stdClass $arguments = null ) {
-		if ( ! is_array( $value ) ) {
-			return null;
-		}
-
 		$return = array();
 		array_walk_recursive(
 			$value,
@@ -33,5 +29,16 @@ class ArrayFlatten implements TransformerInterface {
 		);
 
 		return $return;
+	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		return true;
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * Flatten nested array.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class ArrayFlatten implements TransformerInterface {
+	/**
+	 * ArrayFlatten constructor.
+	 *
+	 * @param stdClass|null $arguments required arguments.
+	 */
+	public function __construct( stdClass $arguments = null ) {}
+	/**
+	 * Search a given value in the array.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed|null
+	 */
+	public function transform( $value ) {
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		$return = array();
+		array_walk_recursive(
+			$value,
+			function( $item ) use ( &$return ) {
+				$return[] = $item;
+			}
+		);
+
+		return $return;
+	}
+}

--- a/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
@@ -22,4 +22,15 @@ class ArrayKeys implements TransformerInterface {
 	public function transform( $value, stdClass $arguments = null ) {
 		return array_keys( $value );
 	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		return true;
+	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
@@ -12,20 +12,14 @@ use stdClass;
  */
 class ArrayKeys implements TransformerInterface {
 	/**
-	 * ArrayKeys constructor.
-	 *
-	 * @param stdClass|null $arguments required arguments.
-	 */
-	public function __construct( stdClass $arguments = null ) {}
-
-	/**
 	 * Search array value by one of its key.
 	 *
-	 * @param mixed $value a value to transform.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments arguments.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value ) {
+	public function transform( $value, stdClass $arguments = null ) {
 		return array_keys( $value );
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use stdClass;
+
+/**
+ * Search array value by one of its key.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class ArrayKeys implements TransformerInterface {
+	/**
+	 * ArrayKeys constructor.
+	 *
+	 * @param stdClass|null $arguments required arguments.
+	 */
+	public function __construct( stdClass $arguments = null ) {}
+
+	/**
+	 * Search array value by one of its key.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed
+	 */
+	public function transform( $value ) {
+		return array_keys( $value );
+	}
+}

--- a/src/RemoteInboxNotifications/Transformers/ArraySearch.php
+++ b/src/RemoteInboxNotifications/Transformers/ArraySearch.php
@@ -13,34 +13,21 @@ use stdClass;
  */
 class ArraySearch implements TransformerInterface {
 	/**
-	 * A value to search in the array.
+	 * Search a given value in the array.
 	 *
-	 * @var string $value a value to search.
-	 */
-	private $value;
-
-	/**
-	 * ArraySearch constructor.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments required argument 'value'.
 	 *
-	 * @param stdClass|null $arguments required arguments.
-	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
+	 * @throws InvalidArgumentException Throws when the required 'value' is missing.
+	 *
+	 * @return mixed|null
 	 */
-	public function __construct( stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null ) {
 		if ( ! isset( $arguments->value ) ) {
 			throw new InvalidArgumentException( "ArraySearch: Missing required argument 'value'" );
 		}
 
-		$this->value = $arguments->value;
-	}
-	/**
-	 * Search a given value in the array.
-	 *
-	 * @param mixed $value a value to transform.
-	 *
-	 * @return mixed|null
-	 */
-	public function transform( $value ) {
-		$key = array_search( $this->value, $value, true );
+		$key = array_search( $arguments->value, $value, true );
 		if ( false !== $key ) {
 			return $value[ $key ];
 		}

--- a/src/RemoteInboxNotifications/Transformers/ArraySearch.php
+++ b/src/RemoteInboxNotifications/Transformers/ArraySearch.php
@@ -23,15 +23,26 @@ class ArraySearch implements TransformerInterface {
 	 * @return mixed|null
 	 */
 	public function transform( $value, stdClass $arguments = null ) {
-		if ( ! isset( $arguments->value ) ) {
-			throw new InvalidArgumentException( "ArraySearch: Missing required argument 'value'" );
-		}
-
 		$key = array_search( $arguments->value, $value, true );
 		if ( false !== $key ) {
 			return $value[ $key ];
 		}
 
 		return null;
+	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		if ( ! isset( $arguments->value ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArraySearch.php
+++ b/src/RemoteInboxNotifications/Transformers/ArraySearch.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * Searches a given a given value in the array.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class ArraySearch implements TransformerInterface {
+	/**
+	 * A value to search in the array.
+	 *
+	 * @var string $value a value to search.
+	 */
+	private $value;
+
+	/**
+	 * ArraySearch constructor.
+	 *
+	 * @param stdClass|null $arguments required arguments.
+	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
+	 */
+	public function __construct( stdClass $arguments = null ) {
+		if ( ! isset( $arguments->value ) ) {
+			throw new InvalidArgumentException( "ArraySearch: Missing required argument 'value'" );
+		}
+
+		$this->value = $arguments->value;
+	}
+	/**
+	 * Search a given value in the array.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed|null
+	 */
+	public function transform( $value ) {
+		$key = array_search( $this->value, $value, true );
+		if ( false !== $key ) {
+			return $value[ $key ];
+		}
+
+		return null;
+	}
+}

--- a/src/RemoteInboxNotifications/Transformers/ArrayValues.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayValues.php
@@ -22,4 +22,15 @@ class ArrayValues implements TransformerInterface {
 	public function transform( $value, stdClass $arguments = null ) {
 		return array_values( $value );
 	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		return true;
+	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayValues.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayValues.php
@@ -12,20 +12,14 @@ use stdClass;
  */
 class ArrayValues implements TransformerInterface {
 	/**
-	 * ArrayValues constructor.
-	 *
-	 * @param stdClass|null $arguments required arguments.
-	 */
-	public function __construct( stdClass $arguments = null ) {}
-
-	/**
 	 * Search array value by one of its key.
 	 *
-	 * @param mixed $value a value to transform.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments arguments.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value ) {
+	public function transform( $value, stdClass $arguments = null ) {
 		return array_values( $value );
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/ArrayValues.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayValues.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use stdClass;
+
+/**
+ * Search array value by one of its key.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class ArrayValues implements TransformerInterface {
+	/**
+	 * ArrayValues constructor.
+	 *
+	 * @param stdClass|null $arguments required arguments.
+	 */
+	public function __construct( stdClass $arguments = null ) {}
+
+	/**
+	 * Search array value by one of its key.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed
+	 */
+	public function transform( $value ) {
+		return array_values( $value );
+	}
+}

--- a/src/RemoteInboxNotifications/Transformers/DotNotation.php
+++ b/src/RemoteInboxNotifications/Transformers/DotNotation.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use InvalidArgumentException;
+use stdClass;
+
+/**
+ * Find an array value by dot notation.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class DotNotation implements  TransformerInterface {
+	/**
+	 * Path for the searching array value.
+	 *
+	 * @var string array path
+	 */
+	private $path;
+
+	/**
+	 * DotNotation constructor.
+	 *
+	 * @param stdClass|null $arguments arguments.
+	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
+	 */
+	public function __construct( stdClass $arguments = null ) {
+		if ( ! isset( $arguments->path ) ) {
+			throw new InvalidArgumentException( "Dot: Missing required argument 'path'" );
+		}
+		$this->path = $arguments->path;
+	}
+	/**
+	 * Find given path from the given value.
+	 *
+	 * @param mixed $value a value to transform.
+	 *
+	 * @return mixed
+	 */
+	public function transform( $value ) {
+		if ( is_object( $value ) ) {
+			// if the value is an object, convert it to an array.
+			$value = json_decode( wp_json_encode( $value ), true );
+		}
+
+		return $this->get( $value, $this->path );
+	}
+
+	/**
+	 * Find the given $path in $array by dot notation.
+	 *
+	 * @param array  $array an array to search in.
+	 * @param string $path a path in the given array.
+	 * @param null   $default default value to return if $path was not found.
+	 *
+	 * @return mixed|null
+	 */
+	public function get( $array, $path, $default = null ) {
+		if ( isset( $array[ $path ] ) ) {
+			return $array[ $path ];
+		}
+
+		foreach ( explode( '.', $path ) as $segment ) {
+			if ( ! is_array( $array ) || ! array_key_exists( $segment, $array ) ) {
+				return $default;
+			}
+
+			$array = $array[ $segment ];
+		}
+
+		return $array;
+	}
+}

--- a/src/RemoteInboxNotifications/Transformers/DotNotation.php
+++ b/src/RemoteInboxNotifications/Transformers/DotNotation.php
@@ -12,39 +12,28 @@ use stdClass;
  * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
  */
 class DotNotation implements  TransformerInterface {
-	/**
-	 * Path for the searching array value.
-	 *
-	 * @var string array path
-	 */
-	private $path;
 
-	/**
-	 * DotNotation constructor.
-	 *
-	 * @param stdClass|null $arguments arguments.
-	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
-	 */
-	public function __construct( stdClass $arguments = null ) {
-		if ( ! isset( $arguments->path ) ) {
-			throw new InvalidArgumentException( "Dot: Missing required argument 'path'" );
-		}
-		$this->path = $arguments->path;
-	}
 	/**
 	 * Find given path from the given value.
 	 *
-	 * @param mixed $value a value to transform.
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments required argument 'path'.
+	 *
+	 * @throws InvalidArgumentException Throws when the required 'path' is missing.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value ) {
+	public function transform( $value, stdclass $arguments = null ) {
+		if ( ! isset( $arguments->path ) ) {
+			throw new InvalidArgumentException( "DotNotation: Missing required argument 'path'" );
+		}
+
 		if ( is_object( $value ) ) {
 			// if the value is an object, convert it to an array.
 			$value = json_decode( wp_json_encode( $value ), true );
 		}
 
-		return $this->get( $value, $this->path );
+		return $this->get( $value, $arguments->path );
 	}
 
 	/**

--- a/src/RemoteInboxNotifications/Transformers/DotNotation.php
+++ b/src/RemoteInboxNotifications/Transformers/DotNotation.php
@@ -24,10 +24,6 @@ class DotNotation implements  TransformerInterface {
 	 * @return mixed
 	 */
 	public function transform( $value, stdclass $arguments = null ) {
-		if ( ! isset( $arguments->path ) ) {
-			throw new InvalidArgumentException( "DotNotation: Missing required argument 'path'" );
-		}
-
 		if ( is_object( $value ) ) {
 			// if the value is an object, convert it to an array.
 			$value = json_decode( wp_json_encode( $value ), true );
@@ -59,5 +55,20 @@ class DotNotation implements  TransformerInterface {
 		}
 
 		return $array;
+	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		if ( ! isset( $arguments->path ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/RemoteInboxNotifications/Transformers/README.md
+++ b/src/RemoteInboxNotifications/Transformers/README.md
@@ -1,0 +1,169 @@
+# Option Transformer
+
+An option transformer is a class that transforms the given option value into a different value for the comparison operation.
+
+Transformers run in the order they are defined. Each transformer passes down the value it transformed to the next transformer to consume.
+
+Definition example:
+
+```
+  {
+    "slug": "test-note",
+     ...
+    ],
+    "rules": [
+      {
+        "type": "option",
+        "transformers": [
+            {
+                "use": "dot_notation",
+                "arguments": {
+                    "path": "industry"
+                }
+            },
+            {
+                "use": "array_column",
+                "arguments": {
+                    "key": "slug"
+                }
+            }
+        ],
+        "option_name": "woocommerce_onboarding_profile",
+        "operation": "!=",
+        "value": "fashion-apparel-accessories",
+        "default": []
+      }
+    ]
+  }
+```
+
+### ArrayColumn (array_column)
+
+This uses PHP's built-in `array_column` to select values by a given array key.
+
+
+Arguments:
+
+|name|descriont|
+|----|---------|
+| key | array key name |
+
+Definition:
+
+```php
+"transformers": [
+    {
+        "use": "array_column",
+        "arguments": {
+            "key": "industry"
+        }
+    }
+],
+```
+
+### ArrayFlatten (array_flatten)
+
+This flattens a nested array.
+
+Arguments: N/A
+
+Definition:
+
+```php
+"transformers": [
+    {
+        "use": "array_flatten"
+    }
+],
+```
+
+### ArrayKeys (array_keys)
+This uses PHP's built-in `array_keys` to return keys from an array.
+
+Arguments: N/A
+
+Definition:
+
+```php
+"transformers": [
+    {
+        "use": "array_keys"
+    }
+],
+```
+
+### ArraySearch (array_search)
+
+This uses PHP's built-in `array_search` to search a value in an array.
+
+Arguments:
+|name|descriont|
+|----|---------|
+| value | a value to search in the given array |
+
+Definition:
+
+```php
+"transformers": [
+    {
+        "use": "array_search",
+        "arguments": {
+            "value": "test"
+        }
+    }
+],
+```
+
+### ArrayValues (array_values)
+
+This uses PHP's built-in array_values to return values from an array.
+
+Arguments: N/A
+
+Definition:
+
+```php
+"transformers": [
+    {
+        "use": "array_values"
+    }
+],
+```
+
+### DotNotation (dot_notation)
+
+This uses dot notation to select a value in an array. Dot notation lets you access an array as if it is an object.
+
+Let's say we have the following array.
+
+```php
+$items = [
+    'name' => 'name',
+    'members' => ['member1', 'member2'] 
+];
+```
+
+
+ Example definition to select `$items['name']`:
+```php
+"transformers": [
+    {
+        "use": "dot_notation",
+        "arguments": {
+            "path": "name"
+        }
+    }
+],
+```
+
+Example definition to select `$items['members'][0]`:
+
+```php
+"transformers": [
+    {
+        "use": "dot_notation",
+        "arguments": {
+            "path": "members.0"
+        }
+    }
+],

--- a/src/RemoteInboxNotifications/Transformers/README.md
+++ b/src/RemoteInboxNotifications/Transformers/README.md
@@ -44,7 +44,7 @@ This uses PHP's built-in `array_column` to select values by a given array key.
 
 Arguments:
 
-|name|descriont|
+|name|description|
 |----|---------|
 | key | array key name |
 
@@ -97,7 +97,7 @@ Definition:
 This uses PHP's built-in `array_search` to search a value in an array.
 
 Arguments:
-|name|descriont|
+|name|description|
 |----|---------|
 | value | a value to search in the given array |
 

--- a/tests/remote-inbox-notifications/Transformers/array-column.php
+++ b/tests/remote-inbox-notifications/Transformers/array-column.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ArrayColumn tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayColumn;
+
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_ArrayColumn
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_ArrayColumn extends WC_Unit_Test_Case {
+	/**
+	 * Test it throw InvalidArgumentException when required argument is missing.
+	 *
+	 * @expectedException InvalidArgumentException
+	 */
+	public function test_it_throws_exception_when_required_argument_is_missing() {
+		$arguments = (object) array();
+		new ArrayColumn( $arguments );
+	}
+
+	/**
+	 * Test it returns value by array column.
+	 */
+	public function test_it_returns_value_by_array_column() {
+		$items = array(
+			array(
+				'name' => 'mothra',
+			),
+			array(
+				'name' => 'gezora',
+			),
+			array(
+				'name' => 'ghidorah',
+			),
+		);
+
+		$arguments    = (object) array( 'key' => 'name' );
+		$array_column = new ArrayColumn( $arguments );
+		$result       = $array_column->transform( $items );
+		$expected     = array( 'mothra', 'gezora', 'ghidorah' );
+		$this->assertEquals( $expected, $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/array-column.php
+++ b/tests/remote-inbox-notifications/Transformers/array-column.php
@@ -13,13 +13,12 @@ use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayColu
  */
 class WC_Tests_RemoteInboxNotifications_Transformers_ArrayColumn extends WC_Unit_Test_Case {
 	/**
-	 * Test it throw InvalidArgumentException when required argument is missing.
-	 *
-	 * @expectedException InvalidArgumentException
+	 * Test validate method returns false when 'key' argument is missing
 	 */
-	public function test_it_throws_exception_when_required_argument_is_missing() {
+	public function test_validate_returns_false_when_key_argument_is_missing() {
 		$array_column = new ArrayColumn();
-		$array_column->transform( array() );
+		$result       = $array_column->validate( (object) array() );
+		$this->assertFalse( false, $result );
 	}
 
 	/**

--- a/tests/remote-inbox-notifications/Transformers/array-column.php
+++ b/tests/remote-inbox-notifications/Transformers/array-column.php
@@ -18,8 +18,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_ArrayColumn extends WC_Unit
 	 * @expectedException InvalidArgumentException
 	 */
 	public function test_it_throws_exception_when_required_argument_is_missing() {
-		$arguments = (object) array();
-		new ArrayColumn( $arguments );
+		$array_column = new ArrayColumn();
+		$array_column->transform( array() );
 	}
 
 	/**
@@ -39,8 +39,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_ArrayColumn extends WC_Unit
 		);
 
 		$arguments    = (object) array( 'key' => 'name' );
-		$array_column = new ArrayColumn( $arguments );
-		$result       = $array_column->transform( $items );
+		$array_column = new ArrayColumn();
+		$result       = $array_column->transform( $items, $arguments );
 		$expected     = array( 'mothra', 'gezora', 'ghidorah' );
 		$this->assertEquals( $expected, $result );
 	}

--- a/tests/remote-inbox-notifications/Transformers/array-flatten.php
+++ b/tests/remote-inbox-notifications/Transformers/array-flatten.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * ArrayKeys tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayFlatten;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_ArrayKeys
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_ArrayFlatten extends WC_Unit_Test_Case {
+	/**
+	 * Test it returns flatten array
+	 */
+	public function test_it_returns_flatten_array() {
+		$items = array(
+			array(
+				'member1',
+			),
+			array(
+				'member2',
+			),
+			array(
+				'member3',
+			),
+		);
+
+		$array_keys = new ArrayFlatten();
+		$result     = $array_keys->transform( $items );
+		$this->assertEquals( array( 'member1', 'member2', 'member3' ), $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/array-keys.php
+++ b/tests/remote-inbox-notifications/Transformers/array-keys.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * ArrayKeys tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayKeys;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_ArrayKeys
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_ArrayKeys extends WC_Unit_Test_Case {
+	/**
+	 * Test it returns array values.
+	 */
+	public function test_it_returns_array_values() {
+		$items = array(
+			'size'  => 'XL',
+			'color' => 'gold',
+		);
+
+		$array_keys = new ArrayKeys();
+		$result     = $array_keys->transform( $items );
+		$this->assertEquals( array( 'size', 'color' ), $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/array-search.php
+++ b/tests/remote-inbox-notifications/Transformers/array-search.php
@@ -17,8 +17,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_ArraySearch extends WC_Unit
 	 * @expectedException InvalidArgumentException
 	 */
 	public function test_it_throws_exception_when_required_argument_is_missing() {
-		$arguments = (object) array();
-		new ArraySearch( $arguments );
+		$array_search = new ArraySearch();
+		$array_search->transform( array() );
 	}
 
 	/**
@@ -27,8 +27,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_ArraySearch extends WC_Unit
 	public function test_it_returns_null_if_value_is_not_found() {
 		$items        = array( 'item1', 'item2' );
 		$arguments    = (object) array( 'value' => 'item3' );
-		$array_column = new ArraySearch( $arguments );
-		$result       = $array_column->transform( $items );
+		$array_column = new ArraySearch();
+		$result       = $array_column->transform( $items, $arguments );
 		$this->assertEquals( null, $result );
 	}
 
@@ -38,8 +38,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_ArraySearch extends WC_Unit
 	public function test_it_returns_value_by_array_value() {
 		$items        = array( 'item1', 'item2' );
 		$arguments    = (object) array( 'value' => 'item2' );
-		$array_column = new ArraySearch( $arguments );
-		$result       = $array_column->transform( $items );
+		$array_column = new ArraySearch();
+		$result       = $array_column->transform( $items, $arguments );
 		$this->assertEquals( 'item2', $result );
 	}
 }

--- a/tests/remote-inbox-notifications/Transformers/array-search.php
+++ b/tests/remote-inbox-notifications/Transformers/array-search.php
@@ -12,13 +12,12 @@ use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArraySear
  */
 class WC_Tests_RemoteInboxNotifications_Transformers_ArraySearch extends WC_Unit_Test_Case {
 	/**
-	 * Test it throw InvalidArgumentException when required argument is missing.
-	 *
-	 * @expectedException InvalidArgumentException
+	 * Test validate method returns false when 'value' argument is missing
 	 */
-	public function test_it_throws_exception_when_required_argument_is_missing() {
-		$array_search = new ArraySearch();
-		$array_search->transform( array() );
+	public function test_validate_returns_false_when_value_argument_is_missing() {
+		$array_column = new ArraySearch();
+		$result       = $array_column->validate( (object) array() );
+		$this->assertFalse( false, $result );
 	}
 
 	/**

--- a/tests/remote-inbox-notifications/Transformers/array-search.php
+++ b/tests/remote-inbox-notifications/Transformers/array-search.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * ArraySearch tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArraySearch;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_ArraySearch
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_ArraySearch extends WC_Unit_Test_Case {
+	/**
+	 * Test it throw InvalidArgumentException when required argument is missing.
+	 *
+	 * @expectedException InvalidArgumentException
+	 */
+	public function test_it_throws_exception_when_required_argument_is_missing() {
+		$arguments = (object) array();
+		new ArraySearch( $arguments );
+	}
+
+	/**
+	 * Test it returns null if value is not found.
+	 */
+	public function test_it_returns_null_if_value_is_not_found() {
+		$items        = array( 'item1', 'item2' );
+		$arguments    = (object) array( 'value' => 'item3' );
+		$array_column = new ArraySearch( $arguments );
+		$result       = $array_column->transform( $items );
+		$this->assertEquals( null, $result );
+	}
+
+	/**
+	 * Test it returns value by array value.
+	 */
+	public function test_it_returns_value_by_array_value() {
+		$items        = array( 'item1', 'item2' );
+		$arguments    = (object) array( 'value' => 'item2' );
+		$array_column = new ArraySearch( $arguments );
+		$result       = $array_column->transform( $items );
+		$this->assertEquals( 'item2', $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/array-values.php
+++ b/tests/remote-inbox-notifications/Transformers/array-values.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * ArrayValues tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayValues;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_ArrayValues
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_ArrayValues extends WC_Unit_Test_Case {
+	/**
+	 * Test it returns array values.
+	 */
+	public function test_it_returns_array_values() {
+		$items        = array(
+			'size'  => 'XL',
+			'color' => 'gold',
+		);
+		$array_values = new ArrayValues();
+		$result       = $array_values->transform( $items );
+		$this->assertEquals( array( 'XL', 'gold' ), $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/dot-notation.php
+++ b/tests/remote-inbox-notifications/Transformers/dot-notation.php
@@ -19,8 +19,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation extends WC_Unit
 	 * @expectedException InvalidArgumentException
 	 */
 	public function test_it_throws_exception_when_required_argument_is_missing() {
-		$arguments = (object) array();
-		new DotNotation( $arguments );
+		$dot_notation = new DotNotation();
+		$dot_notation->transform( array() );
 	}
 
 	/**
@@ -28,11 +28,11 @@ class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation extends WC_Unit
 	 */
 	public function test_it_can_get_value_by_index() {
 		$arguments    = (object) array( 'path' => '0' );
-		$dot_notation = new DotNotation( $arguments );
+		$dot_notation = new DotNotation();
 		$item         = array( 'name' => 'test' );
 		$items        = array( $item );
 
-		$result = $dot_notation->transform( $items );
+		$result = $dot_notation->transform( $items, $arguments );
 		$this->assertEquals( $result, $item );
 	}
 
@@ -48,8 +48,8 @@ class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation extends WC_Unit
 			),
 		);
 
-		$dot_notation = new DotNotation( $arguments );
-		$result       = $dot_notation->transform( $items );
+		$dot_notation = new DotNotation();
+		$result       = $dot_notation->transform( $items, $arguments );
 		$this->assertEquals( 'nice!', $result );
 	}
 }

--- a/tests/remote-inbox-notifications/Transformers/dot-notation.php
+++ b/tests/remote-inbox-notifications/Transformers/dot-notation.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * DotNotation tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\DotNotation;
+
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation extends WC_Unit_Test_Case {
+
+	/**
+	 * Test it throw InvalidArgumentException when required argument is missing
+	 *
+	 * @expectedException InvalidArgumentException
+	 */
+	public function test_it_throws_exception_when_required_argument_is_missing() {
+		$arguments = (object) array();
+		new DotNotation( $arguments );
+	}
+
+	/**
+	 * Test it can get value by index
+	 */
+	public function test_it_can_get_value_by_index() {
+		$arguments    = (object) array( 'path' => '0' );
+		$dot_notation = new DotNotation( $arguments );
+		$item         = array( 'name' => 'test' );
+		$items        = array( $item );
+
+		$result = $dot_notation->transform( $items );
+		$this->assertEquals( $result, $item );
+	}
+
+	/**
+	 * Test it get getvalue by dot notation.
+	 */
+	public function test_it_can_get_value_by_dot_notation() {
+		$arguments = (object) array( 'path' => 'teams.mothra' );
+
+		$items = array(
+			'teams' => array(
+				'mothra' => 'nice!',
+			),
+		);
+
+		$dot_notation = new DotNotation( $arguments );
+		$result       = $dot_notation->transform( $items );
+		$this->assertEquals( 'nice!', $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/dot-notation.php
+++ b/tests/remote-inbox-notifications/Transformers/dot-notation.php
@@ -14,13 +14,12 @@ use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\DotNotati
 class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation extends WC_Unit_Test_Case {
 
 	/**
-	 * Test it throw InvalidArgumentException when required argument is missing
-	 *
-	 * @expectedException InvalidArgumentException
+	 * Test validate method returns false when 'path' argument is missing
 	 */
-	public function test_it_throws_exception_when_required_argument_is_missing() {
-		$dot_notation = new DotNotation();
-		$dot_notation->transform( array() );
+	public function test_validate_returns_false_when_path_argument_is_missing() {
+		$array_column = new DotNotation();
+		$result       = $array_column->validate( (object) array() );
+		$this->assertFalse( false, $result );
 	}
 
 	/**

--- a/tests/remote-inbox-notifications/transformer-service.php
+++ b/tests/remote-inbox-notifications/transformer-service.php
@@ -5,10 +5,7 @@
  * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
  */
 
-use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayColumn;
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayKeys;
-use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArraySearch;
-use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\DotNotation;
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerService;
 
 /**

--- a/tests/remote-inbox-notifications/transformer-service.php
+++ b/tests/remote-inbox-notifications/transformer-service.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * TransformerService tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayColumn;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArrayKeys;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\ArraySearch;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\DotNotation;
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerService;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_TransformerService
+ */
+class WC_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit_Test_Case {
+	/**
+	 * Test it creates a transformer with snake case 'use' value
+	 */
+	public function test_it_creates_a_transformer_with_snake_case_use_value() {
+		$array_keys = TransformerService::create_transformer( 'array_keys' );
+		$this->assertInstanceOf( ArrayKeys::class, $array_keys );
+	}
+
+	/**
+	 * Test it returns null when a transformer is not found.
+	 */
+	public function test_it_returns_null_when_transformer_is_not_found() {
+		$transformer = TransformerService::create_transformer( 'i_do_not_exist' );
+		$this->assertNull( $transformer );
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage Missing required config value: use
+	 */
+	public function test_it_throw_exception_when_transformer_config_is_missing_use() {
+		TransformerService::apply( array( 'value' ), array( new stdClass() ) );
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage Unable to find a transformer by name: i_do_not_exist
+	 */
+	public function test_it_throws_exception_when_transformer_is_not_found() {
+		$transformer = $this->transformer_config( 'i_do_not_exist' );
+		TransformerService::apply( array( 'value' ), array( $transformer ) );
+	}
+
+	/**
+	 * Given two transformers
+	 * When the second transformer returns null
+	 * Then the value transformed by the first transformer should be returned.
+	 */
+	public function test_it_returns_previously_transformed_value_when_transformer_returns_null() {
+		$dot_notation = $this->transformer_config( 'dot_notation', array( 'path' => 'industries' ) );
+		$array_search = $this->transformer_config( 'array_search', array( 'value' => 'i_do_not_exist' ) );
+		$items        = array(
+			'industries' => array( 'item1', 'item2' ),
+		);
+		$result       = TransformerService::apply( $items, array( $dot_notation, $array_search ) );
+		$this->assertEquals( $result, $items['industries'] );
+	}
+
+	/**
+	 * Given a nested array
+	 * When it uses DotNotation to select 'teams'
+	 * When it uses ArrayColumn to select 'members' in 'teams'
+	 * When it uses ArrayFlatten to flatten 'members'
+	 * When it uses ArraySearch to select 'mothra-member'
+	 * Then 'mothra-member' should be returned.
+	 */
+	public function test_it_returns_transformed_value() {
+		// Given.
+		$items = array(
+			'teams' => array(
+				array(
+					'name'    => 'mothra',
+					'members' => array( 'mothra-member' ),
+				),
+				array(
+					'name'    => 'gezora',
+					'members' => array( 'gezora-member' ),
+				),
+				array(
+					'name'    => 'ghidorah',
+					'members' => array( 'ghidorah-member' ),
+				),
+			),
+		);
+
+		// When.
+		$dot_notation  = $this->transformer_config( 'dot_notation', array( 'path' => 'teams' ) );
+		$array_column  = $this->transformer_config( 'array_column', array( 'key' => 'members' ) );
+		$array_flatten = $this->transformer_config( 'array_flatten' );
+		$array_search  = $this->transformer_config( 'array_search', array( 'value' => 'mothra-member' ) );
+
+		$result = TransformerService::apply( $items, array( $dot_notation, $array_column, $array_flatten, $array_search ) );
+
+		// Then.
+		$this->assertEquals( 'mothra-member', $result );
+	}
+
+	/**
+	 * Creates transformer config object
+	 *
+	 * @param string $name name of the transformer in snake_case.
+	 * @param array  $arguments transformer arguments.
+	 *
+	 * @return stdClass
+	 */
+	private function transformer_config( $name, array $arguments = array() ) {
+		$transformer            = new stdClass();
+		$transformer->use       = $name;
+		$transformer->arguments = (object) $arguments;
+		return $transformer;
+	}
+}


### PR DESCRIPTION
Fixes #6936 

This PR adds `Transformer` concept to the Remote Inbox Notification.

I think the Remote Inbox Notification works very similarly to how an E.T.L (Extract, Transform, and Load) system works, but without a transformer. We extract a value from the database, compare them, and load a note. I figured adding transformers makes sense and it's flexible.

This is an example of transformer definition.

```
  {
    "slug": "wc-payments-qualitative-feedback",
     ....
    ],
    "rules": [
      {
        "type": "option",
        "transformers": [
            {
                "use": "dotNotation",
                "arguments": {
                    "path": "industry"
                }
            },
            {
                "use": "arrayColumn",
                "arguments": {
                    "key": "slug"
                }
            },
            {
                "use": "arraySearch",
                "arguments": {
                    "value": "cbd-other-hemp-derived-products"
                }
            }
        ],
        "option_name": "woocommerce_onboarding_profile",
        "operation": "!=",
        "value": "cbd-other-hemp-derived-products",
        "default": []
      }
    ]
  }
```

This example uses three transformers -- dotNotation, arrayColumn, and arraySearch.

We use dotNotation transformer to select `industry` array -> use arrayColumn to get the values -> search for `cbd-other-hemp-derived-products`.

**woocommerce_onboarding_profile** value

```
Array
(
    [setup_client] => 
    [industry] => Array
        (
            [0] => Array
                (
                    [slug] => food-drink
                )

            [1] => Array
                (
                    [slug] => fashion-apparel-accessories
                )

            [2] => Array
                (
                    [slug] => health-beauty
                )

            [3] => Array
                (
                    [slug] => other
                    [detail] => test
                )

        )

    [product_types] => Array
        (
            [0] => downloads
        )

    [product_count] => 0
    [selling_venues] => no
    [business_extensions] => Array
        (
        )

    [theme] => twentytwentyone
    [completed] => 1
)
```

The [$option_value](https://github.com/woocommerce/woocommerce-admin/pull/6948/files#diff-d1413e004b7819467e9e6b12e3d4b0b19f27d4f719187bf828b8797a21b55fafR45) would be an array of selected industries since `arraySearch` transformer wasn't able to find `cbd-other-hemp-derived-products`

```
(
    [0] => food-drink
    [1] => fashion-apparel-accessories
    [2] => health-beauty
    [3] => other
)
```


### Detailed test instructions:

1. Prepare woocommerce.com local test environment.
2. Once your woocommerce.com local test environment is ready, open `plugins/wccom-plugins/inbox-notifications/includes/notifications.json.php` and add the following test note definition.

```
[
  {
    "slug": "test-note",
    "type": "info",
    "status": "unactioned",
    "is_snoozable": 0,
    "source": "woocommerce.com",
    "locales": [
      {
        "locale": "en_US",
        "title": "test note",
        "content": "test note"
      }
    ],
    "actions": [
      {
        "name": "test note",
        "locales": [
          {
            "locale": "en_US",
            "label": "Share feedback"
          }
        ],
        "url": "https://automattic.survey.fm/wc-pay-new",
        "url_is_admin_query": false,
        "is_primary": true,
        "status": "actioned"
      }
    ],
    "rules": [
      {
        "type": "option",
        "transformers": [
            {
                "use": "dot_notation",
                "arguments": {
                    "path": "industry"
                }
            },
            {
                "use": "array_column",
                "arguments": {
                    "key": "slug"
                }
            },
            {
                "use": "array_search",
                "arguments": {
                    "value": "fashion-apparel-accessories"
                }
            }
        ],
        "option_name": "woocommerce_onboarding_profile",
        "operation": "=",
        "value": "fashion-apparel-accessories",
        "default": []
      }
    ]
  }
]
```

3. Open `src/RemoteInboxNotifications/DataSourcePoller.php` in WC Admin and replace `DATA_SOURCES` to use your `woocommerce.test` local environment. 
4. Start OBW and choose 'Fashion, apparel, and accessories from the Industry selection.
5. Install [WP Crontrol 
](https://wordpress.org/plugins/wp-crontrol/)
6. Navigate to Tools -> Cron Events and run `wp_admin_daily`
7. Navigate to WooCommerce -> Home and confirm that the `test note` has been added.