### PR TITLE
Bug fixes for the new low in stock endpoint

### DIFF
--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -205,9 +205,9 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 			'low_stock_amount' => $query_result->low_stock_amount,
 			'last_order_date'  => wc_rest_prepare_date_response( $query_result->last_order_date ),
 			'name'             => $query_result->post_title,
-			'parent_id'        => $query_result->post_parent,
+			'parent_id'        => (int) $query_result->post_parent,
 			'stock_quantity'   => (int) $query_result->stock_quantity,
-			'type'             => 'product_variation' === $query_result->post_type ? 'variation' : 'product',
+			'type'             => 'product_variation' === $query_result->post_type ? 'variation' : 'simple',
 		);
 	}
 

--- a/src/API/ProductsLowInStock.php
+++ b/src/API/ProductsLowInStock.php
@@ -77,7 +77,6 @@ final class ProductsLowInStock extends \WC_REST_Products_Controller {
 		$response = rest_ensure_response( array_values( $query_results['results'] ) );
 		$response->header( 'X-WP-Total', $query_results['total'] );
 		$response->header( 'X-WP-TotalPages', $query_results['pages'] );
-		$response->header( 'Cache-Control', 'max-age=300' );
 
 		return $response;
 	}


### PR DESCRIPTION
This PR fixes `update stock` related bugs for the new `low in stock` endpoint


1. `parent_id` should be an integer.
2. `type` for the simple product should be `simple`, not `product`



### Detailed test instructions:

1. Load the stock panel
2. Update stock qty of simple and variation products and ensure they're updating without an error.

no changelog needed