### PR TITLE
Rule Processing: pass in default

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Dev: Add source param support for notes query. #6979
 - Enhancement: Add expand/collapse to extendable task list. #6910
 - Enhancement: Add task hierarchy support to extended task list. #6916
+- Fix: Rule Processing Transformer to handle dotNotation default value #7009
 - Fix: Remove Navigation's uneeded SlotFill context #6832
 - Fix: Report filters expecting specific ordering. #6847
 - Fix: Render bug with report comparison mode selections. #6862

--- a/src/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -42,7 +42,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		}
 
 		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
-			$option_value = TransformerService::apply( $option_value, $rule->transformers );
+			$option_value = TransformerService::apply( $option_value, $rule->transformers, $rule->default );
 		}
 
 		return ComparisonOperation::compare(

--- a/src/RemoteInboxNotifications/TransformerInterface.php
+++ b/src/RemoteInboxNotifications/TransformerInterface.php
@@ -17,10 +17,11 @@ interface TransformerInterface {
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments arguments.
+	 * @param string|null   $default default value.
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null);
+	public function transform( $value, stdClass $arguments = null, $default = null);
 
 	/**
 	 * Validate Transformer arguments.

--- a/src/RemoteInboxNotifications/TransformerService.php
+++ b/src/RemoteInboxNotifications/TransformerService.php
@@ -34,13 +34,14 @@ class TransformerService {
 	/**
 	 * Apply transformers to the given value.
 	 *
-	 * @param mixed $target_value a value to transform.
-	 * @param array $transformer_configs transform configuration.
+	 * @param mixed  $target_value a value to transform.
+	 * @param array  $transformer_configs transform configuration.
+	 * @param string $default default value.
 	 *
 	 * @throws InvalidArgumentException Throws when one of the requried arguments is missing.
 	 * @return mixed|null
 	 */
-	public static function apply( $target_value, array $transformer_configs ) {
+	public static function apply( $target_value, array $transformer_configs, $default ) {
 		foreach ( $transformer_configs as $transformer_config ) {
 			if ( ! isset( $transformer_config->use ) ) {
 				throw new InvalidArgumentException( 'Missing required config value: use' );
@@ -55,7 +56,7 @@ class TransformerService {
 				throw new InvalidArgumentException( "Unable to find a transformer by name: {$transformer_config->use}" );
 			}
 
-			$transformed_value = $transformer->transform( $target_value, $transformer_config->arguments );
+			$transformed_value = $transformer->transform( $target_value, $transformer_config->arguments, $default );
 			// if the transformer returns null, then return the previously transformed value.
 			if ( null === $transformed_value ) {
 				return $target_value;

--- a/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayColumn.php
@@ -17,12 +17,13 @@ class ArrayColumn implements TransformerInterface {
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments required arguments 'key'.
+	 * @param string|null   $default default value.
 	 *
 	 * @throws InvalidArgumentException Throws when the required argument 'key' is missing.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
 		return array_column( $value, $arguments->key );
 	}
 

--- a/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayFlatten.php
@@ -16,10 +16,11 @@ class ArrayFlatten implements TransformerInterface {
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments arguments.
+	 * @param string|null   $default default value.
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
 		$return = array();
 		array_walk_recursive(
 			$value,

--- a/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayKeys.php
@@ -16,10 +16,11 @@ class ArrayKeys implements TransformerInterface {
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments arguments.
+	 * @param string|null   $default default value.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
 		return array_keys( $value );
 	}
 

--- a/src/RemoteInboxNotifications/Transformers/ArraySearch.php
+++ b/src/RemoteInboxNotifications/Transformers/ArraySearch.php
@@ -17,12 +17,13 @@ class ArraySearch implements TransformerInterface {
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments required argument 'value'.
+	 * @param string|null   $default default value.
 	 *
 	 * @throws InvalidArgumentException Throws when the required 'value' is missing.
 	 *
 	 * @return mixed|null
 	 */
-	public function transform( $value, stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
 		$key = array_search( $arguments->value, $value, true );
 		if ( false !== $key ) {
 			return $value[ $key ];

--- a/src/RemoteInboxNotifications/Transformers/ArrayValues.php
+++ b/src/RemoteInboxNotifications/Transformers/ArrayValues.php
@@ -16,10 +16,11 @@ class ArrayValues implements TransformerInterface {
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments arguments.
+	 * @param string|null   $default default value.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
 		return array_values( $value );
 	}
 

--- a/src/RemoteInboxNotifications/Transformers/DotNotation.php
+++ b/src/RemoteInboxNotifications/Transformers/DotNotation.php
@@ -11,25 +11,26 @@ use stdClass;
  *
  * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
  */
-class DotNotation implements  TransformerInterface {
+class DotNotation implements TransformerInterface {
 
 	/**
 	 * Find given path from the given value.
 	 *
 	 * @param mixed         $value a value to transform.
 	 * @param stdClass|null $arguments required argument 'path'.
+	 * @param string|null   $default default value.
 	 *
 	 * @throws InvalidArgumentException Throws when the required 'path' is missing.
 	 *
 	 * @return mixed
 	 */
-	public function transform( $value, stdclass $arguments = null ) {
+	public function transform( $value, stdclass $arguments = null, $default = null ) {
 		if ( is_object( $value ) ) {
 			// if the value is an object, convert it to an array.
 			$value = json_decode( wp_json_encode( $value ), true );
 		}
 
-		return $this->get( $value, $arguments->path );
+		return $this->get( $value, $arguments->path, $default );
 	}
 
 	/**

--- a/tests/remote-inbox-notifications/Transformers/dot-notation.php
+++ b/tests/remote-inbox-notifications/Transformers/dot-notation.php
@@ -51,4 +51,22 @@ class WC_Tests_RemoteInboxNotifications_Transformers_DotNotation extends WC_Unit
 		$result       = $dot_notation->transform( $items, $arguments );
 		$this->assertEquals( 'nice!', $result );
 	}
+
+	/**
+	 * Test it returns default value when path is undefined
+	 */
+	public function test_it_can_get_default_value_by_dot_notation() {
+		$arguments = (object) array( 'path' => 'teams.property_that_does_not_exist' );
+
+		$items = array(
+			'teams' => array(
+				'mothra' => 'nice!',
+			),
+		);
+
+		$dot_notation = new DotNotation();
+		$default      = 'default value';
+		$result       = $dot_notation->transform( $items, $arguments, $default );
+		$this->assertEquals( $default, $result );
+	}
 }

--- a/tests/remote-inbox-notifications/transformer-service.php
+++ b/tests/remote-inbox-notifications/transformer-service.php
@@ -33,7 +33,7 @@ class WC_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit_Test_
 	 * @expectedExceptionMessage Missing required config value: use
 	 */
 	public function test_it_throw_exception_when_transformer_config_is_missing_use() {
-		TransformerService::apply( array( 'value' ), array( new stdClass() ) );
+		TransformerService::apply( array( 'value' ), array( new stdClass() ), null );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class WC_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit_Test_
 	 */
 	public function test_it_throws_exception_when_transformer_is_not_found() {
 		$transformer = $this->transformer_config( 'i_do_not_exist' );
-		TransformerService::apply( array( 'value' ), array( $transformer ) );
+		TransformerService::apply( array( 'value' ), array( $transformer ), null );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class WC_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit_Test_
 		$items        = array(
 			'industries' => array( 'item1', 'item2' ),
 		);
-		$result       = TransformerService::apply( $items, array( $dot_notation, $array_search ) );
+		$result       = TransformerService::apply( $items, array( $dot_notation, $array_search ), null );
 		$this->assertEquals( $result, $items['industries'] );
 	}
 
@@ -93,7 +93,7 @@ class WC_Tests_RemoteInboxNotifications_TransformerService extends WC_Unit_Test_
 		$array_flatten = $this->transformer_config( 'array_flatten' );
 		$array_search  = $this->transformer_config( 'array_search', array( 'value' => 'mothra-member' ) );
 
-		$result = TransformerService::apply( $items, array( $dot_notation, $array_column, $array_flatten, $array_search ) );
+		$result = TransformerService::apply( $items, array( $dot_notation, $array_column, $array_flatten, $array_search ), null );
 
 		// Then.
 		$this->assertEquals( 'mothra-member', $result );


### PR DESCRIPTION
Pass in `$default` value to `dotNotation` rule. The value wasn't passed down to the `transform` function and wasn't being returned when a path didn't exist in an object.


