### PR TITLE
Display green indicator for a drop in refunds in report summary

### DIFF
--- a/changelogs/add-reverse-trend-support-summary-number
+++ b/changelogs/add-reverse-trend-support-summary-number
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add boolean isReverseTrend prop to SummaryNumber to show "positive" delta for negative numbers.

--- a/client/analytics/components/report-summary/index.js
+++ b/client/analytics/components/report-summary/index.js
@@ -75,7 +75,14 @@ export class ReportSummary extends Component {
 
 		const renderSummaryNumbers = ( { onToggle } ) =>
 			charts.map( ( chart ) => {
-				const { key, order, orderby, label, type } = chart;
+				const {
+					key,
+					order,
+					orderby,
+					label,
+					type,
+					isReverseTrend,
+				} = chart;
 				const newPath = { chart: key };
 				if ( orderby ) {
 					newPath.orderby = orderby;
@@ -93,6 +100,7 @@ export class ReportSummary extends Component {
 						delta={ delta }
 						href={ href }
 						label={ label }
+						reverseTrend={ isReverseTrend }
 						prevLabel={
 							compare === 'previous_period'
 								? __( 'Previous Period:', 'woocommerce-admin' )

--- a/client/analytics/report/revenue/config.js
+++ b/client/analytics/report/revenue/config.js
@@ -17,6 +17,7 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 		order: 'desc',
 		orderby: 'gross_sales',
 		type: 'currency',
+		isReverseTrend: false,
 	},
 	{
 		key: 'refunds',
@@ -24,6 +25,7 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 		order: 'desc',
 		orderby: 'refunds',
 		type: 'currency',
+		isReverseTrend: true,
 	},
 	{
 		key: 'coupons',
@@ -31,12 +33,14 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 		order: 'desc',
 		orderby: 'coupons',
 		type: 'currency',
+		isReverseTrend: false,
 	},
 	{
 		key: 'net_revenue',
 		label: __( 'Net Sales', 'woocommerce-admin' ),
 		orderby: 'net_revenue',
 		type: 'currency',
+		isReverseTrend: false,
 	},
 	{
 		key: 'taxes',
@@ -44,12 +48,14 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 		order: 'desc',
 		orderby: 'taxes',
 		type: 'currency',
+		isReverseTrend: false,
 	},
 	{
 		key: 'shipping',
 		label: __( 'Shipping', 'woocommerce-admin' ),
 		orderby: 'shipping',
 		type: 'currency',
+		isReverseTrend: false,
 	},
 	{
 		key: 'total_sales',
@@ -57,6 +63,7 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
 		order: 'desc',
 		orderby: 'total_sales',
 		type: 'currency',
+		isReverseTrend: false,
 	},
 ] );
 


### PR DESCRIPTION
Fixes #7306

By adding a `isReverseTrend` prop we can pass to `SummaryNumber` we can indicate that a negative trend in refunds is a good thing and therefore display a green indicator.

### Detailed test instructions:

You could test as described in the original issue, or you could fix the delta [here](https://github.com/woocommerce/woocommerce-admin/blob/80c1b1701c93e99b5a9bbae0fbe5d72059216650/client/analytics/components/report-summary/index.js?plain=1#L100) to a negative number like `-10` and then go to the report summary and see that the "Returns" item is the only one that renders with a green tag. 

No changelog required.

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
