### PR TITLE
Add HK and SG countries to back up wc pay supported lists

### DIFF
--- a/client/task-list/tasks/PaymentGatewaySuggestions/components/WCPay/utils.js
+++ b/client/task-list/tasks/PaymentGatewaySuggestions/components/WCPay/utils.js
@@ -68,6 +68,8 @@ export function isWCPaySupported( countryCode ) {
 		'PL',
 		'PT',
 		'CH',
+		'HK',
+		'SG',
 	];
 
 	return supportedCountries.includes( countryCode );

--- a/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
+++ b/src/Features/PaymentGatewaySuggestions/DefaultPaymentGateways.php
@@ -252,7 +252,7 @@ class DefaultPaymentGateways {
 	 * @return array Array of countries.
 	 */
 	public static function get_wcpay_countries() {
-		return array( 'US', 'PR', 'AU', 'CA', 'DE', 'ES', 'FR', 'GB', 'IE', 'IT', 'NZ', 'AT', 'BE', 'NL', 'PL', 'PT', 'CH' );
+		return array( 'US', 'PR', 'AU', 'CA', 'DE', 'ES', 'FR', 'GB', 'IE', 'IT', 'NZ', 'AT', 'BE', 'NL', 'PL', 'PT', 'CH', 'HK', 'SG' );
 	}
 
 	/**


### PR DESCRIPTION
Partly fixes #7547 

Add HK and SG to the wc pay supported list 

### Detailed test instructions:

- Change your stores country to Hong kong or Singapore
- Make sure you delete the `woocommerce_admin_payment_gateway_suggestions_specs` transient
- Go to **WooCommerce > Settings > Payments**
- WooCommerce Payments should be listed in the recommended card below the table.
- Update the DataSourcePoller to an invalid url in [Payment Gateway list](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Features/PaymentGatewaySuggestions/DataSourcePoller.php#L24)
- Go to the payments task, WooCommerce Payments should be displayed

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
