### PR TITLE
Make asset registry loading safer, fallback to different file suffix if it doesn't exist

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: Task list component with new Experimental Task list. #6849
 - Dev: Add disabled prop to SelectControl #6902
 - Update: Redirect to WC Home after setting up a payment method #6891
+- Dev: Fix a bug where trying to load an asset registry causes a crash. #6951
 
 == 2.2.0 3/30/2021 ==
 

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -244,15 +244,30 @@ class Loader {
 	}
 
 	/**
-	 * Gets a script asset filename
+	 * Gets a script asset registry filename. The asset registry lists dependencies for the given script.
 	 *
+	 * @param  string $script_path_name Path to where the script asset registry is contained.
 	 * @param  string $file File name (without extension).
 	 * @return string complete asset filename.
+	 *
+	 * @throws Exception Throws an exception when a readable asset registry file cannot be found.
 	 */
-	public static function get_script_asset_filename( $file ) {
-		$minification_suffix = Features::exists( 'minified-js' ) ? '.min' : '';
+	public static function get_script_asset_filename( $script_path_name, $file ) {
+		$minification_supported = Features::exists( 'minified-js' );
+		$script_min_filename    = $file . '.min.asset.php';
+		$script_nonmin_filename = $file . '.asset.php';
+		$script_asset_path      = WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/';
 
-		return $file . $minification_suffix . '.asset.php';
+		// Check minification is supported first, to avoid multiple is_readable checks when minification is
+		// not supported.
+		if ( $minification_supported && is_readable( $script_asset_path . $script_min_filename ) ) {
+			return $script_min_filename;
+		} elseif ( is_readable( $script_asset_path . $script_nonmin_filename ) ) {
+			return $script_nonmin_filename;
+		} else {
+			// could not find an asset file, throw an error.
+			throw new \Exception( 'Could not find asset registry for ' . $script_path_name );
+		}
 	}
 
 	/**
@@ -369,20 +384,26 @@ class Loader {
 		);
 
 		foreach ( $scripts as $script ) {
-			$script_path_name       = isset( $scripts_map[ $script ] ) ? $scripts_map[ $script ] : str_replace( 'wc-', '', $script );
-			$script_assets_filename = self::get_script_asset_filename( 'index' );
-			$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
+			$script_path_name = isset( $scripts_map[ $script ] ) ? $scripts_map[ $script ] : str_replace( 'wc-', '', $script );
 
-			wp_register_script(
-				$script,
-				self::get_url( $script_path_name . '/index', 'js' ),
-				$script_assets ['dependencies'],
-				$js_file_version,
-				true
-			);
+			try {
+				$script_assets_filename = self::get_script_asset_filename( $script_path_name, 'index' );
+				$script_assets          = require WC_ADMIN_ABSPATH . WC_ADMIN_DIST_JS_FOLDER . $script_path_name . '/' . $script_assets_filename;
 
-			if ( in_array( $script, $translated_scripts, true ) ) {
-				wp_set_script_translations( $script, 'woocommerce-admin' );
+				wp_register_script(
+					$script,
+					self::get_url( $script_path_name . '/index', 'js' ),
+					$script_assets ['dependencies'],
+					$js_file_version,
+					true
+				);
+
+				if ( in_array( $script, $translated_scripts, true ) ) {
+					wp_set_script_translations( $script, 'woocommerce-admin' );
+				}
+			} catch ( \Exception $e ) {
+				// Avoid crashing WordPress if an asset file could not be loaded.
+				wc_caught_exception( $e, __CLASS__ . '::' . __FUNCTION__, $script_path_name );
 			}
 		}
 


### PR DESCRIPTION
Currently the code that determines the asset registry filename depends on `Features` which is fragile since 3PDs can switch features off via a filter, this means it looks for the wrong asset registry file and crashes both Wordpress and WooCommerce.

This makes the asset registry file loading safer in 2 ways:

1. It checks through the `min` and non `min` file suffixes to try find the right registry to load
2. Instead of crashing Wordpress the error is caught and logged. In this case wc-admin JS will not load but it won't crash Wordpress entirely.

I considered bundling the non-min file, but I think this achieves the same safety, if someone accidentally bundles the wrong file suffix for their asset registry, the app will continue to function. Since the asset files have the exact same contents this seems like a good approach.

I do try to minimize the is_readable check to 1 check where possible, by also checking `Features` first.

Testing instructions:

1. In an environment where minified js is enabled, try renaming some asset files under `dist` by removing the `min` suffix. Wordpress should continue to function and WooCommerce should continue working properly.

2. try deleting an asset registry altogether. You should see that Wordpress does not crash, but going to WooCommerce admin will present a white screen. The error should be logged (via wc_caught_exception)