### PR TITLE
Fix/7660 Remove note->read_meta

### DIFF
--- a/changelogs/fix-7660-remove-note-read-meta-data-calls
+++ b/changelogs/fix-7660-remove-note-read-meta-data-calls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Remove calls to read_meta_data in the Note DataStore. #7988

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -79,7 +79,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		if ( 0 === $note->get_id() || '0' === $note->get_id() ) {
 			$this->read_actions( $note );
-			$note->read_meta_data();
 			$note->set_object_read( true );
 
 			/**
@@ -114,7 +113,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$note->set_layout( $note_row->layout );
 			$note->set_image( $note_row->image );
 			$this->read_actions( $note );
-			$note->read_meta_data();
 			$note->set_object_read( true );
 
 			/**

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -43,7 +43,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		$wpdb->insert( $wpdb->prefix . 'wc_admin_notes', $note_to_be_inserted );
 		$note_id = $wpdb->insert_id;
 		$note->set_id( $note_id );
-		$note->save_meta_data();
 		$this->save_actions( $note );
 		$note->apply_changes();
 
@@ -170,7 +169,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			);
 		}
 
-		$note->save_meta_data();
 		$this->save_actions( $note );
 		$note->apply_changes();
 


### PR DESCRIPTION
Fixes #7660 

Removes calls to `read_meta_data()` in the Notes DataStore as they are not used.