### PR TITLE
Avoid duplicate preload tags.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Correct the left position of transient notices when the new nav is used. #6914
 - Fix: Exclude WC Shipping for store that are only offering downloadable products #6917
 - Fix: SelectControl focus and de-focus bug #6906
+- Fix: Multiple preload tag output bug. #6998
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Update: Task list component with new Experimental Task list. #6849
 - Update: Experimental task list import to the experimental package. #6950


### PR DESCRIPTION
Fixes #6841

### Detailed test instructions:

- Create a new plugin `npm run create-wc-extension`
- Add `wc-components` as one of the script dependencies
- `npm install && npm start` and activate the plugin
- View the page source of a WooCommerce Admin pages such as Analytics > Overview
- Verify that the preload link for `components/index.js` is not shown twice

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
