### PR TITLE
Go back to using latest version of WP docker image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,6 @@ jobs:
                   WC_E2E_SCREENSHOTS: 1
                   E2E_SLACK_CHANNEL: ${{ secrets.E2E_SLACK_CHANNEL }}
                   E2E_SLACK_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
-                  WP_VERSION: 5.7.1
               run: |
                   npm i
                   composer require wp-cli/i18n-command


### PR DESCRIPTION
When we changed this there had been a bunch of rebuilds of the latest version of the docker WP image, I suspect they were having issues and patching last minute bugs. It has settled down now and the checks should pass.

No changelog required 