### PR TITLE
Present Inbox notes in a panel with header

### DIFF
--- a/changelogs/feature-7242-inbox-notes-in-panel-with-header
+++ b/changelogs/feature-7242-inbox-notes-in-panel-with-header
@@ -1,4 +1,4 @@
 Significance: minor
 Type: Update
 
-Update the inbox panel with the new design
+Update the inbox panel with the new design #7864

--- a/changelogs/feature-7242-inbox-notes-in-panel-with-header
+++ b/changelogs/feature-7242-inbox-notes-in-panel-with-header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Update the inbox panel with the new design

--- a/client/header/activity-panel/panels/inbox/inbox.scss
+++ b/client/header/activity-panel/panels/inbox/inbox.scss
@@ -1,8 +1,4 @@
 .woocommerce-layout__activity-panel-content {
-	.woocommerce-inbox-message,
-	.woocommerce-notification-panels > div {
-		margin-top: $gap-large;
-	}
 
 	.woocommerce-abbreviated-notifications {
 		border-top: 1px solid $gray-200;

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -94,9 +94,9 @@ const renderNotes = ( {
 					<Badge count={ notesArray.length } />
 				</div>
 				<EllipsisMenu
-					label={ __( 'Task List Options', 'woocommerce-admin' ) }
+					label={ __( 'Inbox Notes Options', 'woocommerce-admin' ) }
 					renderContent={ ( {} ) => (
-						<div className="woocommerce-task-card__section-controls">
+						<div className="woocommerce-inbox-card__section-controls">
 							<Button>
 								{ __( 'Hide this', 'woocommerce-admin' ) }
 							</Button>

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -3,7 +3,13 @@
  */
 import { __, _n } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { EmptyContent, Section } from '@woocommerce/components';
+import {
+	EmptyContent,
+	Section,
+	Badge,
+	EllipsisMenu,
+} from '@woocommerce/components';
+import { Card, CardHeader, Button } from '@wordpress/components';
 import {
 	NOTES_STORE_NAME,
 	useUserPreferences,
@@ -16,6 +22,7 @@ import {
 	InboxNoteCard,
 	InboxDismissConfirmationModal,
 	InboxNotePlaceholder,
+	Text,
 } from '@woocommerce/experimental';
 
 /**
@@ -78,31 +85,51 @@ const renderNotes = ( {
 	const notesArray = Object.keys( notes ).map( ( key ) => notes[ key ] );
 
 	return (
-		<TransitionGroup role="menu">
-			{ notesArray.map( ( note ) => {
-				const { id: noteId, is_deleted: isDeleted } = note;
-				if ( isDeleted ) {
-					return null;
-				}
-				return (
-					<CSSTransition
-						key={ noteId }
-						timeout={ 500 }
-						classNames="woocommerce-inbox-message"
-					>
-						<InboxNoteCard
+		<Card size="large">
+			<CardHeader size="medium">
+				<div className="wooocommerce-inbox-card__header">
+					<Text size="20" lineHeight="28px" variant="title.small">
+						{ __( 'Inbox', 'woocommerce-admin' ) }
+					</Text>
+					<Badge count={ notesArray.length } />
+				</div>
+				<EllipsisMenu
+					label={ __( 'Task List Options', 'woocommerce-admin' ) }
+					renderContent={ ( {} ) => (
+						<div className="woocommerce-task-card__section-controls">
+							<Button>
+								{ __( 'Hide this', 'woocommerce-admin' ) }
+							</Button>
+						</div>
+					) }
+				/>
+			</CardHeader>
+			<TransitionGroup role="menu">
+				{ notesArray.map( ( note ) => {
+					const { id: noteId, is_deleted: isDeleted } = note;
+					if ( isDeleted ) {
+						return null;
+					}
+					return (
+						<CSSTransition
 							key={ noteId }
-							note={ note }
-							lastRead={ lastRead }
-							onDismiss={ onDismiss }
-							onNoteActionClick={ onNoteActionClick }
-							onBodyLinkClick={ onBodyLinkClick }
-							onNoteVisible={ onNoteVisible }
-						/>
-					</CSSTransition>
-				);
-			} ) }
-		</TransitionGroup>
+							timeout={ 500 }
+							classNames="woocommerce-inbox-message"
+						>
+							<InboxNoteCard
+								key={ noteId }
+								note={ note }
+								lastRead={ lastRead }
+								onDismiss={ onDismiss }
+								onNoteActionClick={ onNoteActionClick }
+								onBodyLinkClick={ onBodyLinkClick }
+								onNoteVisible={ onNoteVisible }
+							/>
+						</CSSTransition>
+					);
+				} ) }
+			</TransitionGroup>
+		</Card>
 	);
 };
 

--- a/client/inbox-panel/index.scss
+++ b/client/inbox-panel/index.scss
@@ -34,3 +34,9 @@
 	transform: translateX(50%);
 	transition: opacity 500ms, transform 500ms, max-height 500ms;
 }
+
+.wooocommerce-inbox-card__header {
+	.woocommerce-badge {
+		margin-left: 16px;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.7.0-dev",
+	"version": "2.9.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -10907,6 +10907,7 @@
 				"@wordpress/i18n": "3.17.0",
 				"@wordpress/url": "2.21.0",
 				"md5": "^2.3.0",
+				"qs": "6.9.6",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/admin-library",
-	"version": "2.9.0-dev",
+	"version": "2.7.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -10907,7 +10907,6 @@
 				"@wordpress/i18n": "3.17.0",
 				"@wordpress/url": "2.21.0",
 				"md5": "^2.3.0",
-				"qs": "6.9.6",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Renaming remindMeLater() to onSnooze() for consistency. #7616
+-   Applied new Inbox 2.0 design to the inbox-note component. #7864
 
 # 2.0.3
 

--- a/packages/experimental/src/inbox-note/action.tsx
+++ b/packages/experimental/src/inbox-note/action.tsx
@@ -47,7 +47,7 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 
 	return (
 		<Button
-			isSecondary
+			isLink={ true }
 			isBusy={ inAction }
 			disabled={ inAction }
 			href={ href }

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -249,7 +249,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		! dateCreatedGmt ||
 		new Date( dateCreatedGmt + 'Z' ).getTime() > lastRead;
 	const date = dateCreated;
-	const hasImage = layout !== 'plain' && layout !== '';
+	const hasImage = layout === 'thumbnail';
 	const cardClassName = classnames(
 		'woocommerce-inbox-message',
 		className,

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createElement, Fragment, useState, useRef } from '@wordpress/element';
-import { Button, Dropdown, Popover } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import VisibilitySensor from 'react-visibility-sensor';
 import moment from 'moment';
 import classnames from 'classnames';
@@ -51,16 +51,12 @@ type InboxNote = {
 type InboxNoteProps = {
 	note: InboxNote;
 	lastRead: number;
-	onDismiss?: ( note: InboxNote, type: 'all' | 'note' ) => void;
+	onDismiss?: ( note: InboxNote ) => void;
 	onNoteActionClick?: ( note: InboxNote, action: InboxNoteAction ) => void;
 	onBodyLinkClick?: ( note: InboxNote, link: string ) => void;
 	onNoteVisible?: ( note: InboxNote ) => void;
 	className?: string;
 };
-
-const DropdownWithPopoverProps = Dropdown as React.ComponentType<
-	Dropdown.Props & { popoverProps: Omit< Popover.Props, 'children' > }
->;
 
 const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 	note,
@@ -73,7 +69,6 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 } ) => {
 	const [ clickedActionText, setClickedActionText ] = useState( false );
 	const hasBeenSeen = useRef( false );
-	const toggleButtonRef = useRef< HTMLButtonElement >( null );
 	const linkCallbackRef = useCallbackOnLinkClick( ( innerLink ) => {
 		if ( onBodyLinkClick ) {
 			onBodyLinkClick( note, innerLink );
@@ -91,101 +86,18 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 		}
 	};
 
-	const handleBlur = ( event: React.FocusEvent, onClose: () => void ) => {
-		const dropdownClasses = [
-			'woocommerce-admin-dismiss-notification',
-			'components-popover__content',
-			'components-dropdown__content',
-		];
-		// This line is for IE compatibility.
-		let relatedTarget: EventTarget | Element | null = null;
-		if ( event.relatedTarget ) {
-			relatedTarget = event.relatedTarget;
-		} else if ( toggleButtonRef.current ) {
-			const ownerDoc = toggleButtonRef.current.ownerDocument;
-			relatedTarget = ownerDoc ? ownerDoc.activeElement : null;
-		}
-		let isClickOutsideDropdown = false;
-		if ( relatedTarget && 'className' in relatedTarget ) {
-			const classNames = relatedTarget.className;
-			isClickOutsideDropdown = dropdownClasses.some( ( cName ) =>
-				classNames.includes( cName )
-			);
-		}
-		if ( isClickOutsideDropdown ) {
-			event.preventDefault();
-		} else {
-			onClose();
-		}
-	};
-
-	const onDropdownDismiss = (
-		type: 'note' | 'all',
-		onToggle: () => void
-	) => {
-		if ( onDismiss ) {
-			onDismiss( note, type );
-		}
-		onToggle();
-	};
-
 	const renderDismissButton = () => {
 		if ( clickedActionText ) {
 			return null;
 		}
 
 		return (
-			<DropdownWithPopoverProps
-				contentClassName="woocommerce-admin-dismiss-dropdown"
-				position="bottom right"
-				renderToggle={ ( { onClose, onToggle } ) => (
-					<Button
-						isTertiary
-						onClick={ ( event: React.MouseEvent ) => {
-							( event.target as HTMLElement ).focus();
-							onToggle();
-						} }
-						ref={ toggleButtonRef }
-						onBlur={ ( event: React.FocusEvent ) =>
-							handleBlur( event, onClose )
-						}
-					>
-						{ __( 'Dismiss', 'woocommerce-admin' ) }
-					</Button>
-				) }
-				focusOnMount={ false }
-				popoverProps={ { noArrow: true } }
-				renderContent={ ( { onToggle } ) => (
-					<ul>
-						<li>
-							<Button
-								className="woocommerce-admin-dismiss-notification"
-								onClick={ () =>
-									onDropdownDismiss( 'note', onToggle )
-								}
-							>
-								{ __(
-									'Dismiss this message',
-									'woocommerce-admin'
-								) }
-							</Button>
-						</li>
-						<li>
-							<Button
-								className="woocommerce-admin-dismiss-notification"
-								onClick={ () =>
-									onDropdownDismiss( 'all', onToggle )
-								}
-							>
-								{ __(
-									'Dismiss all messages',
-									'woocommerce-admin'
-								) }
-							</Button>
-						</li>
-					</ul>
-				) }
-			/>
+			<Button
+				className="woocommerce-admin-dismiss-notification"
+				onClick={ () => onDismiss && onDismiss( note ) }
+			>
+				{ __( 'Dismiss', 'woocommerce-admin' ) }
+			</Button>
 		);
 	};
 

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -25,7 +25,7 @@
 	&:hover {
 		background: $gray-100;
 		cursor: pointer;
-		.woocommerce-inbox-message__actions button.is-tertiary {
+		.woocommerce-inbox-message__actions button.woocommerce-admin-dismiss-notification {
 			visibility: visible;
 		}
 	}
@@ -135,7 +135,7 @@
 		cursor: pointer;
 	}
 
-	button.is-tertiary {
+	button.woocommerce-admin-dismiss-notification {
 		color: $gray-700;
 		&:hover {
 			box-shadow: none !important;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -35,6 +35,7 @@
 	}
 
 	&:not(.is-placeholder) {
+		border: 0;
 		border-bottom: 1px solid $gray-200;
 	}
 
@@ -133,7 +134,12 @@
 	a,
 	button {
 		cursor: pointer;
+		&.is-link {
+			text-decoration: none;
+		}
 	}
+
+	border-top: 0;
 
 	button.woocommerce-admin-dismiss-notification {
 		color: $gray-700;

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -22,6 +22,13 @@
 			height: 100%;
 		}
 	}
+	&:hover {
+		background: $gray-100;
+		cursor: pointer;
+		.woocommerce-inbox-message__actions button.is-tertiary {
+			visibility: visible;
+		}
+	}
 
 	.woocommerce-homepage-column & {
 		margin: 20px 0;
@@ -133,6 +140,7 @@
 		&:hover {
 			box-shadow: none !important;
 		}
+		visibility: hidden;
 	}
 
 	.components-dropdown {

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -4,7 +4,7 @@
 	background: $studio-white;
 	border-radius: 2px;
 	@include font-size( 13 );
-	margin: 0 0 $gap-large;
+	margin: 0 0;
 	-ms-box-orient: horizontal;
 	&.banner {
 		-webkit-flex-direction: column;
@@ -28,7 +28,7 @@
 	}
 
 	&:not(.is-placeholder) {
-		border: 1px solid $gray-200;
+		border-bottom: 1px solid $gray-200;
 	}
 
 	.line {
@@ -91,6 +91,10 @@
 	}
 }
 
+.woocommerce-inbox-message__wrapper .woocommerce-inbox-message__content {
+	padding-bottom: 0;
+}
+
 .woocommerce-inbox-message__text {
 	color: $gray-700;
 	font-style: normal;
@@ -114,9 +118,6 @@
 }
 
 .woocommerce-inbox-message__actions {
-	padding-top: $gap;
-	border-top: 1px solid $gray-200;
-
 	// Ensures any immediate child with a sibling has space between the items
 	& > * + * {
 		margin-left: 0.5em;
@@ -126,6 +127,14 @@
 	button {
 		cursor: pointer;
 	}
+
+	button.is-tertiary {
+		color: $gray-700;
+		&:hover {
+			box-shadow: none !important;
+		}
+	}
+
 	.components-dropdown {
 		display: inline;
 
@@ -150,6 +159,10 @@
 		}
 	}
 }
+.woocommerce-inbox-message__wrapper .woocommerce-inbox-message__actions {
+	padding-top: 0;
+}
+
 .woocommerce-inbox-dismiss-confirmation_modal {
 	text-align: left;
 }

--- a/packages/experimental/src/inbox-note/test/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/test/inbox-note.tsx
@@ -155,7 +155,7 @@ describe( 'InboxNoteCard', () => {
 	} );
 
 	describe( 'callbacks', () => {
-		it( 'should call onDismiss with note type when "Dismiss this message" is clicked', () => {
+		it( 'should call onDismiss with note when "Dismiss this message" is clicked', () => {
 			const onDismiss = jest.fn();
 			const { getByText } = render(
 				<InboxNoteCard
@@ -166,23 +166,7 @@ describe( 'InboxNoteCard', () => {
 				/>
 			);
 			userEvent.click( getByText( 'Dismiss' ) );
-			userEvent.click( getByText( 'Dismiss this message' ) );
-			expect( onDismiss ).toHaveBeenCalledWith( note, 'note' );
-		} );
-
-		it( 'should call onDismiss with all type when "Dismiss all messages" is clicked', () => {
-			const onDismiss = jest.fn();
-			const { getByText } = render(
-				<InboxNoteCard
-					key={ note.id }
-					note={ note }
-					lastRead={ lastRead }
-					onDismiss={ onDismiss }
-				/>
-			);
-			userEvent.click( getByText( 'Dismiss' ) );
-			userEvent.click( getByText( 'Dismiss all messages' ) );
-			expect( onDismiss ).toHaveBeenCalledWith( note, 'all' );
+			expect( onDismiss ).toHaveBeenCalledWith( note );
 		} );
 
 		it( 'should call onNoteActionClick with specific action when action is clicked', () => {


### PR DESCRIPTION
Fixes #7242

This PR adds the Inbox notes into `Card` component with some CSS changes to reflect the new design shown in the issue.

This PR also includes changes for https://github.com/woocommerce/woocommerce-admin/issues/7246

This PR does not include the following changes. 

1. Icons 
2. Unread state
3. Dismiss all from the ellipsis menu
4. ~Clicking `dismiss` still shows a popup menu~  https://github.com/woocommerce/woocommerce-admin/pull/7868 has been merged

### Screenshots
![Screen Shot 2021-10-28 at 4 39 13 PM](https://user-images.githubusercontent.com/4723145/139350622-2c5ce5f3-69f8-4692-a2fa-91b400450e13.jpg)

### Detailed test instructions:

1. Clone this branch
2. Navigate to WooCommerce -> Home
3. Confirm the new design