### PR TITLE
Move TaskItem component to experimental package for reuse.

### DIFF
--- a/client/task-list/style.scss
+++ b/client/task-list/style.scss
@@ -19,32 +19,6 @@
 				}
 			}
 
-			.woocommerce-list__item:not(.complete) {
-				.woocommerce-task__icon {
-					border: 1px solid $gray-100;
-					background: $white;
-				}
-			}
-
-			.woocommerce-list__item.complete {
-				.woocommerce-list__item-title {
-					color: $gray-700;
-				}
-			}
-
-			.woocommerce-list__item-before .woocommerce-task__icon {
-				border-radius: 50%;
-				width: 32px;
-				height: 32px;
-			}
-
-			.woocommerce-list__item-before .woocommerce-task__icon svg {
-				fill: $white;
-				position: relative;
-				top: 4px;
-				left: 5px;
-			}
-
 			.woocommerce-list__item-text {
 				.woocommerce-pill {
 					padding: 1px $gap-smaller;
@@ -56,13 +30,6 @@
 				min-width: unset;
 			}
 		}
-	}
-
-	.woocommerce-task__additional-info,
-	.woocommerce-task__estimated-time {
-		color: $gray-700;
-		font-weight: 400;
-		font-size: 12px;
 	}
 
 	#wpbody-content {

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -9,12 +9,12 @@ import { EllipsisMenu, Badge } from '@woocommerce/components';
 import { updateQueryString } from '@woocommerce/navigation';
 import { OPTIONS_STORE_NAME, ONBOARDING_STORE_NAME } from '@woocommerce/data';
 import { recordEvent } from '@woocommerce/tracks';
-import { Text, List, CollapsibleList } from '@woocommerce/experimental';
-
-/**
- * Internal dependencies
- */
-import { TaskItem } from './task-item';
+import {
+	Text,
+	List,
+	CollapsibleList,
+	TaskItem,
+} from '@woocommerce/experimental';
 
 export const TaskList = ( {
 	query,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7759,6 +7759,15 @@
 			"integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
 			"dev": true
 		},
+		"@types/dompurify": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.2.2.tgz",
+			"integrity": "sha512-8nNWfAa8/oZjH3OLY5Wsxu9ueo0NwVUotIi353g0P2+N5BuTLJyAVOnF4xBUY0NyFUGJHY05o1pO2bqLto+lmA==",
+			"dev": true,
+			"requires": {
+				"@types/trusted-types": "*"
+			}
+		},
 		"@types/expect-puppeteer": {
 			"version": "4.4.5",
 			"resolved": "https://registry.npmjs.org/@types/expect-puppeteer/-/expect-puppeteer-4.4.5.tgz",
@@ -8279,6 +8288,12 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
 			"integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==",
+			"dev": true
+		},
+		"@types/trusted-types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.0.tgz",
+			"integrity": "sha512-I8MnZqNXsOLHsU111oHbn3khtvKMi5Bn4qVFsIWSJcCP1KKDiXX5AEw8UPk0nSopeC+Hvxt6yAy1/a5PailFqg==",
 			"dev": true
 		},
 		"@types/uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
 				"config": "^3.2.4",
 				"eslint": "6.7.2",
 				"jest": "^24.9.0",
+				"prettier": "npm:wp-prettier@1.19.1",
 				"puppeteer": "^2.0.0"
 			},
 			"dependencies": {
@@ -134,6 +135,11 @@
 							}
 						}
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@1.19.1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 				}
 			}
 		},
@@ -10192,8 +10198,12 @@
 				"@babel/runtime": "7.14.0",
 				"@wordpress/components": "10.2.0",
 				"@wordpress/element": "2.19.0",
+				"@wordpress/i18n": "3.17.0",
+				"@wordpress/icons": "2.9.0",
 				"@wordpress/keycodes": "2.18.0",
 				"classnames": "^2.3.1",
+				"dompurify": "2.2.7",
+				"gridicons": "3.3.1",
 				"react-transition-group": "4.4.1"
 			},
 			"dependencies": {
@@ -15218,6 +15228,15 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"optional": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"bl": {
 			"version": "4.1.0",
@@ -21064,6 +21083,12 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
+		},
 		"filelist": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -26591,6 +26616,7 @@
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}
@@ -38931,6 +38957,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
 		"@testing-library/react-hooks": "3.7.0",
 		"@testing-library/user-event": "13.1.8",
 		"@types/cookie": "0.4.0",
+		"@types/dompurify": "^2.2.2",
 		"@types/expect-puppeteer": "4.4.5",
 		"@types/history": "4.7.8",
 		"@types/jest": "26.0.23",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Add task item component.
+
 # 1.1.0
 
 -   Add collapsible list item component. #6869

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 1.2.0
 
--   Add task item component.
+-   Add task item component. #6978
 
 # 1.1.0
 

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -24,11 +24,18 @@
 		"@babel/runtime": "7.14.0",
 		"@wordpress/components": "10.2.0",
 		"@wordpress/element": "2.19.0",
+		"@wordpress/i18n": "3.17.0",
+		"@wordpress/icons": "2.9.0",
 		"@wordpress/keycodes": "2.18.0",
 		"classnames": "^2.3.1",
+		"dompurify": "2.2.7",
+		"gridicons": "3.3.1",
 		"react-transition-group": "4.4.1"
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"devDependencies": {
+		"@types/dompurify": "^2.2.2"
 	}
 }

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -33,6 +33,13 @@ $task-alert-yellow: #f0b849;
 		color: $foreground-color;
 	}
 
+	.woocommerce-task__additional-info,
+	.woocommerce-task__estimated-time {
+		color: $gray-700;
+		font-weight: 400;
+		font-size: 12px;
+	}
+
 	.woocommerce-task-list__item-before {
 		display: flex;
 		align-items: center;
@@ -81,6 +88,13 @@ $task-alert-yellow: #f0b849;
 
 		.woocommerce-task-list__item-content {
 			display: none;
+		}
+	}
+
+	&:not(.complete) {
+		.woocommerce-task__icon {
+			border: 1px solid $gray-100;
+			background: $white;
 		}
 	}
 

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -4,15 +4,23 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
 import { Button, Tooltip } from '@wordpress/components';
-import { Text, ListItem } from '@woocommerce/experimental';
 import NoticeOutline from 'gridicons/dist/notice-outline';
 import classnames from 'classnames';
+import { sanitize } from 'dompurify';
 
 /**
  * Internal dependencies
  */
-import './task-item.scss';
-import sanitizeHTML from '../lib/sanitize-html';
+import { Text, ListItem } from '../';
+
+const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong', 'p', 'br' ];
+const ALLOWED_ATTR = [ 'target', 'href', 'rel', 'name', 'download' ];
+
+const sanitizeHTML = ( html: string ) => {
+	return {
+		__html: sanitize( html, { ALLOWED_TAGS, ALLOWED_ATTR } ),
+	};
+};
 
 type TaskLevel = 1 | 2 | 3;
 

--- a/packages/experimental/src/index.js
+++ b/packages/experimental/src/index.js
@@ -36,3 +36,4 @@ export const useSlot = useSlotHook || __experimentalUseSlot;
 export { ExperimentalListItem as ListItem } from './experimental-list/experimental-list-item';
 export { ExperimentalList as List } from './experimental-list/experimental-list';
 export { ExperimentalCollapsibleList as CollapsibleList } from './experimental-list/collapsible-list';
+export { TaskItem } from './experimental-list/task-item';

--- a/packages/experimental/src/style.scss
+++ b/packages/experimental/src/style.scss
@@ -3,3 +3,4 @@
  */
 @import 'experimental-list/style.scss';
 @import 'experimental-list/collapsible-list/style.scss';
+@import 'experimental-list/task-item.scss';


### PR DESCRIPTION
In support of https://github.com/automattic/woocommerce-payments/issues/1657, this PR moves the `TaskItem` component to the `@woocommerce/experimental` package so it can be reused.

After this PR is merged, the package will be published.

### Detailed test instructions:

- Smoke test the Task List
- Add `level: 2` and `level: 1` props to some tasks to verify priority still works.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

No changelog.
