### PR TITLE
Preloaded options: remove unused feature options

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix: Cache product/variation revenue query results. #7067
 - Fix: Transient overlapping adjacent content. #7302
 - Sync the category lookup table when a new category gets created #7290
+- Fix: Unused feature preloaded options #7299
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
 - Fix: Fix missing translation strings for CES #7270
 - Fix: Add missing translation strings in the business features section #7268

--- a/src/Features/Analytics.php
+++ b/src/Features/Analytics.php
@@ -46,7 +46,6 @@ class Analytics {
 	public function __construct() {
 		add_filter( 'woocommerce_settings_features', array( $this, 'add_feature_toggle' ) );
 		add_action( 'update_option_' . self::TOGGLE_OPTION_NAME, array( $this, 'reload_page_on_toggle' ), 10, 2 );
-		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 
 		if ( ! Features::is_enabled( 'analytics' ) ) {
 			return;
@@ -80,18 +79,6 @@ class Analytics {
 		);
 
 		return $features;
-	}
-
-	/**
-	 * Preload options to prime state of the application.
-	 *
-	 * @param array $options Array of options to preload.
-	 * @return array
-	 */
-	public function preload_options( $options ) {
-		$options[] = self::TOGGLE_OPTION_NAME;
-
-		return $options;
 	}
 
 	/**

--- a/src/Features/Navigation/Init.php
+++ b/src/Features/Navigation/Init.php
@@ -28,7 +28,6 @@ class Init {
 	 */
 	public function __construct() {
 		add_filter( 'woocommerce_settings_features', array( $this, 'add_feature_toggle' ) );
-		add_filter( 'woocommerce_admin_preload_options', array( $this, 'preload_options' ) );
 		add_action( 'update_option_' . self::TOGGLE_OPTION_NAME, array( $this, 'reload_page_on_toggle' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'maybe_enqueue_opt_out_scripts' ) );
 
@@ -99,18 +98,6 @@ class Init {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Preload options to prime state of the application.
-	 *
-	 * @param array $options Array of options to preload.
-	 * @return array
-	 */
-	public function preload_options( $options ) {
-		$options[] = self::TOGGLE_OPTION_NAME;
-
-		return $options;
 	}
 
 	/**


### PR DESCRIPTION
While working on https://github.com/woocommerce/woocommerce-admin/pull/7298, I came across these additions to the preloaded options. I don't see them used anywhere in the UI, which makes sense because the feature flags are checked instead of the option.

1. Ensure Analytics and Navigation features can be toggled off without error.
2. Confirm the UI has no reference to `woocommerce_analytics_enabled` or `woocommerce_navigation_enabled`.

