### PR TITLE
Only display expanded content when expanded is true

### DIFF
--- a/changelogs/fix-7609_task_item_content_logic
+++ b/changelogs/fix-7609_task_item_content_logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Update task-item logic to only display content when expanded is true. #7611

--- a/client/task-list/test/index.js
+++ b/client/task-list/test/index.js
@@ -705,11 +705,12 @@ describe( 'TaskDashboard and TaskList', () => {
 		} ) );
 		act( () => {
 			const { queryByText } = render( <TaskDashboard query={ {} } /> );
-			expect(
-				queryByText( 'This is the optional task content' )
-			).not.toHaveClass(
+			expect( queryByText( 'This task is optional' ) ).not.toHaveClass(
 				'woocommerce-task-list__item-expandable-content-appear'
 			);
+			expect(
+				queryByText( 'This is the optional task content' )
+			).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Adjust task-item css class to prevent css conflicts. #7593
+-   Update task-item logic to only display content when expanded is true. #7611
 
 # 1.5.1
 

--- a/packages/experimental/src/experimental-list/task-item.tsx
+++ b/packages/experimental/src/experimental-list/task-item.tsx
@@ -80,7 +80,7 @@ const OptionalExpansionWrapper: React.FC< {
 	expanded: boolean;
 } > = ( { children, expandable, expanded } ) => {
 	if ( ! expandable ) {
-		return <>{ children }</>;
+		return expanded ? <>{ children }</> : null;
 	}
 	return (
 		<VerticalCSSTransition


### PR DESCRIPTION
Fixes #7609 

Fixes issue where content is being displayed in a task item when expanded is set to `false`.
Introduced by me here: #7263 in the beginning of July.

### Screenshots

<img width="876" alt="Screen Shot 2021-09-02 at 10 16 43 AM" src="https://user-images.githubusercontent.com/2240960/131850319-9ccfb73d-8ed0-4ec9-a408-83513c832329.png">

### Detailed test instructions:

- Load this branch and go to **WooCommerce > Home** having completed the onboarding wizard
- Look at the task list it should match [this screenshot](https://user-images.githubusercontent.com/5121465/131781913-6446264f-fe2e-4b02-9c80-ba0e5d89b761.png) referred to in #7609 

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
