### PR TITLE
Add additional countries to WCPay for business features and payment task fallback

### DIFF
--- a/changelogs/update-7295-wcpay-add-more-countries
+++ b/changelogs/update-7295-wcpay-add-more-countries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Add additional countries to WCPay for business features and payment task fallback #7436

--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/WCPay/utils.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/WCPay/utils.js
@@ -62,6 +62,12 @@ export function isWCPaySupported( countryCode ) {
 		'IE',
 		'IT',
 		'NZ',
+		'AT',
+		'BE',
+		'NL',
+		'PL',
+		'PT',
+		'CH',
 	];
 
 	return supportedCountries.includes( countryCode );

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -252,7 +252,7 @@ class DefaultPaymentGateways {
 	 * @return array Array of countries.
 	 */
 	public static function get_wcpay_countries() {
-		return array( 'US', 'PR', 'AU', 'CA', 'DE', 'ES', 'FR', 'GB', 'IE', 'IT', 'NZ' );
+		return array( 'US', 'PR', 'AU', 'CA', 'DE', 'ES', 'FR', 'GB', 'IE', 'IT', 'NZ', 'AT', 'BE', 'NL', 'PL', 'PT', 'CH' );
 	}
 
 	/**


### PR DESCRIPTION
Partially fixes https://github.com/woocommerce/woocommerce-admin/issues/7295

This PR adds more European countries to WCPay's supported countries in Business features step and Payments task's fallback configuration. The respective remote config is updated in 10902-gh-Automattic/woocommerce.com

### Detailed test instructions:

**Some preps in order to display the fallback instead of remote config:**
- Set `remote-extensions-list` to `false` in `config/development.json` and rebuild app.
- Set `woocommerce_show_marketplace_suggestions` option to `no`.
- Delete the transient `woocommerce_admin_payment_gateway_suggestions_specs`.
- If WooCommerce payments plugin is activated, deactivate it.

**Actual testing:**
- Set store address to one of the countries: `AT, BE, NL, PL, PT, CH`.
- Go to the OBW and look at the Free features tab.
- Observe WCPay is displayed in the plugins list.
- Navigate directly to `/wp-admin/admin.php?page=wc-admin&task=payments`.
- Observe WCPay is displayed.