### PR TITLE
Allow storybook use different style based on a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ npm install
 npm run storybook
 ```
 
+Moreover, If you would like to view the storybook docs in rtl style, then you can run
+
+```
+npm install
+npm run storybook-rtl
+```
+
 ## Common Issues
 
 If you're encountering any issue setting things up, chances are we have been there too. Please have a look at our [wiki](https://github.com/woocommerce/woocommerce-admin/wiki/Common-Issues) for a list of common problems.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm install
 npm run storybook
 ```
 
-Moreover, If you would like to view the storybook docs in rtl style, then you can run
+If you would like to view the storybook docs in right-to-left styling, you can run this instead:
 
 ```
 npm install

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"pre-release": "./bin/pre-release.sh",
 		"create-wc-extension": "node ./bin/starter-pack/starter-pack.js",
 		"storybook": "./bin/import-wp-css-storybook.sh && STORYBOOK=true start-storybook -c ./storybook/.storybook -p 6007 --ci",
+		"storybook-rtl": "USE_RTL_STYLE=true npm run storybook",
 		"build-storybook": "build-storybook  -c ./storybook/.storybook",
 		"changelog": "node ./bin/changelog --changelogSrcType='ZENHUB_RELEASE'",
 		"bump-version": "npm run -s install-if-deps-outdated && php ./bin/update-version.php",

--- a/storybook/.storybook/main.js
+++ b/storybook/.storybook/main.js
@@ -22,4 +22,28 @@ module.exports = {
 	},
 
 	webpackFinal: webpackOverride,
+
+	previewHead: ( head ) => `
+		${ head }
+
+		${
+			process.env.USE_RTL_STYLE === 'true'
+				? `
+			<link href="experimental-css/style-rtl.css" rel="stylesheet" />
+			<link href="component-css/style-rtl.css" rel="stylesheet" />
+			`
+				: `
+			<link href="component-css/style.css" rel="stylesheet" />
+			<link href="experimental-css/style.css" rel="stylesheet" />
+			`
+		}
+
+		<style>
+			/* Use system font, consistent with WordPress core (wp-admin) */
+			body {
+				font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+					Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+			}
+		</style>
+	`,
 };

--- a/storybook/.storybook/preview-head.html
+++ b/storybook/.storybook/preview-head.html
@@ -17,15 +17,3 @@
 <link href="wordpress/css/site-icon.min.css" rel="stylesheet" />
 <link href="wordpress/css/l10n.min.css" rel="stylesheet" />
 <link href="wordpress/css/site-health.min.css" rel="stylesheet" />
-<link href="component-css/style.css" rel="stylesheet" />
-<link href="component-css/style-rtl.css" rel="stylesheet" />
-<link href="experimental-css/style.css" rel="stylesheet" />
-<link href="experimental-css/style-rtl.css" rel="stylesheet" />
-
-<style>
-	/* Use system font, consistent with WordPress core (wp-admin) */
-	body {
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-			Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
-	}
-</style>


### PR DESCRIPTION
Let us easily view the storybook with `ltr` and `rtl` styles.

Moved our internal style links to `main.js` so we can programmatically set the links based on the environmental variable.

### Detailed test instructions:

Default:

- `npm start`
- `npm run storybook`
- Go to http://localhost:6007/?path=/story/woocommerce-admin-components-selectcontrol--basic and select an option for one input.
- You should see the input value aligned to left.
![Screen Shot 2021-12-20 at 4 00 44 PM](https://user-images.githubusercontent.com/4344253/146736103-cce805d3-db2a-4325-97dc-88d1bb233589.png)



With rtl style:

- `npm start`
- `npm run storybook-rtl`
- Go to http://localhost:6007/?path=/story/woocommerce-admin-components-selectcontrol--basic and select an option for one input.
- You should see the input value aligned to right.
![Screen Shot 2021-12-20 at 4 20 12 PM](https://user-images.githubusercontent.com/4344253/146736118-bd8b2f0d-5746-403f-aef9-ec3ff045ecfd.png)

No changelog