### PR TITLE
Fix the failing e2e test

### DIFF
--- a/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
+++ b/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { waitForElementByText, getElementByText } from '../utils/actions';
+import {
+	waitForElementByText,
+	getElementByText,
+	waitForTimeout,
+} from '../utils/actions';
 import { BasePage } from './BasePage';
 
 type PaymentMethodWithSetupButton =
@@ -50,5 +54,6 @@ export class PaymentsSetup extends BasePage {
 	async enableCashOnDelivery() {
 		await this.page.waitForSelector( '.woocommerce-task-payment-cod' );
 		await this.clickButtonWithText( 'Enable' );
+		await waitForTimeout( 500 );
 	}
 }

--- a/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
+++ b/packages/admin-e2e-tests/src/pages/PaymentsSetup.ts
@@ -48,6 +48,7 @@ export class PaymentsSetup extends BasePage {
 	}
 
 	async enableCashOnDelivery() {
+		await this.page.waitForSelector( '.woocommerce-task-payment-cod' );
 		await this.clickButtonWithText( 'Enable' );
 	}
 }

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -77,9 +77,6 @@ const testAdminPaymentSetupTask = () => {
 			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.enableCashOnDelivery();
-			await homeScreen.navigate();
-			await homeScreen.isDisplayed();
-			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
 			await paymentsSetup.isDisplayed();
 			await paymentsSetup.methodHasBeenSetup( 'cod' );

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -11,7 +11,7 @@ import { OnboardingWizard } from '../../pages/OnboardingWizard';
 import { PaymentsSetup } from '../../pages/PaymentsSetup';
 import { WcHomescreen } from '../../pages/WcHomescreen';
 import { BankAccountTransferSetup } from '../../sections/payment-setup/BankAccountTransferSetup';
-import { waitForTimeout, waitForElementByText } from '../../utils/actions';
+import { waitForTimeout } from '../../utils/actions';
 import { WcSettings } from '../../pages/WcSettings';
 
 /* eslint-disable @typescript-eslint/no-var-requires */

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -11,7 +11,7 @@ import { OnboardingWizard } from '../../pages/OnboardingWizard';
 import { PaymentsSetup } from '../../pages/PaymentsSetup';
 import { WcHomescreen } from '../../pages/WcHomescreen';
 import { BankAccountTransferSetup } from '../../sections/payment-setup/BankAccountTransferSetup';
-import { waitForTimeout } from '../../utils/actions';
+import { waitForTimeout, waitForElementByText } from '../../utils/actions';
 import { WcSettings } from '../../pages/WcSettings';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -76,6 +76,7 @@ const testAdminPaymentSetupTask = () => {
 			await homeScreen.isDisplayed();
 			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
+			await waitForElementByText( 'h2', 'Additional payment gateways' );
 			await paymentsSetup.enableCashOnDelivery();
 			await homeScreen.navigate();
 			await homeScreen.isDisplayed();

--- a/packages/admin-e2e-tests/src/specs/tasks/payment.ts
+++ b/packages/admin-e2e-tests/src/specs/tasks/payment.ts
@@ -76,7 +76,6 @@ const testAdminPaymentSetupTask = () => {
 			await homeScreen.isDisplayed();
 			await waitForTimeout( 1000 );
 			await homeScreen.clickOnTaskList( 'Set up payments' );
-			await waitForElementByText( 'h2', 'Additional payment gateways' );
 			await paymentsSetup.enableCashOnDelivery();
 			await homeScreen.navigate();
 			await homeScreen.isDisplayed();


### PR DESCRIPTION
One of the Payment task E2E tests started failing in the newly created [PRs](https://github.com/woocommerce/woocommerce-admin/runs/4300970852?check_suite_focus=true).

I've looked into the test and it tried to run `paymentsSetup.enableCashOnDelivery()` before the button elements are available.

This PR makes sure the COD is ready.

### Detailed test instructions:

Make sure this PR passes E2E tests.

no changelog