### PR TITLE
Add API methods to store task lists and tasks

### DIFF
--- a/src/Features/OnboardingTasks/Init.php
+++ b/src/Features/OnboardingTasks/Init.php
@@ -54,6 +54,7 @@ class Init {
 		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
 		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
 		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
+		TaskLists::add_defaults();
 
 		if ( ! is_admin() ) {
 			return;

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -102,6 +102,15 @@ class TaskList {
 	}
 
 	/**
+	 * Add task to the task list.
+	 *
+	 * @param array $args Task properties.
+	 */
+	public function add_task( $args ) {
+		$this->tasks[] = $args;
+	}
+
+	/**
 	 * Get the list for use in JSON.
 	 *
 	 * @return array

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Admin\API\Reports\Taxes\Stats\DataStore as TaxDataSto
 use Automattic\WooCommerce\Admin\Features\Features;
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Init as OnboardingTasks;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\StoreDetails;
 use Automattic\WooCommerce\Admin\Features\RemoteFreeExtensions\Init as RemoteFreeExtensions;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 
@@ -16,6 +17,79 @@ use Automattic\WooCommerce\Admin\PluginsHelper;
  * Task Lists class.
  */
 class TaskLists {
+	/**
+	 * Class instance.
+	 *
+	 * @var TaskLists instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * An array of all registered lists.
+	 *
+	 * @var array
+	 */
+	protected static $lists = array();
+
+	/**
+	 * Get class instance.
+	 */
+	final public static function instance() {
+		if ( ! static::$instance ) {
+			static::$instance = new static();
+		}
+		return static::$instance;
+	}
+
+	/**
+	 * Add a task list.
+	 *
+	 * @param array $args Task list properties.
+	 * @return WP_Error|Task
+	 */
+	public static function add_list( $args ) {
+		if ( isset( self::$lists[ $args['id'] ] ) ) {
+			return new \WP_Error(
+				'woocommerce_task_list_exists',
+				__( 'Task list ID already exists', 'woocommerce-admin' )
+			);
+		}
+
+		self::$lists[ $args['id'] ] = new TaskList( $args );
+	}
+
+	/**
+	 * Add task to a given task list.
+	 *
+	 * @param string $list_id List ID to add the task to.
+	 * @param array  $args Task properties.
+	 * @return WP_Error|Task
+	 */
+	public static function add_task( $list_id, $args ) {
+		if ( ! isset( self::$lists[ $list_id ] ) ) {
+			return new \WP_Error(
+				'woocommerce_task_list_invalid_list',
+				__( 'Task list ID does not exist', 'woocommerce-admin' )
+			);
+		}
+
+		self::$lists[ $list_id ]->add_task( $args );
+	}
+
+	/**
+	 * Add default task lists.
+	 */
+	public static function add_defaults() {
+		self::add_list(
+			array(
+				'id'    => 'setup',
+				'title' => 'Get ready to start selling',
+			)
+		);
+
+		self::add_task( 'setup', StoreDetails::get_task() );
+	}
+
 	/**
 	 * Get all task lists.
 	 *

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -83,7 +83,7 @@ class TaskLists {
 		self::add_list(
 			array(
 				'id'    => 'setup',
-				'title' => 'Get ready to start selling',
+				'title' => __( 'Get ready to start selling', 'woocommerce-admin' ),
 			)
 		);
 

--- a/src/Features/OnboardingTasks/Tasks/StoreDetails.php
+++ b/src/Features/OnboardingTasks/Tasks/StoreDetails.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\Onboarding;
+
+/**
+ * Store Details Task
+ */
+class StoreDetails {
+	/**
+	 * Get the task arguments.
+	 *
+	 * @return array
+	 */
+	public static function get_task() {
+		$profiler_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+
+		return array(
+			'id'          => 'store_details',
+			'title'       => __( 'Store details', 'woocommerce-admin' ),
+			'content'     => __(
+				'Your store address is required to set the origin country for shipping, currencies, and payment options.',
+				'woocommerce-admin'
+			),
+			'actionLabel' => __( "Let's go", 'woocommerce-admin' ),
+			'actionUrl'   => '/setup-wizard',
+			'isComplete'  => isset( $profiler_data['completed'] ) && true === $profiler_data['completed'],
+			'isVisible'   => true,
+			'time'        => __( '4 minutes', 'woocommerce-admin' ),
+		);
+	}
+}


### PR DESCRIPTION
Fixes (part of) #7661 

This adds an instance that stores the added lists and tasks along with API methods to add those items.  A single task has been migrated for testing and POC.

Follow-up PRs:
* Add the `Task` model
* Migrate remaining tasks

### Detailed test instructions:

There's not much to test here, but you can verify things have been added by:

1. Add a `wp_die( self::$lists );` at the end of the `TaskLists::add_task()` method.
2. Navigate to any WooCommerce page.
3. Check that the list is shown with the "Store Details" task.