### PR TITLE
Update e2e matcher for tasklist header

### DIFF
--- a/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
+++ b/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
@@ -30,7 +30,7 @@ export class WcHomescreen extends BasePage {
 		await page.waitForSelector(
 			'.woocommerce-task-card .woocommerce-task-list__item-title'
 		);
-		await waitForElementByText( 'span', 'Get ready to start selling' );
+		await waitForElementByText( '*', 'Get ready to start selling' );
 		const list = await this.page.$$eval(
 			'.woocommerce-task-card .woocommerce-task-list__item-title',
 			( items ) => items.map( ( item ) => item.textContent )


### PR DESCRIPTION
This should fix failing E2E tests for a japanese store when doing this test:
`should display the choose payments task, and not the woocommerce payments task`

Not sure if this was our change or not, but the tasklist header is now wrapped in a `span` versus a `p` prior.

FYI, there might still be one E2E test failing, which would be fixed once https://github.com/woocommerce/woocommerce-admin/pull/7405 is merged.

No changelog necessary.