### PR TITLE
Fix nesting div inside p element

### DIFF
--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -277,7 +277,7 @@ class AdvancedFilters extends Component {
 				<CardHeader justify="flex-start">
 					<Text
 						variant="subtitle.small"
-						as="p"
+						as="div"
 						weight="600"
 						size="14"
 						lineHeight="20px"

--- a/packages/components/src/advanced-filters/style.scss
+++ b/packages/components/src/advanced-filters/style.scss
@@ -26,7 +26,7 @@
 			margin-bottom: 0;
 		}
 
-		p {
+		div {
 			display: flex;
 			line-height: 38px;
 		}


### PR DESCRIPTION
This PR fixes a warning that would show when using the AdvancedFilters component

Fixes #7703 

As noted on #7703 some warnings are being thrown when using the AdvancedFilters component. This breaks some checks on the WC Payments repository because p elements do not accept nesting div elements. Also that could cause strange behaviors on some browsers. Making this ```<p><div></div></p>``` become this ```<p></p><div></div><p></p>```


### Screenshots
Before:
<img width="1270" alt="Captura de Tela 2021-09-23 às 17 05 34" src="https://user-images.githubusercontent.com/6342964/134578181-7b4da7a1-b8bc-4354-a245-42eccb035a32.png">

After:

<img width="1376" alt="Captura de Tela 2021-09-23 às 17 22 31" src="https://user-images.githubusercontent.com/6342964/134578355-9f6e0ee0-cf16-4868-b653-3ef767103281.png">

There are no visual changes
### Detailed test instructions:

This can be seen by going to:

Wp-admin > Analytics > Orders > Select Advanced filters >
Inspect elements on the select element and validate if "Orders match " is not inside a p element
<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
