### PR TITLE
Fix/7427 collapsible list transition

### DIFF
--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Fix animations for collapsible list. #7429
+
 # 1.5.0
 
 -   Fix commonjs module build, allow package to be built in isolation. #7286

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -10,8 +10,13 @@ import {
 	Children,
 	useRef,
 	isValidElement,
+	cloneElement,
 } from '@wordpress/element';
-import { Transition } from 'react-transition-group';
+import {
+	Transition,
+	CSSTransition,
+	TransitionGroup,
+} from 'react-transition-group';
 import classnames from 'classnames';
 
 /**
@@ -242,7 +247,39 @@ export const ExperimentalCollapsibleList: React.FC< CollapsibleListProps > = ( {
 								ref={ collapseContainerRef }
 								style={ transitionStyles }
 							>
-								{ displayedChildren.hidden }
+								<TransitionGroup className="woocommerce-experimental-list">
+									{ Children.map(
+										displayedChildren.hidden,
+										( child ) => {
+											const {
+												onExited,
+												in: inTransition,
+												enter,
+												exit,
+												...remainingProps
+											} = child.props;
+											const animationProp =
+												remainingProps.animation ||
+												listProps.animation;
+											return (
+												<CSSTransition
+													key={ child.key }
+													timeout={ 500 }
+													onExited={ onExited }
+													in={ inTransition }
+													enter={ enter }
+													exit={ exit }
+													classNames="woocommerce-list__item"
+												>
+													{ cloneElement( child, {
+														animation: animationProp,
+														...remainingProps,
+													} ) }
+												</CSSTransition>
+											);
+										}
+									) }
+								</TransitionGroup>
 							</div>
 						);
 					} }

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -146,7 +146,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					) }
 				</div>
 			</OptionalTaskTooltip>
-			<div className="woocommerce-task-list__item-text-test">
+			<div className="woocommerce-task-list__item-text">
 				<Text
 					as="div"
 					size="14"

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -112,6 +112,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 	level = 3,
 	action,
 	actionLabel,
+	...listItemProps
 } ) => {
 	const className = classnames( 'woocommerce-task-list__item', {
 		complete: completed,
@@ -128,7 +129,12 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 		( onDelete && completed );
 
 	return (
-		<ListItem disableGutters className={ className } onClick={ onClick }>
+		<ListItem
+			disableGutters
+			className={ className }
+			onClick={ onClick }
+			{ ...listItemProps }
+		>
 			<OptionalTaskTooltip level={ level } completed={ completed }>
 				<div className="woocommerce-task-list__item-before">
 					{ level === 1 && ! completed ? (
@@ -140,7 +146,7 @@ export const TaskItem: React.FC< TaskItemProps > = ( {
 					) }
 				</div>
 			</OptionalTaskTooltip>
-			<div className="woocommerce-task-list__item-text">
+			<div className="woocommerce-task-list__item-text-test">
 				<Text
 					as="div"
 					size="14"


### PR DESCRIPTION
Fixes #7427 

Fixes issue where transitions were not working for the collapsible list items. It also wasn't correctly passing down the
animation prop.

No changelog as it is in the package.

### Accessibility

-   [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)

### Screenshots

![fixed-list-animations](https://user-images.githubusercontent.com/2240960/127217337-4585c257-61a6-4b26-b634-c78667c9eb3f.gif)

### Detailed test instructions:

- Run `npm run example -- --ext=add-task` and enable the plugin
- Make sure there is 4 or more tasks that can be dismissed (edit the tasks returned in the `woocommerce_admin_onboarding_task_list` filter in `docs/examples/extensions/add-task/js/index.js)
- Go to **WooCommerce > Home**
- Expand the **Things to do next** list
- Dismiss one of the collapsible items and notice how it correctly transitions
- Dismiss one of the items that wasn't previously hidden it should still correctly transition
     - When the list is collapsed this shows two transitions, as a new item of the collapsed items moves up, which in theory doesn't make a difference, but given they act as two different transition items it still shows the transition.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
