### PR TITLE
Make inbox note title clickable

### DIFF
--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+-	Make the Inbox note title clickable. #7975
 
 # 2.1.0
 

--- a/packages/experimental/src/inbox-note/action.tsx
+++ b/packages/experimental/src/inbox-note/action.tsx
@@ -8,6 +8,7 @@ type InboxNoteActionProps = {
 	onClick: () => void;
 	label: string;
 	href?: string;
+	preventBusyState?: boolean;
 };
 
 /**
@@ -18,6 +19,7 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 	label,
 	onClick,
 	href,
+	preventBusyState,
 } ) => {
 	const [ inAction, setInAction ] = useState( false );
 
@@ -39,6 +41,10 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 			event.preventDefault();
 			isActionable = false; // link buttons shouldn't be "busy".
 			window.open( targetHref, '_blank' );
+		}
+
+		if ( preventBusyState ) {
+			isActionable = false;
 		}
 
 		setInAction( isActionable );

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -194,7 +194,24 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 							</span>
 						) }
 						<H className="woocommerce-inbox-message__title">
-							{ title }
+							{ note.actions && note.actions.length === 1 && (
+								<InboxNoteActionButton
+									key={ note.actions[ 0 ].id }
+									label={ title }
+									preventBusyState={ true }
+									href={
+										note.actions[ 0 ].url &&
+										note.actions[ 0 ].url.length
+											? note.actions[ 0 ].url
+											: undefined
+									}
+									onClick={ () =>
+										onActionClicked( note.actions[ 0 ] )
+									}
+								/>
+							) }
+
+							{ note.actions && note.actions.length > 1 && title }
 						</H>
 						<Section className="woocommerce-inbox-message__text">
 							<span

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -24,7 +24,6 @@
 	}
 	&:hover {
 		background: $gray-100;
-		cursor: pointer;
 		.woocommerce-inbox-message__actions button.woocommerce-admin-dismiss-notification {
 			visibility: visible;
 		}
@@ -33,6 +32,9 @@
 	&:not(.message-is-unread) {
 		h3 {
 			font-weight: normal;
+			a {
+				font-weight: normal;
+			}
 		}
 		.woocommerce-inbox-message__actions a {
 			color: $gray-900;
@@ -80,6 +82,14 @@
 				margin: 5px 0;
 			}
 			margin-bottom: 10px;
+		}
+	}
+
+	h3 {
+		a {
+			@extend .woocommerce-inbox-message__title;
+			color: $gray-900 !important;
+			text-decoration: none !important;
 		}
 	}
 


### PR DESCRIPTION
Fixes #7975 

This PR makes the inbox note title clickable.

### Detailed test instructions:

1. Navigate to WooCommerce -> Home
2. Confirm hovering a note text doesn't change the mouse cursor to a pointer.
3. Click a note title. It should behave the same as the CTA.

no changelog
