### PR TITLE
Bump admin-e2e-tests version to 0.1.1

### DIFF
--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Unreleased
 
+# 0.1.1
+
+-   Updated onboarding tests to include email prefill and move client setup checkbox to business step.
+-   Payment task update. #7577
 -   Add test cases for the home screen tasklist and activity panels. #7509
+-   Add wait for orders text on activity panel. #7550
+-   Allow CBD to be optional in business details in E2E. #7675
 
 # 0.1.0
 

--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 0.1.1
 
+-   Allow packages to be built in isolation. #7286
+-   Add scope to BACS slotfill #7405
+-   Update e2e matcher for tasklist header #7406
+-   Update homescreen, utils, payment task, payments setup. #7338
+-   Refactor package style builds #7531
 -   Updated onboarding tests to include email prefill and move client setup checkbox to business step.
 -   Payment task update. #7577
 -   Add test cases for the home screen tasklist and activity panels. #7509

--- a/packages/admin-e2e-tests/package.json
+++ b/packages/admin-e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-e2e-tests",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"author": "Automattic",
 	"description": "E2E tests for the new WooCommerce interface.",
 	"homepage": "https://github.com/woocommerce/woocommerce-admin/tree/main/packages/admin-e2e-tests/README.md",


### PR DESCRIPTION
Bump admin-e2e-tests to 0.1.1 prior to publishing.

No changelog