### PR TITLE
Rule processing transformers: Add count rule

### DIFF
--- a/src/RemoteInboxNotifications/Transformers/Count.php
+++ b/src/RemoteInboxNotifications/Transformers/Count.php
@@ -6,18 +6,18 @@ use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
 use stdClass;
 
 /**
- * Count elements in Countable or Array.
+ * Count elements in Array.
  *
  * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
  */
 class Count implements TransformerInterface {
 	/**
-	 *  Count elements in Countable or Array.
+	 *  Count elements in Array.
 	 *
-	 * @param mixed         $value a value to transform.
+	 * @param array         $value an array to count.
 	 * @param stdClass|null $arguments arguments.
 	 *
-	 * @return mixed
+	 * @return number
 	 */
 	public function transform( $value, stdClass $arguments = null ) {
 		return count( $value );

--- a/src/RemoteInboxNotifications/Transformers/Count.php
+++ b/src/RemoteInboxNotifications/Transformers/Count.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers;
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerInterface;
+use stdClass;
+
+/**
+ * Count elements in Countable or Array.
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers
+ */
+class Count implements TransformerInterface {
+	/**
+	 *  Count elements in Countable or Array.
+	 *
+	 * @param mixed         $value a value to transform.
+	 * @param stdClass|null $arguments arguments.
+	 *
+	 * @return mixed
+	 */
+	public function transform( $value, stdClass $arguments = null ) {
+		return count( $value );
+	}
+
+	/**
+	 * Validate Transformer arguments.
+	 *
+	 * @param stdClass|null $arguments arguments to validate.
+	 *
+	 * @return mixed
+	 */
+	public function validate( stdClass $arguments = null ) {
+		return true;
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/count.php
+++ b/tests/remote-inbox-notifications/Transformers/count.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * ArrayValues tests.
+ *
+ * @package WooCommerce\Admin\Tests\RemoteInboxNotifications
+ */
+
+use Automattic\WooCommerce\Admin\RemoteInboxNotifications\Transformers\Count;
+
+/**
+ * class WC_Tests_RemoteInboxNotifications_Transformers_ArrayValues
+ */
+class WC_Tests_RemoteInboxNotifications_Transformers_ArrayCount extends WC_Unit_Test_Case {
+	/**
+	 * Test it returns array count.
+	 */
+	public function test_it_returns_array_values() {
+		$items        = array( 'one', 'two', 'three', 'four' );
+		$array_values = new Count();
+		$result       = $array_values->transform( $items );
+		$this->assertEquals( 4, $result );
+	}
+}

--- a/tests/remote-inbox-notifications/Transformers/count.php
+++ b/tests/remote-inbox-notifications/Transformers/count.php
@@ -14,7 +14,7 @@ class WC_Tests_RemoteInboxNotifications_Transformers_ArrayCount extends WC_Unit_
 	/**
 	 * Test it returns array count.
 	 */
-	public function test_it_returns_array_values() {
+	public function test_it_returns_array_count() {
 		$items        = array( 'one', 'two', 'three', 'four' );
 		$array_values = new Count();
 		$result       = $array_values->transform( $items );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/7036

Add a `count` transformer rule so that data objects with countable arrays can determine a length.

### Detailed test instructions:

1. Review the test case and make sure it makes sense.
2. See PHP unit tests passing

No changelog needed because this updates unreleased functionality