### PR TITLE
Vertical CSS transition component helper

### DIFF
--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -51,7 +51,7 @@ describe( 'TaskDashboard and TaskList', () => {
 	const updateOptions = jest.fn();
 	const createNotice = jest.fn();
 	const originalClientHeight = Object.getOwnPropertyDescriptor(
-		HTMLElement.prototype,
+		global.HTMLElement.prototype,
 		'clientHeight'
 	);
 
@@ -61,7 +61,7 @@ describe( 'TaskDashboard and TaskList', () => {
 			createNotice,
 			installAndActivatePlugins: jest.fn(),
 		} ) );
-		Object.defineProperty( HTMLElement.prototype, 'clientHeight', {
+		Object.defineProperty( global.HTMLElement.prototype, 'clientHeight', {
 			configurable: true,
 			value: 100,
 		} );
@@ -70,7 +70,7 @@ describe( 'TaskDashboard and TaskList', () => {
 		jest.clearAllMocks();
 		if ( originalClientHeight ) {
 			Object.defineProperty(
-				HTMLElement.prototype,
+				global.HTMLElement.prototype,
 				'offsetHeight',
 				originalClientHeight
 			);

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -50,14 +50,32 @@ const EXTENDED_TASK_LIST_HEADING = 'Things to do next';
 describe( 'TaskDashboard and TaskList', () => {
 	const updateOptions = jest.fn();
 	const createNotice = jest.fn();
+	const originalClientHeight = Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		'clientHeight'
+	);
+
 	beforeEach( () => {
 		useDispatch.mockImplementation( () => ( {
 			updateOptions,
 			createNotice,
 			installAndActivatePlugins: jest.fn(),
 		} ) );
+		Object.defineProperty( HTMLElement.prototype, 'clientHeight', {
+			configurable: true,
+			value: 100,
+		} );
 	} );
-	afterEach( () => jest.clearAllMocks() );
+	afterEach( () => {
+		jest.clearAllMocks();
+		if ( originalClientHeight ) {
+			Object.defineProperty(
+				HTMLElement.prototype,
+				'offsetHeight',
+				originalClientHeight
+			);
+		}
+	} );
 	const MockTask = () => {
 		return <div>mock task</div>;
 	};
@@ -695,16 +713,19 @@ describe( 'TaskDashboard and TaskList', () => {
 
 			// Expect the first incomplete task to be expanded
 			expect(
-				await findByText(
-					container,
-					'This is the optional task content'
-				)
-			).toHaveClass( 'woocommerce-task-list__item-content-appear' );
+				(
+					await findByText(
+						container,
+						'This is the optional task content'
+					)
+				 ).parentElement.style.maxHeight
+			).not.toBe( '0' );
 
 			// Expect the second not to be.
 			expect(
-				queryByText( 'This is the required task content' )
-			).not.toHaveClass( 'woocommerce-task-list__item-content-appear' );
+				queryByText( 'This is the required task content' ).parentElement
+					.style.maxHeight
+			).toBe( '0' );
 		} );
 	} );
 

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+-   Add new VerticalCSSTransition component for handling height transitions. #7203
+-   Update TaskItem to make use of the VerticalCSSTransition. #7203
+
 # 1.3.0
 
 -   Remove the use of Dashicons and replace with @wordpress/icons or gridicons #7020

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -45,6 +45,7 @@
 	"devDependencies": {
 		"@storybook/addon-console": "1.2.3",
 		"@storybook/react": "6.2.9",
-		"@types/dompurify": "2.2.2"
+		"@types/dompurify": "2.2.2",
+		"@types/react-transition-group": "4.4.1"
 	}
 }

--- a/packages/experimental/src/experimental-list/task-item.scss
+++ b/packages/experimental/src/experimental-list/task-item.scss
@@ -65,39 +65,27 @@ $task-alert-yellow: #f0b849;
 	}
 
 	.woocommerce-task-list__item-content {
-		max-height: 0;
-		opacity: 0;
 		margin-top: $gap-smallest;
 		overflow: hidden;
 
 		&.woocommerce-task-list__item-content-enter {
 			opacity: 0;
-			max-height: 0;
 		}
 
 		&.woocommerce-task-list__item-content-enter-active {
 			opacity: 1;
-			max-height: 100vh;
-			transition: opacity 500ms, max-height 500ms;
 		}
 
-		&.woocommerce-task-list__item-content-appear,
-		&.woocommerce-task-list__item-content-appear-active,
-		&.woocommerce-task-list__item-content-appear-done,
 		&.woocommerce-task-list__item-content-enter-done {
 			opacity: 1;
-			max-height: 100vh;
 		}
 
 		&.woocommerce-task-list__item-content-exit {
 			opacity: 1;
-			max-height: 100vh;
 		}
 
 		&.woocommerce-task-list__item-content-exit-active {
 			opacity: 0;
-			max-height: 0;
-			transition: opacity 500ms, max-height 500ms;
 		}
 
 		.woocommerce-task__additional-info {

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -8,12 +8,12 @@ import NoticeOutline from 'gridicons/dist/notice-outline';
 import { EllipsisMenu } from '@woocommerce/components';
 import classnames from 'classnames';
 import { sanitize } from 'dompurify';
-import { CSSTransition } from 'react-transition-group';
 
 /**
  * Internal dependencies
  */
 import { Text, ListItem } from '../';
+import { VerticalCSSTransition } from '../vertical-css-transition';
 
 const ALLOWED_TAGS = [ 'a', 'b', 'em', 'i', 'strong', 'p', 'br' ];
 const ALLOWED_ATTR = [ 'target', 'href', 'rel', 'name', 'download' ];
@@ -113,11 +113,13 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					<span className="woocommerce-task-list__item-title">
 						{ title }
 					</span>
-					<CSSTransition
-						appear
+					<VerticalCSSTransition
 						timeout={ 500 }
 						in={ expanded }
 						classNames="woocommerce-task-list__item-content"
+						defaultStyle={ {
+							transitionProperty: 'max-height, opacity',
+						} }
 					>
 						<div className="woocommerce-task-list__item-content">
 							{ content }
@@ -146,7 +148,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 								</Button>
 							) }
 						</div>
-					</CSSTransition>
+					</VerticalCSSTransition>
 
 					{ ! expandable && ! completed && additionalInfo && (
 						<div

--- a/packages/experimental/src/index.js
+++ b/packages/experimental/src/index.js
@@ -38,3 +38,5 @@ export { ExperimentalList as List } from './experimental-list/experimental-list'
 export { ExperimentalCollapsibleList as CollapsibleList } from './experimental-list/collapsible-list';
 export { TaskItem } from './experimental-list/task-item';
 export * from './inbox-note';
+
+export * from './vertical-css-transition';

--- a/packages/experimental/src/vertical-css-transition/README.md
+++ b/packages/experimental/src/vertical-css-transition/README.md
@@ -1,0 +1,36 @@
+# VerticalCSSTransition
+
+This is a wrapper to the [React CSSTransition](https://reactcommunity.org/react-transition-group/css-transition) component, allowing for each vertical height transitions (collapsing/expanding). CSS does not support height: auto transitions, this uses JavaScript instead.
+
+## Usage
+
+```jsx
+<VerticalCSSTransition timeout={ 500 } in={ true } classNames="my-node" defaultStyle={ transitionProperty: 'max-height, opacity' }>
+	<div>some content</div>
+	<div>
+		some more content <br /> line 2 <br /> line 3
+	</div>
+</VerticalCSSTransition>
+```
+
+```css
+.my-node-enter {
+	opacity: 0;
+}
+
+.my-node-enter-active {
+	opacity: 1;
+}
+```
+
+### Props
+
+Props extends the [CSSTransition props](https://reactcommunity.org/react-transition-group/css-transition#CSSTransition-props).
+Name | Type | Default | Description
+--- | --- | --- | ---
+`defaultStyle` | CSSProperties | `null` | Custom CSS properties for the transition component.
+
+### defaultStyle
+
+`defaultStyle` is used to extend the current list of CSS properties added by this component. It also allows you to add extra transition
+properties by overwriting the `transitionProperty` property (see above for example).

--- a/packages/experimental/src/vertical-css-transition/index.ts
+++ b/packages/experimental/src/vertical-css-transition/index.ts
@@ -1,0 +1,1 @@
+export * from './vertical-css-transition';

--- a/packages/experimental/src/vertical-css-transition/stories/index.tsx
+++ b/packages/experimental/src/vertical-css-transition/stories/index.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { withConsole } from '@storybook/addon-console';
+import { Meta, Story } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	VerticalCSSTransition,
+	VerticalCSSTransitionProps,
+} from '../vertical-css-transition';
+import './style.scss';
+
+export default {
+	title: 'WooCommerce Admin/experimental/VerticalCSSTransition',
+	component: VerticalCSSTransition,
+	decorators: [ ( storyFn, context ) => withConsole()( storyFn )( context ) ],
+} as Meta;
+
+const Parent: React.FC< VerticalCSSTransitionProps > = ( args ) => {
+	const [ expanded, setExpanded ] = useState( true );
+	return (
+		<>
+			<button onClick={ () => setExpanded( ! expanded ) }>
+				{ expanded ? 'collapse' : 'expand' }
+			</button>
+			<VerticalCSSTransition { ...args } in={ expanded }>
+				<div>some content</div>
+				<div>
+					some more content <br /> line 2 <br /> line 3
+				</div>
+			</VerticalCSSTransition>
+		</>
+	);
+};
+
+const Template: Story< VerticalCSSTransitionProps > = ( args ) => (
+	<Parent { ...args } />
+);
+
+export const Primary = Template.bind( { onClick: () => {} } );
+
+Primary.args = {
+	appear: true,
+	timeout: 500,
+	classNames: 'collapsible-content',
+	defaultStyle: {
+		transitionProperty: 'max-height, opacity',
+	},
+};

--- a/packages/experimental/src/vertical-css-transition/stories/style.scss
+++ b/packages/experimental/src/vertical-css-transition/stories/style.scss
@@ -1,0 +1,23 @@
+.collapsible-content-enter,
+.collapsible-content-exit-done {
+	opacity: 0;
+}
+
+.collapsible-content-enter-active {
+	opacity: 1;
+}
+
+.collapsible-content-appear,
+.collapsible-content-appear-active,
+.collapsible-content-appear-done,
+.collapsible-content-enter-done {
+	opacity: 1;
+}
+
+.collapsible-content-exit {
+	opacity: 1;
+}
+
+.collapsible-content-exit-active {
+	opacity: 0;
+}

--- a/packages/experimental/src/vertical-css-transition/test/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/test/vertical-css-transition.tsx
@@ -1,0 +1,228 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { createRef } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import {
+	VerticalCSSTransition,
+	VerticalCSSTransitionProps,
+} from '../vertical-css-transition';
+
+describe( 'VerticalCSSTransition', () => {
+	const originalClientHeight = Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		'clientHeight'
+	);
+
+	beforeEach( () => {
+		Object.defineProperty( HTMLElement.prototype, 'clientHeight', {
+			configurable: true,
+			value: 100,
+		} );
+	} );
+
+	afterEach( () => {
+		if ( originalClientHeight ) {
+			Object.defineProperty(
+				HTMLElement.prototype,
+				'offsetHeight',
+				originalClientHeight
+			);
+		}
+	} );
+
+	it( 'should set maxHeight of children to container on render', () => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		render(
+			<VerticalCSSTransition
+				in={ true }
+				timeout={ 0 }
+				nodeRef={ nodeRef as React.RefObject< undefined > }
+				classNames="test"
+			>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+
+		expect(
+			nodeRef.current && nodeRef.current.parentElement?.style.maxHeight
+		).toBe( '100px' );
+	} );
+
+	it( 'should update maxHeight when children are updated', () => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		const props: VerticalCSSTransitionProps = {
+			in: true,
+			timeout: 0,
+			nodeRef: nodeRef as React.RefObject< undefined >,
+			classNames: 'test',
+		};
+		const { rerender } = render(
+			<VerticalCSSTransition { ...props }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+
+		expect(
+			nodeRef.current && nodeRef.current.parentElement?.style.maxHeight
+		).toBe( '100px' );
+
+		rerender(
+			<VerticalCSSTransition { ...props }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+				<div>New child</div>
+			</VerticalCSSTransition>
+		);
+		expect(
+			nodeRef.current && nodeRef.current.parentElement?.style.maxHeight
+		).toBe( '200px' );
+	} );
+
+	it( 'should set maxHeight to zero if in is set to false', () => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		render(
+			<VerticalCSSTransition
+				in={ false }
+				timeout={ 0 }
+				nodeRef={ nodeRef as React.RefObject< undefined > }
+				classNames="test"
+			>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+
+		expect(
+			nodeRef.current && nodeRef.current.parentElement?.style.maxHeight
+		).toBe( '0' );
+	} );
+
+	it( 'should set transitionDuration to the passed in timeout', () => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		render(
+			<VerticalCSSTransition
+				in={ false }
+				timeout={ 10 }
+				nodeRef={ nodeRef as React.RefObject< undefined > }
+				classNames="test"
+			>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+
+		expect(
+			nodeRef.current &&
+				nodeRef.current.parentElement?.style.transitionDuration
+		).toBe( '10ms' );
+	} );
+
+	it( 'should still set css classes on enter transition', ( done ) => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		const props: VerticalCSSTransitionProps = {
+			in: false,
+			timeout: 0,
+			nodeRef: nodeRef as React.RefObject< undefined >,
+			classNames: 'test',
+			onEntering: () => {
+				expect(
+					nodeRef.current &&
+						nodeRef.current.classList.contains( 'test-enter' )
+				).toEqual( true );
+				expect(
+					nodeRef.current &&
+						nodeRef.current.classList.contains(
+							'test-enter-active'
+						)
+				).toEqual( true );
+				done();
+			},
+		};
+		const { rerender } = render(
+			<VerticalCSSTransition { ...props }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+		rerender(
+			<VerticalCSSTransition { ...props } in={ true }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+	} );
+
+	it( 'should still set css classes on exit transition', ( done ) => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		const props: VerticalCSSTransitionProps = {
+			in: true,
+			timeout: 0,
+			nodeRef: nodeRef as React.RefObject< undefined >,
+			classNames: 'test',
+			onExiting: () => {
+				expect(
+					nodeRef.current &&
+						nodeRef.current.classList.contains( 'test-exit' )
+				).toEqual( true );
+				expect(
+					nodeRef.current &&
+						nodeRef.current.classList.contains( 'test-exit-active' )
+				).toEqual( true );
+				done();
+			},
+		};
+		const { rerender } = render(
+			<VerticalCSSTransition { ...props }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+		rerender(
+			<VerticalCSSTransition { ...props } in={ false }>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
+	} );
+
+	describe( 'defaultStyle', () => {
+		it( 'should overwrite default style when passed in', () => {
+			const nodeRef = createRef< undefined | HTMLDivElement >();
+			render(
+				<VerticalCSSTransition
+					in={ false }
+					timeout={ 0 }
+					nodeRef={ nodeRef as React.RefObject< undefined > }
+					classNames="test"
+					defaultStyle={ {
+						transitionProperty: 'max-height, opacity',
+					} }
+				>
+					<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+						Test
+					</div>
+				</VerticalCSSTransition>
+			);
+
+			expect(
+				nodeRef.current &&
+					nodeRef.current.parentElement?.style.transitionProperty
+			).toBe( 'max-height, opacity' );
+		} );
+	} );
+} );

--- a/packages/experimental/src/vertical-css-transition/test/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/test/vertical-css-transition.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { createRef } from '@wordpress/element';
 /**
  * Internal dependencies
@@ -107,12 +107,12 @@ describe( 'VerticalCSSTransition', () => {
 		).toBe( '0' );
 	} );
 
-	it( 'should set transitionDuration to the passed in timeout', () => {
+	it( 'should not set transition variables when not in transition', () => {
 		const nodeRef = createRef< undefined | HTMLDivElement >();
 		render(
 			<VerticalCSSTransition
-				in={ false }
-				timeout={ 10 }
+				in={ true }
+				timeout={ 0 }
 				nodeRef={ nodeRef as React.RefObject< undefined > }
 				classNames="test"
 			>
@@ -125,7 +125,41 @@ describe( 'VerticalCSSTransition', () => {
 		expect(
 			nodeRef.current &&
 				nodeRef.current.parentElement?.style.transitionDuration
-		).toBe( '10ms' );
+		).toBe( '' );
+		expect(
+			nodeRef.current &&
+				nodeRef.current.parentElement?.style.transitionProperty
+		).toBe( '' );
+	} );
+
+	it( 'should add transition style properties when in transition', ( done ) => {
+		const nodeRef = createRef< undefined | HTMLDivElement >();
+		render(
+			<VerticalCSSTransition
+				in={ true }
+				appear
+				timeout={ 0 }
+				nodeRef={ nodeRef as React.RefObject< undefined > }
+				classNames="test"
+				onEntering={ () => {
+					expect(
+						nodeRef.current &&
+							nodeRef.current.parentElement?.style
+								.transitionDuration
+					).toBe( '0ms' );
+					expect(
+						nodeRef.current &&
+							nodeRef.current.parentElement?.style
+								.transitionProperty
+					).toBe( 'max-height' );
+					done();
+				} }
+			>
+				<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
+					Test
+				</div>
+			</VerticalCSSTransition>
+		);
 	} );
 
 	it( 'should still set css classes on enter transition', ( done ) => {
@@ -201,16 +235,25 @@ describe( 'VerticalCSSTransition', () => {
 	} );
 
 	describe( 'defaultStyle', () => {
-		it( 'should overwrite default style when passed in', () => {
+		it( 'should overwrite default style when passed in', ( done ) => {
 			const nodeRef = createRef< undefined | HTMLDivElement >();
 			render(
 				<VerticalCSSTransition
-					in={ false }
+					in={ true }
+					appear
 					timeout={ 0 }
 					nodeRef={ nodeRef as React.RefObject< undefined > }
 					classNames="test"
 					defaultStyle={ {
 						transitionProperty: 'max-height, opacity',
+					} }
+					onEntering={ () => {
+						expect(
+							nodeRef.current &&
+								nodeRef.current.parentElement?.style
+									.transitionProperty
+						).toBe( 'max-height, opacity' );
+						done();
 					} }
 				>
 					<div ref={ nodeRef as React.RefObject< HTMLDivElement > }>
@@ -218,11 +261,6 @@ describe( 'VerticalCSSTransition', () => {
 					</div>
 				</VerticalCSSTransition>
 			);
-
-			expect(
-				nodeRef.current &&
-					nodeRef.current.parentElement?.style.transitionProperty
-			).toBe( 'max-height, opacity' );
 		} );
 	} );
 } );

--- a/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
@@ -89,9 +89,9 @@ export const VerticalCSSTransition: React.FC< VerticalCSSTransitionProps > = ( {
 		};
 		// only include transition styles when entering or exiting.
 		if ( state !== 'entering' && state !== 'exiting' ) {
-			styles.transitionDuration = undefined;
-			styles.transition = undefined;
-			styles.transitionProperty = undefined;
+			delete styles.transitionDuration;
+			delete styles.transition;
+			delete styles.transitionProperty;
 		}
 		return styles;
 	};

--- a/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
+++ b/packages/experimental/src/vertical-css-transition/vertical-css-transition.tsx
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { CSSTransitionProps } from 'react-transition-group/CSSTransition';
+import { CSSTransition } from 'react-transition-group';
+
+export type VerticalCSSTransitionProps<
+	Ref extends HTMLElement | undefined = undefined
+> = CSSTransitionProps< Ref > & {
+	defaultStyle?: React.CSSProperties;
+};
+
+function getContainerHeight( container: HTMLDivElement ) {
+	let containerHeight = 0;
+	for ( const child of container.children ) {
+		containerHeight += child.clientHeight;
+	}
+	return containerHeight;
+}
+
+/**
+ * VerticalCSSTransition is a wrapper for CSSTransition, automatically adding a vertical height transition.
+ * The maxHeight is calculated through JS, something CSS does not support.
+ */
+export const VerticalCSSTransition: React.FC< VerticalCSSTransitionProps > = ( {
+	children,
+	defaultStyle,
+	...props
+} ) => {
+	const [ containerHeight, setContainerHeight ] = useState( 0 );
+	const collapseContainerRef = useCallback(
+		( containerElement: HTMLDivElement ) => {
+			if ( containerElement ) {
+				setContainerHeight( getContainerHeight( containerElement ) );
+			}
+		},
+		[ children ]
+	);
+
+	const transitionStyles = {
+		entered: { maxHeight: containerHeight },
+		entering: { maxHeight: containerHeight },
+		exiting: { maxHeight: 0 },
+		exited: { maxHeight: 0 },
+	};
+	const transitionDuration =
+		( typeof props.timeout === 'number' ? props.timeout : 500 ) + 'ms';
+	defaultStyle = {
+		transitionProperty: 'max-height',
+		transitionDuration,
+		maxHeight: 0,
+		overflow: 'hidden',
+		...( defaultStyle || {} ),
+	};
+
+	return (
+		<CSSTransition { ...props }>
+			{ ( state: 'entering' | 'entered' | 'exiting' | 'exited' ) => (
+				<div
+					className="vertical-css-transition-container"
+					style={ {
+						...defaultStyle,
+						...transitionStyles[ state ],
+					} }
+					ref={ collapseContainerRef }
+				>
+					{ children }
+				</div>
+			) }
+		</CSSTransition>
+	);
+};


### PR DESCRIPTION
Fixes #7132 

This is a wrapper around the React CSSTransition, which automatically handles the height transition, by calculating the height of the wrapped component (using `clientHeight`). This makes for easy smooth height transitions.

I updated the [new task list content](https://github.com/woocommerce/woocommerce-admin/pull/7128) to make use of this (see gif below)

No changelog as it is in the experimental library.

### Screenshots

![vertical-transition-example](https://user-images.githubusercontent.com/2240960/122416207-ecb39680-cf5e-11eb-9792-94ceced6533a.gif)

### Detailed test instructions:
**Storybook**
- Run `npm run storybook` and go to **experimental > VerticalCSSTransition**
- See if the example works well

**WooCommerce Admin**
- Ensure the task list is visible on **WooCommerce > Home**
- Force the `expandingItems` prop to be `true` here: https://github.com/woocommerce/woocommerce-admin/blob/4413194a5e2f7f0135368b605a1de19a3a2a3b1e/client/task-list/index.js#L224
- Verify the transition animations occur when expanding/collapsing list items on **WooCommerce > Home**
- You can also increase the content of one of the task items here: https://github.com/woocommerce/woocommerce-admin/blob/4413194a5e2f7f0135368b605a1de19a3a2a3b1e/client/task-list/tasks.js#L147 to see if it adjusts well to different heights.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
