### PR TITLE
update waitFor calls to waitForFunction, waitForTimeout

### DIFF
--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Add test cases for the home screen tasklist and activity panels. #7509
+-   Add `BasePage.waitForTimeout` function #7572
 
 # 0.1.0
 

--- a/packages/admin-e2e-tests/src/pages/AnalyticsOverview.ts
+++ b/packages/admin-e2e-tests/src/pages/AnalyticsOverview.ts
@@ -68,7 +68,7 @@ export class AnalyticsOverview extends Analytics {
 				'.woocommerce-ellipsis-menu .woocommerce-ellipsis-menu__toggle'
 			);
 			await ellipsisMenu?.click();
-			await page.waitFor(
+			await page.waitForFunction(
 				() =>
 					! document.querySelector(
 						'.woocommerce-ellipsis-menu div[role=menu]'

--- a/packages/admin-e2e-tests/src/pages/BasePage.ts
+++ b/packages/admin-e2e-tests/src/pages/BasePage.ts
@@ -132,6 +132,10 @@ export abstract class BasePage {
 		await this.goto( this.url );
 	}
 
+	async waitForTimeout( timeout: number ) {
+		await new Promise( resolve => setTimeout( resolve, timeout ) );
+	}
+
 	protected async goto( url: string ) {
 		const fullUrl = baseUrl + url;
 		try {

--- a/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
+++ b/packages/admin-e2e-tests/src/pages/WcHomescreen.ts
@@ -32,11 +32,11 @@ export class WcHomescreen extends BasePage {
 
 		if ( modal ) {
 			await this.clickButtonWithText( 'Next' );
-			await this.page.waitFor( 1000 );
+			await this.waitForTimeout( 1000 );
 			await this.clickButtonWithText( 'Next' );
-			await this.page.waitFor( 1000 );
+			await this.waitForTimeout( 1000 );
 			await this.click( '.components-guide__finish-button' );
-			await this.page.waitFor( 500 );
+			await this.waitForTimeout( 500 );
 		}
 	}
 
@@ -88,7 +88,7 @@ export class WcHomescreen extends BasePage {
 		await waitForElementByText( 'button', 'Hide this' );
 		const hideThisButton = await getElementByText( 'button', 'Hide this' );
 		await hideThisButton?.click();
-		await this.page.waitFor( 500 );
+		await this.waitForTimeout( 500 );
 	}
 
 	async waitForNotesRequestToBeLoaded(): Promise< void > {

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -61,7 +61,7 @@ const testAdminPaymentSetupTask = () => {
 			} );
 
 			await homeScreen.isDisplayed();
-			await page.waitFor( 1000 );
+			await homeScreen.waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.isDisplayed();
 			await paymentsSetup.methodHasBeenSetup( 'bacs' );
@@ -70,7 +70,7 @@ const testAdminPaymentSetupTask = () => {
 		it( 'Enabling cash on delivery enables the payment method', async () => {
 			await paymentsSetup.enableCashOnDelivery();
 			await homeScreen.isDisplayed();
-			await page.waitFor( 1000 );
+			await homeScreen.waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.isDisplayed();
 			await paymentsSetup.methodHasBeenSetup( 'cod' );

--- a/packages/admin-e2e-tests/src/utils/actions.ts
+++ b/packages/admin-e2e-tests/src/utils/actions.ts
@@ -3,6 +3,11 @@
  */
 import { ElementHandle } from 'puppeteer';
 
+/**
+ * Internal dependencies
+ */
+import { NewOrder } from '../pages/NewOrder';
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { expect } = require( '@jest/globals' );
 /* eslint-enable @typescript-eslint/no-var-requires */
@@ -29,8 +34,9 @@ const verifyPublishAndTrash = async (
 	publishVerification: string,
 	trashVerification: string
 ) => {
+	const newOrder = new NewOrder( page );
 	// Wait for auto save
-	await page.waitFor( 2000 );
+	await newOrder.waitForTimeout( 2000 );
 	// Publish
 	await page.click( button );
 
@@ -147,7 +153,7 @@ export const waitForElementByTextWithoutThrow = async (
 		if ( selected ) {
 			break;
 		}
-		await page.waitFor( 1000 );
+		await new Promise( resolve => setTimeout( resolve, 1000 ) );
 		selected = await getElementByText( element, text );
 	}
 	return Boolean( selected );


### PR DESCRIPTION
Fixes #7572

This PR replaces E2E `page.waitFor` calls with `page.waitForFunction`, `BasePage.waitForTimeout`, or a JS timeout promise when the page is unknown.

### Detailed test instructions:

-   Verify CI
-   Run tests locally

No testing instructions needed for inclusion into WC core.

No changelog required.