### PR TITLE
Add asynchronous plugin install and activation endpoints

### DIFF
--- a/changelogs/update-as-plugin-install
+++ b/changelogs/update-as-plugin-install
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add asynchronous plugin install and activation endpoints #8079

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -53,6 +53,19 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/install/status',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_installation_status' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/active',
 			array(
 				array(
@@ -248,6 +261,16 @@ class Plugins extends \WC_REST_Data_Controller {
 				: __( 'There was a problem installing some of the requested plugins.', 'woocommerce-admin' ),
 		);
 	}
+
+	/**
+	 * Returns a list of recently scheduled installation jobs.
+	 *
+	 * @return array Jobs.
+	 */
+	public function get_installation_status() {
+		return PluginsHelper::get_jobs();
+	}
+
 
 	/**
 	 * Returns a list of active plugins in API format.

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -53,11 +53,24 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/install/status/(?P<job_id>[a-z0-9_\-]+)',
+			'/' . $this->rest_base . '/install/status',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_installation_status' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/install/status/(?P<job_id>[a-z0-9_\-]+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_job_installation_status' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
@@ -105,11 +118,24 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/activate/status/(?P<job_id>[a-z0-9_\-]+)',
+			'/' . $this->rest_base . '/activate/status',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_activation_status' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/activate/status/(?P<job_id>[a-z0-9_\-]+)',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_job_activation_status' ),
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_item_schema' ),
@@ -282,8 +308,19 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * @return array Jobs.
 	 */
 	public function get_installation_status( $request ) {
+		return PluginsHelper::get_installation_status();
+	}
+
+	/**
+	 * Returns a list of recently scheduled installation jobs.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array Job.
+	 */
+	public function get_job_installation_status( $request ) {
 		$job_id = $request->get_param( 'job_id' );
-		return PluginsHelper::get_installation_status( $job_id );
+		$jobs   = PluginsHelper::get_installation_status( $job_id );
+		return reset( $jobs );
 	}
 
 	/**
@@ -361,11 +398,22 @@ class Plugins extends \WC_REST_Data_Controller {
 	 * Returns a list of recently scheduled activation jobs.
 	 *
 	 * @param  WP_REST_Request $request Full details about the request.
-	 * @return array Jobs.
+	 * @return array Job.
 	 */
 	public function get_activation_status( $request ) {
+		return PluginsHelper::get_activation_status();
+	}
+
+	/**
+	 * Returns a list of recently scheduled activation jobs.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array Jobs.
+	 */
+	public function get_job_activation_status( $request ) {
 		$job_id = $request->get_param( 'job_id' );
-		return PluginsHelper::get_activation_status( $job_id );
+		$jobs   = PluginsHelper::get_activation_status( $job_id );
+		return reset( $jobs );
 	}
 
 	/**

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -218,17 +218,15 @@ class Plugins extends \WC_REST_Data_Controller {
 		$plugins = explode( ',', $request['plugins'] );
 
 		if ( isset( $request['async'] ) && $request['async'] ) {
-			PluginsHelper::schedule_install_plugins( $plugins );
+			$job_id = PluginsHelper::schedule_install_plugins( $plugins );
 
-			$response = array(
+			return array(
 				'data'    => array(
-					'job_id'  => $id,
+					'job_id'  => $job_id,
 					'plugins' => $plugins,
 				),
 				'message' => __( 'Plugin installation has been scheduled.', 'woocommerce-admin' ),
 			);
-
-			return rest_ensure_response( $response );
 		}
 
 		$data = PluginsHelper::install_plugins( $plugins );

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -336,7 +336,7 @@ class Plugins extends \WC_REST_Data_Controller {
 			);
 		}
 
-		$data = PluginsHelper::install_plugins( $plugins );
+		$data = PluginsHelper::activate_plugins( $plugins );
 
 		return( array(
 			'data'    => array(

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -217,7 +217,25 @@ class Plugins extends \WC_REST_Data_Controller {
 	public function install_plugins( $request ) {
 		$plugins = explode( ',', $request['plugins'] );
 
+		if ( isset( $request['async'] ) && $request['async'] ) {
+			PluginsHelper::schedule_install_plugins( $plugins );
+
+			$response = array(
+				'data'    => array(
+					'job_id'  => $id,
+					'plugins' => $plugins,
+				),
+				'message' => __( 'Plugin installation has been scheduled.', 'woocommerce-admin' ),
+			);
+
+			return rest_ensure_response( $response );
+		}
+
 		$data = PluginsHelper::install_plugins( $plugins );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
 
 		return array(
 			'data'    => array(

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -53,7 +53,7 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/install/status',
+			'/' . $this->rest_base . '/install/status/(?P<job_id>[a-z0-9_\-]+)',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
@@ -105,7 +105,7 @@ class Plugins extends \WC_REST_Data_Controller {
 
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/activate/status',
+			'/' . $this->rest_base . '/activate/status/(?P<job_id>[a-z0-9_\-]+)',
 			array(
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
@@ -278,10 +278,12 @@ class Plugins extends \WC_REST_Data_Controller {
 	/**
 	 * Returns a list of recently scheduled installation jobs.
 	 *
+	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array Jobs.
 	 */
-	public function get_installation_status() {
-		return PluginsHelper::get_installation_status();
+	public function get_installation_status( $request ) {
+		$job_id = $request->get_param( 'job_id' );
+		return PluginsHelper::get_installation_status( $job_id );
 	}
 
 	/**
@@ -358,10 +360,12 @@ class Plugins extends \WC_REST_Data_Controller {
 	/**
 	 * Returns a list of recently scheduled activation jobs.
 	 *
+	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array Jobs.
 	 */
-	public function get_activation_status() {
-		return PluginsHelper::get_activation_status();
+	public function get_activation_status( $request ) {
+		$job_id = $request->get_param( 'job_id' );
+		return PluginsHelper::get_activation_status( $job_id );
 	}
 
 	/**

--- a/src/API/Plugins.php
+++ b/src/API/Plugins.php
@@ -243,6 +243,10 @@ class Plugins extends \WC_REST_Data_Controller {
 	public function install_plugins( $request ) {
 		$plugins = explode( ',', $request['plugins'] );
 
+		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
+			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+		}
+
 		if ( isset( $request['async'] ) && $request['async'] ) {
 			$job_id = PluginsHelper::schedule_install_plugins( $plugins );
 
@@ -256,10 +260,6 @@ class Plugins extends \WC_REST_Data_Controller {
 		}
 
 		$data = PluginsHelper::install_plugins( $plugins );
-
-		if ( is_wp_error( $data ) ) {
-			return $data;
-		}
 
 		return array(
 			'data'    => array(
@@ -323,6 +323,10 @@ class Plugins extends \WC_REST_Data_Controller {
 	 */
 	public function activate_plugins( $request ) {
 		$plugins = explode( ',', $request['plugins'] );
+
+		if ( empty( $request['plugins'] ) || ! is_array( $plugins ) ) {
+			return new \WP_Error( 'woocommerce_rest_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+		}
 
 		if ( isset( $request['async'] ) && $request['async'] ) {
 			$job_id = PluginsHelper::schedule_activate_plugins( $plugins );

--- a/src/FeaturePlugin.php
+++ b/src/FeaturePlugin.php
@@ -167,6 +167,7 @@ class FeaturePlugin {
 
 		// Initialize Plugins Installer.
 		PluginsInstaller::init();
+		PluginsHelper::init();
 
 		// Initialize API.
 		API\Init::instance();

--- a/src/Notes/InstallJPAndWCSPlugins.php
+++ b/src/Notes/InstallJPAndWCSPlugins.php
@@ -132,7 +132,7 @@ class InstallJPAndWCSPlugins {
 	 *
 	 * @param string $slug The slug of the plugin being installed.
 	 */
-	private function on_install_error( $slug ) {
+	public function on_install_error( $slug ) {
 		// Exit early if we're not installing the Jetpack or the WooCommerce Shipping & Tax plugins.
 		if ( 'jetpack' !== $slug && 'woocommerce-services' !== $slug ) {
 			return;

--- a/src/Notes/InstallJPAndWCSPlugins.php
+++ b/src/Notes/InstallJPAndWCSPlugins.php
@@ -33,6 +33,8 @@ class InstallJPAndWCSPlugins {
 	public function __construct() {
 		add_action( 'woocommerce_note_action_install-jp-and-wcs-plugins', array( $this, 'install_jp_and_wcs_plugins' ) );
 		add_action( 'activated_plugin', array( $this, 'action_note' ) );
+		add_action( 'woocommerce_plugins_install_api_error', array( $this, 'on_install_error' ) );
+		add_action( 'woocommerce_plugins_install_error', array( $this, 'on_install_error' ) );
 	}
 
 	/**
@@ -122,5 +124,19 @@ class InstallJPAndWCSPlugins {
 		$activate_request = array( 'plugins' => $plugin );
 
 		$installer->activate_plugins( $activate_request );
+	}
+
+	/**
+	 * Create an alert notification in response to an error installing a plugin.
+	 *
+	 * @param string $slug The slug of the plugin being installed.
+	 */
+	private function on_install_error( $slug ) {
+		// Exit early if we're not installing the Jetpack or the WooCommerce Shipping & Tax plugins.
+		if ( 'jetpack' !== $slug && 'woocommerce-services' !== $slug ) {
+			return;
+		}
+
+		self::possibly_add_note();
 	}
 }

--- a/src/Notes/InstallJPAndWCSPlugins.php
+++ b/src/Notes/InstallJPAndWCSPlugins.php
@@ -35,6 +35,7 @@ class InstallJPAndWCSPlugins {
 		add_action( 'activated_plugin', array( $this, 'action_note' ) );
 		add_action( 'woocommerce_plugins_install_api_error', array( $this, 'on_install_error' ) );
 		add_action( 'woocommerce_plugins_install_error', array( $this, 'on_install_error' ) );
+		add_action( 'woocommerce_plugins_activate_error', array( $this, 'on_install_error' ) );
 	}
 
 	/**

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -19,10 +19,10 @@ if ( ! function_exists( 'get_plugins' ) ) {
 class PluginsHelper {
 
 	/**
-	 * Constructor
+	 * Initialize hooks.
 	 */
-	public function __construct() {
-		add_action( 'woocommerce_plugins_install_callback', array( $this, 'install_plugins' ), 10, 2 );
+	public static function init() {
+		add_action( 'woocommerce_plugins_install_callback', array( __CLASS__, 'install_plugins' ), 10, 2 );
 	}
 
 	/**
@@ -155,7 +155,7 @@ class PluginsHelper {
 
 		if ( empty( $plugins ) || ! is_array( $plugins ) ) {
 			if ( $job_id ) {
-				set_job_status( $job_id, 'failed' );
+				self::set_job_status( $job_id, 'failed' );
 			}
 			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
@@ -256,7 +256,7 @@ class PluginsHelper {
 		);
 
 		if ( $job_id ) {
-			set_job_status( $job_id, 'complete', $data );
+			self::set_job_status( $job_id, 'complete', $data );
 		}
 
 		return $data;
@@ -273,9 +273,9 @@ class PluginsHelper {
 			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
 
-		$event_id = WC()->queue()->schedule_single( time() + 5, 'woocommerce_plugins_install_callback', array( $plugins, $job_id ) );
-		$job_id   = 'job_id123';
-		set_job_status( $job_id, 'pending' );
+		$job_id = 'random';
+		self::set_job_status( $job_id, 'pending' );
+		WC()->queue()->schedule_single( time() + 5, 'woocommerce_plugins_install_callback', array( $plugins, $job_id ) );
 
 		return $job_id;
 	}
@@ -288,8 +288,8 @@ class PluginsHelper {
 	 * @param array  $data Job data.
 	 */
 	public static function set_job_status( $id, $status, $data = array() ) {
-		$install_jobs            = get_transient( 'woocommerce_plugins_install_jobs', array() );
-		$install_jobs[ $job_id ] = array(
+		$install_jobs        = get_transient( 'woocommerce_plugins_install_jobs', array() );
+		$install_jobs[ $id ] = array(
 			'status' => $status,
 			'data'   => $data,
 		);

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -158,7 +158,7 @@ class PluginsHelper {
 			if ( $job_id ) {
 				self::set_installation_status( $job_id, 'failed' );
 			}
-			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
+			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ) );
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -359,11 +359,39 @@ class PluginsHelper {
 	 * @return array Job data.
 	 */
 	public static function get_installation_status( $job_id ) {
-		return WC()->queue()->search(
+		$actions = WC()->queue()->search(
 			array(
+				'hook'   => 'woocommerce_plugins_install_callback',
 				'search' => $job_id,
 			)
 		);
+
+		return self::get_action_data( $actions );
+	}
+
+	/**
+	 * Gets the plugin data for the first action.
+	 *
+	 * @param array $actions Array of AS actions.
+	 * @return array
+	 */
+	public static function get_action_data( $actions ) {
+		if ( count( $actions ) ) {
+			reset( $actions );
+			$action_id = key( $actions );
+			$action    = $actions[ $action_id ];
+			$store     = new \ActionScheduler_DBStore();
+			$status    = $store->get_status( $action_id );
+			$args      = $action->get_args();
+
+			return array(
+				'job_id'  => $args[1],
+				'plugins' => $args[0],
+				'status'  => $store->get_status( $action_id ),
+			);
+		}
+
+		return null;
 	}
 
 	/**
@@ -373,11 +401,14 @@ class PluginsHelper {
 	 * @return array
 	 */
 	public static function get_activation_status( $job_id ) {
-		return WC()->queue()->search(
+		$actions = WC()->queue()->search(
 			array(
+				'hook'   => 'woocommerce_plugins_activate_callback',
 				'search' => $job_id,
 			)
 		);
+
+		return self::get_action_data( $actions );
 	}
 
 }

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -359,11 +359,13 @@ class PluginsHelper {
 	 * @param int $job_id Job ID.
 	 * @return array Job data.
 	 */
-	public static function get_installation_status( $job_id ) {
+	public static function get_installation_status( $job_id = null ) {
 		$actions = WC()->queue()->search(
 			array(
-				'hook'   => 'woocommerce_plugins_install_callback',
-				'search' => $job_id,
+				'hook'    => 'woocommerce_plugins_install_callback',
+				'search'  => $job_id,
+				'orderby' => 'date',
+				'order'   => 'DESC',
 			)
 		);
 
@@ -374,38 +376,38 @@ class PluginsHelper {
 	 * Gets the plugin data for the first action.
 	 *
 	 * @param array $actions Array of AS actions.
-	 * @return array
+	 * @return array Array of action data.
 	 */
 	public static function get_action_data( $actions ) {
-		if ( count( $actions ) ) {
-			reset( $actions );
-			$action_id = key( $actions );
-			$action    = $actions[ $action_id ];
-			$store     = new \ActionScheduler_DBStore();
-			$status    = $store->get_status( $action_id );
-			$args      = $action->get_args();
+		$data = [];
 
-			return array(
+		foreach ( $actions as $action_id => $action ) {
+			$store  = new \ActionScheduler_DBStore();
+			$status = $store->get_status( $action_id );
+			$args   = $action->get_args();
+			$data[] = array(
 				'job_id'  => $args[1],
 				'plugins' => $args[0],
 				'status'  => $store->get_status( $action_id ),
 			);
 		}
 
-		return null;
+		return $data;
 	}
 
 	/**
 	 * Activation status.
 	 *
 	 * @param int $job_id Job ID.
-	 * @return array
+	 * @return array Array of action data.
 	 */
-	public static function get_activation_status( $job_id ) {
+	public static function get_activation_status( $job_id = null ) {
 		$actions = WC()->queue()->search(
 			array(
-				'hook'   => 'woocommerce_plugins_activate_callback',
-				'search' => $job_id,
+				'hook'    => 'woocommerce_plugins_activate_callback',
+				'search'  => $job_id,
+				'orderby' => 'date',
+				'order'   => 'DESC',
 			)
 		);
 

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -347,9 +347,10 @@ class PluginsHelper {
 			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
 
-		$action_id = WC()->queue()->schedule_single( time() + 5, 'woocommerce_plugins_activate_callback', array( $plugins ) );
+		$job_id = uniqid();
+		WC()->queue()->schedule_single( time() + 5, 'woocommerce_plugins_activate_callback', array( $plugins, $job_id ) );
 
-		return $action_id;
+		return $job_id;
 	}
 
 	/**

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -309,7 +309,6 @@ class PluginsHelper {
 		$plugins = apply_filters( 'woocommerce_admin_plugins_pre_activate', $plugins );
 
 		$plugin_paths      = self::get_installed_plugins_paths();
-		$plugins           = explode( ',', $request['plugins'] );
 		$errors            = new \WP_Error();
 		$activated_plugins = array();
 
@@ -343,7 +342,7 @@ class PluginsHelper {
 
 		$data = array(
 			'activated' => $activated_plugins,
-			'active'    => self::get_active_plugins(),
+			'active'    => self::get_active_plugin_slugs(),
 			'errors'    => $errors,
 		);
 

--- a/src/PluginsHelper.php
+++ b/src/PluginsHelper.php
@@ -146,7 +146,7 @@ class PluginsHelper {
 	 * @param string $job_id Job ID to update status.
 	 * @return array
 	 */
-	public static function install_plugins( $plugins, $job_id ) {
+	public static function install_plugins( $plugins, $job_id = null ) {
 		/**
 		 * Filter the list of plugins to install.
 		 *
@@ -274,7 +274,7 @@ class PluginsHelper {
 			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
 
-		$job_id = 'random';
+		$job_id = uniqid();
 		self::set_installation_status( $job_id, 'pending' );
 		WC()->queue()->schedule_single( time() + 5, 'woocommerce_plugins_install_callback', array( $plugins, $job_id ) );
 
@@ -364,7 +364,7 @@ class PluginsHelper {
 			return new \WP_Error( 'woocommerce_plugins_invalid_plugins', __( 'Plugins must be a non-empty array.', 'woocommerce-admin' ), 404 );
 		}
 
-		$job_id = 'random';
+		$job_id = uniqid();
 		self::set_activation_status( $job_id, 'pending' );
 		WC()->queue()->schedule_single( time() + 5, 'woocommerce_plugins_activate_callback', array( $plugins, $job_id ) );
 

--- a/tests/api/plugins.php
+++ b/tests/api/plugins.php
@@ -64,6 +64,27 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that scheduling a plugin install works.
+	 */
+	public function test_install_plugin_async() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint . '/install' );
+		$request->set_query_params(
+			array(
+				'async'   => true,
+				'plugins' => 'facebook-for-woocommerce',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$plugins  = get_plugins();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'job_id', $data['data'] );
+	}
+
+	/**
 	 * Test that installing with invalid params fails.
 	 */
 	public function test_install_invalid_plugins_param() {
@@ -96,6 +117,27 @@ class WC_Tests_API_Plugins extends WC_REST_Unit_Test_Case {
 		$this->assertContains( 'facebook-for-woocommerce', $data['data']['activated'] );
 		$this->assertEquals( true, $data['success'] );
 		$this->assertContains( 'facebook-for-woocommerce', $active_plugins );
+	}
+
+	/**
+	 * Test that scheduling a plugin activation works.
+	 */
+	public function test_activate_plugin_async() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', $this->endpoint . '/activate' );
+		$request->set_query_params(
+			array(
+				'async'   => true,
+				'plugins' => 'facebook-for-woocommerce',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$plugins  = get_plugins();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'job_id', $data['data'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8078 

* Adds async endpoints for installation of plugins.
* Adds async endpoints for activation of plugins.
* Adds status endpoints.
* Migrates plugin installation logic out of the controller (potentially some consolidation needed behind `PluginInstaller` and `PluginHelper` classes)

### Screenshots


<img width="605" alt="Screen Shot 2021-12-23 at 3 19 28 PM" src="https://user-images.githubusercontent.com/10561050/147288267-53a50df5-e3f7-476f-9d96-e725aba63a74.png">

### Detailed test instructions:

**Installation**

1. Make a POST request to the `/wp-json/wc-admin/plugins/install` endpoint with the `plugins` param (comma separated string of plugins to install) and `async=1`
2. Check that you have a successfully scheduled response and a job ID is returned
3. Make a `GET` request to `/wp-json/wc-admin/plugins/install/status/{job_id}`
4. Check that the aforementioned job ID exists as `pending` (if done relatively quickly)
5. Optionally run the `woocommerce_plugins_install_callback` scheduled action under Tools->Scheduled actions to speed things up.
6. Check that plugins have been installed
7. Make a `GET` request to `/wp-json/wc-admin/plugins/install/status/{job_id}` to verify that the status has been updated

**Activation**

1. Make a POST request to the `/wp-json/wc-admin/plugins/activate` endpoint with the `plugins` param (comma separated string of plugins to install) and `async=1`
2. Check that you have a successfully scheduled response
3. Make a `GET` request to `/wp-json/wc-admin/plugins/activate/status/{job_id}`
4. Check that the aforementioned job ID exists as `pending` (if done relatively quickly)
5. Optionally run the `woocommerce_plugins_activate_callback` scheduled action under Tools->Scheduled actions to speed things up.
6. Check that plugins have been activated
7. Make a `GET` request to `/wp-json/wc-admin/plugins/activate/status/{job_id}` to verify that the status has been updated