### PR TITLE
Prevent coupon move notice for new installs.

### DIFF
--- a/changelogs/fix-wc31285-disable-coupon-notice-for-new-installs
+++ b/changelogs/fix-wc31285-disable-coupon-notice-for-new-installs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Prevent coupon move notice for new installs.
+Prevent coupon move notice for new installs. #7995

--- a/changelogs/fix-wc31285-disable-coupon-notice-for-new-installs
+++ b/changelogs/fix-wc31285-disable-coupon-notice-for-new-installs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Prevent coupon move notice for new installs.

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -45,6 +45,11 @@ class CouponPageMoved {
 			return false;
 		}
 
+		// Don't add the notice if the legacy coupon menu is already disabled.
+		if ( ! self::should_display_legacy_menu() ) {
+			return false;
+		}
+
 		// Don't add the notice if it's been hidden by the user before.
 		if ( self::has_dismissed_note() ) {
 			return false;
@@ -52,11 +57,6 @@ class CouponPageMoved {
 
 		// If we already have a notice, don't add a new one.
 		if ( self::has_unactioned_note() ) {
-			return false;
-		}
-
-		// If new navigation feature is enabled.
-		if ( Features::is_enabled( 'navigation' ) ) {
 			return false;
 		}
 

--- a/src/Notes/CouponPageMoved.php
+++ b/src/Notes/CouponPageMoved.php
@@ -33,6 +33,7 @@ class CouponPageMoved {
 
 		add_action( 'admin_init', [ $this, 'possibly_add_note' ] );
 		add_action( 'admin_init', [ $this, 'redirect_to_coupons' ] );
+		add_action( 'woocommerce_admin_newly_installed', [ $this, 'disable_legacy_menu_for_new_install' ] );
 	}
 
 	/**
@@ -147,5 +148,12 @@ class CouponPageMoved {
 		$this->display_legacy_menu( false );
 		wp_safe_redirect( self::get_management_url( 'coupons' ) );
 		exit;
+	}
+
+	/**
+	 * Disable legacy coupon menu when installing for the first time.
+	 */
+	public function disable_legacy_menu_for_new_install() {
+		$this->display_legacy_menu( false );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/31285

This PR sets the option `wc_admin_show_legacy_coupon_menu` to false upon initial installation. In addition to setting the option it's also checked and if it's been disabled already it will prevent the note from being added.

These changes change the following behaviour after initial install:
- The WooCommerce > Coupons menu item does not show up
- When visiting Marketing > Coupons we do not see the notice that the coupon menu entry has moved

An added benefit is that for newly installed sites or sites that removed the previous coupon menu entry, will no longer check on each init if the coupon moved note has already been added. Which is related to the issue #7986 

### Detailed test instructions:

1. Install on a clean site (if installing WC Admin as a plugin, activate WC and WC Admin at the same time to prevent WC triggering an install with the packaged version of WC Admin)
2. Confirm the menu entry WooCommerce > Coupons does not show
3. Visit Marketing > Coupons and confirm the notice does not show

Alternative test instructions for testing on an already installed site

1. Remove the option `wc_admin_show_legacy_coupon_menu`
2. Remove the option `woocommerce_admin_version` (this will trigger a new install)
3. Remove any previous notes in the table `wp_wc_admin_notes` with the name `wc-admin-coupon-page-moved`
4. Reload the backend which will trigger a new install
5. Confirm the menu entry WooCommerce > Coupons does not show
6. Visit Marketing > Coupons and confirm the notice does not show
