### PR TITLE
Assign parent order status as children order status if refund order

### DIFF
--- a/changelogs/fix-7197
+++ b/changelogs/fix-7197
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Assign parent order status as children order status if refund order #7253

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -178,3 +178,25 @@ function wc_admin_update_270_update_task_list_options() {
 function wc_admin_update_270_db_version() {
 	Installer::update_db_version( '2.7.0' );
 }
+
+ /**
+  * Update order stats `status`.
+  */
+function wc_admin_update_280_order_status() {
+	global $wpdb;
+
+	$wpdb->query(
+		"UPDATE {$wpdb->prefix}wc_order_stats refunds
+		INNER JOIN {$wpdb->prefix}wc_order_stats orders
+			ON orders.order_id = refunds.parent_id
+		SET refunds.status = orders.status
+		WHERE refunds.parent_id != 0"
+	);
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_280_db_version() {
+	Installer::update_db_version( '2.8.0' );
+}

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -544,7 +544,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			$parent_order = wc_get_order( $order->get_parent_id() );
 			if ( $parent_order ) {
 				$data['parent_id'] = $parent_order->get_id();
-				$format[]          = '%d';
+				$data['status']    = self::normalize_order_status( $parent_order->get_status() );
 			}
 		} else {
 			$data['returning_customer'] = self::is_returning_customer( $order );

--- a/src/Install.php
+++ b/src/Install.php
@@ -61,6 +61,10 @@ class Install {
 			'wc_admin_update_270_update_task_list_options',
 			'wc_admin_update_270_db_version',
 		),
+		'2.8.0'  => array(
+			'wc_admin_update_280_order_status',
+			'wc_admin_update_280_db_version',
+		),
 	);
 
 	/**

--- a/src/Schedulers/OrdersScheduler.php
+++ b/src/Schedulers/OrdersScheduler.php
@@ -165,10 +165,12 @@ class OrdersScheduler extends ImportScheduler {
 			CustomersDataStore::sync_order_customer( $order_id ),
 		);
 
-		$order_refunds = $order->get_refunds();
+		if ( 'shop_order' === $type ) {
+			$order_refunds = $order->get_refunds();
 
-		foreach ( $order_refunds as $refund ) {
-			OrdersStatsDataStore::sync_order( $refund->get_id() );
+			foreach ( $order_refunds as $refund ) {
+				OrdersStatsDataStore::sync_order( $refund->get_id() );
+			}
 		}
 
 		ReportsCache::invalidate();

--- a/src/Schedulers/OrdersScheduler.php
+++ b/src/Schedulers/OrdersScheduler.php
@@ -165,6 +165,12 @@ class OrdersScheduler extends ImportScheduler {
 			CustomersDataStore::sync_order_customer( $order_id ),
 		);
 
+		$order_refunds = $order->get_refunds();
+
+		foreach ( $order_refunds as $refund ) {
+			OrdersStatsDataStore::sync_order( $refund->get_id() );
+		}
+
 		ReportsCache::invalidate();
 	}
 


### PR DESCRIPTION
Fixes #7197 

Assign parent order status as children order status if refund order


### Screenshots
Before
<img width="281" alt="螢幕快照 2021-06-24 下午9 55 05" src="https://user-images.githubusercontent.com/56378160/123359764-13636580-d53b-11eb-9c9c-81378bec5866.png">


After
<img width="297" alt="螢幕快照 2021-06-24 下午10 24 22" src="https://user-images.githubusercontent.com/56378160/123360392-3aba3280-d53b-11eb-85df-2b0e6834bb43.png">




### Detailed test instructions:

1. Make a Refund for an order.
2. Go to WooCommerce -> Settings -> Analytics.
3.  Select "Completed" for Excluded Statuses.
4. Go to WooCommerce -> Analytics -> Revenue.
5. See summary 'Returns' item renders as expected.

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
