### PR TITLE
Add date range support to remaining notes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165
 - Fix:  Use tab char for the CSV injection prevention. #7154
+- Update: Notes to use a date range. #7222
 
 == 2.4.0 6/10/2021 ==
 - Dev: Add Jetpack Backup admin note #6738

--- a/src/Notes/AddingAndManangingProducts.php
+++ b/src/Notes/AddingAndManangingProducts.php
@@ -35,7 +35,7 @@ class AddingAndManangingProducts {
 	 */
 	public static function get_note() {
 		// Store must have been at least 3 days.
-		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS * 3 ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', DAY_IN_SECONDS * 3 ) ) {
 			return;
 		}
 

--- a/src/Notes/ChoosingTheme.php
+++ b/src/Notes/ChoosingTheme.php
@@ -30,7 +30,7 @@ class ChoosingTheme {
 	 */
 	protected static function get_note() {
 		// We need to show choosing a theme notification after 1 day of install.
-		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/CustomizeStoreWithBlocks.php
+++ b/src/Notes/CustomizeStoreWithBlocks.php
@@ -48,7 +48,7 @@ class CustomizeStoreWithBlocks {
 		}
 
 		// We want to show the note after fourteen days.
-		if ( ! self::wc_admin_active_for( 14 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4', 14 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/DrawAttention.php
+++ b/src/Notes/DrawAttention.php
@@ -40,7 +40,7 @@ class DrawAttention {
 	 */
 	public static function get_note() {
 		// We want to show the note after 3 days.
-		if ( ! self::wc_admin_active_for( 3 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', 3 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/FirstProduct.php
+++ b/src/Notes/FirstProduct.php
@@ -30,7 +30,7 @@ class FirstProduct {
 	 */
 	public static function get_note() {
 		// We want to show the note after seven days.
-		if ( ! self::wc_admin_active_for( 7 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) ) {
 			return;
 		}
 

--- a/src/Notes/InsightFirstProductAndPayment.php
+++ b/src/Notes/InsightFirstProductAndPayment.php
@@ -32,7 +32,7 @@ class InsightFirstProductAndPayment {
 	 */
 	public static function get_note() {
 		// We want to show the note after 1 day.
-		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/LaunchChecklist.php
+++ b/src/Notes/LaunchChecklist.php
@@ -36,7 +36,7 @@ class LaunchChecklist {
 			! get_option( 'woocommerce_task_list_complete' ) &&
 			(
 				count( $completed_tasks ) < 3 ||
-				self::wc_admin_active_for( $ten_days_in_seconds )
+				self::is_wc_admin_active_in_date_range( 'week-1-4', $ten_days_in_seconds )
 			)
 		) {
 			return;

--- a/src/Notes/ManageOrdersOnTheGo.php
+++ b/src/Notes/ManageOrdersOnTheGo.php
@@ -30,8 +30,7 @@ class ManageOrdersOnTheGo {
 	 */
 	public static function get_note() {
 		// Only add this note if this store is at least 6 months old.
-		$six_months_in_seconds = MONTH_IN_SECONDS * 6;
-		if ( ! self::wc_admin_active_for( $six_months_in_seconds ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'month-6+' ) ) {
 			return;
 		}
 

--- a/src/Notes/Marketing.php
+++ b/src/Notes/Marketing.php
@@ -31,7 +31,7 @@ class Marketing {
 	 */
 	public static function get_note() {
 		// Don't show the note unless the store has been active at least 5 days.
-		if ( ! self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4', 5 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/MarketingJetpack.php
+++ b/src/Notes/MarketingJetpack.php
@@ -84,7 +84,7 @@ class MarketingJetpack {
 		}
 
 		// Check requirements.
-		if ( ! self::wc_admin_active_for( WEEK_IN_SECONDS ) || ! self::can_be_added() || self::has_backups() ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) || ! self::can_be_added() || self::has_backups() ) {
 			return;
 		}
 

--- a/src/Notes/MigrateFromShopify.php
+++ b/src/Notes/MigrateFromShopify.php
@@ -32,7 +32,7 @@ class MigrateFromShopify {
 
 		// We want to show the note after two days.
 		$two_days = 2 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $two_days ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', $two_days ) ) {
 			return;
 		}
 

--- a/src/Notes/MobileApp.php
+++ b/src/Notes/MobileApp.php
@@ -31,7 +31,7 @@ class MobileApp {
 	public static function get_note() {
 		// We want to show the mobile app note after day 2.
 		$two_days_in_seconds = 2 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $two_days_in_seconds ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', $two_days_in_seconds ) ) {
 			return;
 		}
 

--- a/src/Notes/NeedSomeInspiration.php
+++ b/src/Notes/NeedSomeInspiration.php
@@ -30,12 +30,7 @@ class NeedSomeInspiration {
 	 */
 	public static function get_note() {
 		// We want to show the note after 4 days.
-		if ( ! self::wc_admin_active_for( 4 * DAY_IN_SECONDS ) ) {
-			return;
-		}
-
-		// We don't want to show the note after 30 days.
-		if ( self::wc_admin_active_for( 30 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4', 4 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -29,10 +29,11 @@ trait NoteTraits {
 	 * Test if WooCommerce Admin has been active within a pre-defined range.
 	 *
 	 * @param string $range range available in WC_ADMIN_STORE_AGE_RANGES.
+	 * @param int    $custom_start custom start in range.
 	 * @return bool Whether or not WooCommerce admin has been active within the range.
 	 */
-	private static function is_wc_admin_active_in_date_range( $range ) {
-		return WCAdminHelper::is_wc_admin_active_in_date_range( $range );
+	private static function is_wc_admin_active_in_date_range( $range, $custom_start = null ) {
+		return WCAdminHelper::is_wc_admin_active_in_date_range( $range, $custom_start );
 	}
 
 	/**

--- a/src/Notes/OnboardingPayments.php
+++ b/src/Notes/OnboardingPayments.php
@@ -30,7 +30,7 @@ class OnboardingPayments {
 	 */
 	public static function get_note() {
 		// We want to show the note after five days.
-		if ( ! self::wc_admin_active_for( 5 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4', 5 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/OnlineClothingStore.php
+++ b/src/Notes/OnlineClothingStore.php
@@ -48,7 +48,7 @@ class OnlineClothingStore {
 	 */
 	public static function get_note() {
 		// We want to show the note after two days.
-		if ( ! self::wc_admin_active_for( 2 * DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', 2 * DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/PersonalizeStore.php
+++ b/src/Notes/PersonalizeStore.php
@@ -41,7 +41,7 @@ class PersonalizeStore {
 		// We want to show the note after day 5.
 		$five_days_in_seconds = 5 * DAY_IN_SECONDS;
 
-		if ( ! self::wc_admin_active_for( $five_days_in_seconds ) && ! $is_task_list_complete ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4', $five_days_in_seconds ) && ! $is_task_list_complete ) {
 			return;
 		}
 

--- a/src/Notes/RealTimeOrderAlerts.php
+++ b/src/Notes/RealTimeOrderAlerts.php
@@ -30,8 +30,7 @@ class RealTimeOrderAlerts {
 	 */
 	public static function get_note() {
 		// Only add this note if the store is 3 months old.
-		$ninety_days_in_seconds = 90 * DAY_IN_SECONDS;
-		if ( ! self::wc_admin_active_for( $ninety_days_in_seconds ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'month-3-6' ) ) {
 			return;
 		}
 

--- a/src/Notes/StartDropshippingBusiness.php
+++ b/src/Notes/StartDropshippingBusiness.php
@@ -31,7 +31,7 @@ class StartDropshippingBusiness {
 	public static function get_note() {
 
 		// We want to show the note after one day.
-		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/Notes/TrackingOptIn.php
+++ b/src/Notes/TrackingOptIn.php
@@ -42,7 +42,7 @@ class TrackingOptIn {
 		}
 
 		// We want to show the note after one week.
-		if ( ! self::wc_admin_active_for( WEEK_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) ) {
 			return;
 		}
 

--- a/src/Notes/WooCommercePayments.php
+++ b/src/Notes/WooCommercePayments.php
@@ -45,7 +45,7 @@ class WooCommercePayments {
 	 * Maybe add a note on WooCommerce Payments for US based sites older than a week without the plugin installed.
 	 */
 	public static function possibly_add_note() {
-		if ( ! self::wc_admin_active_for( WEEK_IN_SECONDS ) || 'US' !== WC()->countries->get_base_country() ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1-4' ) || 'US' !== WC()->countries->get_base_country() ) {
 			return;
 		}
 

--- a/src/Notes/WooCommerceSubscriptions.php
+++ b/src/Notes/WooCommerceSubscriptions.php
@@ -37,7 +37,7 @@ class WooCommerceSubscriptions {
 			return;
 		}
 
-		if ( ! self::wc_admin_active_for( DAY_IN_SECONDS ) ) {
+		if ( ! self::is_wc_admin_active_in_date_range( 'week-1', DAY_IN_SECONDS ) ) {
 			return;
 		}
 

--- a/src/WCAdminHelper.php
+++ b/src/WCAdminHelper.php
@@ -73,10 +73,11 @@ class WCAdminHelper {
 	 * Test if WooCommerce Admin has been active within a pre-defined range.
 	 *
 	 * @param string $range range available in WC_ADMIN_STORE_AGE_RANGES.
+	 * @param int    $custom_start custom start in range.
 	 * @throws \InvalidArgumentException Throws exception when invalid $range is passed in.
 	 * @return bool Whether or not WooCommerce admin has been active within the range.
 	 */
-	public static function is_wc_admin_active_in_date_range( $range ) {
+	public static function is_wc_admin_active_in_date_range( $range, $custom_start = null ) {
 		if ( ! array_key_exists( $range, self::WC_ADMIN_STORE_AGE_RANGES ) ) {
 			throw new \InvalidArgumentException(
 				sprintf(
@@ -89,7 +90,8 @@ class WCAdminHelper {
 		$wc_admin_active_for = self::get_wcadmin_active_for_in_seconds();
 
 		$range_data = self::WC_ADMIN_STORE_AGE_RANGES[ $range ];
-		if ( $range_data && $wc_admin_active_for >= $range_data['start'] ) {
+		$start      = null !== $custom_start ? $custom_start : $range_data['start'];
+		if ( $range_data && $wc_admin_active_for >= $start ) {
 			return isset( $range_data['end'] ) ? $wc_admin_active_for < $range_data['end'] : true;
 		}
 		return false;

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -36,7 +36,7 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test wc_admin_active_in_date_range with invalid range
+	 * Test wc_admin_active_in_date_range with invalid range.
 	 */
 	public function test_is_wc_admin_active_in_date_range_with_invalid_range() {
 		$this->expectException( \InvalidArgumentException::class );
@@ -46,7 +46,7 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test wc_admin_active_in_date_range with custom start date
+	 * Test wc_admin_active_in_date_range with custom start date.
 	 */
 	public function test_is_wc_admin_active_in_date_range_with_custom_start_date() {
 		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - DAY_IN_SECONDS );
@@ -55,6 +55,41 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 
 		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - ( 4 * DAY_IN_SECONDS ) );
 		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1', 2 * DAY_IN_SECONDS );
+		$this->assertEquals( $active_for, true );
+	}
+
+	/**
+	 * Test wc_admin_active_in_date_range with times right around a date range.
+	 */
+	public function test_is_wc_admin_not_active_around_date_range() {
+		// one minute before 7 days.
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, ( time() - ( 7 * DAY_IN_SECONDS ) ) + MINUTE_IN_SECONDS );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1-4' );
+		$this->assertEquals( $active_for, false );
+
+		// one minute after 28 days.
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, ( time() - ( 28 * DAY_IN_SECONDS ) ) - MINUTE_IN_SECONDS );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1-4' );
+		$this->assertEquals( $active_for, false );
+	}
+
+	/**
+	 * Test wc_admin_active_in_date_range with times within a date range.
+	 */
+	public function test_is_wc_admin_active_within_date_range() {
+		// one minute after 7 days.
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, ( time() - ( 7 * DAY_IN_SECONDS ) ) - MINUTE_IN_SECONDS );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1-4' );
+		$this->assertEquals( $active_for, true );
+
+		// one minute before 28 days.
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, ( time() - ( 28 * DAY_IN_SECONDS ) ) + MINUTE_IN_SECONDS );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1-4' );
+		$this->assertEquals( $active_for, true );
+
+		// 10 days.
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, ( time() - ( 10 * DAY_IN_SECONDS ) ) );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1-4' );
 		$this->assertEquals( $active_for, true );
 	}
 

--- a/tests/wc-admin-helper.php
+++ b/tests/wc-admin-helper.php
@@ -46,6 +46,19 @@ class WC_Admin_Tests_Admin_Helper extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wc_admin_active_in_date_range with custom start date
+	 */
+	public function test_is_wc_admin_active_in_date_range_with_custom_start_date() {
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - DAY_IN_SECONDS );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1', 2 * DAY_IN_SECONDS );
+		$this->assertEquals( $active_for, false );
+
+		update_option( WCAdminHelper::WC_ADMIN_TIMESTAMP_OPTION, time() - ( 4 * DAY_IN_SECONDS ) );
+		$active_for = WCAdminHelper::is_wc_admin_active_in_date_range( 'week-1', 2 * DAY_IN_SECONDS );
+		$this->assertEquals( $active_for, true );
+	}
+
+	/**
 	 * @dataProvider range_provider
 	 * Test wc_admin_active_in_date_range with data provided from range_provider.
 	 *


### PR DESCRIPTION
Fixes #4789 

This updates the remaining notes that made use of `is_wc_admin_active_for`, to use the `is_wc_admin_active_in_date_range` function instead. Given most of the notes didn't strictly fit in a range, I added the option for a custom start time, to keep the range aspect.

**Alternate Option**
Instead of passing the specified date range in (`week-2-4`), I could change it so we still pass the minimum start date and we automatically choose the end date depending on where the start date fits in the ranges. I stuck with the more manual approach.

Here is the list of the updated notes (I tried to sort them from young to old). Do note that some of these notes have several other conditions aside from the date:

| Note File  | Range |
| ------------- | ------------- |
| ChoosingTheme | 1 - 7 days |
| WooCommerceSubscriptions | 1 - 7 days |
| InsightFirstProductAndPayment | 1 - 7days |
| StartDropShipping | 1 - 7 days |
| MigrateFromShopify | 2 - 7 days |
| MobileApp | 2 - 7 days |
| OnlineClothingStore | 2 - 7 days |
| AddingAndManagingProducts | 3 - 7 days |
| DrawAttention | 3 - 7 days |
| NeedSomeInspiration | 4 - 28 days |
| OnboardingPayments | 5 - 28 days |
| Marketing | 5 - 28 days |
| PersonalizeStore | 5 - 28 days |
| FirstProduct | 1 - 4weeks |
| MarketingJetpack | 1 - 4 weeks |
| TrackingOptin | 1 - 4 weeks |
| WooCommercePayments | 1 - 4weeks |
| LaunchChecklist | 10 - 28 days |
| CustomizeStoreWithBlocks | 2 - 4 weeks |
| RealTimeOrderAlerts | 3 - 6 months |

### Detailed test instructions:

- On a new store finish the onboarding flow
- Make your store over 6 months old by setting the `woocommerce_admin_install_timestamp` option to something later then 6 months - `1604252517` (Nov 1, 2020)
- Run the `wc_admin_daily` job, using the [WC Admin test helper ](https://github.com/woocommerce/woocommerce-admin-test-helper/releases/tag/v0.4.0) go to **Tools > WCA Test Helper > Tools > Run wc_admin_daily job**
- Go to **WooCommerce > Home** 
- It should only display the 6+ month notes (should only be a couple of them)
- You could now test either all or do a rough test of the modified notes listed above by setting the store age to something within the date range, running the `wc_admin_daily` job, and checking the home screen.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
