### PR TITLE
Fix transient overlapping adjacent content

### DIFF
--- a/client/layout/transient-notices/style.scss
+++ b/client/layout/transient-notices/style.scss
@@ -5,6 +5,7 @@
 	bottom: $gap-small;
 	left: $admin-menu-width + $gap;
 	z-index: 99999;
+	width: auto;
 
 	@media ( max-width: 960px ) {
 		left: 50px;

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ Release and roadmap notes are available on the [WooCommerce Developers Blog](htt
 - Fix:  Use tab char for the CSV injection prevention. #7154
 - Fix: Fix and refactor explat polling to use setTimeout #7274
 - Fix: Cache product/variation revenue query results. #7067
+- Fix: Transient overlapping adjacent content. #7302
 - Tweak: Remove performance indicators when Analytics Flag disabled #7234
 - Tweak: Revert Card component removal #7167
 - Tweak: Removed unused feature flags #7233 and #7273


### PR DESCRIPTION
Fixes #7252 

Overwrites the 100% width that the[ snackbar package adds ](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/snackbar/style.scss#L82) and use auto instead. Given we use snackbars as a floatable versus a header, overwriting the width on our side is the best option.

### Screenshots

<img width="1327" alt="Screen Shot 2021-07-06 at 4 55 47 PM" src="https://user-images.githubusercontent.com/2240960/124659151-061f7280-de7b-11eb-97cc-b62afdb29857.png">

### Detailed test instructions:

- Go to admin > WooCommerce with some things to dismiss.
- Dismiss a note (Dismiss > Dismiss this message)
- Snackbar appears.
- Scroll so that the notice is displayed beside a button (another dismiss button of a note for example).
- Try to click the dismiss button, it should be clickable
- You can inspect the notice, and see it only uses it's specific width

<!-- 
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note following the WooCommerce core format using prefixes of Enhancement:, Tweak:, Dev:, Fix:, Performance: to readme.txt under the "unreleased" list at the top of the changelog. If none exists, please add it. Also include PR number.

If changes pertain to a package, also update CHANGELOG.md in the package's folder in a similar manner.--->
