### PR TITLE
allow CBD to be optional in business details in E2E

### DIFF
--- a/packages/admin-e2e-tests/src/sections/onboarding/IndustrySection.ts
+++ b/packages/admin-e2e-tests/src/sections/onboarding/IndustrySection.ts
@@ -5,7 +5,7 @@ import { BasePage } from '../../pages/BasePage';
 import { waitForElementByText } from '../../utils/actions';
 
 export class IndustrySection extends BasePage {
-	async isDisplayed( industryCount?: number ) {
+	async isDisplayed( industryCount?: number, industryCountMax?: number ) {
 		await waitForElementByText(
 			'h2',
 			'In which industry does the store operate?'
@@ -17,7 +17,13 @@ export class IndustrySection extends BasePage {
 				( items ) => items.length
 			);
 
-			expect( length === industryCount ).toBeTruthy();
+			if ( industryCountMax ) {
+				expect(
+					length >= industryCount && length <= industryCountMax
+				).toBeTruthy();
+			} else {
+				expect( length === industryCount ).toBeTruthy();
+			}
 		}
 	}
 

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -48,7 +48,7 @@ const testAdminOnboardingWizard = () => {
 
 		it( 'can complete the industry section', async () => {
 			// Query for the industries checkboxes
-			await profileWizard.industry.isDisplayed( 8 );
+			await profileWizard.industry.isDisplayed( 7, 8 );
 			await profileWizard.industry.uncheckIndustries();
 
 			// Select just "fashion" and "health/beauty" to get the single checkbox business section when


### PR DESCRIPTION
The WooCommerce core E2E smoke tests run on persistent sites. In the profile wizard business details, the CBD option being displayed is conditional on site settings (eg. enabled payment gateways). The core smoke test runs fail due to the CDB industry not being displayed in the business details. See screenshot.

This PR changes the business details test to allow the industries list to contain 7 or 8 industries.

One alternative approach to resolve this issue is to determine which settings in the smoke test sites are removing it and include resets for those settings.
A second approach would be to use the `IS_RETEST_MODE` constant to implement the alternate test.

I'm happy to proceed with either of the alternatives.

### Screenshots

![screenshot_of_failed_test](https://user-images.githubusercontent.com/343847/133820225-38ee2838-4892-4463-a82c-d3c027f91b31.png)

### Detailed test instructions:

-   Verify CI run

No testing instructions needed for inclusion into WC core.

No changelog required.