### PR TITLE
Fix TaskList UI experiment enablement logic

### DIFF
--- a/changelogs/fix-tasklist-ui-experiment-enablement-logic
+++ b/changelogs/fix-tasklist-ui-experiment-enablement-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix TaskList UI experiment enablement logic #7930

--- a/client/homescreen/layout.js
+++ b/client/homescreen/layout.js
@@ -88,9 +88,6 @@ export const Layout = ( {
 			momentDate.format( 'MM' )
 	);
 
-	const isRunningTaskListExperiment =
-		experimentAssignment?.variationName === 'treatment';
-
 	const [
 		isLoadingTwoColExperimentAssignment,
 		twoColExperimentAssignment,
@@ -104,13 +101,18 @@ export const Layout = ( {
 	const isRunningTwoColumnExperiment =
 		twoColExperimentAssignment?.variationName === 'treatment';
 
+	// New TaskList UI is enabled when either experiment is treatment.
+	const isRunningTaskListExperiment =
+		experimentAssignment?.variationName === 'treatment' ||
+		isRunningTwoColumnExperiment;
+
 	// Override defaultHomescreenLayout if store is in the experiment.
 	const defaultHomescreenLayoutOverride = () => {
 		if (
 			isLoadingExperimentAssignment ||
 			isLoadingTwoColExperimentAssignment
 		) {
-			return defaultHomescreenLayout; // Experiments are still loading, don't override.;
+			return defaultHomescreenLayout; // Experiments are still loading, don't override.
 		}
 
 		if ( ! isRunningTaskListExperiment ) {

--- a/client/two-column-tasks/headers/payments.js
+++ b/client/two-column-tasks/headers/payments.js
@@ -13,7 +13,7 @@ import GetPaid from './illustrations/get-paid';
 const PaymentsHeader = ( { task, goToTask } ) => {
 	return (
 		<div className="woocommerce-task-header__contents-container">
-			<GetPaid class="svg-background" />
+			<GetPaid className="svg-background" />
 			<div className="woocommerce-task-header__contents">
 				<h1>{ __( 'Choose payment methods', 'woocommerce-admin' ) }</h1>
 				<p>


### PR DESCRIPTION
This PR is a follow-up to #7872.

1. Fix logic to enable TaskList UI experiment when either experiment `woocommerce_tasklist_progression_headercard_` or `woocommerce_tasklist_progression_headercard_2col_` is enabled.
2. Fix React warning for using `class` instead of `className`.

### Detailed test instructions:

**Prerequisite**
- If you're using an existing site, you'll need to run the query ```DELETE FROM `wp_usermeta` WHERE `meta_key` = 'woocommerce_admin_homepage_layout'```
- Run the control bookmarklet for both experiments `woocommerce_tasklist_progression_headercard_2021_11` and `woocommerce_tasklist_progression_headercard_2col_2021_11`
- Open your browser console, go to Application > Local Storage > Your site domain. Delete both `explat-experiment--woocommerce_tasklist_progression_headercard_2021_11` and `explat-experiment--woocommerce_tasklist_progression_headercard_2col_2021_11`

**Test single column**
- Run the treatment bookmarklet for `woocommerce_tasklist_progression_headercard_2021_11`
- Refresh WooCommerce > Home, observe the TaskList experiment is shown with single column layout

**Test two column**
- Run the control bookmarklet for experiment `woocommerce_tasklist_progression_headercard_2021_11`
- Run the treatment bookmarklet for `woocommerce_tasklist_progression_headercard_2col_2021_11`
- Delete `explat-experiment--woocommerce_tasklist_progression_headercard_2021_11` in Local Storage
- Refresh WooCommerce > Home, observe the TaskList experiment is shown with two column layout