### PR TITLE
Add filters to get new hidden options

### DIFF
--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -464,9 +464,9 @@ class OnboardingTasks {
 	 * @return string
 	 */
 	public function get_deprecated_options( $pre_option, $option ) {
-		if ( defined( 'WC_ADMIN_INSTALLING' ) && WC_ADMIN_INSTALLING ) {
+		if ( 'yes' === get_transient( 'wc_admin_installing' ) ) {
 			return $pre_option;
-		};
+		}
 
 		$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
 		switch ( $option ) {

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -47,6 +47,10 @@ class OnboardingTasks {
 		add_action( 'add_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'update_option_woocommerce_task_list_tracked_completed_tasks', array( $this, 'track_task_completion' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_option_extended_task_list' ), 15 );
+		add_filter( 'pre_option_woocommerce_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
+		add_filter( 'pre_option_woocommerce_extended_task_list_hidden', array( $this, 'get_deprecated_options' ), 10, 2 );
+		add_action( 'pre_update_option_woocommerce_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
+		add_action( 'pre_update_option_woocommerce_extended_task_list_hidden', array( $this, 'update_deprecated_options' ), 10, 3 );
 
 		if ( ! is_admin() ) {
 			return;
@@ -449,6 +453,61 @@ class OnboardingTasks {
 		if ( $registered_extended_tasks_list_items !== $extended_tasks_list_items ) {
 			update_option( 'woocommerce_extended_task_list_items', $registered_extended_tasks_list_items );
 			update_option( 'woocommerce_extended_task_list_hidden', 'no' );
+		}
+	}
+
+	/**
+	 * Get the values from the correct source when attempting to retrieve deprecated options.
+	 *
+	 * @param string $pre_option Pre option value.
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	public function get_deprecated_options( $pre_option, $option ) {
+		if ( defined( 'WC_ADMIN_INSTALLING' ) && WC_ADMIN_INSTALLING ) {
+			return $pre_option;
+		};
+
+		$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+		switch ( $option ) {
+			case 'woocommerce_task_list_hidden':
+				return in_array( 'setup', $hidden, true ) ? 'yes' : 'no';
+			case 'woocommerce_extended_task_list_hidden':
+				return in_array( 'extended', $hidden, true ) ? 'yes' : 'no';
+		}
+	}
+
+	/**
+	 * Updates the new option names when deprecated options are updated.
+	 * This is a temporary fallback until we can fully remove the old task list components.
+	 *
+	 * @param string $value New value.
+	 * @param string $old_value Old value.
+	 * @param string $option Option name.
+	 * @return string
+	 */
+	public function update_deprecated_options( $value, $old_value, $option ) {
+		switch ( $option ) {
+			case 'woocommerce_task_list_hidden':
+				$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+				if ( 'yes' === $value ) {
+					$hidden[] = 'setup';
+				} else {
+					array_diff( $hidden, array( 'setup' ) );
+				}
+				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
+				delete_option( 'woocommerce_task_list_hidden' );
+				return false;
+			case 'woocommerce_extended_task_list_hidden':
+				$hidden = get_option( 'woocommerce_task_list_hidden_lists', array() );
+				if ( 'yes' === $value ) {
+					$hidden[] = 'extended';
+				} else {
+					array_diff( $hidden, array( 'extended' ) );
+				}
+				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
+				delete_option( 'woocommerce_extended_task_list_hidden' );
+				return false;
 		}
 	}
 }

--- a/src/Features/OnboardingTasks.php
+++ b/src/Features/OnboardingTasks.php
@@ -493,7 +493,7 @@ class OnboardingTasks {
 				if ( 'yes' === $value ) {
 					$hidden[] = 'setup';
 				} else {
-					array_diff( $hidden, array( 'setup' ) );
+					$hidden = array_diff( $hidden, array( 'setup' ) );
 				}
 				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
 				delete_option( 'woocommerce_task_list_hidden' );
@@ -503,7 +503,7 @@ class OnboardingTasks {
 				if ( 'yes' === $value ) {
 					$hidden[] = 'extended';
 				} else {
-					array_diff( $hidden, array( 'extended' ) );
+					$hidden = array_diff( $hidden, array( 'extended' ) );
 				}
 				update_option( 'woocommerce_task_list_hidden_lists', array_unique( $hidden ) );
 				delete_option( 'woocommerce_extended_task_list_hidden' );


### PR DESCRIPTION
Related PR: https://github.com/woocommerce/woocommerce-admin/pull/7698

The first PR did not pass one of the core tests as `WC_ADMIN_INSTALLING` constant gets set during the test. You can see the failing test [here](https://github.com/woocommerce/woocommerce/pull/30784/checks?check_run_id=3691388273)

This PR uses `wc_admin_installing` instead. 

### Detailed test instructions:

Please refer to the test instructions in https://github.com/woocommerce/woocommerce-admin/pull/7698
