### PR TITLE
Bump version to 2.6.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "2.5.0-dev",
+	"version": "2.6.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.5.0-dev",
+	"version": "2.6.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.5.0-dev",
+	"version": "2.6.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.7.0
 Requires PHP: 7.0
-Stable tag: 2.5.0-dev
+Stable tag: 2.6.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.5.0-dev';
+	const VERSION = '2.6.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -146,7 +146,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.5.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.6.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 2.5.0-dev
+ * Version: 2.6.0-dev
  * Requires at least: 5.4
  * Requires PHP: 7.0
  *


### PR DESCRIPTION
This PR bumps the WooCommerce Admin version to 2.6.0-dev

(no changelog is necessary)