### PR TITLE
Make sure transformers exist

### DIFF
--- a/src/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -72,10 +72,12 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 			return false;
 		}
 
-		foreach ( $rule->transformers as $transform_args ) {
-			$transformer = TransformerService::create_transformer( $transform_args->use );
-			if ( ! $transformer->validate( $transform_args->arguments ) ) {
-				return false;
+		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
+			foreach ( $rule->transformers as $transform_args ) {
+				$transformer = TransformerService::create_transformer( $transform_args->use );
+				if ( ! $transformer->validate( $transform_args->arguments ) ) {
+					return false;
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes an error in https://github.com/woocommerce/woocommerce-admin/pull/6948

It only runs the transformers when the config exists. 

