### PR TITLE
Add progressive task list experiment

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -210,12 +210,25 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 		<>
 			{ setupTasks && ( ! isSetupTaskListHidden || task ) && (
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ dismissedTasks || [] }
 					isComplete={ isTaskListComplete }
 					query={ query }
 					tasks={ setupTasks }
 					title={ __( 'Finish setup', 'woocommerce-admin' ) }
 					trackedCompletedTasks={ trackedCompletedTasks || [] }
+					onComplete={ () =>
+						updateOptions( {
+							woocommerce_default_homepage_layout: 'two_columns',
+						} )
+					}
+					onHide={ () =>
+						updateOptions( {
+							woocommerce_task_list_prompt_shown: true,
+							woocommerce_default_homepage_layout: 'two_columns',
+						} )
+					}
 				/>
 			) }
 			{ extensionTasks && (
@@ -241,9 +254,11 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 			) }
 			{ extensionTasks && ! isExtendedTaskListHidden && (
 				<TaskList
+					name="extended_task_list"
+					eventName="extended_tasklist"
+					collapsible
 					dismissedTasks={ dismissedTasks || [] }
 					isComplete={ isExtendedTaskListComplete }
-					name={ 'extended_task_list' }
 					query={ query }
 					tasks={ extensionTasks }
 					title={ __( 'Things to do next', 'woocommerce-admin' ) }

--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -12,6 +12,7 @@ import {
 	PLUGINS_STORE_NAME,
 	SETTINGS_STORE_NAME,
 } from '@woocommerce/data';
+import { useExperiment } from '@woocommerce/explat';
 import { recordEvent } from '@woocommerce/tracks';
 
 /**
@@ -24,6 +25,7 @@ import { getCountryCode } from '../dashboard/utils';
 import TaskList from './task-list';
 import { DisplayOption } from '../header/activity-panel/display-options';
 import { TaskStep } from './task-step';
+import TaskListPlaceholder from './placeholder';
 
 const taskDashboardSelect = ( select ) => {
 	const { getProfileItems, getTasksStatus } = select( ONBOARDING_STORE_NAME );
@@ -98,6 +100,9 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 	} = useSelect( taskDashboardSelect );
 
 	const [ isCartModalOpen, setIsCartModalOpen ] = useState( false );
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
+		'woocommerce_tasklist_progression'
+	);
 
 	useEffect( () => {
 		document.body.classList.add( 'woocommerce-onboarding' );
@@ -208,29 +213,38 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 
 	return (
 		<>
-			{ setupTasks && ( ! isSetupTaskListHidden || task ) && (
-				<TaskList
-					name="task_list"
-					eventName="tasklist"
-					dismissedTasks={ dismissedTasks || [] }
-					isComplete={ isTaskListComplete }
-					query={ query }
-					tasks={ setupTasks }
-					title={ __( 'Finish setup', 'woocommerce-admin' ) }
-					trackedCompletedTasks={ trackedCompletedTasks || [] }
-					onComplete={ () =>
-						updateOptions( {
-							woocommerce_default_homepage_layout: 'two_columns',
-						} )
-					}
-					onHide={ () =>
-						updateOptions( {
-							woocommerce_task_list_prompt_shown: true,
-							woocommerce_default_homepage_layout: 'two_columns',
-						} )
-					}
-				/>
-			) }
+			{ setupTasks &&
+				( ! isSetupTaskListHidden || task ) &&
+				( isLoadingExperiment ? (
+					<TaskListPlaceholder />
+				) : (
+					<TaskList
+						name="task_list"
+						eventName="tasklist"
+						expandingItems={
+							experimentAssignment?.variationName === 'treatment'
+						}
+						dismissedTasks={ dismissedTasks || [] }
+						isComplete={ isTaskListComplete }
+						query={ query }
+						tasks={ setupTasks }
+						title={ __( 'Finish setup', 'woocommerce-admin' ) }
+						trackedCompletedTasks={ trackedCompletedTasks || [] }
+						onComplete={ () =>
+							updateOptions( {
+								woocommerce_default_homepage_layout:
+									'two_columns',
+							} )
+						}
+						onHide={ () =>
+							updateOptions( {
+								woocommerce_task_list_prompt_shown: true,
+								woocommerce_default_homepage_layout:
+									'two_columns',
+							} )
+						}
+					/>
+				) ) }
 			{ extensionTasks && (
 				<DisplayOption>
 					<MenuGroup

--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { EllipsisMenu, Badge } from '@woocommerce/components';
@@ -28,6 +28,7 @@ export const TaskList = ( {
 	collapsible = false,
 	onComplete,
 	onHide,
+	expandingItems = false,
 } ) => {
 	const { createNotice } = useDispatch( 'core/notices' );
 	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
@@ -70,6 +71,10 @@ export const TaskList = ( {
 			task.visible &&
 			! task.completed &&
 			! dismissedTasks.includes( task.key )
+	);
+
+	const [ currentTask, setCurrentTask ] = useState(
+		incompleteTasks[ 0 ]?.key
 	);
 
 	const possiblyCompleteTaskList = () => {
@@ -276,7 +281,15 @@ export const TaskList = ( {
 									title={ task.title }
 									completed={ task.completed }
 									content={ task.content }
-									onClick={ task.onClick }
+									onClick={
+										! expandingItems || task.completed
+											? task.onClick
+											: () => setCurrentTask( task.key )
+									}
+									expanded={
+										expandingItems &&
+										currentTask === task.key
+									}
 									isDismissable={ task.isDismissable }
 									onDismiss={ () => dismissTask( task ) }
 									time={ task.time }

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -229,41 +229,48 @@ describe( 'TaskDashboard and TaskList', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'sets homescreen layout default when dismissed', () => {
-		const { getByRole } = render(
-			<TaskList
-				query={ {} }
-				dismissedTasks={ [] }
-				trackedCompletedTasks={ shorterTasksList }
-				tasks={ shorterTasksList }
-			/>
+	it( 'sets homescreen layout default when dismissed', async () => {
+		useSelect.mockImplementation( () => ( {
+			dismissedTasks: [],
+			isSetupTaskListHidden: false,
+			isExtendedTaskListHidden: true,
+			profileItems: {},
+		} ) );
+		apiFetch.mockResolvedValue( {} );
+		getAllTasks.mockReturnValue( tasks );
+		const { container, getByRole } = render(
+			<TaskDashboard query={ {} } />
 		);
+
+		// Wait for the setup task list to render.
+		expect(
+			await findByText( container, TASK_LIST_HEADING )
+		).toBeDefined();
 
 		userEvent.click( getByRole( 'button', { name: 'Task List Options' } ) );
 		userEvent.click( getByRole( 'button', { name: 'Hide this' } ) );
 
 		expect( updateOptions ).toHaveBeenCalledWith( {
-			woocommerce_task_list_hidden: 'yes',
 			woocommerce_task_list_prompt_shown: true,
 			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	} );
 
 	it( 'sets homescreen layout default when completed', () => {
+		useSelect.mockImplementation( () => ( {
+			dismissedTasks: [],
+			isSetupTaskListHidden: false,
+			isExtendedTaskListHidden: true,
+			profileItems: {},
+		} ) );
 		apiFetch.mockResolvedValue( {} );
+		getAllTasks.mockReturnValue( { setup: shorterTasksList } );
+
 		act( () => {
-			render(
-				<TaskList
-					query={ {} }
-					dismissedTasks={ [] }
-					trackedCompletedTasks={ shorterTasksList }
-					tasks={ shorterTasksList }
-				/>
-			);
+			render( <TaskDashboard query={ {} } /> );
 		} );
 
 		expect( updateOptions ).toHaveBeenCalledWith( {
-			woocommerce_task_list_complete: 'yes',
 			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	} );
@@ -273,6 +280,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		const { setup } = tasks;
 		const { queryByText } = render(
 			<TaskList
+				name="task_list"
+				eventName="tasklist"
 				dismissedTasks={ [ 'optional', 'required', 'completed' ] }
 				isComplete={ false }
 				query={ {} }
@@ -289,6 +298,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		const { extension } = tasks;
 		const { queryByText } = render(
 			<TaskList
+				name="extended_task_list"
+				eventName="extended_tasklist"
 				dismissedTasks={ [ 'extension' ] }
 				isComplete={ false }
 				query={ {} }
@@ -301,22 +312,21 @@ describe( 'TaskDashboard and TaskList', () => {
 	} );
 
 	it( 'sets setup tasks list as completed', () => {
+		useSelect.mockImplementation( () => ( {
+			dismissedTasks: [],
+			isSetupTaskListHidden: false,
+			isExtendedTaskListHidden: true,
+			profileItems: {},
+		} ) );
 		apiFetch.mockResolvedValue( {} );
+		getAllTasks.mockReturnValue( { setup: shorterTasksList } );
+
 		act( () => {
-			render(
-				<TaskList
-					dismissedTasks={ [] }
-					isComplete={ false }
-					query={ {} }
-					trackedCompletedTasks={ shorterTasksList }
-					tasks={ shorterTasksList }
-				/>
-			);
+			render( <TaskDashboard query={ {} } /> );
 		} );
 
 		expect( updateOptions ).toHaveBeenCalledWith( {
 			woocommerce_task_list_complete: 'yes',
-			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	} );
 
@@ -325,12 +335,13 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="extended_task_list"
+					eventName="extended_tasklist"
 					dismissedTasks={ [] }
 					isComplete={ false }
 					query={ {} }
 					trackedCompletedTasks={ [] }
 					tasks={ shorterTasksList }
-					name={ 'extended_task_list' }
 				/>
 			);
 		} );
@@ -346,6 +357,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ [ 'optional', 'required', 'completed' ] }
 					isComplete={ false }
 					query={ {} }
@@ -357,7 +370,6 @@ describe( 'TaskDashboard and TaskList', () => {
 
 		expect( updateOptions ).toHaveBeenCalledWith( {
 			woocommerce_task_list_complete: 'yes',
-			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	} );
 
@@ -367,12 +379,13 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="extended_task_list"
+					eventName="extended_tasklist"
 					dismissedTasks={ [ 'extension' ] }
 					isComplete={ false }
 					query={ {} }
 					trackedCompletedTasks={ [] }
 					tasks={ extension }
-					name={ 'extended_task_list' }
 				/>
 			);
 		} );
@@ -388,6 +401,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ [] }
 					isComplete={ true }
 					query={ {} }
@@ -399,7 +414,6 @@ describe( 'TaskDashboard and TaskList', () => {
 
 		expect( updateOptions ).toHaveBeenCalledWith( {
 			woocommerce_task_list_complete: 'no',
-			woocommerce_default_homepage_layout: 'two_columns',
 		} );
 	} );
 
@@ -409,12 +423,13 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="extended_task_list"
+					eventName="extended_tasklist"
 					dismissedTasks={ [] }
 					isComplete={ true }
 					query={ {} }
 					trackedCompletedTasks={ shorterTasksList }
 					tasks={ extension }
-					name={ 'extended_task_list' }
 				/>
 			);
 		} );
@@ -430,6 +445,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ [] }
 					query={ {} }
 					trackedCompletedTasks={ [] }
@@ -449,6 +466,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ [] }
 					query={ {} }
 					trackedCompletedTasks={ [ 'completed', 'extension' ] }
@@ -468,6 +487,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ [] }
 					query={ {} }
 					trackedCompletedTasks={ [ 'extension' ] }
@@ -486,6 +507,8 @@ describe( 'TaskDashboard and TaskList', () => {
 		act( () => {
 			render(
 				<TaskList
+					name="task_list"
+					eventName="tasklist"
 					dismissedTasks={ [ 'completed-1' ] }
 					query={ {} }
 					trackedCompletedTasks={ [] }
@@ -504,12 +527,13 @@ describe( 'TaskDashboard and TaskList', () => {
 		const { extension } = tasks;
 		const { getByText } = render(
 			<TaskList
+				name="extended_task_list"
+				eventName="extended_tasklist"
 				dismissedTasks={ [] }
 				isComplete={ false }
 				query={ {} }
 				trackedCompletedTasks={ [] }
 				tasks={ extension }
-				name={ 'extended_task_list' }
 			/>
 		);
 

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -38,6 +38,9 @@ jest.mock( '@wordpress/data', () => ( {
 	} ),
 	useDispatch: jest.fn(),
 } ) );
+jest.mock( '@woocommerce/explat', () => ( {
+	useExperiment: jest.fn().mockReturnValue( [ false, {} ] ),
+} ) );
 
 const TASK_LIST_HEADING = 'Finish setup';
 const EXTENDED_TASK_LIST_HEADING = 'Things to do next';

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -229,6 +229,51 @@ describe( 'TaskDashboard and TaskList', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'invokes onComplete callback when supplied', () => {
+		apiFetch.mockResolvedValue( {} );
+		const onComplete = jest.fn();
+		act( () => {
+			render(
+				<TaskList
+					name="task_list"
+					eventName="tasklist"
+					dismissedTasks={ [] }
+					isComplete={ false }
+					query={ {} }
+					trackedCompletedTasks={ [] }
+					tasks={ shorterTasksList }
+					onComplete={ onComplete }
+				/>
+			);
+		} );
+
+		expect( onComplete ).toHaveBeenCalled();
+	} );
+
+	it( 'invokes onHide callback when supplied', () => {
+		apiFetch.mockResolvedValue( {} );
+		const onHide = jest.fn();
+		const { getByRole } = render(
+			<TaskList
+				name="task_list"
+				eventName="tasklist"
+				dismissedTasks={ [] }
+				isComplete={ false }
+				query={ {} }
+				trackedCompletedTasks={ [] }
+				tasks={ tasks.setup }
+				onHide={ onHide }
+			/>
+		);
+
+		expect( onHide ).not.toHaveBeenCalled();
+
+		userEvent.click( getByRole( 'button', { name: 'Task List Options' } ) );
+		userEvent.click( getByRole( 'button', { name: 'Hide this' } ) );
+
+		expect( onHide ).toHaveBeenCalled();
+	} );
+
 	it( 'sets homescreen layout default when dismissed', async () => {
 		useSelect.mockImplementation( () => ( {
 			dismissedTasks: [],

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Add: Progressive setup checklist copy and call to action buttons. #6956
 - Add: Add Paystack as fallback gateway #7025
 - Add: Add COD method to default payment gateway recommendations #7057
+- Add: A/B test of progressive checklist features. #7089
 - Dev: Update package-lock to fix versioning of local packages. #6843
 - Dev: Use rule processing for remote payment methods #6830
 - Dev: Update E2E jest config, so it correctly creates screenshots on failure. #6858


### PR DESCRIPTION
Fixes #6949.

This PR introduces the `woocommerce_tasklist_progression` A/B experiment to the setup task list. (It targets [this PR](https://github.com/woocommerce/woocommerce-admin/pull/6956) for merge, which implements the UI changes to support task item expansion)

The `TaskList` component was refactored to remove "setup" task list specific functionality (checking for `name === 'task_list'`). To support the behavioral differences between the "setup" and "extension" lists, the following props were added:

* `eventName` - Artifact of the tracks event names not matching the WP options
* `collapsible` - Whether or not the list should collapse when there are more than 2 tasks. Defaults to `false`. (Used by "extension" task list)
* `onComplete` - Optional callback to fire after the task list is completed. Used by "setup" task list to change the default homepage layout.
* `onHide` - Optional callback to fire when the task list is hidden. Used by "setup" task list to change the default homepage layout and hide the task list prompt.
* `expandingItems` - Whether or not the list items should expand when clicked. Defaults to `false`. (Used by the "setup" task list)

The key to implementing the A/B test is setting the `expandingItems` prop based on the experiment variation.

### Screenshots

Control | Variant
----- | -----
![Screen Shot 2021-05-28 at 4 27 48 PM](https://user-images.githubusercontent.com/63922/120038951-0b62e500-bfd2-11eb-9a49-3ba70e656e5c.png) | ![Screen Shot 2021-05-28 at 4 28 56 PM](https://user-images.githubusercontent.com/63922/120038962-0f8f0280-bfd2-11eb-92a4-a6e33355ec9f.png)


### Detailed test instructions:

- Delete the default homepage layout option (`woocommerce_default_homepage_layout`)
- Delete your `woocommerce_admin_homepage_layout` user meta key
- Go to the homescreen
- Verify that the control (task list as it currently exists) is rendered (FYI: there isn't an experiment with the name yet)
- Hide the task list
- Verify the layout switches to 2 columns
- Delete the `woocommerce_task_list_hidden` option to show the task list again
- Change [this line](https://github.com/woocommerce/woocommerce-admin/blob/ccfab883bbc297f14d860c7f9bdfd337ebd27269/client/task-list/index.js#L104) to `woocommerce_tasklist_progression_dev`
- Use the `treatment` bookmarklet in Abacus (search for the `woocommerce_tasklist_progression_dev` experiment) to assign yourself the test variation
- Reload the homescreen
- Verify that the variant is rendered - the first incomplete task should be expanded
- Verify that clicking other items causes them to expand
- Verify that only one task is expanded at a time

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
