### PR TITLE
Bump the fallback WP version to 5.8.0 in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,7 @@ jobs:
                   WC_E2E_SCREENSHOTS: 1
                   E2E_SLACK_CHANNEL: ${{ secrets.E2E_SLACK_CHANNEL }}
                   E2E_SLACK_TOKEN: ${{ secrets.E2E_SLACK_TOKEN }}
+                  WP_VERSION: '5.8.0'
               run: |
                   npm i
                   composer require wp-cli/i18n-command


### PR DESCRIPTION
This PR fixes broken E2E tests with `Docker container is still being built` error. 

There is also a [PR](https://github.com/woocommerce/woocommerce/pull/30529) in woocmmerce repository.

This is a temporary fix until WooCommerce Core team releases a new version of `@woocommerce/e2e-environment` package.

no changelog
