### PR TITLE
Changelogger Linter: Point to correct file to test presence of changelog entry

### DIFF
--- a/bin/ci/lint-changelog.sh
+++ b/bin/ci/lint-changelog.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-changelog_entry=$(sed -n '/^== Unreleased ==/,/^==/p' readme.txt | grep -w "#$PR_NUMBER")
+changelog_entry=$(sed -n '/^Significance/,/^==/p' changelogs/* | grep -w "#$PR_NUMBER")
 
 if [ -z "$changelog_entry" ]
 then

--- a/changelogs/test-changelogger-lint
+++ b/changelogs/test-changelogger-lint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Dev
+
+This is only a test

--- a/changelogs/test-changelogger-lint
+++ b/changelogs/test-changelogger-lint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Dev
 
-This is only a test #7318
+Point the changelog linter to updated changelog entry location #7318

--- a/changelogs/test-changelogger-lint
+++ b/changelogs/test-changelogger-lint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Dev
 
-This is only a test
+This is only a test #7318


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-admin/pull/6870 introduced Jetpack Changelogger to handle compilation of changelog entries. This PR updates our changelog linter that checks pull requests to make sure they have a changelog.

Note: I'm not that well versed in `sed` and I have it working by looking in the `changelogs/` folder instead of `readme.txt` but I imagine it could be cleaner. @moon0326 could you take a look?

Since this check previously made sure the pull request number was present and correct, I kept that functionality. Ideally, we change the prompts to ask for a PR number.

### Detailed test instructions:

Since this PR has a changelog entry, confirm that the "Lint the changelog" check passes.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
