### PR TITLE
Update test renderer in few components,

### DIFF
--- a/packages/components/src/animation-slider/test/__snapshots__/index.js.snap
+++ b/packages/components/src/animation-slider/test/__snapshots__/index.js.snap
@@ -1,11 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AnimationSlider it renders correctly 1`] = `
-<div
-  className="woocommerce-slide-animation animate-left"
->
-  <div>
-    <div />
-  </div>
-</div>
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="woocommerce-slide-animation animate-left"
+      >
+        <div>
+          <div />
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-slide-animation animate-left"
+    >
+      <div>
+        <div />
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/packages/components/src/animation-slider/test/index.js
+++ b/packages/components/src/animation-slider/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 
 /**
@@ -11,13 +11,11 @@ import AnimationSlider from '../';
 
 describe( 'AnimationSlider', () => {
 	test( 'it renders correctly', () => {
-		const tree = renderer
-			.create(
-				<AnimationSlider animationKey={ 0 } animate={ 'left' }>
-					{ () => <div /> }
-				</AnimationSlider>
-			)
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render(
+			<AnimationSlider animationKey={ 0 } animate={ 'left' }>
+				{ () => <div /> }
+			</AnimationSlider>
+		);
+		expect( component ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/dropdown-button/test/__snapshots__/index.js.snap
+++ b/packages/components/src/dropdown-button/test/__snapshots__/index.js.snap
@@ -1,16 +1,112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DropdownButton it renders correctly 1`] = `
-<button
-  className="components-button woocommerce-dropdown-button"
-  type="button"
->
-  <div
-    className="woocommerce-dropdown-button__labels"
-  >
-    <span>
-      foo
-    </span>
-  </div>
-</button>
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    >
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <button
+        class="components-button woocommerce-dropdown-button"
+        type="button"
+      >
+        <div
+          class="woocommerce-dropdown-button__labels"
+        >
+          <span>
+            foo
+          </span>
+        </div>
+      </button>
+    </div>
+  </body>,
+  "container": <div>
+    <button
+      class="components-button woocommerce-dropdown-button"
+      type="button"
+    >
+      <div
+        class="woocommerce-dropdown-button__labels"
+      >
+        <span>
+          foo
+        </span>
+      </div>
+    </button>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/packages/components/src/dropdown-button/test/index.js
+++ b/packages/components/src/dropdown-button/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 
 /**
@@ -11,9 +11,7 @@ import DropdownButton from '../';
 
 describe( 'DropdownButton', () => {
 	test( 'it renders correctly', () => {
-		const tree = renderer
-			.create( <DropdownButton labels={ [ 'foo' ] } /> )
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render( <DropdownButton labels={ [ 'foo' ] } /> );
+		expect( component ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/search-list-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/search-list-control/test/__snapshots__/index.js.snap
@@ -1,1736 +1,4272 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchListControl should render a search box and list of hierarchical options 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-10"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-10"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-10"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-10"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-1"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-1"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Apricots
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-1"
+              for="search-list-item-1-2"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-2"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-prefix"
+                >
+                  Apricots
+                </span>
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Clementine
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-1"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-prefix"
+                >
+                  Apricots
+                </span>
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elderberry
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-2"
+              for="search-list-item-1-4"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-4"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-prefix"
+                >
+                  Apricots › Elderberry
+                </span>
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Guava
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-5"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-5"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Lychee
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mulberry
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-1"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-1"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Apricots
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-1"
-        htmlFor="search-list-item-1-2"
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-2"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-prefix"
+          <div
+            class="components-base-control__field"
           >
-            Apricots
-          </span>
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Clementine
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-1"
-        htmlFor="search-list-item-1-3"
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-10"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-10"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-prefix"
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-1"
           >
-            Apricots
-          </span>
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-1"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Apricots
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-1"
+            for="search-list-item-1-2"
           >
-            Elderberry
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-2"
-        htmlFor="search-list-item-1-4"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-4"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-prefix"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-2"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-prefix"
+              >
+                Apricots
+              </span>
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Clementine
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-1"
+            for="search-list-item-1-3"
           >
-            Apricots › Elderberry
-          </span>
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-prefix"
+              >
+                Apricots
+              </span>
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elderberry
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-2"
+            for="search-list-item-1-4"
           >
-            Guava
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-5"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-5"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-4"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-prefix"
+              >
+                Apricots › Elderberry
+              </span>
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Guava
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-5"
           >
-            Lychee
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-5"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Lychee
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
           >
-            Mulberry
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mulberry
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box and list of options 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-0"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-0"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-0"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-0"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-1"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-1"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Apricots
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-2"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-2"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Clementine
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elderberry
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-4"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-4"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Guava
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-5"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-5"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Lychee
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mulberry
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-1"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-1"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Apricots
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-2"
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-2"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Clementine
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-0"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-0"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-1"
           >
-            Elderberry
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-4"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-4"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-1"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Apricots
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-2"
           >
-            Guava
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-5"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-5"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-2"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Clementine
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
           >
-            Lychee
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elderberry
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-4"
           >
-            Mulberry
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-4"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Guava
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-5"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-5"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Lychee
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mulberry
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box and list of options with a custom className 1`] = `
-<div
-  className="woocommerce-search-list test-search"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list test-search"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-1"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-1"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-1"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-1"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-1"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-1"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Apricots
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-2"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-2"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Clementine
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elderberry
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-4"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-4"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Guava
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-5"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-5"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Lychee
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mulberry
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-1"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list test-search"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-1"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Apricots
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-2"
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-2"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Clementine
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-1"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-1"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-1"
           >
-            Elderberry
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-4"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-4"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-1"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Apricots
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-2"
           >
-            Guava
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-5"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-5"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-2"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Clementine
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
           >
-            Lychee
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elderberry
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-4"
           >
-            Mulberry
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-4"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Guava
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-5"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-5"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Lychee
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mulberry
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box and list of options, with a custom render callback for each item 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <div
+        class="woocommerce-search-list"
+      >
+        <div
+          class="woocommerce-search-list__selected"
+        >
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-9"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-9"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <div>
+              Apricots
+              !
+            </div>
+          </li>
+          <li>
+            <div>
+              Clementine
+              !
+            </div>
+          </li>
+          <li>
+            <div>
+              Elderberry
+              !
+            </div>
+          </li>
+          <li>
+            <div>
+              Guava
+              !
+            </div>
+          </li>
+          <li>
+            <div>
+              Lychee
+              !
+            </div>
+          </li>
+          <li>
+            <div>
+              Mulberry
+              !
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
     >
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list__selected"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-9"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-9"
-          onChange={[Function]}
-          type="search"
-        />
+          <strong>
+            0 items selected
+          </strong>
+        </div>
       </div>
+      <div
+        class="woocommerce-search-list__search"
+      >
+        <div
+          class="components-base-control"
+        >
+          <div
+            class="components-base-control__field"
+          >
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-9"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-9"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
+      >
+        <li>
+          <div>
+            Apricots
+            !
+          </div>
+        </li>
+        <li>
+          <div>
+            Clementine
+            !
+          </div>
+        </li>
+        <li>
+          <div>
+            Elderberry
+            !
+          </div>
+        </li>
+        <li>
+          <div>
+            Guava
+            !
+          </div>
+        </li>
+        <li>
+          <div>
+            Lychee
+            !
+          </div>
+        </li>
+        <li>
+          <div>
+            Mulberry
+            !
+          </div>
+        </li>
+      </ul>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <div>
-        Apricots
-        !
-      </div>
-    </li>
-    <li>
-      <div>
-        Clementine
-        !
-      </div>
-    </li>
-    <li>
-      <div>
-        Elderberry
-        !
-      </div>
-    </li>
-    <li>
-      <div>
-        Guava
-        !
-      </div>
-    </li>
-    <li>
-      <div>
-        Lychee
-        !
-      </div>
-    </li>
-    <li>
-      <div>
-        Mulberry
-        !
-      </div>
-    </li>
-  </ul>
-</div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box and list of options, with a custom search input message 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-8"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Testing search label
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-8"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-8"
+              >
+                Testing search label
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-8"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-1"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-1"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Apricots
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-2"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-2"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Clementine
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elderberry
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-4"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-4"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Guava
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-5"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-5"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Lychee
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mulberry
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-1"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-1"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Apricots
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-2"
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-2"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Clementine
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-8"
+            >
+              Testing search label
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-8"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-1"
           >
-            Elderberry
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-4"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-4"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-1"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Apricots
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-2"
           >
-            Guava
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-5"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-5"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-2"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Clementine
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
           >
-            Lychee
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elderberry
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-4"
           >
-            Mulberry
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-4"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Guava
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-5"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-5"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Lychee
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mulberry
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box and no options 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-4"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-4"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-4"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-4"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__list is-not-found"
+        >
+          <span
+            class="woocommerce-search-list__not-found-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="gridicon gridicons-notice-outline"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                />
+              </g>
+            </svg>
+          </span>
+          <span
+            class="woocommerce-search-list__not-found-text"
+          >
+            No items found.
+          </span>
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    className="woocommerce-search-list__list is-not-found"
-  >
-    <span
-      className="woocommerce-search-list__not-found-icon"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
     >
-      <svg
-        aria-hidden="true"
-        className="gridicon gridicons-notice-outline"
-        focusable="false"
-        height={24}
-        role="img"
-        viewBox="0 0 24 24"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <g>
-          <path
-            d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-          />
-        </g>
-      </svg>
-    </span>
-    <span
-      className="woocommerce-search-list__not-found-text"
-    >
-      No items found.
-    </span>
-  </div>
-</div>
+        <div
+          class="woocommerce-search-list__selected-header"
+        >
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
+      >
+        <div
+          class="components-base-control"
+        >
+          <div
+            class="components-base-control__field"
+          >
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-4"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-4"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__list is-not-found"
+      >
+        <span
+          class="woocommerce-search-list__not-found-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="gridicon gridicons-notice-outline"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </span>
+        <span
+          class="woocommerce-search-list__not-found-text"
+        >
+          No items found.
+        </span>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box with a search term, and no matching options 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-7"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-7"
-          onChange={[Function]}
-          type="search"
-          value="no matches"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-7"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-7"
+                type="search"
+                value="no matches"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__list is-not-found"
+        >
+          <span
+            class="woocommerce-search-list__not-found-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="gridicon gridicons-notice-outline"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <g>
+                <path
+                  d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+                />
+              </g>
+            </svg>
+          </span>
+          <span
+            class="woocommerce-search-list__not-found-text"
+          >
+            No results for no matches
+          </span>
+        </div>
       </div>
     </div>
-  </div>
-  <div
-    className="woocommerce-search-list__list is-not-found"
-  >
-    <span
-      className="woocommerce-search-list__not-found-icon"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
     >
-      <svg
-        aria-hidden="true"
-        className="gridicon gridicons-notice-outline"
-        focusable="false"
-        height={24}
-        role="img"
-        viewBox="0 0 24 24"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <g>
-          <path
-            d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
-          />
-        </g>
-      </svg>
-    </span>
-    <span
-      className="woocommerce-search-list__not-found-text"
-    >
-      No results for no matches
-    </span>
-  </div>
-</div>
+        <div
+          class="woocommerce-search-list__selected-header"
+        >
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
+      >
+        <div
+          class="components-base-control"
+        >
+          <div
+            class="components-base-control__field"
+          >
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-7"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-7"
+              type="search"
+              value="no matches"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__list is-not-found"
+      >
+        <span
+          class="woocommerce-search-list__not-found-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="gridicon gridicons-notice-outline"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+              />
+            </g>
+          </svg>
+        </span>
+        <span
+          class="woocommerce-search-list__not-found-text"
+        >
+          No results for no matches
+        </span>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box with a search term, and only matching options 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-5"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-5"
-          onChange={[Function]}
-          type="search"
-          value="berry"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-5"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-5"
+                type="search"
+                value="berry"
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elder
+                  <strong>
+                    berry
+                  </strong>
+                  
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mul
+                  <strong>
+                    berry
+                  </strong>
+                  
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Elder
-            <strong>
-              berry
-            </strong>
-            
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Mul
-            <strong>
-              berry
-            </strong>
-            
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-5"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-5"
+              type="search"
+              value="berry"
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
+      >
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elder
+                <strong>
+                  berry
+                </strong>
+                
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mul
+                <strong>
+                  berry
+                </strong>
+                
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box with a search term, and only matching options, regardless of case sensitivity 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        0 items selected
-      </strong>
-    </div>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-6"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-6"
-          onChange={[Function]}
-          type="search"
-          value="bERry"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              0 items selected
+            </strong>
+          </div>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-6"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-6"
+                type="search"
+                value="bERry"
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elder
+                  <strong>
+                    bERry
+                  </strong>
+                  
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mul
+                  <strong>
+                    bERry
+                  </strong>
+                  
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
-          >
-            Elder
-            <strong>
-              bERry
-            </strong>
-            
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
+          <strong>
+            0 items selected
+          </strong>
+        </div>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Mul
-            <strong>
-              bERry
-            </strong>
-            
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-6"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-6"
+              type="search"
+              value="bERry"
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
+      >
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elder
+                <strong>
+                  bERry
+                </strong>
+                
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mul
+                <strong>
+                  bERry
+                </strong>
+                
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box, a list of options, and 1 selected item 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        1 item selected
-      </strong>
-      <button
-        aria-label="Clear all selected items"
-        className="components-button is-link is-destructive"
-        onClick={[Function]}
-        type="button"
-      >
-        Clear all
-      </button>
-    </div>
-    <ul>
-      <li>
-        <span
-          className="woocommerce-tag has-remove"
-        >
-          <span
-            className="woocommerce-tag__text"
-            id="woocommerce-tag__label-0"
-          >
-            <span
-              className="screen-reader-text"
-            >
-              Clementine
-            </span>
-            <span
-              aria-hidden="true"
-            >
-              Clementine
-            </span>
-          </span>
-          <button
-            aria-describedby="woocommerce-tag__label-0"
-            aria-label="Remove Clementine"
-            className="components-button woocommerce-tag__remove"
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden={true}
-              className="clear-icon"
-              focusable={false}
-              height={20}
-              role="img"
-              viewBox="0 0 24 24"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
-              />
-            </svg>
-          </button>
-        </span>
-      </li>
-    </ul>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-2"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-2"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              1 item selected
+            </strong>
+            <button
+              aria-label="Clear all selected items"
+              class="components-button is-link is-destructive"
+              type="button"
+            >
+              Clear all
+            </button>
+          </div>
+          <ul>
+            <li>
+              <span
+                class="woocommerce-tag has-remove"
+              >
+                <span
+                  class="woocommerce-tag__text"
+                  id="woocommerce-tag__label-0"
+                >
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Clementine
+                  </span>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Clementine
+                  </span>
+                </span>
+                <button
+                  aria-describedby="woocommerce-tag__label-0"
+                  aria-label="Remove Clementine"
+                  class="components-button woocommerce-tag__remove"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="clear-icon"
+                    focusable="false"
+                    height="20"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-2"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-2"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-1"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-1"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Apricots
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-2"
+            >
+              <input
+                checked=""
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-2"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Clementine
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elderberry
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-4"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-4"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Guava
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-5"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-5"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Lychee
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mulberry
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-1"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-1"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <strong>
+            1 item selected
+          </strong>
+          <button
+            aria-label="Clear all selected items"
+            class="components-button is-link is-destructive"
+            type="button"
           >
-            Apricots
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-2"
+            Clear all
+          </button>
+        </div>
+        <ul>
+          <li>
+            <span
+              class="woocommerce-tag has-remove"
+            >
+              <span
+                class="woocommerce-tag__text"
+                id="woocommerce-tag__label-0"
+              >
+                <span
+                  class="screen-reader-text"
+                >
+                  Clementine
+                </span>
+                <span
+                  aria-hidden="true"
+                >
+                  Clementine
+                </span>
+              </span>
+              <button
+                aria-describedby="woocommerce-tag__label-0"
+                aria-label="Remove Clementine"
+                class="components-button woocommerce-tag__remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="clear-icon"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </li>
+        </ul>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={true}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-2"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Clementine
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-2"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-2"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-1"
           >
-            Elderberry
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-4"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-4"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-1"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Apricots
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-2"
           >
-            Guava
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-5"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-5"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              checked=""
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-2"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Clementine
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
           >
-            Lychee
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elderberry
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-4"
           >
-            Mulberry
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-4"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Guava
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-5"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-5"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Lychee
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mulberry
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`SearchListControl should render a search box, a list of options, and 2 selected item 1`] = `
-<div
-  className="woocommerce-search-list"
->
-  <div
-    className="woocommerce-search-list__selected"
-  >
-    <div
-      className="woocommerce-search-list__selected-header"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      <strong>
-        2 items selected
-      </strong>
-      <button
-        aria-label="Clear all selected items"
-        className="components-button is-link is-destructive"
-        onClick={[Function]}
-        type="button"
-      >
-        Clear all
-      </button>
-    </div>
-    <ul>
-      <li>
-        <span
-          className="woocommerce-tag has-remove"
-        >
-          <span
-            className="woocommerce-tag__text"
-            id="woocommerce-tag__label-1"
-          >
-            <span
-              className="screen-reader-text"
-            >
-              Clementine
-            </span>
-            <span
-              aria-hidden="true"
-            >
-              Clementine
-            </span>
-          </span>
-          <button
-            aria-describedby="woocommerce-tag__label-1"
-            aria-label="Remove Clementine"
-            className="components-button woocommerce-tag__remove"
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden={true}
-              className="clear-icon"
-              focusable={false}
-              height={20}
-              role="img"
-              viewBox="0 0 24 24"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
-              />
-            </svg>
-          </button>
-        </span>
-      </li>
-      <li>
-        <span
-          className="woocommerce-tag has-remove"
-        >
-          <span
-            className="woocommerce-tag__text"
-            id="woocommerce-tag__label-2"
-          >
-            <span
-              className="screen-reader-text"
-            >
-              Guava
-            </span>
-            <span
-              aria-hidden="true"
-            >
-              Guava
-            </span>
-          </span>
-          <button
-            aria-describedby="woocommerce-tag__label-2"
-            aria-label="Remove Guava"
-            className="components-button woocommerce-tag__remove"
-            onClick={[Function]}
-            type="button"
-          >
-            <svg
-              aria-hidden={true}
-              className="clear-icon"
-              focusable={false}
-              height={20}
-              role="img"
-              viewBox="0 0 24 24"
-              width={20}
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
-              />
-            </svg>
-          </button>
-        </span>
-      </li>
-    </ul>
-  </div>
-  <div
-    className="woocommerce-search-list__search"
-  >
+      Notifications
+    </p>
     <div
-      className="components-base-control"
-    >
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
       <div
-        className="components-base-control__field"
+        class="woocommerce-search-list"
       >
-        <label
-          className="components-base-control__label"
-          htmlFor="inspector-text-control-3"
+        <div
+          class="woocommerce-search-list__selected"
         >
-          Search for items
-        </label>
-        <input
-          className="components-text-control__input"
-          id="inspector-text-control-3"
-          onChange={[Function]}
-          type="search"
-        />
+          <div
+            class="woocommerce-search-list__selected-header"
+          >
+            <strong>
+              2 items selected
+            </strong>
+            <button
+              aria-label="Clear all selected items"
+              class="components-button is-link is-destructive"
+              type="button"
+            >
+              Clear all
+            </button>
+          </div>
+          <ul>
+            <li>
+              <span
+                class="woocommerce-tag has-remove"
+              >
+                <span
+                  class="woocommerce-tag__text"
+                  id="woocommerce-tag__label-1"
+                >
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Clementine
+                  </span>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Clementine
+                  </span>
+                </span>
+                <button
+                  aria-describedby="woocommerce-tag__label-1"
+                  aria-label="Remove Clementine"
+                  class="components-button woocommerce-tag__remove"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="clear-icon"
+                    focusable="false"
+                    height="20"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </li>
+            <li>
+              <span
+                class="woocommerce-tag has-remove"
+              >
+                <span
+                  class="woocommerce-tag__text"
+                  id="woocommerce-tag__label-2"
+                >
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Guava
+                  </span>
+                  <span
+                    aria-hidden="true"
+                  >
+                    Guava
+                  </span>
+                </span>
+                <button
+                  aria-describedby="woocommerce-tag__label-2"
+                  aria-label="Remove Guava"
+                  class="components-button woocommerce-tag__remove"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="clear-icon"
+                    focusable="false"
+                    height="20"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+                    />
+                  </svg>
+                </button>
+              </span>
+            </li>
+          </ul>
+        </div>
+        <div
+          class="woocommerce-search-list__search"
+        >
+          <div
+            class="components-base-control"
+          >
+            <div
+              class="components-base-control__field"
+            >
+              <label
+                class="components-base-control__label"
+                for="inspector-text-control-3"
+              >
+                Search for items
+              </label>
+              <input
+                class="components-text-control__input"
+                id="inspector-text-control-3"
+                type="search"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
+        <ul
+          class="woocommerce-search-list__list"
+        >
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-1"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-1"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Apricots
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-2"
+            >
+              <input
+                checked=""
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-2"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Clementine
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-3"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-3"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Elderberry
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-4"
+            >
+              <input
+                checked=""
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-4"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Guava
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-5"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-5"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Lychee
+                </span>
+              </span>
+            </label>
+          </li>
+          <li>
+            <label
+              class=" woocommerce-search-list__item depth-0"
+              for="search-list-item-1-6"
+            >
+              <input
+                class="woocommerce-search-list__item-input"
+                id="search-list-item-1-6"
+                name="search-list-item-1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="woocommerce-search-list__item-label"
+              >
+                <span
+                  class="woocommerce-search-list__item-name"
+                >
+                  Mulberry
+                </span>
+              </span>
+            </label>
+          </li>
+        </ul>
       </div>
     </div>
-  </div>
-  <ul
-    className="woocommerce-search-list__list"
-  >
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-1"
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-search-list"
+    >
+      <div
+        class="woocommerce-search-list__selected"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-1"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="woocommerce-search-list__selected-header"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <strong>
+            2 items selected
+          </strong>
+          <button
+            aria-label="Clear all selected items"
+            class="components-button is-link is-destructive"
+            type="button"
           >
-            Apricots
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-2"
+            Clear all
+          </button>
+        </div>
+        <ul>
+          <li>
+            <span
+              class="woocommerce-tag has-remove"
+            >
+              <span
+                class="woocommerce-tag__text"
+                id="woocommerce-tag__label-1"
+              >
+                <span
+                  class="screen-reader-text"
+                >
+                  Clementine
+                </span>
+                <span
+                  aria-hidden="true"
+                >
+                  Clementine
+                </span>
+              </span>
+              <button
+                aria-describedby="woocommerce-tag__label-1"
+                aria-label="Remove Clementine"
+                class="components-button woocommerce-tag__remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="clear-icon"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </li>
+          <li>
+            <span
+              class="woocommerce-tag has-remove"
+            >
+              <span
+                class="woocommerce-tag__text"
+                id="woocommerce-tag__label-2"
+              >
+                <span
+                  class="screen-reader-text"
+                >
+                  Guava
+                </span>
+                <span
+                  aria-hidden="true"
+                >
+                  Guava
+                </span>
+              </span>
+              <button
+                aria-describedby="woocommerce-tag__label-2"
+                aria-label="Remove Guava"
+                class="components-button woocommerce-tag__remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="clear-icon"
+                  focusable="false"
+                  height="20"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="20"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+                  />
+                </svg>
+              </button>
+            </span>
+          </li>
+        </ul>
+      </div>
+      <div
+        class="woocommerce-search-list__search"
       >
-        <input
-          checked={true}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-2"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
+        <div
+          class="components-base-control"
         >
-          <span
-            className="woocommerce-search-list__item-name"
+          <div
+            class="components-base-control__field"
           >
-            Clementine
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-3"
+            <label
+              class="components-base-control__label"
+              for="inspector-text-control-3"
+            >
+              Search for items
+            </label>
+            <input
+              class="components-text-control__input"
+              id="inspector-text-control-3"
+              type="search"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+      <ul
+        class="woocommerce-search-list__list"
       >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-3"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-1"
           >
-            Elderberry
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-4"
-      >
-        <input
-          checked={true}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-4"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-1"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Apricots
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-2"
           >
-            Guava
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-5"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-5"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              checked=""
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-2"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Clementine
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-3"
           >
-            Lychee
-          </span>
-        </span>
-      </label>
-    </li>
-    <li>
-      <label
-        className=" woocommerce-search-list__item depth-0"
-        htmlFor="search-list-item-1-6"
-      >
-        <input
-          checked={false}
-          className="woocommerce-search-list__item-input"
-          id="search-list-item-1-6"
-          name="search-list-item-1"
-          onChange={[Function]}
-          type="checkbox"
-        />
-        <span
-          className="woocommerce-search-list__item-label"
-        >
-          <span
-            className="woocommerce-search-list__item-name"
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-3"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Elderberry
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-4"
           >
-            Mulberry
-          </span>
-        </span>
-      </label>
-    </li>
-  </ul>
-</div>
+            <input
+              checked=""
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-4"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Guava
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-5"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-5"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Lychee
+              </span>
+            </span>
+          </label>
+        </li>
+        <li>
+          <label
+            class=" woocommerce-search-list__item depth-0"
+            for="search-list-item-1-6"
+          >
+            <input
+              class="woocommerce-search-list__item-input"
+              id="search-list-item-1-6"
+              name="search-list-item-1"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="woocommerce-search-list__item-label"
+            >
+              <span
+                class="woocommerce-search-list__item-name"
+              >
+                Mulberry
+              </span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/packages/components/src/search-list-control/test/index.js
+++ b/packages/components/src/search-list-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { noop } from 'lodash';
 import { createElement } from '@wordpress/element';
 
@@ -30,7 +30,7 @@ const hierarchicalList = [
 
 describe( 'SearchListControl', () => {
 	test( 'should render a search box and list of options', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -38,11 +38,11 @@ describe( 'SearchListControl', () => {
 				onChange={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and list of options with a custom className', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				className="test-search"
@@ -51,11 +51,11 @@ describe( 'SearchListControl', () => {
 				onChange={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box, a list of options, and 1 selected item', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -63,11 +63,11 @@ describe( 'SearchListControl', () => {
 				onChange={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box, a list of options, and 2 selected item', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -75,11 +75,11 @@ describe( 'SearchListControl', () => {
 				onChange={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and no options', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ [] }
@@ -87,11 +87,11 @@ describe( 'SearchListControl', () => {
 				onChange={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box with a search term, and only matching options', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -101,11 +101,11 @@ describe( 'SearchListControl', () => {
 				debouncedSpeak={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box with a search term, and only matching options, regardless of case sensitivity', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -115,11 +115,11 @@ describe( 'SearchListControl', () => {
 				debouncedSpeak={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box with a search term, and no matching options', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -129,12 +129,12 @@ describe( 'SearchListControl', () => {
 				debouncedSpeak={ noop }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and list of options, with a custom search input message', () => {
 		const messages = { search: 'Testing search label' };
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -143,14 +143,14 @@ describe( 'SearchListControl', () => {
 				messages={ messages }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and list of options, with a custom render callback for each item', () => {
 		const renderItem = ( { item } ) => (
 			<div key={ item.id }>{ item.name }!</div>
 		); // eslint-disable-line
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
@@ -159,11 +159,11 @@ describe( 'SearchListControl', () => {
 				renderItem={ renderItem }
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and list of hierarchical options', () => {
-		const component = renderer.create(
+		const component = render(
 			<SearchListControl
 				instanceId={ 1 }
 				list={ hierarchicalList }
@@ -172,6 +172,6 @@ describe( 'SearchListControl', () => {
 				isHierarchical
 			/>
 		);
-		expect( component.toJSON() ).toMatchSnapshot();
+		expect( component ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/section-header/test/__snapshots__/index.js.snap
+++ b/packages/components/src/section-header/test/__snapshots__/index.js.snap
@@ -1,16 +1,112 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SectionHeader it renders correctly 1`] = `
-<div
-  className="woocommerce-section-header"
->
-  <h2
-    className="woocommerce-section-header__title woocommerce-section-header__header-item"
-  >
-    A SectionHeader Example
-  </h2>
-  <hr
-    role="presentation"
-  />
-</div>
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    >
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <div
+        class="woocommerce-section-header"
+      >
+        <h2
+          class="woocommerce-section-header__title woocommerce-section-header__header-item"
+        >
+          A SectionHeader Example
+        </h2>
+        <hr
+          role="presentation"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="woocommerce-section-header"
+    >
+      <h2
+        class="woocommerce-section-header__title woocommerce-section-header__header-item"
+      >
+        A SectionHeader Example
+      </h2>
+      <hr
+        role="presentation"
+      />
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/packages/components/src/section-header/test/index.js
+++ b/packages/components/src/section-header/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 
 /**
@@ -16,9 +16,9 @@ describe( 'SectionHeader', () => {
 	} );
 
 	test( 'it renders correctly', () => {
-		const tree = renderer
-			.create( <SectionHeader title="A SectionHeader Example" /> )
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render(
+			<SectionHeader title="A SectionHeader Example" />
+		);
+		expect( component ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/tag/test/__snapshots__/index.js.snap
+++ b/packages/components/src/tag/test/__snapshots__/index.js.snap
@@ -1,112 +1,545 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag <Tag label="foo" /> should render a tag with the label foo 1`] = `
-<span
-  className="woocommerce-tag"
->
-  <span
-    className="woocommerce-tag__text"
-    id="woocommerce-tag__label-0"
-  >
-    <span
-      className="screen-reader-text"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      foo
-    </span>
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <span
+        class="woocommerce-tag"
+      >
+        <span
+          class="woocommerce-tag__text"
+          id="woocommerce-tag__label-0"
+        >
+          <span
+            class="screen-reader-text"
+          >
+            foo
+          </span>
+          <span
+            aria-hidden="true"
+          >
+            foo
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
     <span
-      aria-hidden="true"
+      class="woocommerce-tag"
     >
-      foo
+      <span
+        class="woocommerce-tag__text"
+        id="woocommerce-tag__label-0"
+      >
+        <span
+          class="screen-reader-text"
+        >
+          foo
+        </span>
+        <span
+          aria-hidden="true"
+        >
+          foo
+        </span>
+      </span>
     </span>
-  </span>
-</span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`Tag <Tag label="foo" popoverContents={ <p>This is a popover</p> } /> should render a tag with a popover 1`] = `
-<span
-  className="woocommerce-tag"
->
-  <button
-    className="components-button woocommerce-tag__text"
-    id="woocommerce-tag__label-2"
-    onClick={[Function]}
-    type="button"
-  >
-    <span
-      className="screen-reader-text"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      foo
-    </span>
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <span
+        class="woocommerce-tag"
+      >
+        <button
+          class="components-button woocommerce-tag__text"
+          id="woocommerce-tag__label-2"
+          type="button"
+        >
+          <span
+            class="screen-reader-text"
+          >
+            foo
+          </span>
+          <span
+            aria-hidden="true"
+          >
+            foo
+          </span>
+        </button>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
     <span
-      aria-hidden="true"
+      class="woocommerce-tag"
     >
-      foo
+      <button
+        class="components-button woocommerce-tag__text"
+        id="woocommerce-tag__label-2"
+        type="button"
+      >
+        <span
+          class="screen-reader-text"
+        >
+          foo
+        </span>
+        <span
+          aria-hidden="true"
+        >
+          foo
+        </span>
+      </button>
     </span>
-  </button>
-</span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`Tag <Tag label="foo" remove={ noop } /> should render a tag with a close button 1`] = `
-<span
-  className="woocommerce-tag has-remove"
->
-  <span
-    className="woocommerce-tag__text"
-    id="woocommerce-tag__label-1"
-  >
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    >
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <span
+        class="woocommerce-tag has-remove"
+      >
+        <span
+          class="woocommerce-tag__text"
+          id="woocommerce-tag__label-1"
+        >
+          <span
+            class="screen-reader-text"
+          >
+            foo
+          </span>
+          <span
+            aria-hidden="true"
+          >
+            foo
+          </span>
+        </span>
+        <button
+          aria-describedby="woocommerce-tag__label-1"
+          aria-label="Remove foo"
+          class="components-button woocommerce-tag__remove"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="clear-icon"
+            focusable="false"
+            height="20"
+            role="img"
+            viewBox="0 0 24 24"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+            />
+          </svg>
+        </button>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
     <span
-      className="screen-reader-text"
+      class="woocommerce-tag has-remove"
     >
-      foo
+      <span
+        class="woocommerce-tag__text"
+        id="woocommerce-tag__label-1"
+      >
+        <span
+          class="screen-reader-text"
+        >
+          foo
+        </span>
+        <span
+          aria-hidden="true"
+        >
+          foo
+        </span>
+      </span>
+      <button
+        aria-describedby="woocommerce-tag__label-1"
+        aria-label="Remove foo"
+        class="components-button woocommerce-tag__remove"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="clear-icon"
+          focusable="false"
+          height="20"
+          role="img"
+          viewBox="0 0 24 24"
+          width="20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
+          />
+        </svg>
+      </button>
     </span>
-    <span
-      aria-hidden="true"
-    >
-      foo
-    </span>
-  </span>
-  <button
-    aria-describedby="woocommerce-tag__label-1"
-    aria-label="Remove foo"
-    className="components-button woocommerce-tag__remove"
-    type="button"
-  >
-    <svg
-      aria-hidden={true}
-      className="clear-icon"
-      focusable={false}
-      height={20}
-      role="img"
-      viewBox="0 0 24 24"
-      width={20}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM15.5303 8.46967C15.8232 8.76256 15.8232 9.23744 15.5303 9.53033L13.0607 12L15.5303 14.4697C15.8232 14.7626 15.8232 15.2374 15.5303 15.5303C15.2374 15.8232 14.7626 15.8232 14.4697 15.5303L12 13.0607L9.53033 15.5303C9.23744 15.8232 8.76256 15.8232 8.46967 15.5303C8.17678 15.2374 8.17678 14.7626 8.46967 14.4697L10.9393 12L8.46967 9.53033C8.17678 9.23744 8.17678 8.76256 8.46967 8.46967C8.76256 8.17678 9.23744 8.17678 9.53033 8.46967L12 10.9393L14.4697 8.46967C14.7626 8.17678 15.2374 8.17678 15.5303 8.46967Z"
-      />
-    </svg>
-  </button>
-</span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`Tag <Tag label="foo" screenReaderLabel="FooBar" /> should render a tag with a screen reader label 1`] = `
-<span
-  className="woocommerce-tag"
->
-  <span
-    className="woocommerce-tag__text"
-    id="woocommerce-tag__label-3"
-  >
-    <span
-      className="screen-reader-text"
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <p
+      class="a11y-speak-intro-text"
+      hidden="hidden"
+      id="a11y-speak-intro-text"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
     >
-      FooBar
-    </span>
+      Notifications
+    </p>
+    <div
+      aria-atomic="true"
+      aria-live="assertive"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-assertive"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      aria-relevant="additions text"
+      class="a11y-speak-region"
+      id="a11y-speak-polite"
+      style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+    />
+    <div>
+      <span
+        class="woocommerce-tag"
+      >
+        <span
+          class="woocommerce-tag__text"
+          id="woocommerce-tag__label-3"
+        >
+          <span
+            class="screen-reader-text"
+          >
+            FooBar
+          </span>
+          <span
+            aria-hidden="true"
+          >
+            foo
+          </span>
+        </span>
+      </span>
+    </div>
+  </body>,
+  "container": <div>
     <span
-      aria-hidden="true"
+      class="woocommerce-tag"
     >
-      foo
+      <span
+        class="woocommerce-tag__text"
+        id="woocommerce-tag__label-3"
+      >
+        <span
+          class="screen-reader-text"
+        >
+          FooBar
+        </span>
+        <span
+          aria-hidden="true"
+        >
+          foo
+        </span>
+      </span>
     </span>
-  </span>
-</span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/packages/components/src/tag/test/index.js
+++ b/packages/components/src/tag/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 
 /**
@@ -13,30 +13,26 @@ const noop = () => {};
 
 describe( 'Tag', () => {
 	test( '<Tag label="foo" /> should render a tag with the label foo', () => {
-		const tree = renderer.create( <Tag label="foo" /> ).toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render( <Tag label="foo" /> );
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( '<Tag label="foo" remove={ noop } /> should render a tag with a close button', () => {
-		const tree = renderer
-			.create( <Tag label="foo" remove={ noop } /> )
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render( <Tag label="foo" remove={ noop } /> );
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( '<Tag label="foo" popoverContents={ <p>This is a popover</p> } /> should render a tag with a popover', () => {
-		const tree = renderer
-			.create(
-				<Tag label="foo" popoverContents={ <p>This is a popover</p> } />
-			)
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render(
+			<Tag label="foo" popoverContents={ <p>This is a popover</p> } />
+		);
+		expect( component ).toMatchSnapshot();
 	} );
 
 	test( '<Tag label="foo" screenReaderLabel="FooBar" /> should render a tag with a screen reader label', () => {
-		const tree = renderer
-			.create( <Tag label="foo" screenReaderLabel="FooBar" /> )
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		const component = render(
+			<Tag label="foo" screenReaderLabel="FooBar" />
+		);
+		expect( component ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
from `react-test-renderer` to `{ render } from '@testing-library/react'`,
to avoid confision like https://github.com/woocommerce/woocommerce-admin/pull/7378#issuecomment-885870676.

Update snapshots respectively.

This update is base on @louwie17's suggestion https://github.com/woocommerce/woocommerce-admin/pull/7378#issuecomment-887498836

> the example you saw used an old test renderer, we usually use the `render` function from `@testing-library/react`

### Accessibility

n/a - it updates only automated tests internals

### Screenshots

### Detailed test instructions:

1. `npm run test`
2. Review snapshot changes

### Additional notes
1. We could also assert only `renderedComponent.container` to make snapshots shorter. The current way, is a tad shorter from the test's code perspective.

----

no changelog needed, it's a code cleanup in tests
<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
