### PR TITLE
Update PageController.php

### DIFF
--- a/changelogs/fix-7758
+++ b/changelogs/fix-7758
@@ -3,4 +3,4 @@ Type: Fix
 
 Fix an issue with the code that makes use of an invalid parameter
 with a PHP function. The use of this invalid parameter causes PHP 8 to 
-throw a Fatal Error.
+throw a Fatal Error. #7855

--- a/changelogs/fix-7758
+++ b/changelogs/fix-7758
@@ -1,0 +1,6 @@
+Significance: minor
+Type: Fix
+
+Fix an issue with the code that makes use of an invalid parameter
+with a PHP function. The use of this invalid parameter causes PHP 8 to 
+throw a Fatal Error.

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -356,10 +356,8 @@ class PageController {
 
 		// Disable embed on the block editor.
 		$current_screen = did_action( 'current_screen' ) ? get_current_screen() : false;
-		if ( $current_screen !== false ) {
-			if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
-				$is_connected_page = false;
-			}
+		if ( false !== $current_screen && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+			$is_connected_page = false;
 		}
 
 		/**

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -356,7 +356,7 @@ class PageController {
 
 		// Disable embed on the block editor.
 		$current_screen = did_action( 'current_screen' ) ? get_current_screen() : false;
-		if ( !empty($current_screen) && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+		if ( ! empty( $current_screen ) && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
 			$is_connected_page = false;
 		}
 

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -356,7 +356,7 @@ class PageController {
 
 		// Disable embed on the block editor.
 		$current_screen = did_action( 'current_screen' ) ? get_current_screen() : false;
-		if ( false !== $current_screen && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+		if ( !empty($current_screen) && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
 			$is_connected_page = false;
 		}
 

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -356,8 +356,10 @@ class PageController {
 
 		// Disable embed on the block editor.
 		$current_screen = did_action( 'current_screen' ) ? get_current_screen() : false;
-		if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
-			$is_connected_page = false;
+		if ( $current_screen !== false ) {
+			if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
+				$is_connected_page = false;
+			}
 		}
 
 		/**


### PR DESCRIPTION
Fixes #7758

The logic for this fix is outlined in [issue 7758](https://github.com/woocommerce/woocommerce-admin/issues/7758)

The Fatal Error happens because the first parameter to the PHP method_exists() is set to false which is
not the expected type.

The bad parameter was ignored by PHP 7 but causes a Fatal Error in PHP 8.

The fix is simply to refrain from calling method_exists() with the bad parameter.

I discovered this problem while going through the Wizard Setup in this plugin: [GDPR Framework](https://wordpress.org/plugins/gdpr-framework/)
