### PR TITLE
Only load default tasks during REST requests

### DIFF
--- a/changelogs/fix-task-performance-2.9
+++ b/changelogs/fix-task-performance-2.9
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Performance
+
+Only load default tasks during REST requests #7904

--- a/src/API/OnboardingTasks.php
+++ b/src/API/OnboardingTasks.php
@@ -769,6 +769,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	public function get_tasks( $request ) {
 		$extended_tasks = $request->get_param( 'extended_tasks' );
 
+		TaskLists::maybe_add_default_tasks();
 		TaskLists::maybe_add_extended_tasks( $extended_tasks );
 
 		$lists = TaskLists::get_lists();
@@ -790,6 +791,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function dismiss_task( $request ) {
+		TaskLists::maybe_add_default_tasks();
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
@@ -824,6 +826,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function undo_dismiss_task( $request ) {
+		TaskLists::maybe_add_default_tasks();
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
@@ -860,6 +863,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function snooze_task( $request ) {
+		TaskLists::maybe_add_default_tasks();
 		$task_id      = $request->get_param( 'id' );
 		$task_list_id = $request->get_param( 'task_list_id' );
 		$duration     = $request->get_param( 'duration' );
@@ -897,6 +901,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function undo_snooze_task( $request ) {
+		TaskLists::maybe_add_default_tasks();
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 
@@ -932,6 +937,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function hide_task_list( $request ) {
+		TaskLists::maybe_add_default_tasks();
 		$id        = $request->get_param( 'id' );
 		$task_list = TaskLists::get_list( $id );
 
@@ -958,6 +964,7 @@ class OnboardingTasks extends \WC_REST_Data_Controller {
 	 * @return WP_REST_Request|WP_Error
 	 */
 	public function action_task( $request ) {
+		TaskLists::maybe_add_default_tasks();
 		$id   = $request->get_param( 'id' );
 		$task = TaskLists::get_task( $id );
 

--- a/src/Features/OnboardingTasks/TaskLists.php
+++ b/src/Features/OnboardingTasks/TaskLists.php
@@ -65,7 +65,6 @@ class TaskLists {
 	 */
 	public static function init() {
 		self::init_default_lists();
-		add_action( 'init', array( __CLASS__, 'maybe_add_default_tasks' ) );
 		add_action( 'admin_init', array( __CLASS__, 'set_active_task' ), 5 );
 		add_action( 'admin_init', array( __CLASS__, 'init_tasks' ) );
 	}


### PR DESCRIPTION
Only loads the task list tasks during REST API requests.

This is a temporary fix and a more robust fix will be added to allow the tasks to continue working during non-REST reqeusts.

### Detailed test instructions:

**Smoke testing**
1 Make a `GET` request to `wp-json/wc-admin/onboarding/tasks`
2. Make sure the task lists and all tasks are returned as expected
3. Go to Products->Help (tab)->Setup Wizard
4. Attempt to Disable/Enable the task lists and make sure these actions work as expected
5. Smoke test the task list, viewing, snoozing, dismissing, and undoing those actions


**Performance testing**

1. Use `main` and not this branch
2. Create a site with 1k+ products using WC Smooth Generator
2. Install the Query Monitor plugin - https://wordpress.org/plugins/query-monitor/
3. Sort "Queries" by time to load
4. Navigate to a core WC page (like orders or products)
4. Note the highest is most likely the task list functions
5. Check out this branch
6. Note that this is no longer the case