### PR TITLE
Fix/7322 unable to dismiss inbox note

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -7,6 +7,14 @@
 1. Navigate to WooCommerce -> Settings -> Advanced -> Features. Uncheck Analytics and save the changes.
 2. Navigate to WooCommerce -> Home and confirm the page loads without an error.
 
+### Fix Fix links on the dismiss dropdown are not clickable #7342
+
+Please make sure to test it on Safari as well.
+
+1. Navigate to WooCommerce -> Home
+2. Click [ Dismiss ] button
+3. Confirm that the links are clickable
+
 ### Fix missing translation strings for CES #7270
 
 1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).

--- a/changelogs/fix-7322-unable-to-dismiss-inbox-note
+++ b/changelogs/fix-7322-unable-to-dismiss-inbox-note
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix links on the dismiss dropdown are not clickable
+Fix links on the dismiss dropdown are not clickable #7342

--- a/changelogs/fix-7322-unable-to-dismiss-inbox-note
+++ b/changelogs/fix-7322-unable-to-dismiss-inbox-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix links on the dismiss dropdown are not clickable

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -95,6 +95,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		const dropdownClasses = [
 			'woocommerce-admin-dismiss-notification',
 			'components-popover__content',
+			'components-dropdown__content',
 		];
 		// This line is for IE compatibility.
 		let relatedTarget: EventTarget | Element | null = null;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -128,7 +128,6 @@
 	}
 	.components-dropdown {
 		display: inline;
-		position: absolute;
 
 		.components-popover__content {
 			min-width: 195px;


### PR DESCRIPTION
Fixes #7322 

This PR adds `components-dropdown__content` class to the event target class list so that the links are clickable on Safari.

The value of `event.relatedTarget` is the clicked link on Chrome and Firefox, but it is the parent of the link on Safari. This is a bit tricky problem to solve and needs further investigation. I'm applying this fix for now as it's a high-priority issue.

The only change is that the dropdown content does not close when a user clicks the dropdown background. You can see it in action in the `Screenshots` section. 

### Screenshots

Before: The dropdown closes when you click on it

![](https://cdn-std.droplr.net/files/acc_1104316/9zQI2a)

After: The dropdown does not close when you click on it. It only closes when you click the link or outside of the dropdown.

![](https://cdn-std.droplr.net/files/acc_1104316/1cwOTF)



### Detailed test instructions:

Please make sure to test it on Safari as well.

1. Navigate to WooCommerce -> Home
2. Click [ Dismiss ] button 
3. Confirm that the links are clickable

