### PR TITLE
Fix an issue with OBW when wc-pay and Jetpack are both being installed

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -140,6 +140,12 @@ In case the report shows "no data", please reimport historical data by following
 -   Click on the 3 dots of the card, click `Hide this`, it should make the card disappear, it should also not show on refresh.
     This can't be shown again unless the `woocommerce_show_marketplace_suggestions` option is deleted (through PHPMyAdmin or using `wp option delete woocommerce_show_marketplace_suggestions`).
 
+### Fix an issue with OBW when wc-pay and Jetpack are both being installed. #6957
+
+- Complete the OBW until you get to the business details step.
+- Deselect "Add recommended business features to my site", and select only Jetpack and WooCommerce Payments for installation.
+- The plugins should be installed and activated correctly, and you should be able to continue in the flow.
+
 ## 2.2.0
 
 ### Fixed event tracking for merchant email notes #6616

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Redirect to WC Home after setting up a payment method #6891
 - Dev: Fix a bug where trying to load an asset registry causes a crash. #6951
+- Fix: Address an issue with OBW when installing only WooCommerce payments and Jetpack. #6957
 
 == 2.2.0 3/30/2021 ==
 

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -220,11 +220,12 @@ class Plugins extends \WC_REST_Data_Controller {
 	public function install_plugins( $request ) {
 		$plugins = explode( ',', $request['plugins'] );
 
-		// If both Jetpack and WooCommerce Payments are being installed, Jetpack must be installed first.
-		if ( in_array( 'jetpack', $plugins, true ) && in_array( 'woocommerce-payments', $plugins, true ) ) {
-			array_unshift( $plugins, 'jetpack' );
-			$plugins = array_unique( $plugins );
-		}
+		/**
+		 * Filter the list of plugins to install.
+		 *
+		 * @param array $plugins A list of the plugins to install.
+		 */
+		$plugins = apply_filters( 'woocommerce_admin_plugins_pre_install', $plugins );
 
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
@@ -379,11 +380,12 @@ class Plugins extends \WC_REST_Data_Controller {
 		// the mollie-payments-for-woocommerce plugin calls `WP_Filesystem()` during it's activation hook, which crashes without this include.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
-		// If both Jetpack and WooCommerce Payments are being activated, Jetpack must be activated first.
-		if ( in_array( 'jetpack', $plugins, true ) && in_array( 'woocommerce-payments', $plugins, true ) ) {
-			array_unshift( $plugins, 'jetpack' );
-			$plugins = array_unique( $plugins );
-		}
+		/**
+		 * Filter the list of plugins to activate.
+		 *
+		 * @param array $plugins A list of the plugins to activate.
+		 */
+		$plugins = apply_filters( 'woocommerce_admin_plugins_pre_activate', $plugins );
 
 		foreach ( $plugins as $plugin ) {
 			$slug = $plugin;

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -220,6 +220,12 @@ class Plugins extends \WC_REST_Data_Controller {
 	public function install_plugins( $request ) {
 		$plugins = explode( ',', $request['plugins'] );
 
+		// If both Jetpack and WooCommerce Payments are being installed, Jetpack must be installed first.
+		if ( in_array( 'jetpack', $plugins, true ) && in_array( 'woocommerce-payments', $plugins, true ) ) {
+			array_unshift( $plugins, 'jetpack' );
+			$plugins = array_unique( $plugins );
+		}
+
 		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
 			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
@@ -372,6 +378,12 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		// the mollie-payments-for-woocommerce plugin calls `WP_Filesystem()` during it's activation hook, which crashes without this include.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		// If both Jetpack and WooCommerce Payments are being activated, Jetpack must be activated first.
+		if ( in_array( 'jetpack', $plugins, true ) && in_array( 'woocommerce-payments', $plugins, true ) ) {
+			array_unshift( $plugins, 'jetpack' );
+			$plugins = array_unique( $plugins );
+		}
 
 		foreach ( $plugins as $plugin ) {
 			$slug = $plugin;

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -91,6 +91,8 @@ class Onboarding {
 			10,
 			2
 		);
+		add_action( 'woocommerce_admin_plugins_pre_activate', array( $this, 'activate_and_install_jetpack_ahead_of_wcpay' ) );
+		add_action( 'woocommerce_admin_plugins_pre_install', array( $this, 'activate_and_install_jetpack_ahead_of_wcpay' ) );
 
 		// Always hook into Jetpack connection even if outside of admin.
 		add_action( 'jetpack_site_registered', array( $this, 'set_woocommerce_setup_jetpack_opted_in' ) );
@@ -1069,5 +1071,24 @@ class Onboarding {
 		if ( ! WCAdminHelper::is_wc_admin_active_for( DAY_IN_SECONDS ) ) {
 			update_option( 'woocommerce_task_list_hidden', 'yes' );
 		}
+	}
+
+	/**
+	 * Ensure that Jetpack gets installed and activated ahead of WooCommerce Payments
+	 * if both are being installed/activated at the same time.
+	 *
+	 * See: https://github.com/Automattic/woocommerce-payments/issues/1663
+	 * See: https://github.com/Automattic/jetpack/issues/19624
+	 *
+	 * @param array $plugins A list of plugins to install or activate.
+	 *
+	 * @return array
+	 */
+	public static function activate_and_install_jetpack_ahead_of_wcpay( $plugins ) {
+		if ( in_array( 'jetpack', $plugins, true ) && in_array( 'woocommerce-payments', $plugins, true ) ) {
+			array_unshift( $plugins, 'jetpack' );
+			$plugins = array_unique( $plugins );
+		}
+		return $plugins;
 	}
 }


### PR DESCRIPTION
This PR addresses an issue in the OBW that would prevent you from continuing in the flow if both WCPay and Jetpack were selected for installation. Ultimately, this should probably be fixed in Jetpack and/or WCPay, but this PR patches a pretty bad user-experience by ensuring that Jetpack gets installed and activated ahead of WCPay.

See https://github.com/Automattic/jetpack/issues/19624 and https://github.com/Automattic/woocommerce-payments/issues/1663


### Screenshots

Before:

![image](https://user-images.githubusercontent.com/363749/117491160-73735d80-af35-11eb-9a6a-bf6147f58457.png)

After:

No screenshot: you should be able to continue in the flow without the above error.


### Detailed test instructions:

- Complete the OBW until you get to the business details step.
- Deselect "Add recommended business features to my site", and select only Jetpack and WooCommerce Payments for installation.
- Prior to this PR, you would receive an error message and would be unable to continue the flow.
- After applying this PR, the plugins should be installed and activated correctly, and you should be able to continue in the flow.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
