### PR TITLE
Revert store setup task list title.

### DIFF
--- a/client/task-list/index.js
+++ b/client/task-list/index.js
@@ -233,7 +233,10 @@ const TaskDashboard = ( { userPreferences, query } ) => {
 						isComplete={ isTaskListComplete }
 						query={ query }
 						tasks={ setupTasks }
-						title={ __( 'Finish setup', 'woocommerce-admin' ) }
+						title={ __(
+							'Get ready to start selling',
+							'woocommerce-admin'
+						) }
 						trackedCompletedTasks={ trackedCompletedTasks || [] }
 						onComplete={ () =>
 							updateOptions( {

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -44,7 +44,7 @@ jest.mock( '@woocommerce/explat', () => ( {
 	useExperiment: jest.fn().mockReturnValue( [ false, {} ] ),
 } ) );
 
-const TASK_LIST_HEADING = 'Finish setup';
+const TASK_LIST_HEADING = 'Get ready to start selling';
 const EXTENDED_TASK_LIST_HEADING = 'Things to do next';
 
 describe( 'TaskDashboard and TaskList', () => {

--- a/tests/e2e/pages/WcHomescreen.ts
+++ b/tests/e2e/pages/WcHomescreen.ts
@@ -27,7 +27,7 @@ export class WcHomescreen extends BasePage {
 		await page.waitForSelector(
 			'.woocommerce-task-card .woocommerce-task-list__item-title'
 		);
-		await waitForElementByText( 'p', 'Finish setup' );
+		await waitForElementByText( 'p', 'Get ready to start selling' );
 		const list = await this.page.$$eval(
 			'.woocommerce-task-card .woocommerce-task-list__item-title',
 			( items ) => items.map( ( item ) => item.textContent )


### PR DESCRIPTION
Per p1620236228018000/1620167367.009700-slack-GSH552L56, the store setup list title change was supposed to be reverted.

No changelog.