### PR TITLE
Add missing argument to match TransformerInterface

### DIFF
--- a/src/RemoteInboxNotifications/Transformers/Count.php
+++ b/src/RemoteInboxNotifications/Transformers/Count.php
@@ -16,10 +16,11 @@ class Count implements TransformerInterface {
 	 *
 	 * @param array         $value an array to count.
 	 * @param stdClass|null $arguments arguments.
+	 * @param string|null   $default default value.
 	 *
 	 * @return number
 	 */
-	public function transform( $value, stdClass $arguments = null ) {
+	public function transform( $value, stdClass $arguments = null, $default = null ) {
 		return count( $value );
 	}
 


### PR DESCRIPTION
Fixes a fatal error in the php unit tests that was caused by two separate PR's merged at the same time.
The error:

<img width="1276" alt="Screen Shot 2021-05-25 at 11 33 20 AM" src="https://user-images.githubusercontent.com/2240960/119516304-09d4bb00-bd4d-11eb-89e1-097362b443ec.png">

No changelog necessary.

### Detailed test instructions:

- Check if the php unit tests pass in GH actions (of this PR)
- Tests should pass locally `npm run test:php`

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
