### PR TITLE
Bump @woocommerce/experimental version.

### DIFF
--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,7 +1,7 @@
-# Unreleased
+# 1.1.0
 
--   Add new (experimental) collapsible list item to collapse list items. #6869
--   Add new (experimental) list. #6787
+-   Add collapsible list item component. #6869
+-   Add new list component. #6787
 
 # 1.0.0
 

--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -1,8 +1,10 @@
 # Experimental
 
-This is a private package and will not be published for external use.
+This is a private package not meant for use by third parties.
 
-A collection of component imports and exports that are aliases for components transitioning from experimental to non-experimental.  This package prevents the component from being undefined when the `@wordpress/components` library version is unclear.
+A collection of component imports and exports that are aliases for components transitioning from experimental to non-experimental. This package prevents the component from being undefined when the `@wordpress/components` library version is unclear.
+
+It also contains several in-development components that are slated for inclusion in later releases of `@woocommerce/components`.
 
 ## Installation
 
@@ -14,7 +16,7 @@ npm install @woocommerce/experimental --save
 
 ## Usage
 
-Simply import the component name with the `__experimental` prefix.  If found, the non-experimental version will be imported and if not, this will fallback to the experimental version.
+Simply import the component name with the `__experimental` prefix. If found, the non-experimental version will be imported and if not, this will fallback to the experimental version.
 
 ```jsx
 import { Text } from '@woocommerce/experimental';

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Update `@woocommerce/experimental` version number in prep for publishing.

This is in support of the WC Pay overview page task list.

No changelog.