### PR TITLE
Fix/7548 set up marketing tools title

### DIFF
--- a/changelogs/fix-7548_set_up_marketing_tools_title
+++ b/changelogs/fix-7548_set_up_marketing_tools_title
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Add missing title text for marketing task.
+Add missing title text for marketing task. #7640

--- a/changelogs/fix-7548_set_up_marketing_tools_title
+++ b/changelogs/fix-7548_set_up_marketing_tools_title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Add missing title text for marketing task.

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -70,6 +70,7 @@ const getPageTitle = ( defaultTitle ) => {
 			payments: __( 'Set up payments', 'woocommerce-admin' ),
 			tax: __( 'Add tax rates', 'woocommerce-admin' ),
 			appearance: __( 'Personalize your store', 'woocommerce-admin' ),
+			marketing: __( 'Set up marketing tools', 'woocommerce-admin' ),
 			products: __( 'Add products', 'woocommerce-admin' ),
 			shipping: __( 'Set up shipping costs', 'woocommerce-admin' ),
 		}[ task ] || defaultTitle


### PR DESCRIPTION
Fixes #7548 

For the "Set up marketing tools" task page, there was no defined title in the Header component, so it went back to the default title of "Home".
Added a line for the "marketing" task.

### Screenshots
![image](https://user-images.githubusercontent.com/890809/132563769-1cea0d64-70f4-420a-a8b4-e3b0c6a77ea6.png)

### Detailed test instructions:

- Go to "WooCommerce -> Home"
- Select "Set up markting tools" option
- Verify the header displays a sensible title
