### PR TITLE
Update help tooltip styling

### DIFF
--- a/changelogs/fix-7413_help_tooltip_styling
+++ b/changelogs/fix-7413_help_tooltip_styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Update tooltip styling to fix new Gutenberg updates. #7414

--- a/client/header/activity-panel/highlight-tooltip/style.scss
+++ b/client/header/activity-panel/highlight-tooltip/style.scss
@@ -34,9 +34,10 @@
 	.components-card__header {
 		@include font-size( 16 );
 		font-weight: 600;
-		height: 60px;
+		box-sizing: border-box;
 	}
 	.components-card__footer {
 		justify-content: flex-end;
+		box-sizing: border-box;
 	}
 }


### PR DESCRIPTION
Fixes #7413 

Updates the tooltip card with the needed changes of the latest Gutenberg updates.

### Screenshots

<img width="930" alt="Screen Shot 2021-07-23 at 1 59 29 PM" src="https://user-images.githubusercontent.com/2240960/126816330-282dc625-0302-4630-a61e-2df7533cf2d0.png">

### Detailed test instructions:

- Load this branch and install and enable the "Gutenberg" plugin
- Go to **WooCommerce > Home** and one of the uncompleted task list items
- Go back to the home screen and select the task list again
- The help tooltip should popup and be displayed correctly (it only shows up once, to have it show up again you can update the user settings -> `wp user meta update <your user id> woocommerce_admin_help_panel_highlight_shown "no"`)

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
