### PR TITLE
Increase ellipsis toggle specificity

### DIFF
--- a/packages/components/src/ellipsis-menu/style.scss
+++ b/packages/components/src/ellipsis-menu/style.scss
@@ -1,14 +1,15 @@
 .woocommerce-ellipsis-menu {
 	text-align: center;
-}
 
-.woocommerce-ellipsis-menu__toggle {
-	justify-content: center;
-	vertical-align: middle;
-	width: 24px;
+	.woocommerce-ellipsis-menu__toggle {
+		justify-content: center;
+		vertical-align: middle;
+		width: 24px;
+		padding: 0;
 
-	.gridicon {
-		transform: rotate(90deg);
+		.gridicon {
+			transform: rotate(90deg);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #7172
Increase the toggle specificity so it is not overwritten.
No changelog necessary.

### Screenshots

<img width="256" alt="Screen Shot 2021-06-11 at 10 22 43 AM" src="https://user-images.githubusercontent.com/2240960/121692919-f8a2e280-ca9e-11eb-840b-c83864466c23.png">

### Detailed test instructions:

- Go to **Analytics > Revenue**
- The ellipsis icon should show up correctly beside the **Download** button (see screenshot)

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->