### PR TITLE
Sync changelog to 2.6.0-beta.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,9 +8,15 @@
 - Add: Adding links to help panel for marketing task #7384
 - Add: Add installed marketing extensions card to extensions task #7419
 - Add: Add marketing extensions task to task list #7383
+- Add: Add tracks to marketing manage button click #7467
+- Add: Add default marketing extensions as fallbacks #7466
+- Add: Add marketing task completion check and tests #7451
 - Update: Add locale param as part of free extensions request #7391
 - Update: Increase per_page value for search results on the Analytics pages. #7385
 - Update: Removing grow section from local free extensions in OBW #7386
+- Update: Don't show the marketing task if no marketing tasks exist #7460
+- Update: Delete free extensions transient on WCA update #7454
+- Update: Update business details to use extensions data store #7452
 - Dev: Added utm_medium=product to woocommerce.com links. #7408
 - Dev: Update Jest to version 27. #7430
 - Tweak: Refactor on payment settings recommendations eligibility component for reuse. #7447


### PR DESCRIPTION
This PR sync changelog entries to 2.6.0-beta.2

no changelog needed
