### PR TITLE
Bump up csv-export version

### DIFF
--- a/packages/csv-export/package.json
+++ b/packages/csv-export/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/csv-export",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "WooCommerce utility library to convert data to CSV files.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
This PR bumps up the version of `csv-export` so that it can be published.

I forgot to bump the version in my previous [PR](https://github.com/woocommerce/woocommerce-admin/pull/7154)

No changelog necessary.