### PR TITLE
Bump version to 2.7.0-dev

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -13,7 +13,7 @@
 
 ## 2.5.0
 
-### Fix WC Home crash when the Analytics is disabled.
+### Fix WC Home crash when the Analytics is disabled #7339
 
 1. Navigate to WooCommerce -> Settings -> Advanced -> Features. Uncheck Analytics and save the changes.
 2. Navigate to WooCommerce -> Home and confirm the page loads without an error.

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Match stock status value in CSV download to the table #7284
+
+1. Clone this branch and run npm start
+2. Add some products and set stock value.
+3. Place an order and make it completed.
+4. Navigate to Analytics -> Stocks
+5. Click the Download button.
+6. Open the downloaded file and confirm the status values match the table.
+
+## 2.5.0
+
 ### Fix WC Home crash when the Analytics is disabled.
 
 1. Navigate to WooCommerce -> Settings -> Advanced -> Features. Uncheck Analytics and save the changes.
@@ -73,14 +84,6 @@ Please make sure to test it on Safari as well.
 5. Click on "Set up Tax" option on Task list.
 6. TOS should not blink. 
 
-### Match stock status value in CSV download to the table #7284
-
-1. Clone this branch and run npm start
-2. Add some products and set stock value.
-3. Place an order and make it completed.
-4. Navigate to Analytics -> Stocks
-5. Click the Download button.
-6. Open the downloaded file and confirm the status values match the table.
 
 ### Use saved values if available when switching tabs #7226
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,21 @@
+== 2.6.0 08/04/2021 == 
+
+- Fix: Fixes action button mis-alignment within card footer. #7412
+- Fix: Fixing issues with ReportTable component data not populating correctly #7355
+- Fix: Fix tracks events for payment gateway suggestions #7304
+- Fix: Update status values in CSV download to match the table #7284
+- Add: Add boolean isReverseTrend prop to SummaryNumber to show "positive" delta for negative numbers. #7357
+- Add: Adding links to help panel for marketing task #7384
+- Add: Add installed marketing extensions card to extensions task #7419
+- Add: Add marketing extensions task to task list #7383
+- Update: Add locale param as part of free extensions request #7391
+- Update: Increase per_page value for search results on the Analytics pages. #7385
+- Update: Removing grow section from local free extensions in OBW #7386
+- Dev: Added utm_medium=product to woocommerce.com links. #7408
+- Dev: Update Jest to version 27. #7430
+- Tweak: Refactor on payment settings recommendations eligibility component for reuse. #7447
+- Tweak: Register wc-admin page for all users and handle authorization in client #7285
+
 == 2.5.0 07/8/2021 ==
 
 - Add: Add a delete option to completed tasks #7300

--- a/changelogs/fix-7339-home-crashes-after-disabling-analytics-feature
+++ b/changelogs/fix-7339-home-crashes-after-disabling-analytics-feature
@@ -1,4 +1,0 @@
-Significance: patch
-Type: Fix
-
-Set default value for performanceIndicators variable #7343

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce/woocommerce-admin",
-	"version": "2.6.0-dev",
+	"version": "2.7.0-dev",
 	"description": "A modern, javascript-driven WooCommerce Admin experience.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin",
 	"type": "wordpress-plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.6.0-dev",
+	"version": "2.7.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.6.0-dev",
+	"version": "2.7.0-dev",
 	"homepage": "https://woocommerce.github.io/woocommerce-admin/",
 	"repository": {
 		"type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, e-commerce, store, sales, reports, analytics, dashboard, activi
 Requires at least: 5.4.0
 Tested up to: 5.7.0
 Requires PHP: 7.0
-Stable tag: 2.6.0-dev
+Stable tag: 2.7.0-dev
 License: GPLv3
 License URI: https://github.com/woocommerce/woocommerce-admin/blob/main/license.txt
 

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.6.0-dev';
+	const VERSION = '2.7.0-dev';
 
 	/**
 	 * Package active.

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -146,7 +146,7 @@ class FeaturePlugin {
 		$this->define( 'WC_ADMIN_PLUGIN_FILE', WC_ADMIN_ABSPATH . 'woocommerce-admin.php' );
 		// WARNING: Do not directly edit this version number constant.
 		// It is updated as part of the prebuild process from the package.json value.
-		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.6.0-dev' );
+		$this->define( 'WC_ADMIN_VERSION_NUMBER', '2.7.0-dev' );
 	}
 
 	/**

--- a/woocommerce-admin.php
+++ b/woocommerce-admin.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-admin
  * Domain Path: /languages
- * Version: 2.6.0-dev
+ * Version: 2.7.0-dev
  * Requires at least: 5.4
  * Requires PHP: 7.0
  *


### PR DESCRIPTION
Changes

- Bumps the WC Admin version to 2.7.0-dev
- Added missing test instructions for 2.5.0
- Added 2.6.0 changelogs

no changelog needed