### PR TITLE
Fix category lookup class

### DIFF
--- a/changelogs/fix-7680_category_lookup_class
+++ b/changelogs/fix-7680_category_lookup_class
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix category lookup logic to update children correctly. #7680
+Fix category lookup logic to update children correctly. #7709

--- a/changelogs/fix-7680_category_lookup_class
+++ b/changelogs/fix-7680_category_lookup_class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix category lookup logic to update children correctly. #7680

--- a/src/CategoryLookup.php
+++ b/src/CategoryLookup.php
@@ -179,10 +179,11 @@ class CategoryLookup {
 	protected function update( $category_id ) {
 		global $wpdb;
 
-		$ancestors = get_ancestors( $category_id, 'product_cat', 'taxonomy' );
-		$children  = get_term_children( $category_id, 'product_cat' );
-		$inserts   = array();
-		$inserts[] = $this->get_insert_sql( $category_id, $category_id );
+		$ancestors    = get_ancestors( $category_id, 'product_cat', 'taxonomy' );
+		$children     = get_term_children( $category_id, 'product_cat' );
+		$inserts      = array();
+		$inserts[]    = $this->get_insert_sql( $category_id, $category_id );
+		$children_ids = array_map( 'intval', array_unique( array_filter( $children ) ) );
 
 		foreach ( $ancestors as $ancestor ) {
 			$inserts[] = $this->get_insert_sql( $category_id, $ancestor );
@@ -190,6 +191,9 @@ class CategoryLookup {
 			foreach ( $children as $child ) {
 				$inserts[] = $this->get_insert_sql( $child->category_id, $ancestor );
 			}
+			/*foreach ( $children_ids as $child_category_id ) {
+				$inserts[] = $this->get_insert_sql( $child_category_id, $ancestor );
+			}*/
 		}
 
 		$insert_string = implode( ',', $inserts );

--- a/src/CategoryLookup.php
+++ b/src/CategoryLookup.php
@@ -188,12 +188,9 @@ class CategoryLookup {
 		foreach ( $ancestors as $ancestor ) {
 			$inserts[] = $this->get_insert_sql( $category_id, $ancestor );
 
-			foreach ( $children as $child ) {
-				$inserts[] = $this->get_insert_sql( $child->category_id, $ancestor );
-			}
-			/*foreach ( $children_ids as $child_category_id ) {
+			foreach ( $children_ids as $child_category_id ) {
 				$inserts[] = $this->get_insert_sql( $child_category_id, $ancestor );
-			}*/
+			}
 		}
 
 		$insert_string = implode( ',', $inserts );

--- a/tests/category-lookup.php
+++ b/tests/category-lookup.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * CategoryLookup tests
+ *
+ * @package WooCommerce\Admin\Tests\CategoryLookup
+ */
+
+use \Automattic\WooCommerce\Admin\CategoryLookup;
+
+/**
+ * WC_Admin_Tests_Admin_Helper Class
+ *
+ * @package WooCommerce\Admin\Tests\CategoryLookup
+ */
+class WC_Admin_Tests_Category_Lookup extends WP_UnitTestCase {
+
+	public function test_product_category_edit_should_update_table() {
+		$insert = wp_insert_term( 'test_parent', 'product_cat' );
+		$insert2 = wp_insert_term( 'test_parent', 'product_cat', array(
+			'parent' => $insert['term_id']
+		) );
+		CategoryLookup::instance()->init();
+
+		$update = wp_update_term( $insert2['term_id'], 'product_cat', array(
+			'slug' => 'test'
+		) );
+	}
+}

--- a/tests/category-lookup.php
+++ b/tests/category-lookup.php
@@ -14,6 +14,47 @@ use \Automattic\WooCommerce\Admin\CategoryLookup;
  */
 class WC_Admin_Tests_Category_Lookup extends WP_UnitTestCase {
 
+	/** @var int parent term id */
+	protected $parent_term_id;
+	/** @var int parent 2 term id */
+	protected $parent2_term_id;
+	/** @var int child term id */
+	protected $child_term_id;
+
+	/**
+	 * Setup
+	 */
+	public function setUp() {
+		parent::setUp();
+		$parent                = wp_insert_term( 'test_parent', 'product_cat' );
+		$parent2               = wp_insert_term( 'test_parent_2', 'product_cat' );
+		$child                 = wp_insert_term(
+			'test_child',
+			'product_cat',
+			array(
+				'parent' => $parent['term_id'],
+			)
+		);
+		$this->parent_term_id  = $parent['term_id'];
+		$this->parent2_term_id = $parent2['term_id'];
+		$this->child_term_id   = $child['term_id'];
+		CategoryLookup::instance()->init();
+	}
+
+	/**
+	 * Tear Down
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		wp_delete_term( $this->parent_term_id, 'product_cat' );
+		wp_delete_term( $this->parent2_term_id, 'product_cat' );
+		wp_delete_term( $this->child_term_id, 'product_cat' );
+	}
+
+	/**
+	 * @param int $category_id category id.
+	 * @return int[] list of category tree ids
+	 */
 	public function get_category_parent_id( $category_id ) {
 		global $wpdb;
 
@@ -27,27 +68,72 @@ class WC_Admin_Tests_Category_Lookup extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Test on_create callback for when product category is created.
+	 */
+	public function test_create_product_category_update_lookup_table() {
+		$parent_ids = $this->get_category_parent_id( $this->parent_term_id );
+		$this->assertCount( 1, $parent_ids );
+		$this->assertContains( $this->parent_term_id, $parent_ids );
+		$parent2_ids = $this->get_category_parent_id( $this->parent2_term_id );
+		$this->assertCount( 1, $parent2_ids );
+		$this->assertContains( $this->parent2_term_id, $parent2_ids );
+		$child_ids = $this->get_category_parent_id( $this->child_term_id );
+		$this->assertCount( 2, $child_ids );
+		$this->assertContains( $this->parent_term_id, $child_ids );
+	}
+
+	/**
+	 * Test update callback for product category update.
+	 */
 	public function test_product_category_edit_should_update_table() {
-		$insert_parent = wp_insert_term( 'test_parent', 'product_cat' );
-		$insert_parent2 = wp_insert_term( 'test_parent_2', 'product_cat' );
-		$insert_child = wp_insert_term( 'test_child', 'product_cat', array(
-			'parent' => $insert_parent['term_id']
-		) );
-		CategoryLookup::instance()->init();
-
-		wp_update_term( $insert_child['term_id'], 'product_cat', array(
-			'slug' => 'test'
-		) );
-		$child_parent_ids = $this->get_category_parent_id( $insert_child['term_id'] );
+		wp_update_term(
+			$this->child_term_id,
+			'product_cat',
+			array(
+				'slug' => 'test',
+			)
+		);
+		$child_parent_ids = $this->get_category_parent_id( $this->child_term_id );
 		$this->assertCount( 2, $child_parent_ids );
+		$this->assertContains( $this->parent_term_id, $child_parent_ids );
+	}
 
-		$this->assertContains( $insert_parent['term_id'], $child_parent_ids );
-		wp_update_term( $insert_parent['term_id'], 'product_cat', array(
-			'parent' => $insert_parent2['term_id']
-		) );
-		$parent_parent_ids = $this->get_category_parent_id( $insert_parent['term_id'] );
+	/**
+	 * Test update of product category with children.
+	 */
+	public function test_product_category_update_with_children() {
+		wp_update_term(
+			$this->parent_term_id,
+			'product_cat',
+			array(
+				'parent' => $this->parent2_term_id,
+			)
+		);
+		$parent_parent_ids = $this->get_category_parent_id( $this->parent_term_id );
 
 		$this->assertCount( 2, $parent_parent_ids );
-		$this->assertContains( $insert_parent2['term_id'], $parent_parent_ids );
+		$this->assertContains( $this->parent2_term_id, $parent_parent_ids );
+	}
+
+	/**
+	 * Test deleting old lookup data upon product category update.
+	 */
+	public function test_product_category_update_should_delete_old_lookups() {
+		$parent_parent_ids = $this->get_category_parent_id( $this->parent_term_id );
+		$this->assertCount( 1, $parent_parent_ids );
+		$this->assertNotContains( $this->parent2_term_id, $parent_parent_ids );
+
+		wp_update_term(
+			$this->parent_term_id,
+			'product_cat',
+			array(
+				'parent' => $this->parent2_term_id,
+			)
+		);
+		$parent_parent_ids = $this->get_category_parent_id( $this->parent_term_id );
+
+		$this->assertCount( 2, $parent_parent_ids );
+		$this->assertContains( $this->parent2_term_id, $parent_parent_ids );
 	}
 }

--- a/tests/category-lookup.php
+++ b/tests/category-lookup.php
@@ -14,15 +14,40 @@ use \Automattic\WooCommerce\Admin\CategoryLookup;
  */
 class WC_Admin_Tests_Category_Lookup extends WP_UnitTestCase {
 
+	public function get_category_parent_id( $category_id ) {
+		global $wpdb;
+
+		return wp_parse_id_list(
+			$wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT category_tree_id FROM $wpdb->wc_category_lookup WHERE category_id = %d",
+					$category_id
+				)
+			)
+		);
+	}
+
 	public function test_product_category_edit_should_update_table() {
-		$insert = wp_insert_term( 'test_parent', 'product_cat' );
-		$insert2 = wp_insert_term( 'test_parent', 'product_cat', array(
-			'parent' => $insert['term_id']
+		$insert_parent = wp_insert_term( 'test_parent', 'product_cat' );
+		$insert_parent2 = wp_insert_term( 'test_parent_2', 'product_cat' );
+		$insert_child = wp_insert_term( 'test_child', 'product_cat', array(
+			'parent' => $insert_parent['term_id']
 		) );
 		CategoryLookup::instance()->init();
 
-		$update = wp_update_term( $insert2['term_id'], 'product_cat', array(
+		wp_update_term( $insert_child['term_id'], 'product_cat', array(
 			'slug' => 'test'
 		) );
+		$child_parent_ids = $this->get_category_parent_id( $insert_child['term_id'] );
+		$this->assertCount( 2, $child_parent_ids );
+
+		$this->assertContains( $insert_parent['term_id'], $child_parent_ids );
+		wp_update_term( $insert_parent['term_id'], 'product_cat', array(
+			'parent' => $insert_parent2['term_id']
+		) );
+		$parent_parent_ids = $this->get_category_parent_id( $insert_parent['term_id'] );
+
+		$this->assertCount( 2, $parent_parent_ids );
+		$this->assertContains( $insert_parent2['term_id'], $parent_parent_ids );
 	}
 }


### PR DESCRIPTION
Fixes #7680 

Fixes a warning that showed when changing the parent of a product category that has children. I added several PHP tests for this.
I am not as familiar with the `category_lookup` use cases, so I didn't find any direct area's where this could off broken functionality.

### Detailed test instructions:

- Revert the change locally in the `CategoryLookup.php` file and run `npm run test:php`
- Notice how tests fail with the error mentioned in #7680 
- Reset the `CategoryLookup.php` file to the changes made as part of this branch
- Run `npm run test:php` again, all tests should pass this time

To see the warning in a live environment:
- Load `main` and create a product category
- For the same category add some children product categories
- Now add a parent to the product category with the children (parent > parent > children)
- Load `debug.log` and notice the `Trying to get property 'category_id' of non-object` warning
- Load this branch and do the same thing, and notice how there are no warnings.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
