### PR TITLE
Fix 'cannot read property' error from ExPlat

### DIFF
--- a/packages/explat/CHANGELOG.md
+++ b/packages/explat/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Fix an error when getting woocommerce_default_country value. #7600
+- Attempts to get the woocommerce_default_country value in wcSettings.preloadSettings.general first for the backward compatibility #7600
 # 1.1.3 
 
 - Retry fix for missing build-module folder

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -22,8 +22,10 @@ export const fetchExperimentAssignment = async ( {
 		experiment_name: experimentName,
 		anon_id: anonId ?? undefined,
 		woo_country_code:
-			window.wcSettings.admin.preloadSettings.general
-				.woocommerce_default_country,
+			window.wcSettings?.preloadSettings?.general
+				?.woocommerce_default_country ||
+			window.wcSettings?.admin?.preloadSettings?.general
+				?.woocommerce_default_country,
 	} );
 
 	const response = await window.fetch(

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -22,7 +22,7 @@ export const fetchExperimentAssignment = async ( {
 		experiment_name: experimentName,
 		anon_id: anonId ?? undefined,
 		woo_country_code:
-			window.wcSettings.preloadSettings.general
+			window.wcSettings.admin.preloadSettings.general
 				.woocommerce_default_country,
 	} );
 

--- a/packages/explat/src/utils.ts
+++ b/packages/explat/src/utils.ts
@@ -10,10 +10,14 @@ interface generalSettings {
 interface preloadSettings {
 	general: generalSettings;
 }
-
-interface wcSettings {
+interface admin {
 	preloadSettings: preloadSettings;
 }
+
+interface wcSettings {
+	admin: admin;
+}
+
 declare global {
 	interface Window {
 		wcSettings: wcSettings;

--- a/packages/explat/src/utils.ts
+++ b/packages/explat/src/utils.ts
@@ -16,6 +16,7 @@ interface admin {
 
 interface wcSettings {
 	admin: admin;
+	preloadSettings: preloadSettings;
 }
 
 declare global {


### PR DESCRIPTION
Fixes #7599 

This PR fixes `Cannot read property 'general' of undefined` error from the ExPlat package by correctly accessing `woocommerce_default_country` value.



### Detailed test instructions:

1. Checkout  this branch and run `npm start`
2. Navigate to WooCommerce -> Home
3. Open the inspector and confirm no error from the ExPlat package.

**Testing backward compatibility**

1. Open [WCAdminSharedSettings.php](https://github.com/woocommerce/woocommerce-admin/blob/main/src/WCAdminSharedSettings.php#L64) 
2. Add the following code inside the `if` statement.

```
\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )->add(
	'preloadSettings',
	function() {
		return array(
			'general' => array(
				'woocommerce_default_country' => 'test'
			)
		);
	},
	true
);			
```

3. Open the inspector and navigate to WooCommerce -> Home
4. Go to the network tab and search for `experiment`. You should see a request to the explat endpoint.
5. Confirm the `woo_country_code` value is `test`


no changelog