### PR TITLE
Add `md5` for `/data` dependencies.

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-	Fix, state md5 as npm dependency. #7087
+
 # 1.3.0
 
 -   Fix parsing bad JSON string data in useUserPreferences hook. #6819

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -24,6 +24,7 @@
 		"@woocommerce/date": "file:../date",
 		"@woocommerce/navigation": "file:../navigation",
 		"@wordpress/i18n": "3.17.0",
+		"md5": "^2.3.0",
 		"rememo": "^3.0.0"
 	},
 	"publishConfig": {

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,6 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Changelog ==
 
 == Unreleased ==
-- Fix: State `md5` as `@woocommerce/data`'s npm dependency. #7087
 - Fix: Preventing redundant notices when installing plugins via payments task list. #7026
 - Fix: Autocompleter for custom Search in CompareFilter #6911
 - Dev: Converting <SettingsForm /> component to TypeScript. #6981

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 == Changelog ==
 
 == Unreleased ==
+- Fix: State `md5` as `@woocommerce/data`'s npm dependency. #7087
 - Fix: Preventing redundant notices when installing plugins via payments task list. #7026
 - Fix: Autocompleter for custom Search in CompareFilter #6911
 - Dev: Converting <SettingsForm /> component to TypeScript. #6981


### PR DESCRIPTION
It was used, but not stated in `package.json`.

Fixes: https://github.com/woocommerce/woocommerce-admin/issues/7086

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

n/a this fixes build flow

### Screenshots

### Detailed test instructions:

In external project
- install `@woocommerce/data` as dependency `npm i --save @woocommerce/data`
- import it somewhere `import { SETTINGS_STORE_NAME } from '@woocommerce/data';`
- build with webpack



<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

----

no changelog necessary as it is in data package