### PR TITLE
Use saved form values when switching tabs

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Use saved values if available when switching tabs #7226
+
+1. Start onboarding wizard and continue to step 4.
+2. Enter selections for business details and choose "Continue"
+3. Select the tab "Business details" to go back
+4. Confirm that the previously selected values are shown. 
+
 ## 2.4.0
 
 ### Add target to the button to open it in a new tab #7110

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -466,7 +466,8 @@ class BusinessDetails extends Component {
 					if ( this.state.currentTab !== tabName ) {
 						this.setState( {
 							currentTab: tabName,
-							savedValues: initialValues,
+							savedValues:
+								this.state.savedValues || initialValues,
 						} );
 					}
 				} }

--- a/readme.txt
+++ b/readme.txt
@@ -86,7 +86,8 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Tweak: Revert Card component removal #7167
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165
-- Fix:  Use tab char for the CSV injection prevention. #7154
+- Fix: Use tab char for the CSV injection prevention. #7154
+- Fix: Use saved form values if available when switching tabs #7226
 
 == 2.4.0 6/10/2021 ==
 - Dev: Add Jetpack Backup admin note #6738


### PR DESCRIPTION
Fixes #7018 

This PR uses saved form values when switching tabs.

### Detailed test instructions:

1. Start onboarding wizard and continue to step 4.
2. Enter selections for business details and choose "Continue"
3. Select the tab "Business details" to go back
4. Confirm that the previously selected values are shown. 