### PR TITLE
Fixing invalid key props, changing to id

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: RemoteFreeExtension hide bundle when all of its plugins are not visible #7182
 - Fix: Fixing button state logic for remote payment gateways #7200
 - Fix: Skip schedule customer data deletion on site deletion #7214
+- Fix: Fix obsolete key property in gateway defaults #7229
 - Tweak: Revert Card component removal #7167
 - Fix: Currency display on Orders activity card on homescreen #7181
 - Fix: Report export filtering bug. #7165

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -60,7 +60,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'key'        => 'kco',
+				'id'        => 'kco',
 				'title'      => __( 'Klarna', 'woocommerce-admin' ),
 				'content'    => __( 'Choose the payment that you want, pay now, pay later or slice it. No credit card numbers, no passwords, no worries.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/klarna-black.png',
@@ -71,7 +71,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'key'        => 'mollie_wc_gateway_banktransfer',
+				'id'        => 'mollie_wc_gateway_banktransfer',
 				'title'      => __( 'Mollie', 'woocommerce-admin' ),
 				'content'    => __( 'Effortless payments by Mollie: Offer global and local payment methods, get onboarded in minutes, and supported in your language.', 'woocommerce-admin' ),
 				'image'      => plugins_url( 'images/onboarding/mollie.svg', WC_ADMIN_PLUGIN_FILE ),
@@ -179,7 +179,7 @@ class DefaultPaymentGateways {
 				),
 			),
 			array(
-				'key'        => 'square_credit_card',
+				'id'        => 'square_credit_card',
 				'title'      => __( 'Square', 'woocommerce-admin' ),
 				'content'    => __( 'Securely accept credit and debit cards with one low rate, no surprise fees (custom rates available). Sell online and in store and track sales and inventory in one place.', 'woocommerce-admin' ),
 				'image'      => WC()->plugin_url() . '/assets/images/square-black.png',


### PR DESCRIPTION
A few of the default gateways within the payment gateway feature were still using the obsolete `key` property, resulting in them not appearing when they should. I've just fixed this by changing to the `id` property.

### Detailed test instructions:

-   Checkout branch
-   Ensure payment gateway feature is enabled and defaults are being used (opt out of marketing suggestions or otherwise)
- Switch to Klarna-supported country (such as Finland), and verify that it shows up as a payment method
- For good measure do the same with Mollie and Square to ensure that they're visible
