### PR TITLE
Add optional parameter to `/currency`'s `formatAmount` to display currency code.

### DIFF
--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+-   Tweak - Added `useCode` parameter to `formatAmount`, to render currency code instead of symbol. #7575
+
 # 3.2.0
 
 -   Fix commonjs module build, allow package to be built in isolation. #7286

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -43,19 +43,20 @@ const CurrencyFactory = function ( currencySetting ) {
 	 * Formats money value.
 	 *
 	 * @param   {number|string} number number to format
+	 * @param   {boolean} [useCode=false] Set to `true` to use the currency code instead of the symbol.
 	 * @return {?string} A formatted string.
 	 */
-	function formatAmount( number ) {
+	function formatAmount( number, useCode = false ) {
 		const formattedNumber = numberFormat( currency, number );
 
 		if ( formattedNumber === '' ) {
 			return formattedNumber;
 		}
 
-		const { priceFormat, symbol } = currency;
+		const { priceFormat, symbol, code } = currency;
 
 		// eslint-disable-next-line @wordpress/valid-sprintf
-		return sprintf( priceFormat, symbol, formattedNumber );
+		return sprintf( priceFormat, useCode ? code : symbol, formattedNumber );
 	}
 
 	/**

--- a/packages/currency/src/test/index.js
+++ b/packages/currency/src/test/index.js
@@ -10,6 +10,16 @@ describe( 'formatAmount', () => {
 		expect( currency.formatAmount( 30 ) ).toBe( '$30.00' );
 	} );
 
+	it( 'should return country code instead of symbol, when `useCode` is set to `true`', () => {
+		const currency = Currency();
+		expect( currency.formatAmount( 9.99, true ) ).toBe( 'USD9.99' );
+		const currency2 = Currency( {
+			priceFormat: '%2$s %1$s',
+			symbol: 'EUR',
+		} );
+		expect( currency2.formatAmount( 30 ) ).toBe( '30.00 EUR' );
+	} );
+
 	it( 'should uses store currency settings, not locale-based', () => {
 		const currency = Currency( {
 			code: 'JPY',


### PR DESCRIPTION
Add optional parameter to `/currency`'s `formatAmount` to display currency code.

To support rendering non-ambiguous results.

We needed to display unambiguous amounts in Google Listings and Ads plugin, and simply replace the currency symbol, with currency code, keeping the formating as it was. (To emphasize the difference between Canadian, US $ etc.).

It turned out we cannot use `formatAmount` or any util for that, but rather [duplicate the `formatAmount` code](https://github.com/woocommerce/google-listings-and-ads/blob/daf9f687cf44f609face656e3908ff3e64dd4876/js/src/dashboard/all-programs-table-card/format-amount-with-code.js#L19-L30) with just one bit changed inside, [plus the glue code to provide currency config back again.

This PR adds this functionality to the `@woocommerce/currency`'s `formatAmount()` via additional optional parameter `useCode`

I think such utility may be useful for other plugins as well.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [n/a] I've tested using only a keyboard (no mouse)
-   [n/a] I've tested using a screen reader
-   [n/a] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [n/a] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

n/a - this PR is providing just dev tooling.

### Screenshots

### Detailed test instructions:
```js
// import the currency factory
import CurrencyFactory from '@woocommerce/currency';
// Get the currency config.
const storeCurrency = CurrencyFactory();
// Use formatAmount to get unambiguous value
const total = storeCurrency.formatAmount( 20.923, true ); // '20.92 EUR'
```


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->

---- 

No changelog is needed.

That's just dev util tweak, added entry to `packages/currency/CHANGELOG.md`