### PR TITLE
Fix orders panel loading

### DIFF
--- a/changelogs/fix-7382_orders_panel_loading
+++ b/changelogs/fix-7382_orders_panel_loading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Fix orders panel not displaying any orders when analytics is disabled #7395

--- a/client/homescreen/activity-panel/orders/index.js
+++ b/client/homescreen/activity-panel/orders/index.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import PropTypes from 'prop-types';
 import interpolateComponents from 'interpolate-components';
 import {
@@ -26,251 +26,305 @@ import {
 	ActivityCard,
 	ActivityCardPlaceholder,
 } from '../../../header/activity-panel/activity-card';
-import { CurrencyContext } from '../../../lib/currency-context';
 import './style.scss';
 
-class OrdersPanel extends Component {
-	recordOrderEvent( eventName ) {
-		recordEvent( `activity_panel_orders_${ eventName }`, {} );
-	}
+function recordOrderEvent( eventName ) {
+	recordEvent( `activity_panel_orders_${ eventName }`, {} );
+}
 
-	renderEmptyCard() {
-		return (
-			<Fragment>
-				<ActivityCard
-					className="woocommerce-empty-activity-card"
-					title=""
-					icon=""
+const renderEmptyCard = () => {
+	return (
+		<>
+			<ActivityCard
+				className="woocommerce-empty-activity-card"
+				title=""
+				icon=""
+			>
+				<span
+					className="woocommerce-order-empty__success-icon"
+					role="img"
+					aria-labelledby="woocommerce-order-empty-message"
 				>
-					<span
-						className="woocommerce-order-empty__success-icon"
-						role="img"
-						aria-labelledby="woocommerce-order-empty-message"
-					>
-						🎉
-					</span>
-					<H id="woocommerce-order-empty-message">
-						{ __(
-							'You’ve fulfilled all your orders',
-							'woocommerce-admin'
-						) }
-					</H>
-				</ActivityCard>
-				<Link
-					href={ 'edit.php?post_type=shop_order' }
-					onClick={ () => this.recordOrderEvent( 'orders_manage' ) }
-					className="woocommerce-layout__activity-panel-outbound-link woocommerce-layout__activity-panel-empty"
-					type="wp-admin"
-				>
-					{ __( 'Manage all orders', 'woocommerce-admin' ) }
-				</Link>
-			</Fragment>
-		);
-	}
-
-	renderOrders() {
-		const { orders } = this.props;
-
-		if ( orders.length === 0 ) {
-			return this.renderEmptyCard();
-		}
-
-		const getCustomerString = ( order ) => {
-			const { first_name: firstName, last_name: lastName } =
-				order.customer || {};
-
-			if ( ! firstName && ! lastName ) {
-				return '';
-			}
-
-			const name = [ firstName, lastName ].join( ' ' );
-			return `{{customerLink}}${ name }{{/customerLink}}`;
-		};
-
-		const orderCardTitle = ( order ) => {
-			const { id: orderId, number: orderNumber, customer } = order;
-			let customerUrl = null;
-			if ( customer && customer.customer_id ) {
-				customerUrl = window.wcAdminFeatures.analytics
-					? getNewPath( {}, '/analytics/customers', {
-							filter: 'single_customer',
-							customers: customer.customer_id,
-					  } )
-					: getAdminLink(
-							'user-edit.php?user_id=' + customer.customer_id
-					  );
-			}
-
-			return (
-				<Fragment>
-					{ interpolateComponents( {
-						mixedString: sprintf(
-							__(
-								'{{orderLink}}Order #%(orderNumber)s{{/orderLink}} %(customerString)s',
-								'woocommerce-admin'
-							),
-							{
-								orderNumber,
-								customerString: getCustomerString( order ),
-							}
-						),
-						components: {
-							orderLink: (
-								<Link
-									href={ getAdminLink(
-										'post.php?action=edit&post=' + orderId
-									) }
-									onClick={ () =>
-										this.recordOrderEvent( 'order_number' )
-									}
-									type="wp-admin"
-								/>
-							),
-							destinationFlag:
-								customer && customer.country ? (
-									<Flag
-										code={ customer && customer.country }
-										round={ false }
-									/>
-								) : null,
-							customerLink: customerUrl ? (
-								<Link
-									href={ customerUrl }
-									onClick={ () =>
-										this.recordOrderEvent( 'customer_name' )
-									}
-									type="wc-admin"
-								/>
-							) : (
-								<span />
-							),
-						},
-					} ) }
-				</Fragment>
-			);
-		};
-
-		const cards = [];
-		orders.forEach( ( order ) => {
-			const {
-				date_created_gmt: dateCreatedGmt,
-				products,
-				id: orderId,
-			} = order;
-			const productsCount = products ? products.length : 0;
-
-			cards.push(
-				<ActivityCard
-					key={ orderId }
-					className="woocommerce-order-activity-card"
-					title={ orderCardTitle( order ) }
-					date={ dateCreatedGmt }
-					onClick={ ( { target } ) => {
-						this.recordOrderEvent( 'orders_begin_fulfillment' );
-						if ( ! target.href ) {
-							window.location.href = getAdminLink(
-								`post.php?action=edit&post=${ orderId }`
-							);
-						}
-					} }
-					subtitle={
-						<div>
-							<span>
-								{ sprintf(
-									_n(
-										'%d product',
-										'%d products',
-										productsCount,
-										'woocommerce-admin'
-									),
-									productsCount
-								) }
-							</span>
-							<span>{ order.total }</span>
-						</div>
-					}
-				>
-					<OrderStatus
-						order={ order }
-						orderStatusMap={ getSetting( 'orderStatuses', {} ) }
-					/>
-				</ActivityCard>
-			);
-		} );
-		return (
-			<Fragment>
-				{ cards }
-				<Link
-					href={ 'edit.php?post_type=shop_order' }
-					className="woocommerce-layout__activity-panel-outbound-link"
-					onClick={ () => this.recordOrderEvent( 'orders_manage' ) }
-					type="wp-admin"
-				>
-					{ __( 'Manage all orders', 'woocommerce-admin' ) }
-				</Link>
-			</Fragment>
-		);
-	}
-
-	render() {
-		const { isRequesting, isError, orderStatuses } = this.props;
-
-		if ( isError ) {
-			if ( ! orderStatuses.length && window.wcAdminFeatures.analytics ) {
-				return (
-					<EmptyContent
-						title={ __(
-							"You currently don't have any actionable statuses. " +
-								'To display orders here, select orders that require further review in settings.',
-							'woocommerce-admin'
-						) }
-						actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
-						actionURL={ getAdminLink(
-							'admin.php?page=wc-admin&path=/analytics/settings'
-						) }
-					/>
-				);
-			}
-
-			const title = __(
-				'There was an error getting your orders. Please try again.',
-				'woocommerce-admin'
-			);
-			const actionLabel = __( 'Reload', 'woocommerce-admin' );
-			const actionCallback = () => {
-				// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
-				window.location.reload();
-			};
-
-			return (
-				<Fragment>
-					<EmptyContent
-						title={ title }
-						actionLabel={ actionLabel }
-						actionURL={ null }
-						actionCallback={ actionCallback }
-					/>
-				</Fragment>
-			);
-		}
-
-		return (
-			<Fragment>
-				<Section>
-					{ isRequesting ? (
-						<ActivityCardPlaceholder
-							className="woocommerce-order-activity-card"
-							hasAction
-							hasDate
-							lines={ 1 }
-						/>
-					) : (
-						this.renderOrders()
+					🎉
+				</span>
+				<H id="woocommerce-order-empty-message">
+					{ __(
+						'You’ve fulfilled all your orders',
+						'woocommerce-admin'
 					) }
-				</Section>
-			</Fragment>
+				</H>
+			</ActivityCard>
+			<Link
+				href={ 'edit.php?post_type=shop_order' }
+				onClick={ () => recordOrderEvent( 'orders_manage' ) }
+				className="woocommerce-layout__activity-panel-outbound-link woocommerce-layout__activity-panel-empty"
+				type="wp-admin"
+			>
+				{ __( 'Manage all orders', 'woocommerce-admin' ) }
+			</Link>
+		</>
+	);
+};
+
+function renderOrders( orders ) {
+	if ( orders.length === 0 ) {
+		return renderEmptyCard();
+	}
+
+	const getCustomerString = ( order ) => {
+		const { first_name: firstName, last_name: lastName } =
+			order.customer || {};
+
+		if ( ! firstName && ! lastName ) {
+			return '';
+		}
+
+		const name = [ firstName, lastName ].join( ' ' );
+		return `{{customerLink}}${ name }{{/customerLink}}`;
+	};
+
+	const orderCardTitle = ( order ) => {
+		const { id: orderId, number: orderNumber, customer } = order;
+		let customerUrl = null;
+		if ( customer && customer.customer_id ) {
+			customerUrl = window.wcAdminFeatures.analytics
+				? getNewPath( {}, '/analytics/customers', {
+						filter: 'single_customer',
+						customers: customer.customer_id,
+				  } )
+				: getAdminLink(
+						'user-edit.php?user_id=' + customer.customer_id
+				  );
+		}
+
+		return (
+			<>
+				{ interpolateComponents( {
+					mixedString: sprintf(
+						__(
+							'{{orderLink}}Order #%(orderNumber)s{{/orderLink}} %(customerString)s',
+							'woocommerce-admin'
+						),
+						{
+							orderNumber,
+							customerString: getCustomerString( order ),
+						}
+					),
+					components: {
+						orderLink: (
+							<Link
+								href={ getAdminLink(
+									'post.php?action=edit&post=' + orderId
+								) }
+								onClick={ () =>
+									recordOrderEvent( 'order_number' )
+								}
+								type="wp-admin"
+							/>
+						),
+						destinationFlag:
+							customer && customer.country ? (
+								<Flag
+									code={ customer && customer.country }
+									round={ false }
+								/>
+							) : null,
+						customerLink: customerUrl ? (
+							<Link
+								href={ customerUrl }
+								onClick={ () =>
+									recordOrderEvent( 'customer_name' )
+								}
+								type="wc-admin"
+							/>
+						) : (
+							<span />
+						),
+					},
+				} ) }
+			</>
+		);
+	};
+
+	const cards = [];
+	orders.forEach( ( order ) => {
+		const {
+			date_created_gmt: dateCreatedGmt,
+			products,
+			id: orderId,
+		} = order;
+		const productsCount = products ? products.length : 0;
+
+		cards.push(
+			<ActivityCard
+				key={ orderId }
+				className="woocommerce-order-activity-card"
+				title={ orderCardTitle( order ) }
+				date={ dateCreatedGmt }
+				onClick={ ( { target } ) => {
+					recordOrderEvent( 'orders_begin_fulfillment' );
+					if ( ! target.href ) {
+						window.location.href = getAdminLink(
+							`post.php?action=edit&post=${ orderId }`
+						);
+					}
+				} }
+				subtitle={
+					<div>
+						<span>
+							{ sprintf(
+								_n(
+									'%d product',
+									'%d products',
+									productsCount,
+									'woocommerce-admin'
+								),
+								productsCount
+							) }
+						</span>
+						<span>{ order.total_formatted }</span>
+					</div>
+				}
+			>
+				<OrderStatus
+					order={ order }
+					orderStatusMap={ getSetting( 'orderStatuses', {} ) }
+				/>
+			</ActivityCard>
+		);
+	} );
+	return (
+		<>
+			{ cards }
+			<Link
+				href={ 'edit.php?post_type=shop_order' }
+				className="woocommerce-layout__activity-panel-outbound-link"
+				onClick={ () => recordOrderEvent( 'orders_manage' ) }
+				type="wp-admin"
+			>
+				{ __( 'Manage all orders', 'woocommerce-admin' ) }
+			</Link>
+		</>
+	);
+}
+
+function OrdersPanel( { countUnreadOrders, orderStatuses } ) {
+	const actionableOrdersQuery = useMemo(
+		() => ( {
+			page: 1,
+			per_page: 5,
+			status: orderStatuses,
+			_fields: [
+				'id',
+				'number',
+				'status',
+				'total_formatted',
+				'customer',
+				'products',
+				'customer_id',
+				'date_created_gmt',
+			],
+		} ),
+		[ orderStatuses ]
+	);
+	const { orders, isRequesting, isError } = useSelect( ( select ) => {
+		const { getItems, getItemsError, isResolving } = select(
+			ITEMS_STORE_NAME
+		);
+
+		if ( ! orderStatuses.length && countUnreadOrders === 0 ) {
+			return { isRequesting: false };
+		}
+
+		/* eslint-disable @wordpress/no-unused-vars-before-return */
+		const orderItems = getItems( 'orders', actionableOrdersQuery, null );
+
+		const isRequestingActionable = isResolving( 'getItems', [
+			'orders',
+			actionableOrdersQuery,
+		] );
+
+		if (
+			isRequestingActionable ||
+			countUnreadOrders === null ||
+			orderItems === null
+		) {
+			return {
+				isError: Boolean(
+					getItemsError( 'orders', actionableOrdersQuery )
+				),
+				isRequesting: true,
+				orderStatuses,
+			};
+		}
+
+		const actionableOrders = orderItems
+			? Array.from( orderItems.values() )
+			: orderItems;
+
+		return {
+			orders: actionableOrders,
+			isError: Boolean( getItemsError( 'orders', actionableOrders ) ),
+			isRequesting: isRequestingActionable,
+			orderStatuses,
+		};
+	} );
+
+	if ( isError ) {
+		if ( ! orderStatuses.length && window.wcAdminFeatures.analytics ) {
+			return (
+				<EmptyContent
+					title={ __(
+						"You currently don't have any actionable statuses. " +
+							'To display orders here, select orders that require further review in settings.',
+						'woocommerce-admin'
+					) }
+					actionLabel={ __( 'Settings', 'woocommerce-admin' ) }
+					actionURL={ getAdminLink(
+						'admin.php?page=wc-admin&path=/analytics/settings'
+					) }
+				/>
+			);
+		}
+
+		const title = __(
+			'There was an error getting your orders. Please try again.',
+			'woocommerce-admin'
+		);
+		const actionLabel = __( 'Reload', 'woocommerce-admin' );
+		const actionCallback = () => {
+			// @todo Add tracking for how often an error is displayed, and the reload action is clicked.
+			window.location.reload();
+		};
+
+		return (
+			<>
+				<EmptyContent
+					title={ title }
+					actionLabel={ actionLabel }
+					actionURL={ null }
+					actionCallback={ actionCallback }
+				/>
+			</>
 		);
 	}
+
+	return (
+		<>
+			<Section>
+				{ isRequesting ? (
+					<ActivityCardPlaceholder
+						className="woocommerce-order-activity-card"
+						hasAction
+						hasDate
+						lines={ 1 }
+					/>
+				) : (
+					renderOrders( orders )
+				) }
+			</Section>
+		</>
+	);
 }
 
 OrdersPanel.propTypes = {
@@ -287,65 +341,4 @@ OrdersPanel.defaultProps = {
 	isRequesting: false,
 };
 
-OrdersPanel.contextType = CurrencyContext;
-
-export default withSelect( ( select, props ) => {
-	const { countUnreadOrders, orderStatuses } = props;
-	const { getItems, getItemsError, isResolving } = select( ITEMS_STORE_NAME );
-
-	if ( ! orderStatuses.length && countUnreadOrders === 0 ) {
-		return { isRequesting: false };
-	}
-
-	// Query the core Orders endpoint for the most up-to-date statuses.
-	const actionableOrdersQuery = {
-		page: 1,
-		per_page: 5,
-		status: orderStatuses,
-		_fields: [
-			'id',
-			'number',
-			'status',
-			'total',
-			'customer',
-			'products',
-			'customer_id',
-			'date_created_gmt',
-		],
-	};
-	/* eslint-disable @wordpress/no-unused-vars-before-return */
-	const actionableOrders = Array.from(
-		getItems( 'orders', actionableOrdersQuery ).values()
-	);
-	const isRequestingActionable = isResolving( 'getItems', [
-		'orders',
-		actionableOrdersQuery,
-	] );
-
-	if ( isRequestingActionable ) {
-		return {
-			isError: Boolean(
-				getItemsError( 'orders', actionableOrdersQuery )
-			),
-			isRequesting: isRequestingActionable,
-			orderStatuses,
-		};
-	}
-
-	const isError = Boolean( getItemsError( 'orders', actionableOrders ) );
-
-	if (
-		countUnreadOrders === null ||
-		typeof actionableOrders === 'undefined' ||
-		! actionableOrders.length
-	) {
-		return { isRequesting: true };
-	}
-
-	return {
-		orders: actionableOrders,
-		isError,
-		isRequesting: isRequestingActionable,
-		orderStatuses,
-	};
-} )( OrdersPanel );
+export default OrdersPanel;

--- a/client/homescreen/activity-panel/orders/test/index.js
+++ b/client/homescreen/activity-panel/orders/test/index.js
@@ -2,23 +2,32 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import OrdersPanel from '../';
 
+jest.mock( '@wordpress/data', () => {
+	// Require the original module to not be mocked...
+	const originalModule = jest.requireActual( '@wordpress/data' );
+
+	return {
+		__esModule: true, // Use it when dealing with esModules
+		...originalModule,
+		useSelect: jest.fn().mockReturnValue( {} ),
+	};
+} );
+
 describe( 'OrdersPanel', () => {
 	it( 'should render an empty order card', () => {
-		render(
-			<OrdersPanel
-				countUnreadOrders={ 0 }
-				isError={ false }
-				isRequesting={ false }
-				orderStatuses={ [] }
-				totalOrderCount={ 10 }
-			/>
-		);
+		useSelect.mockReturnValue( {
+			orders: [],
+			isError: false,
+			isRequesting: false,
+		} );
+		render( <OrdersPanel orderStatuses={ [] } countUnreadOrders={ 0 } /> );
 		expect(
 			screen.queryByText( 'You’ve fulfilled all your orders' )
 		).toBeInTheDocument();

--- a/packages/data/src/items/selectors.js
+++ b/packages/data/src/items/selectors.js
@@ -1,19 +1,32 @@
 /**
+ * External dependencies
+ */
+import createSelector from 'rememo';
+
+/**
  * Internal dependencies
  */
 import { getResourceName } from '../utils';
 import { getTotalCountResourceName } from './utils';
 
-export const getItems = ( state, itemType, query ) => {
-	const resourceName = getResourceName( itemType, query );
-	const ids =
-		( state.items[ resourceName ] && state.items[ resourceName ].data ) ||
-		[];
-	return ids.reduce( ( map, id ) => {
-		map.set( id, state.data[ itemType ][ id ] );
-		return map;
-	}, new Map() );
-};
+export const getItems = createSelector(
+	( state, itemType, query, defaultValue = new Map() ) => {
+		const resourceName = getResourceName( itemType, query );
+		const ids =
+			state.items[ resourceName ] && state.items[ resourceName ].data;
+		if ( ! ids ) {
+			return defaultValue;
+		}
+		return ids.reduce( ( map, id ) => {
+			map.set( id, state.data[ itemType ][ id ] );
+			return map;
+		}, new Map() );
+	},
+	( state, itemType, query ) => {
+		const resourceName = getResourceName( itemType, query );
+		return [ state.items[ resourceName ] ];
+	}
+);
 
 export const getItemsTotalCount = (
 	state,

--- a/src/API/Orders.php
+++ b/src/API/Orders.php
@@ -191,6 +191,11 @@ class Orders extends \WC_REST_Orders_Controller {
 			$data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
 		}
 
+		// format total with order currency.
+		if ( $object instanceof \WC_Order ) {
+			$data['total_formatted'] = wp_strip_all_tags( html_entity_decode( $object->get_formatted_order_total() ), true );
+		}
+
 		// Format date values.
 		foreach ( $format_date as $key ) {
 			$datetime              = $data[ $key ];
@@ -245,6 +250,7 @@ class Orders extends \WC_REST_Orders_Controller {
 				'shipping_tax'         => $data['shipping_tax'],
 				'cart_tax'             => $data['cart_tax'],
 				'total'                => $data['total'],
+				'total_formatted'      => isset( $data['total_formatted'] ) ? $data['total_formatted'] : $data['total'],
 				'total_tax'            => $data['total_tax'],
 				'prices_include_tax'   => $data['prices_include_tax'],
 				'customer_id'          => $data['customer_id'],

--- a/src/API/Orders.php
+++ b/src/API/Orders.php
@@ -81,13 +81,75 @@ class Orders extends \WC_REST_Orders_Controller {
 	}
 
 	/**
+	 * Get product IDs, names, and quantity from order ID.
+	 *
+	 * @param array $order_id ID of order.
+	 * @return array
+	 */
+	protected function get_products_by_order_id( $order_id ) {
+		global $wpdb;
+		$order_product_lookup_table = $wpdb->prefix . 'wc_order_product_lookup';
+		$products                   = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT
+				order_id,
+				product_id,
+				variation_id,
+				post_title as product_name,
+				product_qty as product_quantity
+			FROM {$wpdb->posts}
+			JOIN
+			    {$order_product_lookup_table}
+				ON {$wpdb->posts}.ID = (
+					CASE WHEN variation_id > 0
+						THEN variation_id
+						ELSE product_id
+					END
+				)
+			WHERE
+				order_id = ( %d )
+			", // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$order_id
+			),
+			ARRAY_A
+		);
+
+		return $products;
+	}
+
+	/**
+	 * Get customer data from customer_id.
+	 *
+	 * @param array $customer_id ID of customer.
+	 * @return array
+	 */
+	protected function get_customer_by_id( $customer_id ) {
+		global $wpdb;
+
+		$customer_lookup_table = $wpdb->prefix . 'wc_customer_lookup';
+
+		$customer = $wpdb->get_row(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT * FROM {$customer_lookup_table} WHERE customer_id = ( %d )",
+				$customer_id
+			),
+			ARRAY_A
+		);
+
+		return $customer;
+	}
+
+	/**
 	 * Get formatted item data.
 	 *
 	 * @param  WC_Data $object WC_Data instance.
 	 * @return array
 	 */
 	protected function get_formatted_item_data( $object ) {
-		$fields = false;
+		$extra_fields = array( 'customer', 'products' );
+		$fields       = false;
 		// Determine if the response fields were specified.
 		if ( ! empty( $this->request['_fields'] ) ) {
 			$fields = wp_parse_list( $this->request['_fields'] );
@@ -107,10 +169,23 @@ class Orders extends \WC_REST_Orders_Controller {
 			$data = $object->get_data();
 		}
 
+		$extra_fields      = false === $fields ? array() : array_intersect( $extra_fields, $fields );
 		$format_decimal    = array( 'discount_total', 'discount_tax', 'shipping_total', 'shipping_tax', 'shipping_total', 'shipping_tax', 'cart_tax', 'total', 'total_tax' );
 		$format_date       = array( 'date_created', 'date_modified', 'date_completed', 'date_paid' );
 		$format_line_items = array( 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines' );
 
+		// Add extra data as necessary.
+		$extra_data = array();
+		foreach ( $extra_fields as $field ) {
+			switch ( $field ) {
+				case 'customer':
+					$extra_data['customer'] = $this->get_customer_by_id( $data['customer_id'] );
+					break;
+				case 'products':
+					$extra_data['products'] = $this->get_products_by_order_id( $object->get_id() );
+					break;
+			}
+		}
 		// Format decimal values.
 		foreach ( $format_decimal as $key ) {
 			$data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
@@ -130,7 +205,7 @@ class Orders extends \WC_REST_Orders_Controller {
 		$formatted_line_items = array();
 
 		foreach ( $format_line_items as $key ) {
-			if ( false === $fields || in_array( $key, $fields ) ) {
+			if ( false === $fields || in_array( $key, $fields, true ) ) {
 				if ( $using_order_class_override ) {
 					$line_item_data = $object->get_line_item_data( $key );
 				} else {
@@ -189,7 +264,8 @@ class Orders extends \WC_REST_Orders_Controller {
 				'meta_data'            => $data['meta_data'],
 				'refunds'              => $data['refunds'],
 			),
-			$formatted_line_items
+			$formatted_line_items,
+			$extra_data
 		);
 	}
 }


### PR DESCRIPTION
Fixes #7382 and #7381 

This fixes an issue where the orders in the homescreen panel wouldn't load in large databases, or not load when the analytics was disabled. The main change was to make use of the `wc/admin/items` store instead of the `wc/admin/reports` store.

I had to add support for querying for the customer and products data for orders.

### Screenshots

![homescreen-order-panel](https://user-images.githubusercontent.com/2240960/126554663-db8589f1-74e4-4473-9b3e-951a1c8f243b.gif)

### Detailed test instructions:

- Create a new WooCommerce store
- Create some products and a order that is processing or on-hold
- Disable Analytics in WooCommerce > Settings > Advanced > Features
- Go to WooCommerce > Home
- Hide the task list and expand the Orders panel
- The order you created should be listed

- Install [WC Smooth generator plugin](https://github.com/woocommerce/wc-smooth-generator) and generate several products first (between 10-50 - `wp wc generate products 25` or in **Tools > Woocommerce Smooth Generator**)
- Generate quite a few orders, ~500 - `wp wc generate orders 500` (this could take a little bit and you might want to install the [Disable Emails](https://wordpress.org/plugins/disable-emails/) plugin before that)
- Go to WooCommerce > Home
- Expand the Orders panel
- The order you created should be listed (that are in processing or on-hold)

- Enable the analytics again and open the orders panel again to see if it still works well.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
