### PR TITLE
Add core-data dependency to data package

### DIFF
--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+-   Update dependencies
+
 # 1.3.1
 
 -   Fix, state md5 as npm dependency. #7087

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -23,6 +23,7 @@
 	"dependencies": {
 		"@woocommerce/date": "file:../date",
 		"@woocommerce/navigation": "file:../navigation",
+		"@wordpress/core-data": "2.25.0",
 		"@wordpress/i18n": "3.17.0",
 		"md5": "^2.3.0",
 		"rememo": "^3.0.0"


### PR DESCRIPTION
Add missing @wordpress/core-data dependency to the data package.

No changelog necessary as it is in the data package