### PR TITLE
WP-ENV: Use latest version of WooCommerce

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,14 +1,14 @@
 {
-    "phpVersion": "7.4",
-    "core": null,
-    "plugins": [ 
-        ".", 
-        "https://downloads.wordpress.org/plugin/woocommerce.5.0.0.zip"
-    ],
-    "config": {
-        "JETPACK_AUTOLOAD_DEV": true,
-        "WP_DEBUG_LOG": true,
-        "WP_DEBUG_DISPLAY": true,
-        "ALTERNATE_WP_CRON": true
-    }
+	"phpVersion": "7.4",
+	"core": null,
+	"plugins": [
+		".",
+		"https://downloads.wordpress.org/plugin/woocommerce.zip"
+	],
+	"config": {
+		"JETPACK_AUTOLOAD_DEV": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"ALTERNATE_WP_CRON": true
+	}
 }


### PR DESCRIPTION
Use the latest version of WooCommerce instead of 5.0.0 for those who use wp-env as a dev environment. This hopefully prevents any problems with the latest WooCommerce.

### Testing

1. `wp-env start`
2. Visit http://localhost:8888/wp-admin/plugins.php and see the latest WooCommerce installed