### PR TITLE
Fix TSC config and package build script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"analyze": "cross-env NODE_ENV=production ANALYZE=true webpack",
 		"postbuild": "npm run -s i18n:pot && npm run -s i18n:build",
 		"build:feature-config": "php bin/generate-feature-config.php",
-		"build:packages": "tsc --build && node ./bin/packages/build.js",
+		"build:packages": "lerna run build",
 		"build:release": "./bin/build-plugin-zip.sh",
 		"clean": "rimraf ./dist ./packages/*/build ./packages/*/build-module ./packages/*/build-style",
 		"predev": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,6 @@
 		// Process & infer types from .js files.
 		"allowJs": true,
 		"jsx": "preserve",
-		// Don't emit; allow Babel to transform files.
-		"noEmit": true,
 		// Enable strictest settings like strictNullChecks & noImplicitAny.
 		"strict": true,
 		// Import non-ES modules as default imports.


### PR DESCRIPTION
Fixes p1626321245022700-slack-CBKK5KM41

I must have buggered a merge conflict somewhere - sorry!

For testing, if you're still not seeing `build` and `build-module` after an `npm run build:packages`, delete your `tsconfig.tsbuildinfo` files (or full nuclear: `git clean -dfx`).

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

-   Ex: Open page `url`
-   Click XYZ…

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.