### PR TITLE
Attempt to fix broken test in PHP 7 + WC latest + Composer 1.10.19

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -19,7 +19,7 @@ jobs:
                 include:
                     - php: '7.0'
                       wordpress: '5.5'
-                      woocommerce: 'latest'
+                      woocommerce: '5.5.2'
                       phpunit: '6.5.9'
                       composer: '1.10.19'
                     - php: '7.0'

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -19,9 +19,9 @@ jobs:
                 include:
                     - php: '7.0'
                       wordpress: '5.5'
-                      woocommerce: '5.5.2'
+                      woocommerce: 'latest'
                       phpunit: '6.5.9'
-                      composer: '1.10.19'
+                      composer: '2.0.6'
                     - php: '7.0'
                       wordpress: '5.6'
                       woocommerce: '4.9.1'

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -21,7 +21,7 @@ jobs:
                       wordpress: '5.5'
                       woocommerce: 'latest'
                       phpunit: '6.5.9'
-                      composer: '2.0.6'
+                      composer: '1.10.19'
                     - php: '7.0'
                       wordpress: '5.6'
                       woocommerce: '4.9.1'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,9 @@
  * @package WooCommerce\Admin\Tests
  */
 
+use Automattic\WooCommerce\Proxies\LegacyProxy;
+use Automattic\WooCommerce\Testing\Tools\DependencyManagement\MockableLegacyProxy;
+
 /**
  * Class WC_Admin_Unit_Tests_Bootstrap
  */
@@ -71,6 +74,9 @@ class WC_Admin_Unit_Tests_Bootstrap {
 
 		// load WC testing framework.
 		$this->includes();
+
+		// replace LegacyProxy class to MockableLegacyProxy from WC container.
+		$this->replace_legacy_proxy();
 	}
 
 	/**
@@ -179,6 +185,26 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Replace LegacyProxy to MockableLegacyProxy from the WC container.
+	 *
+	 * @throws \Exception Thrown when reflection fails.
+	 */
+	private function replace_legacy_proxy() {
+		try {
+			$inner_container_property = new \ReflectionProperty( \Automattic\WooCommerce\Container::class, 'container' );
+		} catch ( ReflectionException $ex ) {
+			throw new \Exception( "Error when trying to get the private 'container' property from the " . \Automattic\WooCommerce\Container::class . ' class using reflection during unit testing bootstrap, has the property been removed or renamed?' );
+		}
+
+		$inner_container_property->setAccessible( true );
+		$inner_container = $inner_container_property->getValue( wc_get_container() );
+
+		$inner_container->replace( LegacyProxy::class, MockableLegacyProxy::class );
+		$inner_container->reset_all_resolved();
+
 	}
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -205,6 +205,7 @@ class WC_Admin_Unit_Tests_Bootstrap {
 		$inner_container->replace( LegacyProxy::class, MockableLegacyProxy::class );
 		$inner_container->reset_all_resolved();
 
+		$GLOBALS['wc_container'] = $inner_container;
 	}
 }
 


### PR DESCRIPTION
This PR fixes broken WC Admin tests with the latest WC.

### What caused it?

1. We started seeing `Error: Call to undefined method Automattic\WooCommerce\Proxies\LegacyProxy::reset()` errors with the latest WC.

2. WC Admin tests extend `WC_REST_Unit_Test_Case` and `WC_REST_Unit_Test_Case` extends `WC_Unit_Test_Case`.
3. [WC_Unit_Test_Case](https://github.com/woocommerce/woocommerce/blob/trunk/tests/legacy/framework/class-wc-unit-test-case.php) `setUp()` calls [LegacyProxy::proxy()](https://github.com/woocommerce/woocommerce/blob/trunk/tests/legacy/framework/class-wc-unit-test-case.php#L85), but [LegacyProxy.php](https://github.com/woocommerce/woocommerce/blob/trunk/src/Proxies/LegacyProxy.php) does not have `reset()` method.
4. [WC_Unit_Tests_Bootstrap](https://github.com/woocommerce/woocommerce/blob/trunk/tests/legacy/bootstrap.php#L151), which gets initialized before any PHP Unit tests replaces `LegacyProxy` to `MockableLegacyProxy` from WC IoC Container. This makes `wc_get_container()->get( LegacyProxy::class )` return `MockableLegacyProxy` class.

This PR adds the same code in WC Admin's bootstrap class to replace `LegacyProxy` with `MockableLegacyProxy` to prevent the error.

### Testing instructions

1. Open `docker/wc-admin-php-test-suite/docker-compose.yml`
2. Edit `WC_VERSION` to the latest

Before

```
WC_VERSION=${WC_VERSION:-4.8.0}
```

After

```
WC_VERSION=${WC_VERSION:-latest}
```

3. Run a test `npm run test:php -- --filter=WC_Tests_API_Products` and confirm it passes.


no changelog needed