### PR TITLE
Fix advanced filter operator selector styling.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Fix style regression with the Chart header. #7002
+-   Fix styling of the advanced filter operator selection. #7005
 -   Remove the use of Dashicons and replace with @wordpress/icons or gridicons #7020
 
 # 6.2.0

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -10,15 +10,24 @@
 		}
 	}
 
-	.components-select-control__input {
-		height: 38px;
-		padding: 0 0 0 $gap-smaller;
-		margin: 0;
+	.components-select-control {
+		.components-input-control__container {
+			.components-select-control__input {
+				height: 38px;
+				padding: 0 0 0 $gap-smaller;
+				margin: 0;
+			}
+		}
 	}
 
 	.components-card__header {
 		.components-base-control__field {
 			margin-bottom: 0;
+		}
+
+		p {
+			display: flex;
+			line-height: 38px;
 		}
 	}
 
@@ -29,12 +38,12 @@
 	@include breakpoint( '<400px' ) {
 		margin: $gap-small 0;
 	}
-}
 
-.woocommerce-filters-advanced__title-select {
-	width: 70px;
-	display: inline-block;
-	margin: 0 $gap-smaller;
+	.woocommerce-filters-advanced__title-select {
+		width: 70px;
+		display: inline-block;
+		margin: 0 $gap-smaller;
+	}
 }
 
 .woocommerce-filters-advanced__list {

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Call existing filters for leaderboards in analytics. #6626
 - Fix: Set target to blank for the external links #6999
 - Fix style regression with the Chart header. #7002
+- Fix styling of the advanced filter operator selection. #7005
 - Fix: Deprecated warnings from select control @wordpress/data-controls. #7007
 - Tweak: Only fetch remote payment gateway recommendations when opted in #6964
 - Tweak: Setup checklist copy revert. #7015


### PR DESCRIPTION
Fixes #6864.

Fixes some regressions in styling of the advanced filter select control introduced in #5753. Just needed to increase the specificity of some selectors now that the components are nested further and have CSS-in-JS.

### Screenshots

<img width="289" alt="Screen Shot 2021-05-18 at 10 37 11 AM" src="https://user-images.githubusercontent.com/63922/118670932-44ba7a00-b7b4-11eb-8741-66d11d81e024.png">


### Detailed test instructions:

- Go to a report with advanced filters, like Orders
- Open advanced filters menu (under "show")
- Verify the header is a single line and aligned vertically centered
- Verify the styling of other <select> elements in the advanced filters

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
