### PR TITLE
Fix ExPlat PHP client and experimental onboarding note

### DIFF
--- a/changelogs/fix-explat-php-client-and-profile-note
+++ b/changelogs/fix-explat-php-client-and-profile-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix ExPlat PHP client and experimental onboarding note #7926

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -156,8 +156,9 @@ final class Experimental_Abtest {
 	 */
 	protected function request_variation( $test_name ) {
 		$args = array(
-			'experiment_name' => $test_name,
-			'anon_id'         => $this->anon_id,
+			'experiment_name'  => $test_name,
+			'anon_id'          => rawurlencode( $this->anon_id ),
+			'woo_country_code' => rawurlencode( get_option( 'woocommerce_default_country', 'US:CA' ) ),
 		);
 
 		$url = add_query_arg(

--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -225,9 +225,14 @@ class Notes extends \WC_REST_CRUD_Controller {
 			$date->format( 'm' )
 		);
 
-		$variation_name = $abtest->get_variation( $experiment_name );
+		$experiment_name_2col = sprintf(
+			'woocommerce_tasklist_progression_headercard_2col_%s_%s',
+			$date->format( 'Y' ),
+			$date->format( 'm' )
+		);
 
-		return $abtest->get_variation( $experiment_name ) === 'treatment';
+		return $abtest->get_variation( $experiment_name ) === 'treatment' ||
+			$abtest->get_variation( $experiment_name_2col ) === 'treatment';
 	}
 
 	/**

--- a/src/Notes/CompleteStoreDetails.php
+++ b/src/Notes/CompleteStoreDetails.php
@@ -39,6 +39,11 @@ class CompleteStoreDetails {
 			return;
 		}
 
+		// Bail when profile is already completed.
+		if ( isset( $onboarding_profile['completed'] ) && $onboarding_profile['completed'] ) {
+			return;
+		}
+
 		$note = new Note();
 		$note->set_title( __( 'Add your store details to complete store setup', 'woocommerce-admin' ) );
 		$note->set_content( __( 'Complete your store details with important information for setup such as your store’s base address', 'woocommerce-admin' ) );

--- a/src/Notes/UpdateStoreDetails.php
+++ b/src/Notes/UpdateStoreDetails.php
@@ -47,7 +47,7 @@ class UpdateStoreDetails {
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
-			'add-store-details',
+			'update-store-details',
 			__( 'Update store details', 'woocommerce-admin' ),
 			wc_admin_url( '&path=/setup-wizard' )
 		);

--- a/src/Notes/UpdateStoreDetails.php
+++ b/src/Notes/UpdateStoreDetails.php
@@ -35,7 +35,7 @@ class UpdateStoreDetails {
 		}
 
 		// Bail when profile is not yet completed.
-		if ( isset( $onboarding_profile['completed'] ) && ! $onboarding_profile['completed'] ) {
+		if ( ! isset( $onboarding_profile['completed'] ) || ! $onboarding_profile['completed'] ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR is a follow-up to #7861.

It fixes:

1. ExPlat PHP breaking characters due to non-encoded data in GET request parameters. 
2. Add `2col` experiment
2. `wc-admin-complete-store-details` note showing when onboarding profile is already completed.
3. `wc-admin-update-store-details` note showing when onboarding profile is not yet completed.

### Detailed test instructions:

**Prerequisite**
- Set up proxy for your WordPress instance. You can follow the guide here: p90Yrv-2y1-p2
- You can either use a fresh installation or delete all admin notes and reset onboarding wizard in an existing site via WCAdmin Test Helper
- Clear cookies for the site's domain to make sure no duplicate of `tk_ai` cookie, login back
- Run the control bookmarklet for both experiments `woocommerce_tasklist_progression_headercard_2021_11` and `woocommerce_tasklist_progression_headercard_2col_2021_11`
- If you're using existing site, delete the options `_transient_abtest_variation_woocommerce_tasklist_progression_headercard_2021_11` and `_transient_abtest_variation_woocommerce_tasklist_progression_headercard_2col_2021_11`

**Test CompleteStoreDetails**
- Use the treatment bookmarklet for `woocommerce_tasklist_progression_headercard_2021_11` experiment
- Navigate to WooCommerce > Home, you should be directed to Setup Wizard
- Skip the setup
- Run `wc_admin_daily` job
- Go to WooCommerce > Home, observe "Add your store details to complete store setup" note appears

**Test UpdateStoreDetails**
- Click "Add store details" on the note from the previous test
- For store location, choose anywhere in `US`
- Complete the onboarding wizard
- Run `wc_admin_daily` job
- Go to WooCommerce > Home, observe "Edit your store details if you need to" note appears

**Test non-supported countries**
- Go to WooCommerce > Settings
- Change country to `UK`
- Use the control bookmarklet for `woocommerce_tasklist_progression_headercard_2021_11` experiment
- Delete the option `_transient_abtest_variation_woocommerce_tasklist_progression_headercard_2021_11`
- Go to WooCommerce > Home, you **should not** see "Edit your store details if you need to" note

**Test 2col-supported country**
- Go to WooCommerce > Settings
- Change country to anywhere in `AU` or `CA`
- Use the control bookmarklet for `woocommerce_tasklist_progression_headercard_2021_11` experiment
- Delete the options `_transient_abtest_variation_woocommerce_tasklist_progression_headercard_2021_11` and `_transient_abtest_variation_woocommerce_tasklist_progression_headercard_2col_2021_11`
- Use the treatment bookmarklet for `woocommerce_tasklist_progression_headercard_2col_2021_11` experiment
- Go to WooCommerce > Home, you **should** see "Edit your store details if you need to" note