### PR TITLE
Add `hidden` legendPosition to `Chart`.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Fix a bug in the deprecated callback handlers of Form component. #7356
+-   Add `hidden` legend position to `Chart`. #7378
 
 # 8.0.0
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -25,6 +25,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
+		"@storybook/addon-knobs": "^6.3.0",
 		"@woocommerce/csv-export": "file:../csv-export",
 		"@woocommerce/currency": "file:../currency",
 		"@woocommerce/data": "file:../data",

--- a/packages/components/src/chart/README.md
+++ b/packages/components/src/chart/README.md
@@ -91,7 +91,7 @@ Name | Type | Default | Description
 `interval` | One of: 'hour', 'day', 'week', 'month', 'quarter', 'year' | `'day'` | Interval specification (hourly, daily, weekly etc)
 `intervalData` | Object | `null` | Information about the currently selected interval, and set of allowed intervals for the chart. See `getIntervalsForQuery`
 `isRequesting` | Boolean | `false` | Render a chart placeholder to signify an in-flight data request
-`legendPosition` | One of: 'bottom', 'side', 'top' | `null` | Position the legend must be displayed in. If it's not defined, it's calculated depending on the viewport width and the mode
+`legendPosition` | One of: 'bottom', 'side', 'top', 'hidden' | `null` | Position the legend must be displayed in. If it's not defined, it's calculated depending on the viewport width and the mode
 `legendTotals` | Object | `null` | Values to overwrite the legend totals. If not defined, the sum of all line values will be used
 `screenReaderFormat` | One of type: string, func | `'%B %-d, %Y'` | A datetime formatting string or overriding function to format the screen reader labels
 `showHeaderControls` | Boolean | `true` | Wether header UI controls must be displayed

--- a/packages/components/src/chart/index.js
+++ b/packages/components/src/chart/index.js
@@ -334,18 +334,19 @@ class Chart extends Component {
 		const chartDirection = legendPosition === 'side' ? 'row' : 'column';
 
 		const chartHeight = this.getChartHeight();
-		const legend = isRequesting ? null : (
-			<D3Legend
-				colorScheme={ d3InterpolateViridis }
-				data={ orderedKeys }
-				handleLegendHover={ this.handleLegendHover }
-				handleLegendToggle={ this.handleLegendToggle }
-				interactive={ interactiveLegend }
-				legendDirection={ legendDirection }
-				legendValueFormat={ tooltipValueFormat }
-				totalLabel={ sprintf( itemsLabel, orderedKeys.length ) }
-			/>
-		);
+		const legend =
+			legendPosition !== 'hidden' && isRequesting ? null : (
+				<D3Legend
+					colorScheme={ d3InterpolateViridis }
+					data={ orderedKeys }
+					handleLegendHover={ this.handleLegendHover }
+					handleLegendToggle={ this.handleLegendToggle }
+					interactive={ interactiveLegend }
+					legendDirection={ legendDirection }
+					legendValueFormat={ tooltipValueFormat }
+					totalLabel={ sprintf( itemsLabel, orderedKeys.length ) }
+				/>
+			);
 		const margin = {
 			bottom: 50,
 			left: 80,
@@ -566,7 +567,7 @@ Chart.propTypes = {
 	 * Position the legend must be displayed in. If it's not defined, it's calculated
 	 * depending on the viewport width and the mode.
 	 */
-	legendPosition: PropTypes.oneOf( [ 'bottom', 'side', 'top' ] ),
+	legendPosition: PropTypes.oneOf( [ 'bottom', 'side', 'top', 'hidden' ] ),
 	/**
 	 * Values to overwrite the legend totals. If not defined, the sum of all line values will be used.
 	 */

--- a/packages/components/src/chart/stories/index.js
+++ b/packages/components/src/chart/stories/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { Chart } from '@woocommerce/components';
+import { select } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import Chart from '../';
 
 const data = [
 	{
@@ -66,8 +71,18 @@ const data = [
 	},
 ];
 
-export default () => (
-	<div>
-		<Chart data={ data } title="Example Chart" layout="item-comparison" />
-	</div>
+export default {
+	title: 'WooCommerce Admin/components/Chart',
+	component: Chart,
+};
+
+export const Default = () => (
+	<Chart
+		data={ data }
+		legendPosition={ select(
+			'Legend Position',
+			[ undefined, 'bottom', 'side', 'top', 'hidden' ],
+			undefined
+		) }
+	/>
 );

--- a/packages/components/src/chart/test/legend.js
+++ b/packages/components/src/chart/test/legend.js
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import { render, within } from '@testing-library/react';
+import { createElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Chart from '../';
+
+jest.mock( '../d3chart', () => ( {
+	D3Legend: jest.fn().mockReturnValue( '[D3Legend]' ),
+} ) );
+
+const data = [
+	{
+		date: '2018-05-30T00:00:00',
+		Hoodie: {
+			label: 'Hoodie',
+			value: 21599,
+		},
+		Sunglasses: {
+			label: 'Sunglasses',
+			value: 38537,
+		},
+		Cap: {
+			label: 'Cap',
+			value: 106010,
+		},
+	},
+	{
+		date: '2018-05-31T00:00:00',
+		Hoodie: {
+			label: 'Hoodie',
+			value: 14205,
+		},
+		Sunglasses: {
+			label: 'Sunglasses',
+			value: 24721,
+		},
+		Cap: {
+			label: 'Cap',
+			value: 70131,
+		},
+	},
+];
+
+describe( 'Chart', () => {
+	test( '<Chart legendPosition="hidden" /> should not render any legend', () => {
+		const { queryByText } = render(
+			<Chart data={ data } legendPosition="hidden" />
+		);
+		expect( queryByText( '[D3Legend]' ) ).not.toBeInTheDocument();
+	} );
+
+	test( '<Chart legendPosition="bottom" /> should render the legend at the bottom', () => {
+		const { container } = render(
+			<Chart data={ data } legendPosition="bottom" />
+		);
+		const footer = container.querySelector( '.woocommerce-chart__footer' );
+		expect(
+			within( footer ).queryByText( '[D3Legend]' )
+		).toBeInTheDocument();
+	} );
+
+	test( '<Chart legendPosition="side" /> should render the legend at the side', () => {
+		const { container } = render(
+			<Chart data={ data } legendPosition="side" />
+		);
+		const body = container.querySelector( '.woocommerce-chart__body' );
+		expect(
+			within( body ).queryByText( '[D3Legend]' )
+		).toBeInTheDocument();
+	} );
+
+	test( '<Chart legendPosition="top" /> should render the legend at the top', () => {
+		const { container } = render(
+			<Chart data={ data } legendPosition="top" />
+		);
+		const top = container.querySelector( '.woocommerce-chart__header' );
+		expect( within( top ).queryByText( '[D3Legend]' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
1. Add `hidden` legendPosition to `Chart`.
	  Sometimes, for example, when there is a single data set, there is no need for rendering the legend. It may even introduce more confusion than value. It seems interactive, but there is nothing you can do with it.
	  
	  ![Interactive looking, non-interactive legend](https://user-images.githubusercontent.com/17435/126077779-3b2a384c-44bc-41da-b400-3571f8383cd8.png)
	  
	  
	  Fixes: https://github.com/woocommerce/google-listings-and-ads/issues/618
2. Add @storybook/addon-knobs to devDependencies. 
	It was used but not explicitly stated.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [x] I've tested using only a keyboard (no mouse)
-   [x] I've tested using a screen reader
-   [n/a] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [n/a] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots:
![hidden](https://user-images.githubusercontent.com/17435/126078490-08921481-d77c-4864-ad0b-1cc09ef41dcb.gif)


### Detailed test instructions:

1. Create `<Chart data={ data } legendPosition="hidden" >`
2. Check that no legend is rendered.

or

1. `npm run storybook`
2. visit http://localhost:6007/?path=/docs/woocommerce-admin-components-chart--default play with  `legendPosition` knob


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.


### Additional notes:


1. I added a simple story, to make it appear for discovery, docs, and testing. However, I didn't put all the knobs and test cases to limit the scope of this PR. Also, I'd expect that this should be done automatically as we already defined all the prop types, so the storybook addon should be able to pick it up. Hopefully, after an update (see below) that would be easier.
2. I used `@storybook/addon-knobs` even though it's deprecated, because:
	1. It's already used by other components, and I think it's better to have a codebase that uses deprecated stuff but consistently, rather than having one that is inconsistent and uses deprecated anyway.
	2. Our Storybook version already lags behind.  I'm not sure if it supports the new `controls` approach already.
	3. Given the above, updating those could be a separate PR.
4. Docs tab in Storybook is empty due to the fact, we do not export Char component with its propTypes. We export a wrapper that does not have its proptypes. https://github.com/woocommerce/woocommerce-admin/blob/b79aefa641dc28bbcab477d4032be6668ab2e754/packages/components/src/chart/index.js#L657
	This could be covered by a separate PR.
0. Personally, I'd find it easier to understand the code, document, and test if the default behavior - automatic positioning - would be available as `legendPosition="auto"`, then the "auto" would be simply a default value.


-----
No changelog

Added an entry in the `/components/CHANGELOG.md`