### PR TITLE
Add extended task list support to the new REST api task lists

### DIFF
--- a/client/tasks/task-list-item.tsx
+++ b/client/tasks/task-list-item.tsx
@@ -56,6 +56,8 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 		isSnoozeable,
 		time,
 		title,
+		level,
+		additionalInfo,
 	} = task;
 
 	const slot = useSlot( `woocommerce_onboarding_task_list_item_${ id }` );
@@ -160,8 +162,10 @@ export const TaskListItem: React.FC< TaskListItemProps > = ( {
 					key={ id }
 					title={ title }
 					content={ content }
+					additionalInfo={ additionalInfo }
 					time={ time }
 					action={ onClickActions }
+					level={ level }
 					actionLabel={ actionLabel }
 					{ ...taskItemProps }
 					{ ...props }

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -9,7 +9,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useExperiment } from '@woocommerce/explat';
 import { recordEvent } from '@woocommerce/tracks';
-import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -32,21 +31,11 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 	);
 
 	const { isResolving, taskLists } = useSelect( ( select ) => {
-		const taskListsData = select( ONBOARDING_STORE_NAME ).getTaskLists();
-		if ( taskListsData ) {
-			// const filteredTasks = applyFilters(
-			// 	'woocommerce_admin_onboarding_task_list',
-			// 	[],
-			// 	query
-			// );
-			// for (const filteredTask of filteredTasks) {
-			// }
-		}
 		return {
 			isResolving: select( ONBOARDING_STORE_NAME ).isResolving(
 				'getTaskLists'
 			),
-			taskLists: taskListsData,
+			taskLists: select( ONBOARDING_STORE_NAME ).getTaskLists(),
 		};
 	} );
 

--- a/client/tasks/tasks.tsx
+++ b/client/tasks/tasks.tsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { ONBOARDING_STORE_NAME, OPTIONS_STORE_NAME } from '@woocommerce/data';
 import { useExperiment } from '@woocommerce/explat';
 import { recordEvent } from '@woocommerce/tracks';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -31,11 +32,21 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 	);
 
 	const { isResolving, taskLists } = useSelect( ( select ) => {
+		const taskListsData = select( ONBOARDING_STORE_NAME ).getTaskLists();
+		if ( taskListsData ) {
+			// const filteredTasks = applyFilters(
+			// 	'woocommerce_admin_onboarding_task_list',
+			// 	[],
+			// 	query
+			// );
+			// for (const filteredTask of filteredTasks) {
+			// }
+		}
 		return {
 			isResolving: select( ONBOARDING_STORE_NAME ).isResolving(
 				'getTaskLists'
 			),
-			taskLists: select( ONBOARDING_STORE_NAME ).getTaskLists(),
+			taskLists: taskListsData,
 		};
 	} );
 
@@ -115,6 +126,10 @@ export const Tasks: React.FC< TasksProps > = ( { query } ) => {
 			title,
 			tasks,
 		} = taskList;
+
+		if ( isHidden ) {
+			return null;
+		}
 
 		return (
 			<Fragment key={ id }>

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -91,7 +91,6 @@ addFilter(
 				),
 				time: __( '2 minutes', 'woocommerce-admin' ),
 				isDismissable: true,
-				isSnoozeable: true,
 				onDelete: () => console.log( 'The task was deleted' ),
 				onDismiss: () => console.log( 'The task was dismissed' ),
 				allowRemindMeLater: true,

--- a/docs/examples/extensions/add-task/js/index.js
+++ b/docs/examples/extensions/add-task/js/index.js
@@ -91,6 +91,7 @@ addFilter(
 				),
 				time: __( '2 minutes', 'woocommerce-admin' ),
 				isDismissable: true,
+				isSnoozeable: true,
 				onDelete: () => console.log( 'The task was deleted' ),
 				onDismiss: () => console.log( 'The task was dismissed' ),
 				allowRemindMeLater: true,

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -34,6 +34,7 @@
 		"@wordpress/i18n": "3.17.0",
 		"@wordpress/url": "2.21.0",
 		"md5": "^2.3.0",
+		"qs": "6.9.6",
 		"rememo": "^3.0.0"
 	},
 	"devDependencies": {

--- a/packages/data/src/onboarding/actions.js
+++ b/packages/data/src/onboarding/actions.js
@@ -217,6 +217,22 @@ export function* updateProfileItems( items ) {
 	}
 }
 
+function possiblyPruneTaskData( task, keys ) {
+	if ( ! task.time && ! task.title ) {
+		// client side task
+		return keys.reduce(
+			( simplifiedTask, key ) => {
+				return {
+					...simplifiedTask,
+					[ key ]: task[ key ],
+				};
+			},
+			{ id: task.id }
+		);
+	}
+	return task;
+}
+
 export function* snoozeTask( id ) {
 	yield snoozeTaskRequest( id );
 
@@ -226,7 +242,9 @@ export function* snoozeTask( id ) {
 			method: 'POST',
 		} );
 
-		yield snoozeTaskSuccess( task );
+		yield snoozeTaskSuccess(
+			possiblyPruneTaskData( task, [ 'isSnoozed', 'isDismissed' ] )
+		);
 	} catch ( error ) {
 		yield snoozeTaskError( id, error );
 		throw new Error();
@@ -242,7 +260,9 @@ export function* undoSnoozeTask( id ) {
 			method: 'POST',
 		} );
 
-		yield undoSnoozeTaskSuccess( task );
+		yield undoSnoozeTaskSuccess(
+			possiblyPruneTaskData( task, [ 'isSnoozed', 'isDismissed' ] )
+		);
 	} catch ( error ) {
 		yield undoSnoozeTaskError( id, error );
 		throw new Error();
@@ -258,7 +278,9 @@ export function* dismissTask( id ) {
 			method: 'POST',
 		} );
 
-		yield dismissTaskSuccess( task );
+		yield dismissTaskSuccess(
+			possiblyPruneTaskData( task, [ 'isDismissed', 'isSnoozed' ] )
+		);
 	} catch ( error ) {
 		yield dismissTaskError( id, error );
 		throw new Error();
@@ -274,7 +296,9 @@ export function* undoDismissTask( id ) {
 			method: 'POST',
 		} );
 
-		yield undoDismissTaskSuccess( task );
+		yield undoDismissTaskSuccess(
+			possiblyPruneTaskData( task, [ 'isDismissed', 'isSnoozed' ] )
+		);
 	} catch ( error ) {
 		yield undoDismissTaskError( id, error );
 		throw new Error();

--- a/packages/data/src/onboarding/actions.js
+++ b/packages/data/src/onboarding/actions.js
@@ -217,6 +217,13 @@ export function* updateProfileItems( items ) {
 	}
 }
 
+/**
+ * Used to keep backwards compatibility with the extended task list filter on the client.
+ * This can be removed after version WC Admin 2.10 (see deprecated notice in resolvers.js).
+ *
+ * @param {Object} task the returned task object.
+ * @param {Array}  keys the keeps to keep in the task object.
+ */
 function possiblyPruneTaskData( task, keys ) {
 	if ( ! task.time && ! task.title ) {
 		// client side task
@@ -243,7 +250,11 @@ export function* snoozeTask( id ) {
 		} );
 
 		yield snoozeTaskSuccess(
-			possiblyPruneTaskData( task, [ 'isSnoozed', 'isDismissed' ] )
+			possiblyPruneTaskData( task, [
+				'isSnoozed',
+				'isDismissed',
+				'snoozedUntil',
+			] )
 		);
 	} catch ( error ) {
 		yield snoozeTaskError( id, error );
@@ -261,7 +272,11 @@ export function* undoSnoozeTask( id ) {
 		} );
 
 		yield undoSnoozeTaskSuccess(
-			possiblyPruneTaskData( task, [ 'isSnoozed', 'isDismissed' ] )
+			possiblyPruneTaskData( task, [
+				'isSnoozed',
+				'isDismissed',
+				'snoozedUntil',
+			] )
 		);
 	} catch ( error ) {
 		yield undoSnoozeTaskError( id, error );

--- a/packages/data/src/onboarding/actions.js
+++ b/packages/data/src/onboarding/actions.js
@@ -222,7 +222,8 @@ export function* updateProfileItems( items ) {
  * This can be removed after version WC Admin 2.10 (see deprecated notice in resolvers.js).
  *
  * @param {Object} task the returned task object.
- * @param {Array}  keys the keeps to keep in the task object.
+ * @param {Array}  keys to keep in the task object.
+ * @return {Object} task with the keys specified.
  */
 function possiblyPruneTaskData( task, keys ) {
 	if ( ! task.time && ! task.title ) {

--- a/packages/data/src/onboarding/resolvers.js
+++ b/packages/data/src/onboarding/resolvers.js
@@ -83,7 +83,7 @@ function getQuery() {
  *
  * @param {Array} taskLists array of task lists.
  */
-function* mergeWithFilteredTasks( taskLists ) {
+function* mergeWithTasksFromDeprecatedFilter( taskLists ) {
 	const filteredTasks = applyFilters(
 		'woocommerce_admin_onboarding_task_list',
 		[],
@@ -110,18 +110,18 @@ function* mergeWithFilteredTasks( taskLists ) {
 		// Format the old task items with the new format.
 		for ( const task of filteredTasks ) {
 			task.level = task.level ? parseInt( task.level, 10 ) : 3;
-			task.type = task.type || 'extended';
+			task.listId = task.type || 'extended';
 			task.isVisible = task.isVisible || task.visible;
 			task.id = task.id || task.key;
 			task.isDismissed = dismissedTasks.includes( task.id );
 			task.isSnoozed =
 				snoozedTasks[ task.id ] && snoozedTasks[ task.id ] > Date.now();
 			task.snoozedUntil = snoozedTasks[ task.id ];
-			task.isSnoozable = task.isSnoozable || task.allowRemindMeLater;
+			task.isSnoozeable = task.isSnoozeable || task.allowRemindMeLater;
 		}
 		for ( const taskList of taskLists ) {
 			const filteredTaskItems = filteredTasks.filter(
-				( task ) => task.type === taskList.id
+				( task ) => task.listId === taskList.id
 			);
 			taskList.tasks.push( ...filteredTaskItems );
 		}
@@ -136,7 +136,9 @@ export function* getTaskLists() {
 			method: 'GET',
 		} );
 
-		const taskLists = yield mergeWithFilteredTasks( results || [] );
+		const taskLists = yield mergeWithTasksFromDeprecatedFilter(
+			results || []
+		);
 
 		yield getTaskListsSuccess( taskLists );
 	} catch ( error ) {

--- a/packages/data/src/onboarding/resolvers.js
+++ b/packages/data/src/onboarding/resolvers.js
@@ -106,6 +106,8 @@ function* mergeWithFilteredTasks( taskLists ) {
 			'getOption',
 			'woocommerce_task_list_remind_me_later_tasks'
 		) || {};
+
+		// Format the old task items with the new format.
 		for ( const task of filteredTasks ) {
 			task.level = task.level ? parseInt( task.level, 10 ) : 3;
 			task.type = task.type || 'extended';

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Admin\API;
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Init as OnboardingTasksFeature;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -774,7 +775,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
-		if ( ! $task || ! $task->is_dismissable ) {
+		if ( $task && ! $task->is_dismissable ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
@@ -798,7 +799,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
-		if ( ! $task || ! $task->is_dismissable ) {
+		if ( $task && ! $task->is_dismissable ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
@@ -808,7 +809,12 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			);
 		}
 
+		if ( ! $task && $id ) {
+			$task = new Task( array( 'id' => $id ) );
+		}
+
 		$task->undo_dismiss();
+
 		return rest_ensure_response( $task->get_json() );
 	}
 
@@ -826,7 +832,16 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 
 		$task = TaskLists::get_task( $task_id, $task_list_id );
 
-		if ( ! $task || ! $task->is_snoozeable ) {
+		if ( ! $task && $task_id ) {
+			$snooze_task = new Task(
+				array(
+					'id'            => $task_id,
+					'is_snoozeable' => true,
+				)
+			);
+		}
+
+		if ( $task && ! $task->is_snoozeable ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task',
 				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -775,7 +775,16 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
-		if ( $task && ! $task->is_dismissable ) {
+		if ( ! $task && $id ) {
+			$task = new Task(
+				array(
+					'id'             => $id,
+					'is_dismissable' => true,
+				)
+			);
+		}
+
+		if ( ! $task || ! $task->is_dismissable ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
@@ -799,7 +808,16 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
-		if ( $task && ! $task->is_dismissable ) {
+		if ( ! $task && $id ) {
+			$task = new Task(
+				array(
+					'id'             => $id,
+					'is_dismissable' => true,
+				)
+			);
+		}
+
+		if ( ! $task || ! $task->is_dismissable ) {
 			return new \WP_Error(
 				'woocommerce_rest_invalid_task',
 				__( 'Sorry, no dismissable task with that ID was found.', 'woocommerce-admin' ),
@@ -807,10 +825,6 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 					'status' => 404,
 				)
 			);
-		}
-
-		if ( ! $task && $id ) {
-			$task = new Task( array( 'id' => $id ) );
 		}
 
 		$task->undo_dismiss();
@@ -833,7 +847,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 		$task = TaskLists::get_task( $task_id, $task_list_id );
 
 		if ( ! $task && $task_id ) {
-			$snooze_task = new Task(
+			$task = new Task(
 				array(
 					'id'            => $task_id,
 					'is_snoozeable' => true,
@@ -841,7 +855,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 			);
 		}
 
-		if ( $task && ! $task->is_snoozeable ) {
+		if ( ! $task || ! $task->is_snoozeable ) {
 			return new \WP_Error(
 				'woocommerce_tasks_invalid_task',
 				__( 'Sorry, no snoozeable task with that ID was found.', 'woocommerce-admin' ),
@@ -864,6 +878,15 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function undo_snooze_task( $request ) {
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
+
+		if ( ! $task && $id ) {
+			$task = new Task(
+				array(
+					'id'            => $id,
+					'is_snoozeable' => true,
+				)
+			);
+		}
 
 		if ( ! $task || ! $task->is_snoozeable ) {
 			return new \WP_Error(

--- a/src/Features/Onboarding.php
+++ b/src/Features/Onboarding.php
@@ -815,7 +815,7 @@ class Onboarding {
 		if ( $extended_list ) {
 			$help_tab['content'] .= '<h3>' . __( 'Extended task List', 'woocommerce-admin' ) . '</h3>';
 			$help_tab['content'] .= '<p>' . __( 'If you need to enable or disable the extended task lists, please click on the button below.', 'woocommerce-admin' ) . '</p>' .
-			( $extended_task->is_hidden()
+			( $extended_list->is_hidden()
 				? '<p><a href="' . wc_admin_url( '&reset_extended_task_list=1' ) . '" class="button button-primary">' . __( 'Enable', 'woocommerce-admin' ) . '</a></p>'
 				: '<p><a href="' . wc_admin_url( '&reset_extended_task_list=0' ) . '" class="button button-primary">' . __( 'Disable', 'woocommerce-admin' ) . '</a></p>'
 			);

--- a/src/Features/OnboardingTasks/Task.php
+++ b/src/Features/OnboardingTasks/Task.php
@@ -24,11 +24,18 @@ class Task {
 	public $title = '';
 
 	/**
-	 * Title.
+	 * Content.
 	 *
 	 * @var string
 	 */
 	public $content = '';
+
+	/**
+	 * Additional info.
+	 *
+	 * @var string
+	 */
+	public $additional_info = '';
 
 	/**
 	 * Action label.
@@ -64,6 +71,13 @@ class Task {
 	 * @var string|null
 	 */
 	public $time = null;
+
+	/**
+	 * Level of task importance.
+	 *
+	 * @var int|null
+	 */
+	public $level = null;
 
 	/**
 	 * Dismissability.
@@ -118,31 +132,35 @@ class Task {
 	 */
 	public function __construct( $data = array() ) {
 		$defaults = array(
-			'id'             => null,
-			'title'          => '',
-			'content'        => '',
-			'action_label'   => __( "Let's go", 'woocommerce-admin' ),
-			'action_url'     => null,
-			'is_complete'    => false,
-			'can_view'       => true,
-			'time'           => null,
-			'is_dismissable' => false,
-			'is_snoozeable'  => false,
-			'snoozed_until'  => null,
+			'id'              => null,
+			'title'           => '',
+			'content'         => '',
+			'action_label'    => __( "Let's go", 'woocommerce-admin' ),
+			'action_url'      => null,
+			'is_complete'     => false,
+			'can_view'        => true,
+			'level'           => null,
+			'time'            => null,
+			'is_dismissable'  => false,
+			'is_snoozeable'   => false,
+			'snoozed_until'   => null,
+			'additional_info' => '',
 		);
 
 		$data = wp_parse_args( $data, $defaults );
 
-		$this->id             = (string) $data['id'];
-		$this->title          = (string) $data['title'];
-		$this->content        = (string) $data['content'];
-		$this->action_label   = (string) $data['action_label'];
-		$this->action_url     = (string) $data['action_url'];
-		$this->is_complete    = (bool) $data['is_complete'];
-		$this->can_view       = (bool) $data['can_view'];
-		$this->time           = (string) $data['time'];
-		$this->is_dismissable = (bool) $data['is_dismissable'];
-		$this->is_snoozeable  = (bool) $data['is_snoozeable'];
+		$this->id              = (string) $data['id'];
+		$this->title           = (string) $data['title'];
+		$this->content         = (string) $data['content'];
+		$this->action_label    = (string) $data['action_label'];
+		$this->action_url      = (string) $data['action_url'];
+		$this->is_complete     = (bool) $data['is_complete'];
+		$this->can_view        = (bool) $data['can_view'];
+		$this->level           = (int) $data['level'];
+		$this->additional_info = (string) $data['additional_info'];
+		$this->time            = (string) $data['time'];
+		$this->is_dismissable  = (bool) $data['is_dismissable'];
+		$this->is_snoozeable   = (bool) $data['is_snoozeable'];
 
 		$snoozed_tasks = get_option( self::SNOOZED_OPTION, array() );
 		if ( isset( $snoozed_tasks[ $this->id ] ) ) {
@@ -268,20 +286,22 @@ class Task {
 	 */
 	public function get_json() {
 		return array(
-			'id'            => $this->id,
-			'title'         => $this->title,
-			'canView'       => $this->can_view,
-			'content'       => $this->content,
-			'actionLabel'   => $this->action_label,
-			'actionUrl'     => $this->action_url,
-			'isComplete'    => $this->is_complete,
-			'canView'       => $this->can_view,
-			'time'          => $this->time,
-			'isDismissed'   => $this->is_dismissed(),
-			'isDismissable' => $this->is_dismissable,
-			'isSnoozed'     => $this->is_snoozed(),
-			'isSnoozeable'  => $this->is_snoozeable,
-			'snoozedUntil'  => $this->snoozed_until,
+			'id'             => $this->id,
+			'title'          => $this->title,
+			'canView'        => $this->can_view,
+			'content'        => $this->content,
+			'additionalInfo' => $this->additional_info,
+			'actionLabel'    => $this->action_label,
+			'actionUrl'      => $this->action_url,
+			'isComplete'     => $this->is_complete,
+			'canView'        => $this->can_view,
+			'time'           => $this->time,
+			'level'          => $this->level,
+			'isDismissed'    => $this->is_dismissed(),
+			'isDismissable'  => $this->is_dismissable,
+			'isSnoozed'      => $this->is_snoozed(),
+			'isSnoozeable'   => $this->is_snoozeable,
+			'snoozedUntil'   => $this->snoozed_until,
 		);
 	}
 

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Shipping;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\StoreDetails;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Tax;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\WooCommercePayments;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\Loader;
 
 /**
@@ -115,12 +116,25 @@ class TaskLists {
 	}
 
 	/**
+	 * Add default extended task lists.
+	 *
+	 * @param array $extended_tasks list of extended tasks.
+	 */
+	public static function maybe_add_extended_tasks( $extended_tasks = array() ) {
+		foreach ( $extended_tasks as $extended_task ) {
+			self::add_task( $extended_task['list_id'], $extended_task );
+		}
+	}
+
+	/**
 	 * Get all task lists.
 	 *
+	 * @param array $extended_tasks array of optional extended tasks.
 	 * @return array
 	 */
-	public static function get_lists() {
+	public static function get_lists( $extended_tasks = array() ) {
 		self::maybe_add_default_tasks();
+		self::maybe_add_extended_tasks( $extended_tasks );
 		return self::$lists;
 	}
 

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -96,6 +96,13 @@ class TaskLists {
 			)
 		);
 
+		self::add_list(
+			array(
+				'id'    => 'extended',
+				'title' => __( 'Things to do next', 'woocommerce-admin' ),
+			)
+		);
+
 		self::add_task( 'setup', StoreDetails::get_task() );
 		self::add_task( 'setup', Purchase::get_task() );
 		self::add_task( 'setup', Products::get_task() );

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -16,19 +16,23 @@ class WooCommercePayments {
 	 */
 	public static function get_task() {
 		return array(
-			'id'           => 'woocommerce-payments',
-			'title'        => __( 'Get paid with WooCommerce Payments', 'woocommerce-admin' ),
-			'content'      => __(
+			'id'              => 'woocommerce-payments',
+			'title'           => __( 'Get paid with WooCommerce Payments', 'woocommerce-admin' ),
+			'content'         => __(
 				"You're only one step away from getting paid. Verify your business details to start managing transactions with WooCommerce Payments.",
 				'woocommerce-admin'
 			),
-			'action_label' => __( 'Finish setup', 'woocommerce-admin' ),
-			'expanded'     => true,
-			'is_complete'  => self::is_connected(),
-			'can_view'     => self::is_requested() &&
+			'action_label'    => __( 'Finish setup', 'woocommerce-admin' ),
+			'expanded'        => true,
+			'is_complete'     => self::is_connected(),
+			'can_view'        => self::is_requested() &&
 				self::is_installed() &&
 				self::is_supported(),
-			'time'         => __( '2 minutes', 'woocommerce-admin' ),
+			'time'            => __( '2 minutes', 'woocommerce-admin' ),
+			'additional_info' => __(
+				'By setting up, you are agreeing to the <a href="https://wordpress.com/tos/" target="_blank">Terms of Service</a>',
+				'woocommerce-admin'
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes #7723 

Adds the extendable task list to the new REST api task list. This keeps backwards compatibility with the old way to add extendable tasks.

No changelog necessary

### Screenshots

<img width="657" alt="Screen Shot 2021-09-30 at 2 06 01 PM" src="https://user-images.githubusercontent.com/2240960/135499858-83a6e2b6-90ec-4fb7-a99c-abbd45327447.png">

### Detailed test instructions:

- Load this PR  and make sure the onboarding flow is finished
- Run the `add-task` example with `npm run example -- --ext=add-task` and enabling it as a plugin (`WooCommerce Admin Add Task Example`)
- Go to **WooCommerce > Home** and make sure the **Things to do next** task list shows up with the **Example** task
- Test if you can dismiss and snooze the task and also undo these actions
     - You can easily undo the snooze/dismiss using this in your console: `wp.apiFetch({ method: 'POST', path: '/wc-admin/onboarding/tasks/example/undo_dismiss'});`
- Test if you can hide the extended task list and show it again through the help panel (in a none WC homescreen)
- Add `level: 1` to the task [definition here](https://github.com/woocommerce/woocommerce-admin/blob/main/docs/examples/extensions/add-task/js/index.js#L87) and make sure the UI is reflected correctly, same goes for `level: 2`. 

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
