### PR TITLE
Do not run PHPCS on deleted files

### DIFF
--- a/bin/phpcs.sh
+++ b/bin/phpcs.sh
@@ -3,7 +3,7 @@ PHP_FILES_CHANGED=""
 
 for FILE in $(echo $CHANGED_FILES | tr ',' '\n')
 do
-	if [[ $FILE =~ ".php" ]]; then
+	if [[ $FILE =~ ".php" && -e $FILE ]]; then
 		PHP_FILES_CHANGED+="$FILE "
 	fi	
 done
@@ -15,4 +15,3 @@ if [ "$PHP_FILES_CHANGED" != "" ]; then
 else
 	echo "No changed files detected, sniffer not run."
 fi
-


### PR DESCRIPTION
Fixes #7596 

This PR adds file existence check to prevent PHPCS from running on deleted files.

### Detailed test instructions:

1. Run `export CHANGED_FILES=src/Loader.php,src/Install.php,src/i-do-not-exist.php` to set three files to CHANGED_FILES (this variable is used in phpcs.sh)
2. Run `./bin/phpcs.sh` and confirm PHPCS runs on the first two files. 
