### PR TITLE
Fix calendar not being dismissed when clicked outside

### DIFF
--- a/changelogs/fix-7713-dismiss-calendar-on-blur
+++ b/changelogs/fix-7713-dismiss-calendar-on-blur
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix calendar not being dismissed when clicking outside. #7713

--- a/packages/components/src/calendar/date-picker.js
+++ b/packages/components/src/calendar/date-picker.js
@@ -38,6 +38,26 @@ class DatePicker extends Component {
 		}
 	}
 
+	handleBlur( isOpen, onToggle, event ) {
+		if ( ! isOpen ) {
+			return;
+		}
+
+		const relatedTargetParent = event.relatedTarget?.closest(
+				'.components-dropdown'
+			),
+			currentTargetParent = event.currentTarget?.closest(
+				'.components-dropdown'
+			);
+
+		if (
+			! relatedTargetParent ||
+			relatedTargetParent !== currentTargetParent
+		) {
+			onToggle();
+		}
+	}
+
 	onDateChange( onToggle, dateString ) {
 		const { onUpdate, dateFormat } = this.props;
 		const date = moment( dateString );
@@ -81,6 +101,7 @@ class DatePicker extends Component {
 						disabled={ disabled }
 						value={ text }
 						onChange={ this.onInputChange }
+						onBlur={ partial( this.handleBlur, isOpen, onToggle ) }
 						dateFormat={ dateFormat }
 						label={ __( 'Choose a date', 'woocommerce-admin' ) }
 						error={ error }

--- a/packages/components/src/calendar/date-picker.js
+++ b/packages/components/src/calendar/date-picker.js
@@ -7,7 +7,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { createElement, Component } from '@wordpress/element';
 import { Dropdown, DatePicker as WpDatePicker } from '@wordpress/components';
 import { partial } from 'lodash';
-import { TAB } from '@wordpress/keycodes';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { dateValidationMessages, toMoment } from '@woocommerce/date';
@@ -24,12 +23,6 @@ class DatePicker extends Component {
 
 		this.onDateChange = this.onDateChange.bind( this );
 		this.onInputChange = this.onInputChange.bind( this );
-	}
-
-	handleKeyDown( isOpen, onToggle, { keyCode } ) {
-		if ( TAB === keyCode && isOpen ) {
-			onToggle();
-		}
 	}
 
 	handleFocus( isOpen, onToggle ) {
@@ -119,11 +112,6 @@ class DatePicker extends Component {
 						) }
 						aria-expanded={ isOpen }
 						focusOnMount={ false }
-						onKeyDown={ partial(
-							this.handleKeyDown,
-							isOpen,
-							onToggle
-						) }
 						errorPosition="top center"
 					/>
 				) }

--- a/packages/components/src/calendar/input.js
+++ b/packages/components/src/calendar/input.js
@@ -17,6 +17,7 @@ const DateInput = ( {
 	describedBy,
 	error,
 	onFocus,
+	onBlur,
 	onKeyDown,
 	errorPosition,
 } ) => {
@@ -37,6 +38,7 @@ const DateInput = ( {
 				aria-describedby={ `${ id }-message` }
 				placeholder={ dateFormat.toLowerCase() }
 				onFocus={ onFocus }
+				onBlur={ onBlur }
 				onKeyDown={ onKeyDown }
 				disabled={ disabled }
 			/>
@@ -67,12 +69,14 @@ DateInput.propTypes = {
 	error: PropTypes.string,
 	errorPosition: PropTypes.string,
 	onFocus: PropTypes.func,
+	onBlur: PropTypes.func,
 	onKeyDown: PropTypes.func,
 };
 
 DateInput.defaultProps = {
 	disabled: false,
 	onFocus: () => {},
+	onBlur: () => {},
 	errorPosition: 'bottom center',
 	onKeyDown: noop,
 };


### PR DESCRIPTION
Fixes #7713

* Close the calendar when the elements within the parent dropdown lose focus
* Add an `onBlur` prop to the `DateInput` component
* Remove a now redundant (and possibly not good for accessibility) code that dismissed the calendar when pressing the Tab key

### Accessibility

-   [x] I've tested using only a keyboard (no mouse)

### Screenshots

Gif with the updated behavior
![gif](https://cdn-std.droplr.net/files/acc_1195552/UcK8ju)

### Detailed test instructions:

* Go to the WooCommerce -> Customer page
* Under the "Show" dropdown, select "Advanced filters"
* Click on "Add a filter", and select "Registered"
* Click on the date input so the calendar shows up
* While the calendar is open and the focus is still in the input, click anywhere on the page. Opposite to its previous behavior, now the calendar should close. Also, using the Tab key should now navigate through the calendar instead of closing it.
