### PR TITLE
Improve Customers Sync Performance

### DIFF
--- a/changelogs/fix-26452-customers-sync-performance
+++ b/changelogs/fix-26452-customers-sync-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Performance
+
+Speed up customer syncing action.

--- a/changelogs/fix-26452-customers-sync-performance
+++ b/changelogs/fix-26452-customers-sync-performance
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Performance
 
-Speed up customer syncing action.
+Speed up customer syncing action. #8021

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -705,14 +705,14 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return false;
 		}
 
-		$last_order = $customer->get_last_order();
+		$first_name = $customer->get_first_name();
+		$last_name  = $customer->get_last_name();
 
-		if ( ! $last_order ) {
-			$first_name = get_user_meta( $user_id, 'first_name', true );
-			$last_name  = get_user_meta( $user_id, 'last_name', true );
-		} else {
-			$first_name = $last_order->get_customer_first_name();
-			$last_name  = $last_order->get_customer_last_name();
+		if ( empty( $first_name ) ) {
+			$first_name = $customer->get_billing_first_name();
+		}
+		if ( empty( $last_name ) ) {
+			$last_name = $customer->get_billing_last_name();
 		}
 
 		$last_active = $customer->get_meta( 'wc_last_active', true, 'edit' );

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -780,7 +780,7 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 
 		$customer_roles = (array) apply_filters( 'woocommerce_analytics_customer_roles', array( 'customer' ) );
 
-		if ( empty( $user->roles ) || ! in_array( $user->roles[0], $customer_roles, true ) ) {
+		if ( empty( $user->roles ) || empty( array_intersect( $user->roles, $customer_roles ) ) ) {
 			return false;
 		}
 

--- a/src/API/Reports/Customers/DataStore.php
+++ b/src/API/Reports/Customers/DataStore.php
@@ -772,14 +772,15 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	 * @return bool
 	 */
 	protected static function is_valid_customer( $user_id ) {
-		$customer = new \WC_Customer( $user_id );
+		$user = new \WP_User( $user_id );
 
-		if ( absint( $customer->get_id() ) !== absint( $user_id ) ) {
+		if ( (int) $user_id !== $user->ID ) {
 			return false;
 		}
 
 		$customer_roles = (array) apply_filters( 'woocommerce_analytics_customer_roles', array( 'customer' ) );
-		if ( $customer->get_order_count() < 1 && ! in_array( $customer->get_role(), $customer_roles, true ) ) {
+
+		if ( empty( $user->roles ) || ! in_array( $user->roles[0], $customer_roles, true ) ) {
 			return false;
 		}
 

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -500,8 +500,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
-		$customer_id = $order->get_report_customer_id();
-
 		/**
 		 * Filters order stats data.
 		 *
@@ -521,8 +519,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'shipping_total'     => $order->get_shipping_total(),
 				'net_total'          => self::get_net_total( $order ),
 				'status'             => self::normalize_order_status( $order->get_status() ),
-				'customer_id'        => $customer_id,
-				'returning_customer' => $order->is_returning_customer( $customer_id ),
+				'customer_id'        => $order->get_report_customer_id(),
+				'returning_customer' => $order->is_returning_customer(),
 			),
 			$order
 		);

--- a/src/API/Reports/Orders/Stats/DataStore.php
+++ b/src/API/Reports/Orders/Stats/DataStore.php
@@ -500,6 +500,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 			return -1;
 		}
 
+		$customer_id = $order->get_report_customer_id();
+
 		/**
 		 * Filters order stats data.
 		 *
@@ -519,8 +521,8 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				'shipping_total'     => $order->get_shipping_total(),
 				'net_total'          => self::get_net_total( $order ),
 				'status'             => self::normalize_order_status( $order->get_status() ),
-				'customer_id'        => $order->get_report_customer_id(),
-				'returning_customer' => $order->is_returning_customer(),
+				'customer_id'        => $customer_id,
+				'returning_customer' => $order->is_returning_customer( $customer_id ),
 			),
 			$order
 		);
@@ -546,8 +548,6 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				$data['parent_id'] = $parent_order->get_id();
 				$data['status']    = self::normalize_order_status( $parent_order->get_status() );
 			}
-		} else {
-			$data['returning_customer'] = self::is_returning_customer( $order );
 		}
 
 		// Update or add the information to the DB.
@@ -630,11 +630,14 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 	/**
 	 * Check to see if an order's customer has made previous orders or not
 	 *
-	 * @param array $order WC_Order object.
+	 * @param array     $order WC_Order object.
+	 * @param int|false $customer_id Customer ID. Optional.
 	 * @return bool
 	 */
-	public static function is_returning_customer( $order ) {
-		$customer_id = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_existing_customer_id_from_order( $order );
+	public static function is_returning_customer( $order, $customer_id = null ) {
+		if ( is_null( $customer_id ) ) {
+			$customer_id = \Automattic\WooCommerce\Admin\API\Reports\Customers\DataStore::get_existing_customer_id_from_order( $order );
+		}
 
 		if ( ! $customer_id ) {
 			return false;

--- a/src/Overrides/Order.php
+++ b/src/Overrides/Order.php
@@ -40,8 +40,8 @@ class Order extends \WC_Order {
 			),
 			$this->data,
 			array(
-				'number'         => $this->get_order_number(),
-				'meta_data'      => $this->get_meta_data(),
+				'number'    => $this->get_order_number(),
+				'meta_data' => $this->get_meta_data(),
 			)
 		);
 	}
@@ -105,10 +105,11 @@ class Order extends \WC_Order {
 	/**
 	 * Returns true if the customer has made an earlier order.
 	 *
+	 * @param int|false $customer_id Customer ID. Optional.
 	 * @return bool
 	 */
-	public function is_returning_customer() {
-		return OrdersStatsDataStore::is_returning_customer( $this );
+	public function is_returning_customer( $customer_id = null ) {
+		return OrdersStatsDataStore::is_returning_customer( $this, $customer_id );
 	}
 
 	/**

--- a/src/Overrides/Order.php
+++ b/src/Overrides/Order.php
@@ -29,6 +29,13 @@ class Order extends \WC_Order {
 	protected $refunded_line_items;
 
 	/**
+	 * Caches the customer ID.
+	 *
+	 * @var int
+	 */
+	protected $customer_id = null;
+
+	/**
 	 * Get only core class data in array format.
 	 *
 	 * @return array
@@ -99,17 +106,20 @@ class Order extends \WC_Order {
 	 * @return int
 	 */
 	public function get_report_customer_id() {
-		return CustomersDataStore::get_or_create_customer_from_order( $this );
+		if ( is_null( $this->customer_id ) ) {
+			$this->customer_id = CustomersDataStore::get_or_create_customer_from_order( $this );
+		}
+
+		return $this->customer_id;
 	}
 
 	/**
 	 * Returns true if the customer has made an earlier order.
 	 *
-	 * @param int|false $customer_id Customer ID. Optional.
 	 * @return bool
 	 */
-	public function is_returning_customer( $customer_id = null ) {
-		return OrdersStatsDataStore::is_returning_customer( $this, $customer_id );
+	public function is_returning_customer() {
+		return OrdersStatsDataStore::is_returning_customer( $this, $this->get_report_customer_id() );
 	}
 
 	/**

--- a/src/Overrides/OrderRefund.php
+++ b/src/Overrides/OrderRefund.php
@@ -63,9 +63,10 @@ class OrderRefund extends \WC_Order_Refund {
 	/**
 	 * Returns null since refunds should not be counted towards returning customer counts.
 	 *
+	 * @param int|false $customer_id Customer ID. Optional.
 	 * @return null
 	 */
-	public function is_returning_customer() {
+	public function is_returning_customer( $customer_id = null ) {
 		return null;
 	}
 }

--- a/src/Overrides/OrderRefund.php
+++ b/src/Overrides/OrderRefund.php
@@ -21,6 +21,13 @@ class OrderRefund extends \WC_Order_Refund {
 	use OrderTraits;
 
 	/**
+	 * Caches the customer ID.
+	 *
+	 * @var int
+	 */
+	protected $customer_id = null;
+
+	/**
 	 * Add filter(s) required to hook this class to substitute WC_Order_Refund.
 	 */
 	public static function add_filters() {
@@ -51,22 +58,25 @@ class OrderRefund extends \WC_Order_Refund {
 	 * @return int|bool Customer ID of parent order, or false if parent order not found.
 	 */
 	public function get_report_customer_id() {
-		$parent_order = wc_get_order( $this->get_parent_id() );
+		if ( is_null( $this->customer_id ) ) {
+			$parent_order = \wc_get_order( $this->get_parent_id() );
 
-		if ( ! $parent_order ) {
-			return false;
+			if ( ! $parent_order ) {
+				$this->customer_id = false;
+			}
+
+			$this->customer_id = CustomersDataStore::get_or_create_customer_from_order( $parent_order );
 		}
 
-		return CustomersDataStore::get_or_create_customer_from_order( $parent_order );
+		return $this->customer_id;
 	}
 
 	/**
 	 * Returns null since refunds should not be counted towards returning customer counts.
 	 *
-	 * @param int|false $customer_id Customer ID. Optional.
 	 * @return null
 	 */
-	public function is_returning_customer( $customer_id = null ) {
+	public function is_returning_customer() {
 		return null;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/26452

This PR seeks to (dramatically) improve the performance of the Customer Sync action by removing seemingly unnecessary queries .

### Rationale

In its current form, the `update_registered_customer()` method will call both `WC_Customer:: get_last_order()` and `WC_Customer:: get_order_count()` whose queries require the scanning of ALL `_customer_user` post meta rows. As reported by @DavidAnderson684, this causes serious performance issues on stores with large numbers of customers and orders.

`WC_Customer:: get_last_order()` is invoked simply to grab the customer's name, reasoning that the last order is the most accurate value. So long as the [`woocommerce_checkout_update_customer_data`](https://github.com/woocommerce/woocommerce/blob/4f39c2599108ce75318f4093ea7a5010eca3bd3d/plugins/woocommerce/includes/class-wc-checkout.php#L1065) filter isn't used to disable the default behavior, the customer will have their name updated at checkout. I reckon this is a safe change to make given the potential cost of retrieving the last order.

The sync routine uses `WC_Customer:: get_order_count()` to validate if the WP user should be considered a customer with the logic that either they should have the `Customer` role OR they should have placed at least one order. I believe this is safe to skip when importing customers because a [new row will be inserted](https://github.com/woocommerce/woocommerce-admin/blob/a498a6a4a842133383a8f21ee22d3d48617ba9c7/src/Overrides/Order.php#L102) when their order is encountered in syncing later on.

### Benchmarking

For performance testing I used a store with 100000 customers and over 26000 orders.

Using script: https://gist.github.com/jeffstieler/0c8aec6268e05a2a6584ac6374c861f4

**`main` branch queries:**

```sql
SELECT * FROM wp_users WHERE ID = '73549' LIMIT 1
SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (73549) ORDER BY umeta_id ASC
SELECT umeta_id as meta_id, meta_key, meta_value
				FROM wp_usermeta
				WHERE user_id = 73549
				ORDER BY umeta_id
SELECT umeta_id as meta_id, meta_key, meta_value
				FROM wp_usermeta
				WHERE user_id = 73549
				ORDER BY umeta_id
SELECT COUNT(*)
				FROM wp_posts as posts
				LEFT JOIN wp_postmeta AS meta ON posts.ID = meta.post_id
				WHERE   meta.meta_key = '_customer_user'
				AND     posts.post_type = 'shop_order'
				AND     posts.post_status IN ( 'wc-pending','wc-processing','wc-on-hold','wc-completed','wc-cancelled','wc-refunded','wc-failed' )
				AND     meta_value = '73549'
SELECT umeta_id FROM wp_usermeta WHERE meta_key = '_order_count' AND user_id = 73549
SHOW FULL COLUMNS FROM `wp_usermeta`
INSERT INTO `wp_usermeta` (`user_id`, `meta_key`, `meta_value`) VALUES (73549, '_order_count', '0')
SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (73549) ORDER BY umeta_id ASC
SELECT posts.ID
				FROM wp_posts AS posts
				LEFT JOIN wp_postmeta AS meta on posts.ID = meta.post_id
				WHERE meta.meta_key = '_customer_user'
				AND   meta.meta_value = '73549'
				AND   posts.post_type = 'shop_order'
				AND   posts.post_status IN ( 'wc-pending','wc-processing','wc-on-hold','wc-completed','wc-cancelled','wc-refunded','wc-failed' )
				ORDER BY posts.ID DESC
				LIMIT 1
SELECT umeta_id FROM wp_usermeta WHERE meta_key = '_last_order' AND user_id = 73549
INSERT INTO `wp_usermeta` (`user_id`, `meta_key`, `meta_value`) VALUES (73549, '_last_order', NULL)
SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (73549) ORDER BY umeta_id ASC
SELECT customer_id FROM wp_wc_customer_lookup WHERE user_id = 73549 LIMIT 1
SHOW FULL COLUMNS FROM `wp_wc_customer_lookup`
REPLACE INTO `wp_wc_customer_lookup` (`user_id`, `username`, `first_name`, `last_name`, `email`, `city`, `state`, `postcode`, `country`, `date_registered`, `date_last_active`, `customer_id`) VALUES (73549, 'aabbott', 'Cristian', 'Bauch', 'christine.crooks@example.net', 'West Maritza', 'WA', '68377-2842', 'BN', '2021-12-08 05:01:23', NULL, 73547)
SHOW FULL COLUMNS FROM `wp_options`
UPDATE `wp_options` SET `option_value` = '1638994080' WHERE `option_name` = '_transient_woocommerce_reports-transient-version'
```

**`main` branch average update time:** `0.30210655283928s`

-------------------

**`fix/26452-customers-sync-performance` branch queries:**

```sql
SELECT * FROM wp_users WHERE ID = '73549' LIMIT 1
SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (73549) ORDER BY umeta_id ASC
SELECT umeta_id as meta_id, meta_key, meta_value
				FROM wp_usermeta
				WHERE user_id = 73549
				ORDER BY umeta_id
SELECT customer_id FROM wp_wc_customer_lookup WHERE user_id = 73549 LIMIT 1
SHOW FULL COLUMNS FROM `wp_wc_customer_lookup`
REPLACE INTO `wp_wc_customer_lookup` (`user_id`, `username`, `first_name`, `last_name`, `email`, `city`, `state`, `postcode`, `country`, `date_registered`, `date_last_active`, `customer_id`) VALUES (73549, 'aabbott', 'Cristian', 'Bauch', 'christine.crooks@example.net', 'West Maritza', 'WA', '68377-2842', 'BN', '2021-12-08 05:01:23', NULL, 73547)
SHOW FULL COLUMNS FROM `wp_options`
UPDATE `wp_options` SET `option_value` = '1638993999' WHERE `option_name` = '_transient_woocommerce_reports-transient-version'
```

**`fix/26452-customers-sync-performance` branch average update time:** `0.0031550759315491s`


### Detailed test instructions:

Testing can be pretty involved. Before verifying the performance gains I checked that the data generated by the sync in both the `wp_wc_order_stats` and `wp_wc_customer_lookup` tables matched before and after the changes (by exporting tables as CSV from a smaller dataset and diffing them).

- Verify unit tests pass
- Use `wp eval-file` to run benchmarking script on `main` branch and this one

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->

Performance: speed up customer syncing action.