### PR TITLE
Feature/add logger to rin

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,8 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Fix obsolete key property in gateway defaults #7229
 - Fix: Fixing button state logic for remote payment gateways #7200
+- Add: Add a logger to Remote Inbox Notifications #7194
+- Fix: WCPay not working in local payments task #7151
 - Fix: Include onboarding settings on the analytic pages #7109
 - Fix: Load Analytics API only when feature is turned on #7193
 - Fix: Localize string for description #7219

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Fix obsolete key property in gateway defaults #7229
 - Fix: Fixing button state logic for remote payment gateways #7200
 - Add: Add a logger to Remote Inbox Notifications #7194
+- Add: Add a logger to the rule evaluator #7194
 - Fix: WCPay not working in local payments task #7151
 - Fix: Include onboarding settings on the analytic pages #7109
 - Fix: Load Analytics API only when feature is turned on #7193

--- a/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
+++ b/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
@@ -29,7 +29,14 @@ class EvaluateAndGetStatus {
 			return $current_status;
 		}
 
-		$evaluated_result = $rule_evaluator->evaluate( $spec->rules, $stored_state, array( 'slug' => $spec->slug ) );
+		$evaluated_result = $rule_evaluator->evaluate(
+			$spec->rules,
+			$stored_state,
+			array(
+				'slug'   => $spec->slug,
+				'source' => 'remote-inbox-notifications',
+			)
+		);
 
 		// Pending notes should be the spec status if the spec passes,
 		// left alone otherwise.

--- a/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
+++ b/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
@@ -31,7 +31,9 @@ class EvaluateAndGetStatus {
 
 		$evaluation_logger = new EvaluationLogger( $spec->slug );
 		$evaluated_result  = $rule_evaluator->evaluate( $spec->rules, $stored_state, $evaluation_logger );
-		constant( 'WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS' ) === true && $evaluation_logger->log();
+		defined( 'WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS' )
+		&& true === WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS
+		&& $evaluation_logger->log();
 
 		// Pending notes should be the spec status if the spec passes,
 		// left alone otherwise.

--- a/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
+++ b/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
@@ -31,7 +31,7 @@ class EvaluateAndGetStatus {
 
 		$evaluation_logger = new EvaluationLogger( $spec->slug );
 		$evaluated_result  = $rule_evaluator->evaluate( $spec->rules, $stored_state, $evaluation_logger );
-		$evaluation_logger->log();
+		constant( 'WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS' ) === true && $evaluation_logger->log();
 
 		// Pending notes should be the spec status if the spec passes,
 		// left alone otherwise.

--- a/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
+++ b/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
@@ -16,9 +16,9 @@ class EvaluateAndGetStatus {
 	/**
 	 * Evaluates the spec and returns a status.
 	 *
-	 * @param array  $spec           The spec to evaluate.
+	 * @param array  $spec The spec to evaluate.
 	 * @param string $current_status The note's current status.
-	 * @param object $stored_state   Stored state.
+	 * @param object $stored_state Stored state.
 	 * @param object $rule_evaluator Evaluates rules into true/false.
 	 *
 	 * @return string The evaluated status.
@@ -29,7 +29,9 @@ class EvaluateAndGetStatus {
 			return $current_status;
 		}
 
-		$evaluated_result = $rule_evaluator->evaluate( $spec->rules, $stored_state );
+		$evaluation_logger = new EvaluationLogger( $spec->slug );
+		$evaluated_result  = $rule_evaluator->evaluate( $spec->rules, $stored_state, $evaluation_logger );
+		$evaluation_logger->log();
 
 		// Pending notes should be the spec status if the spec passes,
 		// left alone otherwise.

--- a/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
+++ b/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
@@ -29,11 +29,7 @@ class EvaluateAndGetStatus {
 			return $current_status;
 		}
 
-		$evaluation_logger = new EvaluationLogger( $spec->slug );
-		$evaluated_result  = $rule_evaluator->evaluate( $spec->rules, $stored_state, $evaluation_logger );
-		defined( 'WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS' )
-		&& true === WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS
-		&& $evaluation_logger->log();
+		$evaluated_result = $rule_evaluator->evaluate( $spec->rules, $stored_state, array( 'slug' => $spec->slug ) );
 
 		// Pending notes should be the spec status if the spec passes,
 		// left alone otherwise.

--- a/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
+++ b/src/RemoteInboxNotifications/EvaluateAndGetStatus.php
@@ -31,7 +31,7 @@ class EvaluateAndGetStatus {
 
 		$evaluation_logger = new EvaluationLogger( $spec->slug );
 		$evaluated_result  = $rule_evaluator->evaluate( $spec->rules, $stored_state, $evaluation_logger );
-		constant( 'WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS' ) === true && $evaluation_logger->log();
+		constant( 'WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS' ) === true && $evaluation_logger->log();
 
 		// Pending notes should be the spec status if the spec passes,
 		// left alone otherwise.

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -78,6 +78,7 @@ class EvaluationLogger {
 	 * Log the results.
 	 */
 	public function log() {
-		$this->logger->debug( $this->format(), array( 'source' => 'remote-inbox-notifications' ) );
+		true === constant( 'WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS' )
+		&& $this->logger->debug( $this->format(), array( 'source' => 'remote-inbox-notifications' ) );
 	}
 }

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -71,6 +71,7 @@ class EvaluationLogger {
 					array( 'source' => 'remote-inbox-notifications' )
 				);
 			}
+			$this->logger->debug( "\n" );
 		}
 	}
 }

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -76,12 +76,15 @@ class EvaluationLogger {
 	 * Log the results.
 	 */
 	public function log() {
+		if ( false === defined( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' ) || true !== constant( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' ) ) {
+			return;
+		}
+
 		foreach ( $this->results as $result ) {
 			$this->logger->debug(
 				"[{$this->slug}] {$result['rule']}: {$result['result']}",
 				array( 'source' => $this->source )
 			);
 		}
-		$this->logger->debug( "\n" );
 	}
 }

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -61,24 +61,16 @@ class EvaluationLogger {
 	}
 
 	/**
-	 * Format the results into json.
-	 *
-	 * @return string
-	 */
-	public function format() {
-		return wp_json_encode(
-			array(
-				'slug'    => $this->slug,
-				'results' => $this->results,
-			)
-		);
-	}
-
-	/**
 	 * Log the results.
 	 */
 	public function log() {
-		true === constant( 'WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS' )
-		&& $this->logger->debug( $this->format(), array( 'source' => 'remote-inbox-notifications' ) );
+		if ( true === constant( 'WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS' ) ) {
+			foreach ( $this->results as $result ) {
+				$this->logger->debug(
+					"[{$this->slug}] {$result['rule']}: {$result['result']}",
+					array( 'source' => 'remote-inbox-notifications' )
+				);
+			}
+		}
 	}
 }

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\RemoteInboxNotifications;
+
+/**
+ * Class EvaluationLogger
+ *
+ * @package Automattic\WooCommerce\Admin\RemoteInboxNotifications
+ */
+class EvaluationLogger {
+	/**
+	 * Slug of the spec.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Results of rules in the given spec.
+	 *
+	 * @var array
+	 */
+	private $results = array();
+
+	/**
+	 * Logger class to use.
+	 *
+	 * @var WC_Logger_Interface|null
+	 */
+	private $logger;
+
+	/**
+	 * EvaluationLogger constructor.
+	 *
+	 * @param string                   $slug Slug of a spec that is being evaluated.
+	 * @param WC_Logger_Interface|null $logger Logger class to use.
+	 */
+	public function __construct( $slug, \WC_Logger_Interface $logger = null ) {
+		$this->slug = $slug;
+		if ( null === $logger ) {
+			$logger = wc_get_logger();
+		}
+
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Add evaluation result of a rule.
+	 *
+	 * @param string  $rule_type name of the rule being tested.
+	 * @param boolean $result result of a given rule.
+	 */
+	public function add_result( $rule_type, $result ) {
+		array_push(
+			$this->results,
+			array(
+				'rule'   => $rule_type,
+				'result' => $result ? 'passed' : 'failed',
+			)
+		);
+	}
+
+	/**
+	 * Format the results into json.
+	 *
+	 * @return string
+	 */
+	public function format() {
+		return wp_json_encode(
+			array(
+				'slug'    => $this->slug,
+				'results' => $this->results,
+			)
+		);
+	}
+
+	/**
+	 * Log the results.
+	 */
+	public function log() {
+		$this->logger->debug( $this->format(), array( 'source' => 'remote-inbox-notifications' ) );
+	}
+}

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -64,14 +64,12 @@ class EvaluationLogger {
 	 * Log the results.
 	 */
 	public function log() {
-		if ( true === constant( 'WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS' ) ) {
-			foreach ( $this->results as $result ) {
-				$this->logger->debug(
-					"[{$this->slug}] {$result['rule']}: {$result['result']}",
-					array( 'source' => 'remote-inbox-notifications' )
-				);
-			}
-			$this->logger->debug( "\n" );
+		foreach ( $this->results as $result ) {
+			$this->logger->debug(
+				"[{$this->slug}] {$result['rule']}: {$result['result']}",
+				array( 'source' => 'remote-inbox-notifications' )
+			);
 		}
+		$this->logger->debug( "\n" );
 	}
 }

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -30,15 +30,27 @@ class EvaluationLogger {
 	private $logger;
 
 	/**
+	 * Logger source.
+	 *
+	 * @var string logger source.
+	 */
+	private $source = 'remote-inbox-notifications';
+
+	/**
 	 * EvaluationLogger constructor.
 	 *
-	 * @param string                   $slug Slug of a spec that is being evaluated.
-	 * @param WC_Logger_Interface|null $logger Logger class to use.
+	 * @param string               $slug Slug of a spec that is being evaluated.
+	 * @param null                 $source Logger source.
+	 * @param \WC_Logger_Interface $logger Logger class to use.
 	 */
-	public function __construct( $slug, \WC_Logger_Interface $logger = null ) {
+	public function __construct( $slug, $source = null, \WC_Logger_Interface $logger = null ) {
 		$this->slug = $slug;
 		if ( null === $logger ) {
 			$logger = wc_get_logger();
+		}
+
+		if ( $source ) {
+			$this->source = $source;
 		}
 
 		$this->logger = $logger;
@@ -67,7 +79,7 @@ class EvaluationLogger {
 		foreach ( $this->results as $result ) {
 			$this->logger->debug(
 				"[{$this->slug}] {$result['rule']}: {$result['result']}",
-				array( 'source' => 'remote-inbox-notifications' )
+				array( 'source' => $this->source )
 			);
 		}
 		$this->logger->debug( "\n" );

--- a/src/RemoteInboxNotifications/EvaluationLogger.php
+++ b/src/RemoteInboxNotifications/EvaluationLogger.php
@@ -34,7 +34,7 @@ class EvaluationLogger {
 	 *
 	 * @var string logger source.
 	 */
-	private $source = 'remote-inbox-notifications';
+	private $source = '';
 
 	/**
 	 * EvaluationLogger constructor.

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -497,3 +497,17 @@ WooCommerce Admin plugin.
 ```
 
 No other values are needed.
+
+## Debugging Specification
+
+You can see the evaluation of each specification by turning on an optional evaluation logger.
+
+1. Define `WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS` constant in `wp-config.php`. `define('WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS', true);`
+2. Run `wc_admin_daily`
+3. cd to `wp-content/uploads/wc-logs/` and check a log file in `remote-inbox-notifications-:date-hash.log` format.
+
+You can tail the log file with a slug name to see the evaluation of a rule that you are testing.
+
+Example: 
+
+`tail -f remote-inbox-notifications-2021-06-15-128.log | grep 'wcpay-promo-2021-6-incentive-2'`

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -502,7 +502,7 @@ No other values are needed.
 
 You can see the evaluation of each specification by turning on an optional evaluation logger.
 
-1. Define `WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS` constant in `wp-config.php`. `define('WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS', true);`
+1. Define `WC_ADMIN_DEBUG_RULE_EVALUATOR` constant in `wp-config.php`. `define('WC_ADMIN_DEBUG_RULE_EVALUATOR', true);`
 2. Run `wc_admin_daily`
 3. cd to `wp-content/uploads/wc-logs/` and check a log file in `remote-inbox-notifications-:date-hash.log` format.
 

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -502,7 +502,7 @@ No other values are needed.
 
 You can see the evaluation of each specification by turning on an optional evaluation logger.
 
-1. Define `WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS` constant in `wp-config.php`. `define('WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS', true);`
+1. Define `WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS` constant in `wp-config.php`. `define('WC_ADMIN_DEBUG_REMOTE_INBOX_NOTIFICATIONS', true);`
 2. Run `wc_admin_daily`
 3. cd to `wp-content/uploads/wc-logs/` and check a log file in `remote-inbox-notifications-:date-hash.log` format.
 

--- a/src/RemoteInboxNotifications/RuleEvaluator.php
+++ b/src/RemoteInboxNotifications/RuleEvaluator.php
@@ -63,14 +63,12 @@ class RuleEvaluator {
 			$evaluation_logger && $evaluation_logger->add_result( $rule->type, $processor_result );
 
 			if ( ! $processor_result ) {
+				$evaluation_logger && $evaluation_logger->log();
 				return false;
 			}
 		}
 
-		defined( 'WC_ADMIN_DEBUG_RULE_EVALUATOR' )
-		&& true === WC_ADMIN_DEBUG_RULE_EVALUATOR
-		&& $evaluation_logger
-		&& $evaluation_logger->log();
+		$evaluation_logger && $evaluation_logger->log();
 
 		return true;
 	}

--- a/src/RemoteInboxNotifications/RuleEvaluator.php
+++ b/src/RemoteInboxNotifications/RuleEvaluator.php
@@ -28,12 +28,13 @@ class RuleEvaluator {
 	 * Evaluate the given rules as an AND operation - return false early if a
 	 * rule evaluates to false.
 	 *
-	 * @param array|object $rules        The rule or rules being processed.
-	 * @param object|null  $stored_state Stored state.
+	 * @param array|object          $rules The rule or rules being processed.
+	 * @param object|null           $stored_state Stored state.
+	 * @param EvaluationLogger|null $evaluation_logger logger to use.
 	 *
 	 * @return bool The result of the operation.
 	 */
-	public function evaluate( $rules, $stored_state = null ) {
+	public function evaluate( $rules, $stored_state = null, EvaluationLogger $evaluation_logger = null ) {
 		if ( ! is_array( $rules ) ) {
 			$rules = array( $rules );
 		}
@@ -45,6 +46,7 @@ class RuleEvaluator {
 		foreach ( $rules as $rule ) {
 			$processor        = $this->get_rule_processor->get_processor( $rule->type );
 			$processor_result = $processor->process( $rule, $stored_state );
+			$evaluation_logger && $evaluation_logger->add_result( $rule->type, $processor_result );
 
 			if ( ! $processor_result ) {
 				return false;

--- a/src/RemoteInboxNotifications/RuleEvaluator.php
+++ b/src/RemoteInboxNotifications/RuleEvaluator.php
@@ -30,7 +30,7 @@ class RuleEvaluator {
 	 *
 	 * @param array|object $rules The rule or rules being processed.
 	 * @param object|null  $stored_state Stored state.
-	 * @param array        $logger_args arguments for the event logger. slug is required.
+	 * @param array        $logger_args Arguments for the event logger. `slug` is required.
 	 *
 	 * @throws \InvalidArgumentException Thrown when $logger_args is missing slug.
 	 *

--- a/tests/remote-inbox-notifications/evaluate-and-get-status.php
+++ b/tests/remote-inbox-notifications/evaluate-and-get-status.php
@@ -21,6 +21,7 @@ class WC_Tests_RemoteInboxNotifications_EvaluateAndGetStatus extends WC_Unit_Tes
 	private function get_spec( $allow_redisplay ) {
 		return json_decode(
 			'{
+				"slug": "test",
 				"status": "unactioned",
 				"rules": [],
 				"allow_redisplay": ' . ( $allow_redisplay ? 'true' : 'false' ) . '


### PR DESCRIPTION
Fixes #7187 

This PR adds a class to log evaluation results of rules in Remote Inbox Notifications.

### Detailed test instructions:

1. Add `WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS` constant in your `wp-config.php` `define('WC_DEBUG_REMOTE_INBOX_NOTIFICATIONS', true);`
2. Run `wc_admin_daily` job.
3. Check `wp-content/uploads/wc-logs`. You should see a log file in `remote-inbox-notifications-YYYY-MM-DD-:hash.log` format. 

Tip: If you're working on `wcpay-promo-2021-6-incentive-1` slug, you can use `tail -f :file | grep wcpay-promo-2021-6-incentive-1` to filter the log contents. 

**Log format:**

![Screen Shot 2021-06-17 at 11 15 35 PM](https://user-images.githubusercontent.com/4723145/122515210-f5898400-cfc1-11eb-9bf0-e07d4fcb0362.jpg)

no changelog needed