### PR TITLE
Fix select-control component label value alignment css style

### DIFF
--- a/changelogs/fix-7786-searchable-select-control-label-alginment
+++ b/changelogs/fix-7786-searchable-select-control-label-alginment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix select-control component label/value alignment. #8045

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 -   Fix usage of Wordpress DatePicker component in `DatePicker`. #7982
+-   Fix select-control component label/value alignment. #8045
 
 # 8.1.1
 

--- a/packages/components/src/select-control/style.scss
+++ b/packages/components/src/select-control/style.scss
@@ -152,5 +152,9 @@
 			font-size: 12px;
 			margin-top: -$gap-small;
 		}
+
+		.woocommerce-select-control__control-input {
+			padding-left: 12px;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #7786

Add padding to the input value of the **select-control** component to have the same space as the input label between the search icon.

### Screenshots

#### Before:

![screen shot before](https://user-images.githubusercontent.com/80276/136854550-20d731d2-b383-42ce-b746-e82531fb9314.png)

#### After:

Country/Region

![Screen Shot 2021-12-20 at 1 12 48 PM](https://user-images.githubusercontent.com/4344253/146715661-d34525a0-ce90-47bf-804e-33d52957f1fd.png)

Storybook > select-control:

![Screen Shot 2021-12-20 at 1 12 29 PM](https://user-images.githubusercontent.com/4344253/146715665-984d54b4-5fc7-42d4-a61f-2970d13cb17b.png)


### Detailed test instructions:

1. Go to [/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard](http://localhost:8888/wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard)
2. Click on 'Country/Region' and select an option
3. It should align the label and selected option properly.