### PR TITLE
Add progressive task list animation

### DIFF
--- a/client/task-list/task-list.js
+++ b/client/task-list/task-list.js
@@ -349,6 +349,7 @@ export const TaskList = ( {
 											? task.onClick
 											: () => setCurrentTask( task.key )
 									}
+									expandable={ expandingItems }
 									expanded={
 										expandingItems &&
 										currentTask === task.key

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -85,7 +85,7 @@ describe( 'TaskDashboard and TaskList', () => {
 				isDismissable: false,
 				type: 'setup',
 				action: 'CTA (required)',
-				content: 'This is the require task content',
+				content: 'This is the required task content',
 			},
 			{
 				key: 'completed',
@@ -108,6 +108,8 @@ describe( 'TaskDashboard and TaskList', () => {
 				time: '1 minute',
 				isDismissable: true,
 				type: 'extension',
+				action: 'CTA (extension)',
+				content: 'This is the extension task content',
 			},
 		],
 	};
@@ -663,9 +665,12 @@ describe( 'TaskDashboard and TaskList', () => {
 			isExtendedTaskListHidden: true,
 			profileItems: {},
 		} ) );
-		const { queryByText } = render( <TaskDashboard query={ {} } /> );
-		expect( queryByText( 'This is the optional task content' ) ).toBeNull();
-		expect( queryByText( 'CTA (optional)' ) ).toBeNull();
+		act( () => {
+			const { queryByText } = render( <TaskDashboard query={ {} } /> );
+			expect(
+				queryByText( 'This is the optional task content' )
+			).not.toHaveClass( 'woocommerce-task-list__item-content-appear' );
+		} );
 	} );
 
 	it( 'setup task list renders expandable items in experiment variant', async () => {
@@ -683,21 +688,24 @@ describe( 'TaskDashboard and TaskList', () => {
 				variationName: 'treatment',
 			},
 		] );
-		const { container, queryByText } = render(
-			<TaskDashboard query={ {} } />
-		);
+		await act( async () => {
+			const { container, queryByText } = render(
+				<TaskDashboard query={ {} } />
+			);
 
-		// Expect the first incomplete task to be expanded
-		expect(
-			await findByText( container, 'This is the optional task content' )
-		).not.toBeNull();
-		expect(
-			await findByText( container, 'CTA (optional)' )
-		).not.toBeNull();
+			// Expect the first incomplete task to be expanded
+			expect(
+				await findByText(
+					container,
+					'This is the optional task content'
+				)
+			).toHaveClass( 'woocommerce-task-list__item-content-appear' );
 
-		// Expect the second not to be.
-		expect( queryByText( 'This is the required task content' ) ).toBeNull();
-		expect( queryByText( 'CTA (required)' ) ).toBeNull();
+			// Expect the second not to be.
+			expect(
+				queryByText( 'This is the required task content' )
+			).not.toHaveClass( 'woocommerce-task-list__item-content-appear' );
+		} );
 	} );
 
 	describe( 'getVisibleTasks', () => {

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Remove the use of Dashicons and replace with @wordpress/icons or gridicons #7020
 -   Add expanded item text and CTA button. #6956
 -   Add inbox note components (InboxNoteCard, InboxNotePlaceholder, and InboxDismissConfirmationModal). #7006
+-   Add transition animation to expanding TaskItems.
 
 # 1.2.0
 

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -65,20 +65,50 @@ $task-alert-yellow: #f0b849;
 	}
 
 	.woocommerce-task-list__item-content {
-		max-height: 0px;
-		overflow: hidden;
+		max-height: 0;
+		opacity: 0;
 		margin-top: $gap-smallest;
-		margin-bottom: $gap-smallest;
-	}
+		overflow: hidden;
 
-	&.expanded {
-		.woocommerce-task-list__item-content {
-			max-height: 250px;
+		&.woocommerce-task-list__item-content-enter {
+			opacity: 0;
+			max-height: 0;
+		}
+
+		&.woocommerce-task-list__item-content-enter-active {
+			opacity: 1;
+			max-height: 100vh;
+			transition: opacity 500ms, max-height 500ms;
+		}
+
+		&.woocommerce-task-list__item-content-appear,
+		&.woocommerce-task-list__item-content-appear-active,
+		&.woocommerce-task-list__item-content-appear-done,
+		&.woocommerce-task-list__item-content-enter-done {
+			opacity: 1;
+			max-height: 100vh;
+		}
+
+		&.woocommerce-task-list__item-content-exit {
+			opacity: 1;
+			max-height: 100vh;
+		}
+
+		&.woocommerce-task-list__item-content-exit-active {
+			opacity: 0;
+			max-height: 0;
+			transition: opacity 500ms, max-height 500ms;
+		}
+
+		.woocommerce-task__additional-info {
+			margin-top: $gap-smaller;
 		}
 	}
 
 	.woocommerce-task-list__item-action {
+		margin-top: $gap-smaller;
 		margin-bottom: $gap-smallest;
+		display: block;
 	}
 
 	.woocommerce-task-list__item-after {

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -65,13 +65,20 @@ $task-alert-yellow: #f0b849;
 	}
 
 	.woocommerce-task-list__item-content {
+		max-height: 0px;
+		overflow: hidden;
 		margin-top: $gap-smallest;
 		margin-bottom: $gap-smallest;
 	}
 
+	&.expanded {
+		.woocommerce-task-list__item-content {
+			max-height: 250px;
+		}
+	}
+
 	.woocommerce-task-list__item-action {
-		margin-top: $gap-smallest;
-		margin-bottom: $gap-smaller;
+		margin-bottom: $gap-smallest;
 	}
 
 	.woocommerce-task-list__item-after {

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -8,6 +8,7 @@ import NoticeOutline from 'gridicons/dist/notice-outline';
 import { EllipsisMenu } from '@woocommerce/components';
 import classnames from 'classnames';
 import { sanitize } from 'dompurify';
+import { CSSTransition } from 'react-transition-group';
 
 /**
  * Internal dependencies
@@ -38,6 +39,7 @@ type TaskItemProps = {
 	additionalInfo?: string;
 	time?: string;
 	content: string;
+	expandable?: boolean;
 	expanded?: boolean;
 	level?: TaskLevel;
 	action: (
@@ -79,6 +81,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	additionalInfo,
 	time,
 	content,
+	expandable = false,
 	expanded = false,
 	level = 3,
 	action,
@@ -86,7 +89,6 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,
-		expanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,
 	} );
@@ -111,34 +113,48 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					<span className="woocommerce-task-list__item-title">
 						{ title }
 					</span>
-					<div className="woocommerce-task-list__item-content">
-						{ content }
-					</div>
-					{ additionalInfo && (
+					<CSSTransition
+						appear
+						timeout={ 500 }
+						in={ expanded }
+						classNames="woocommerce-task-list__item-content"
+					>
+						<div className="woocommerce-task-list__item-content">
+							{ content }
+							{ expandable && ! completed && additionalInfo && (
+								<div
+									className="woocommerce-task__additional-info"
+									dangerouslySetInnerHTML={ sanitizeHTML(
+										additionalInfo
+									) }
+								></div>
+							) }
+							{ ! completed && (
+								<Button
+									className="woocommerce-task-list__item-action"
+									isPrimary
+									onClick={ (
+										event:
+											| React.MouseEvent
+											| React.KeyboardEvent
+									) => {
+										event.stopPropagation();
+										action( event, { isExpanded: true } );
+									} }
+								>
+									{ actionLabel || title }
+								</Button>
+							) }
+						</div>
+					</CSSTransition>
+
+					{ ! expandable && ! completed && additionalInfo && (
 						<div
 							className="woocommerce-task__additional-info"
 							dangerouslySetInnerHTML={ sanitizeHTML(
 								additionalInfo
 							) }
 						></div>
-					) }
-					{ ! completed && (
-						<div className="woocommerce-task-list__item-content">
-							<Button
-								className="woocommerce-task-list__item-action"
-								isPrimary
-								onClick={ (
-									event:
-										| React.MouseEvent
-										| React.KeyboardEvent
-								) => {
-									event.stopPropagation();
-									action( event, { isExpanded: true } );
-								} }
-							>
-								{ actionLabel || title }
-							</Button>
-						</div>
 					) }
 					{ time && (
 						<div className="woocommerce-task__estimated-time">

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -86,6 +86,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,
+		expanded,
 		'level-2': level === 2 && ! completed,
 		'level-1': level === 1 && ! completed,
 	} );
@@ -110,11 +111,9 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					<span className="woocommerce-task-list__item-title">
 						{ title }
 					</span>
-					{ expanded && (
-						<div className="woocommerce-task-list__item-content">
-							{ content }
-						</div>
-					) }
+					<div className="woocommerce-task-list__item-content">
+						{ content }
+					</div>
 					{ additionalInfo && (
 						<div
 							className="woocommerce-task__additional-info"
@@ -123,19 +122,23 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 							) }
 						></div>
 					) }
-					{ expanded && ! completed && (
-						<Button
-							className="woocommerce-task-list__item-action"
-							isPrimary
-							onClick={ (
-								event: React.MouseEvent | React.KeyboardEvent
-							) => {
-								event.stopPropagation();
-								action( event, { isExpanded: true } );
-							} }
-						>
-							{ actionLabel || title }
-						</Button>
+					{ ! completed && (
+						<div className="woocommerce-task-list__item-content">
+							<Button
+								className="woocommerce-task-list__item-action"
+								isPrimary
+								onClick={ (
+									event:
+										| React.MouseEvent
+										| React.KeyboardEvent
+								) => {
+									event.stopPropagation();
+									action( event, { isExpanded: true } );
+								} }
+							>
+								{ actionLabel || title }
+							</Button>
+						</div>
 					) }
 					{ time && (
 						<div className="woocommerce-task__estimated-time">


### PR DESCRIPTION
This PR seeks to add an animation to the expansion/collapse of progressive task list items.

In addition to the animation, the `additionalInfo` text is no longer displayed for expandable items that are collapsed.

I was unable to get the two list item transitions to occur simultaneously.. I'm not sure if that's even possible. 🤷‍♂️ 

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Capture 2021-06-04 at 13 04 28](https://user-images.githubusercontent.com/63922/120838204-cafced00-c524-11eb-8a0c-964c02766660.gif)

### Detailed test instructions:

- Ensure the task list is visible on WooCommerce > Home
- Force the `expandingItems` prop to be `true` here: https://github.com/woocommerce/woocommerce-admin/blob/4413194a5e2f7f0135368b605a1de19a3a2a3b1e/client/task-list/index.js#L224
- Verify the transition animations occur when expanding/collapsing list items

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->

No changelog. (Unreleased feature being tweaked)