### PR TITLE
Fix datepicker in advanced filter

### DIFF
--- a/changelogs/fix-7507_fix_datepicker
+++ b/changelogs/fix-7507_fix_datepicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix usage of Wordpress DatePicker component. #7982

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+-   Fix usage of Wordpress DatePicker component in `DatePicker`. #7982
+
 # 8.1.1
 
 -   Fixed warnings when using AdvancedFilters component. #7704

--- a/packages/components/src/calendar/date-picker.js
+++ b/packages/components/src/calendar/date-picker.js
@@ -6,7 +6,7 @@ import 'core-js/features/array/from';
 import { __, sprintf } from '@wordpress/i18n';
 import { createElement, Component } from '@wordpress/element';
 import { Dropdown, DatePicker as WpDatePicker } from '@wordpress/components';
-import { partial } from 'lodash';
+import { partial, noop } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { dateValidationMessages, toMoment } from '@woocommerce/date';
@@ -127,6 +127,8 @@ class DatePicker extends Component {
 									this.onDateChange,
 									onToggle
 								) }
+								// onMonthPreviewed is required to prevent a React error from happening.
+								onMonthPreviewed={ noop }
 								isInvalidDate={ isInvalidDate }
 							/>
 						</div>


### PR DESCRIPTION
Fixes #7507 

Make sure we set the onMonthPreviewed prop as this is required for wp.components.DatePicker

### Screenshots

![date-filter](https://user-images.githubusercontent.com/2240960/144125193-f16372a9-d355-4a47-9bb2-0d00410187c2.gif)

### Detailed test instructions:

1. Go to WooCommerce > Customers
2. In the "Show" data field select "Advanced Filters"
3. Click "Add a filter" and select "Registered" or "Last Active"
4. Click the calendar field to open the calendar 
5. Click on the Next/Prev icon of the calendar it should switch months correctly

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
