### PR TITLE
Fix wrong function name

### DIFF
--- a/src/WCAdminSharedSettings.php
+++ b/src/WCAdminSharedSettings.php
@@ -30,7 +30,7 @@ class WCAdminSharedSettings {
 	 */
 	protected function __construct() {
 		if ( did_action( 'woocommerce_blocks_loaded' ) ) {
-			$this->on_plugins_loaded();
+			$this->on_woocommerce_blocks_loaded();
 		} else {
 			add_action( 'woocommerce_blocks_loaded', array( $this, 'on_woocommerce_blocks_loaded' ), 10 );
 		}


### PR DESCRIPTION
Update function name, that was not changed and is only triggered when enabling woocommerce-admin (it seems).

No changelog necessary

### Detailed test instructions:

- Load this branch
- Disable and enable woocommerce-admin
- There should not be a fatal error
