### PR TITLE
Fix currency display errors in homescreen order activity card

### DIFF
--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -156,7 +156,7 @@ class OrdersPanel extends Component {
 			const {
 				date_created_gmt: dateCreatedGmt,
 				extended_info: extendedInfo,
-				order_id: orderId
+				order_id: orderId,
 			} = order;
 			const productsCount =
 				extendedInfo && extendedInfo.products

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -71,7 +71,6 @@ class OrdersPanel extends Component {
 
 	renderOrders() {
 		const { orders } = this.props;
-		const Currency = this.context;
 
 		if ( orders.length === 0 ) {
 			return this.renderEmptyCard();
@@ -157,15 +156,12 @@ class OrdersPanel extends Component {
 			const {
 				date_created_gmt: dateCreatedGmt,
 				extended_info: extendedInfo,
-				order_id: orderId,
-				total_sales: totalSales,
+				order_id: orderId
 			} = order;
 			const productsCount =
 				extendedInfo && extendedInfo.products
 					? extendedInfo.products.length
 					: 0;
-
-			const total = totalSales;
 
 			cards.push(
 				<ActivityCard
@@ -194,7 +190,7 @@ class OrdersPanel extends Component {
 									productsCount
 								) }
 							</span>
-							<span>{ Currency.formatAmount( total ) }</span>
+							<span>{ order.total_formatted }</span>
 						</div>
 					}
 				>
@@ -347,6 +343,7 @@ export default withSelect( ( select, props ) => {
 			'order_number',
 			'status',
 			'total_sales',
+			'total_formatted',
 			'extended_info.customer',
 			'extended_info.products',
 		],

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Include onboarding settings on the analytic pages #7109
 - Tweak: Revert Card component removal #7167
 - Add: SlotFill to Abbreviated Notification panel #7091
+- Fix: Currency display on Orders activity card on homescreen wcpay-2100
 
 == 2.4.0 6/10/2021 ==
 - Dev: Reduce the specificity and complexity of the ReportError component #6846

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Include onboarding settings on the analytic pages #7109
 - Tweak: Revert Card component removal #7167
 - Add: SlotFill to Abbreviated Notification panel #7091
-- Fix: Currency display on Orders activity card on homescreen wcpay-2100
+- Fix: Currency display on Orders activity card on homescreen #7181
 
 == 2.4.0 6/10/2021 ==
 - Dev: Reduce the specificity and complexity of the ReportError component #6846

--- a/src/API/Reports/Controller.php
+++ b/src/API/Reports/Controller.php
@@ -206,6 +206,27 @@ class Controller extends \WC_REST_Reports_Controller {
 	}
 
 	/**
+	 * Get the order total with the related currency formatting.
+	 * Returns the parent order total if the order is actually a refund.
+	 *
+	 * @param  int $order_id Order ID.
+	 * @return string
+	 */
+	public function get_total_formatted( $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order instanceof \WC_Order && ! $order instanceof \WC_Order_Refund ) {
+			return null;
+		}
+
+		if ( 'shop_order_refund' === $order->get_type() ) {
+			$order = wc_get_order( $order->get_parent_id() );
+		}
+
+		return wp_strip_all_tags( html_entity_decode( $order->get_formatted_order_total() ), true );
+	}
+
+	/**
 	 * Prepare a report object for serialization.
 	 *
 	 * @param stdClass        $report  Report data.

--- a/src/API/Reports/Orders/Controller.php
+++ b/src/API/Reports/Orders/Controller.php
@@ -83,9 +83,10 @@ class Controller extends ReportsController implements ExportableInterface {
 		$data = array();
 
 		foreach ( $report_data->data as $orders_data ) {
-			$orders_data['order_number'] = $this->get_order_number( $orders_data['order_id'] );
-			$item                        = $this->prepare_item_for_response( $orders_data, $request );
-			$data[]                      = $this->prepare_response_for_collection( $item );
+			$orders_data['order_number']    = $this->get_order_number( $orders_data['order_id'] );
+			$orders_data['total_formatted'] = $this->get_total_formatted( $orders_data['order_id'] );
+			$item                           = $this->prepare_item_for_response( $orders_data, $request );
+			$data[]                         = $this->prepare_response_for_collection( $item );
 		}
 
 		$response = rest_ensure_response( $data );
@@ -214,6 +215,12 @@ class Controller extends ReportsController implements ExportableInterface {
 				'net_total'        => array(
 					'description' => __( 'Net total revenue.', 'woocommerce-admin' ),
 					'type'        => 'float',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'total_formatted'  => array(
+					'description' => __( 'Net total revenue (formatted).', 'woocommerce-admin' ),
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
@@ -523,15 +530,16 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function get_export_columns() {
 		$export_columns = array(
-			'date_created'   => __( 'Date', 'woocommerce-admin' ),
-			'order_number'   => __( 'Order #', 'woocommerce-admin' ),
-			'status'         => __( 'Status', 'woocommerce-admin' ),
-			'customer_name'  => __( 'Customer', 'woocommerce-admin' ),
-			'customer_type'  => __( 'Customer Type', 'woocommerce-admin' ),
-			'products'       => __( 'Product(s)', 'woocommerce-admin' ),
-			'num_items_sold' => __( 'Items Sold', 'woocommerce-admin' ),
-			'coupons'        => __( 'Coupon(s)', 'woocommerce-admin' ),
-			'net_total'      => __( 'N. Revenue', 'woocommerce-admin' ),
+			'date_created'    => __( 'Date', 'woocommerce-admin' ),
+			'order_number'    => __( 'Order #', 'woocommerce-admin' ),
+			'total_formatted' => __( 'N. Revenue (Formatted)', 'woocommerce-admin' ),
+			'status'          => __( 'Status', 'woocommerce-admin' ),
+			'customer_name'   => __( 'Customer', 'woocommerce-admin' ),
+			'customer_type'   => __( 'Customer Type', 'woocommerce-admin' ),
+			'products'        => __( 'Product(s)', 'woocommerce-admin' ),
+			'num_items_sold'  => __( 'Items Sold', 'woocommerce-admin' ),
+			'coupons'         => __( 'Coupon(s)', 'woocommerce-admin' ),
+			'net_total'       => __( 'N. Revenue', 'woocommerce-admin' ),
 		);
 
 		/**
@@ -554,15 +562,16 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function prepare_item_for_export( $item ) {
 		$export_item = array(
-			'date_created'   => $item['date_created'],
-			'order_number'   => $item['order_number'],
-			'status'         => $item['status'],
-			'customer_name'  => isset( $item['extended_info']['customer'] ) ? $this->get_customer_name( $item['extended_info']['customer'] ) : null,
-			'customer_type'  => $item['customer_type'],
-			'products'       => isset( $item['extended_info']['products'] ) ? $this->_get_products( $item['extended_info']['products'] ) : null,
-			'num_items_sold' => $item['num_items_sold'],
-			'coupons'        => isset( $item['extended_info']['coupons'] ) ? $this->_get_coupons( $item['extended_info']['coupons'] ) : null,
-			'net_total'      => $item['net_total'],
+			'date_created'    => $item['date_created'],
+			'order_number'    => $item['order_number'],
+			'total_formatted' => $item['total_formatted'],
+			'status'          => $item['status'],
+			'customer_name'   => isset( $item['extended_info']['customer'] ) ? $this->get_customer_name( $item['extended_info']['customer'] ) : null,
+			'customer_type'   => $item['customer_type'],
+			'products'        => isset( $item['extended_info']['products'] ) ? $this->_get_products( $item['extended_info']['products'] ) : null,
+			'num_items_sold'  => $item['num_items_sold'],
+			'coupons'         => isset( $item['extended_info']['coupons'] ) ? $this->_get_coupons( $item['extended_info']['coupons'] ) : null,
+			'net_total'       => $item['net_total'],
 		);
 
 		/**

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -407,4 +407,72 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 1, count( $response_orders ) );
 		$this->assertEquals( $response_orders[0]['order_id'], $order_to_be_excluded->get_id() );
 	}
+
+	/**
+	 * Test filtering by product/variation exclusion.
+	 *
+	 * See: https://github.com/woocommerce/woocommerce-admin/issues/5803#issuecomment-738403405.
+	 */
+	public function test_order_price_formatting_with_different_base_currency() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Reports::reset_stats_dbs();
+
+		// Create a simple order with the base currency.
+		$first_simple_product = WC_Helper_Product::create_simple_product();
+		$first_order          = WC_Helper_Order::create_order( $this->user, $first_simple_product );
+		$first_order->set_currency( get_woocommerce_currency() );
+		$first_order->set_status( 'on-hold' );
+		$first_order->save();
+
+		// Create another simple order with another currency.
+		$currencies = get_woocommerce_currencies();
+		// prevent base currency to be selected again
+		unset( $currencies[ get_woocommerce_currency() ] );
+		$second_currency = array_rand( $currencies );
+
+		$second_simple_product = WC_Helper_Product::create_simple_product();
+		$second_order          = WC_Helper_Order::create_order( $this->user, $second_simple_product );
+		$second_order->set_currency( $second_currency );
+		$second_order->set_status( 'on-hold' );
+		$second_order->save();
+
+		WC_Helper_Queue::run_all_pending();
+
+		// Get the created orders from REST API
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'order_status' => array( 'on-hold' ),
+			)
+		);
+		$response        = $this->server->dispatch( $request );
+		$response_orders = $response->get_data();
+
+		$this->assertIsArray( $response_orders );
+		$this->assertCount( 2, $response_orders );
+
+		// Replace keys with "order_id".
+		$response_orders = array_reduce(
+			$response_orders,
+			function ( array $result, $item ) {
+				$result[ $item['order_id'] ] = $item;
+				return $result;
+			},
+			array()
+		);
+
+		// Check if result has the correct orders.
+		$this->assertArrayHasKey( $first_order->get_id(), $response_orders );
+		$this->assertArrayHasKey( $second_order->get_id(), $response_orders );
+
+		// Check if result orders have the correct formatted totals.
+		$first_order_from_response   = $response_orders[ $first_order->get_id() ];
+		$first_order_formatted_total = wp_strip_all_tags( html_entity_decode( $first_order->get_formatted_order_total() ), true );
+		$this->assertEquals( $first_order_from_response['total_formatted'], $first_order_formatted_total );
+
+		$second_order_from_response   = $response_orders[ $second_order->get_id() ];
+		$second_order_formatted_total = wp_strip_all_tags( html_entity_decode( $second_order->get_formatted_order_total() ), true );
+		$this->assertEquals( $second_order_from_response['total_formatted'], $second_order_formatted_total );
+
+	}
 }

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -448,7 +448,6 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$response        = $this->server->dispatch( $request );
 		$response_orders = $response->get_data();
 
-		$this->assertIsArray( $response_orders );
 		$this->assertCount( 2, $response_orders );
 
 		// Replace keys with "order_id".

--- a/tests/api/reports-orders.php
+++ b/tests/api/reports-orders.php
@@ -116,7 +116,7 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
-		$this->assertEquals( 10, count( $properties ) );
+		$this->assertEquals( 11, count( $properties ) );
 		$this->assertArrayHasKey( 'date_created_gmt', $properties );
 		$this->assertArrayHasKey( 'order_id', $properties );
 		$this->assertArrayHasKey( 'order_number', $properties );
@@ -125,6 +125,7 @@ class WC_Tests_API_Reports_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'customer_id', $properties );
 		$this->assertArrayHasKey( 'net_total', $properties );
 		$this->assertArrayHasKey( 'num_items_sold', $properties );
+		$this->assertArrayHasKey( 'total_formatted', $properties );
 		$this->assertArrayHasKey( 'customer_type', $properties );
 		$this->assertArrayHasKey( 'extended_info', $properties );
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/woocommerce-payments/issues/2100

Add correct currency formatting

Fixes the total amount display on home screen "Orders" activity card. Previously it was using the store's base currency to display all the order totals, now it respects the currency the order was created with. 

Modified the REST API response to contain the formatted currency string, stripped HTML tags and decoded HTML entities before adding it to the API response.

### Screenshots

<img src='https://user-images.githubusercontent.com/3295/121891388-0b7a1900-cd24-11eb-8f4d-b4c5f49e8ba1.png' width="50%">

### Detailed test instructions:

-   Create some orders, but in between, change the user currency.
-	Navigate to WooCommerce > Home and if you didn't complete the onboarding setup, complete them to reach the 'Orders/Stock/Reviews' activity cards. 
- 	Check if the order totals show the correct currency symbols.
