### PR TITLE
Use the original endpoint in products test

### DIFF
--- a/tests/api/products.php
+++ b/tests/api/products.php
@@ -88,7 +88,6 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 
 		$request = new WP_REST_Request( 'GET', '/wc-analytics/products' );
 		$request->set_param( 'low_in_stock', true );
-		$request->set_param( 'status', 'publish' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 

--- a/tests/api/products.php
+++ b/tests/api/products.php
@@ -86,7 +86,7 @@ class WC_Tests_API_Products extends WC_REST_Unit_Test_Case {
 		// Sync analytics data (used for last order date).
 		WC_Helper_Queue::run_all_pending();
 
-		$request = new WP_REST_Request( 'GET', '/wc-analytics/products/low-in-stock' );
+		$request = new WP_REST_Request( 'GET', '/wc-analytics/products' );
 		$request->set_param( 'low_in_stock', true );
 		$request->set_param( 'status', 'publish' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
This PR fixes products test to use the original `low in stock` API


### Detailed test instructions:

Run `npm run test:php -- --filter=WC_Tests_API_Products` and ensure tests are passing. 

no changelog needed
