### PR TITLE
Fix Google Analytics tracking for static docs site.

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,17 @@
 				width: 100%;
 			}
 		</style>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+
+			gtag('config', 'G-8KCYZ2CYMS', {
+				'content_group' : 'WooCommerce Admin Docs',
+			});
+		</script>
 	</head>
 	<body>
 		<div id="app"></div>


### PR DESCRIPTION
This PR re-adds the code for tracking and grouping Google Analytics data for this developer resource.  It looks like _may_ have been inadvertently removed during #7055, but I can't tell if there's a re-generator that runs during the deploy process that will overwrite this change.  Pinging @samueljseay here since you worked on integrating the Storybook docs with the Docsify site.  Are you able to tell if I've added this code to the right location?


### Detailed test instructions:

-   To test locally, make sure dependencies are installed and run `docsify serve` on the root directory
-   View the page source and ensure that the following script tag appears on all of the pages
```
<!-- Global site tag (gtag.js) - Google Analytics -->
		<script async src="https://www.googletagmanager.com/gtag/js?id=G-8KCYZ2CYMS"></script>
		<script>
			window.dataLayer = window.dataLayer || [];
			function gtag(){dataLayer.push(arguments);}
			gtag('js', new Date());

			gtag('config', 'G-8KCYZ2CYMS', {
				'content_group' : 'WooCommerce Admin Docs',
			});
		</script>
```

**Note:** I didn't include a changelog note or testing instructions in the corresponding files since this change only impacts the `gh-pages` branch, but I'm happy to add them if I need to.  Just let me know.  :smiley:
