### PR TITLE
Fix minimum expected recommended extension count.

### DIFF
--- a/tests/e2e/sections/onboarding/BusinessSection.ts
+++ b/tests/e2e/sections/onboarding/BusinessSection.ts
@@ -46,7 +46,7 @@ export class BusinessSection extends BasePage {
 			const inputsNum = document.querySelectorAll(
 				'.components-checkbox-control__input'
 			).length;
-			return inputsNum > 6;
+			return inputsNum > 5;
 		} );
 	}
 

--- a/tests/e2e/sections/onboarding/BusinessSection.ts
+++ b/tests/e2e/sections/onboarding/BusinessSection.ts
@@ -46,7 +46,7 @@ export class BusinessSection extends BasePage {
 			const inputsNum = document.querySelectorAll(
 				'.components-checkbox-control__input'
 			).length;
-			return inputsNum > 5;
+			return inputsNum > 1;
 		} );
 	}
 


### PR DESCRIPTION
This fixes an issue with this test case: 

```
A japanese store can complete the selective bundle install but does not include WCPay.
    ✕ can choose not to install any extensions
```

The test is expecting to find 6 checkboxes (5 recommended extensions, and the select all), but there are only 4 due to the exclusion of region-specific extensions like WC Pay and WC Shipping.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.

No changelog.