### PR TITLE
Make sure defaultSections is a unique object, so we do not remove icon

### DIFF
--- a/changelogs/fix-7350_modifying_overview_screen
+++ b/changelogs/fix-7350_modifying_overview_screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix analytics overview re-arrangement on initial load.

--- a/changelogs/fix-7350_modifying_overview_screen
+++ b/changelogs/fix-7350_modifying_overview_screen
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix analytics overview re-arrangement on initial load.
+Fix analytics overview re-arrangement on initial load. #7475

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { partial } from 'lodash';
 import { Dropdown, Button } from '@wordpress/components';
@@ -36,7 +36,9 @@ const filters = applyFilters( DASHBOARD_FILTERS_FILTER, [] );
 
 const mergeSectionsWithDefaults = ( prefSections ) => {
 	if ( ! prefSections || prefSections.length === 0 ) {
-		return defaultSections;
+		return defaultSections.reduce( ( sections, section ) => {
+			return [ ...sections, { ...section } ];
+		}, [] );
 	}
 	const defaultKeys = defaultSections.map( ( section ) => section.key );
 	const prefKeys = prefSections.map( ( section ) => section.key );
@@ -50,9 +52,8 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 		if ( ! defaultSection ) {
 			return;
 		}
-		const prefSection = prefSections.find(
-			( section ) => section.key === key
-		);
+		const prefSection =
+			prefSections.find( ( section ) => section.key === key ) || {};
 		// Not defined by a string anymore.
 		if ( prefSection ) {
 			delete prefSection.icon;
@@ -70,7 +71,10 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 	const { updateUserPreferences, ...userPrefs } = useUserPreferences();
 
-	const sections = mergeSectionsWithDefaults( userPrefs.dashboard_sections );
+	const sections = useMemo(
+		() => mergeSectionsWithDefaults( userPrefs.dashboard_sections ),
+		[ userPrefs.dashboard_sections ]
+	);
 
 	const updateSections = ( newSections ) => {
 		updateUserPreferences( { dashboard_sections: newSections } );
@@ -181,7 +185,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 					</Button>
 				) }
 				renderContent={ ( { onToggle } ) => (
-					<Fragment>
+					<>
 						<H>
 							{ __( 'Dashboard Sections', 'woocommerce-admin' ) }
 						</H>
@@ -215,7 +219,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 								);
 							} ) }
 						</div>
-					</Fragment>
+					</>
 				) }
 			/>
 		);
@@ -243,7 +247,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 			.map( ( section ) => section.key );
 
 		return (
-			<Fragment>
+			<>
 				<ReportFilters
 					report="dashboard"
 					query={ query }
@@ -286,7 +290,7 @@ const CustomizableDashboard = ( { defaultDateRange, path, query } ) => {
 					return null;
 				} ) }
 				{ renderAddMore() }
-			</Fragment>
+			</>
 		);
 	};
 

--- a/client/dashboard/customizable.js
+++ b/client/dashboard/customizable.js
@@ -52,8 +52,9 @@ const mergeSectionsWithDefaults = ( prefSections ) => {
 		if ( ! defaultSection ) {
 			return;
 		}
-		const prefSection =
-			prefSections.find( ( section ) => section.key === key ) || {};
+		const prefSection = prefSections.find(
+			( section ) => section.key === key
+		);
 		// Not defined by a string anymore.
 		if ( prefSection ) {
 			delete prefSection.icon;


### PR DESCRIPTION
Fixes #7350 

When the `woocommerce_admin_dashboard_sections` is not defined yet it uses the default sections, we were referencing the default sections object for this. Later if a user updated it we had some logic in place that would remove the old `icon`, in this case it would remove the `icon` from the default sections object and never add it anymore.

### Screenshots

![analytics-overview-delete-section](https://user-images.githubusercontent.com/2240960/128519396-207cb65c-e00b-48f4-a43b-77a9c179ad26.gif)

### Detailed test instructions:

It would be helpful to follow these steps on `main` first to notice the error it fixes, and then load this branch and follow these steps again.

1. On a WooCommerce store make sure the users `woocommerce_admin_dashboard_sections` meta field is deleted (representing a fresh install) - `wp user meta delete <user id> woocommerce_admin_dashboard_sections`
1. Visit to Analytics->Overview screen ( probably do an empty cache and hard reload for this, incase dashboard_sections was previously set ).
1. Click on three dots button of any section say Performance section.
1. Turn ON the toggle of any options say "Total Tax" and "Shipping".
1. Click on "Remove section" option on three dot menu.
1. Note that section gets removed and "+" button appears at the bottom screen.
1. Click on "+" button.
1. Notice how the dropdown pops up correctly and you can re-add the performance section (this breaks on main).

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes.
