### PR TITLE
OBW - Business Details - Consolidate selling options

### DIFF
--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -81,6 +81,17 @@ export const prepareExtensionTrackingData = (
 	return installedExtensions;
 };
 
+export const isSellingElsewhere = ( selectedOption ) =>
+	[
+		'other',
+		'brick-mortar',
+		'brick-mortar-other',
+		'other-woocommerce',
+	].includes( selectedOption );
+
+export const isSellingOtherPlatformInPerson = ( selectedOption ) =>
+	[ 'other', 'brick-mortar-other' ].includes( selectedOption );
+
 class BusinessDetails extends Component {
 	constructor() {
 		super();
@@ -219,7 +230,7 @@ class BusinessDetails extends Component {
 
 		if (
 			! values.other_platform.length &&
-			[ 'other', 'brick-mortar-other' ].includes( values.selling_venues )
+			isSellingOtherPlatformInPerson( values.selling_venues )
 		) {
 			errors.other_platform = __(
 				'This field is required',
@@ -230,7 +241,7 @@ class BusinessDetails extends Component {
 		if (
 			! values.other_platform_name &&
 			values.other_platform === 'other' &&
-			[ 'other', 'brick-mortar-other' ].includes( values.selling_venues )
+			isSellingOtherPlatformInPerson( values.selling_venues )
 		) {
 			errors.other_platform_name = __(
 				'This field is required',
@@ -240,12 +251,7 @@ class BusinessDetails extends Component {
 
 		if (
 			! values.number_employees.length &&
-			[
-				'other',
-				'brick-mortar',
-				'brick-mortar-other',
-				'other-woocommerce',
-			].includes( values.selling_venues )
+			isSellingElsewhere( values.selling_venues )
 		) {
 			errors.number_employees = __(
 				'This field is required',
@@ -255,12 +261,7 @@ class BusinessDetails extends Component {
 
 		if (
 			! values.revenue.length &&
-			[
-				'other',
-				'brick-mortar',
-				'brick-mortar-other',
-				'other-woocommerce',
-			].includes( values.selling_venues )
+			isSellingElsewhere( values.selling_venues )
 		) {
 			errors.revenue = __(
 				'This field is required',
@@ -392,12 +393,9 @@ class BusinessDetails extends Component {
 										) }
 									/>
 
-									{ [
-										'other',
-										'brick-mortar',
-										'brick-mortar-other',
-										'other-woocommerce',
-									].includes( values.selling_venues ) && (
+									{ isSellingElsewhere(
+										values.selling_venues
+									) && (
 										<SelectControl
 											excludeSelectedOptions={ false }
 											label={ __(
@@ -413,12 +411,9 @@ class BusinessDetails extends Component {
 										/>
 									) }
 
-									{ [
-										'other',
-										'brick-mortar',
-										'brick-mortar-other',
-										'other-woocommerce',
-									].includes( values.selling_venues ) && (
+									{ isSellingElsewhere(
+										values.selling_venues
+									) && (
 										<SelectControl
 											excludeSelectedOptions={ false }
 											label={ __(
@@ -439,10 +434,9 @@ class BusinessDetails extends Component {
 										/>
 									) }
 
-									{ [
-										'other',
-										'brick-mortar-other',
-									].includes( values.selling_venues ) && (
+									{ isSellingOtherPlatformInPerson(
+										values.selling_venues
+									) && (
 										<>
 											<div className="business-competitors">
 												<SelectControl

--- a/client/profile-wizard/steps/business-details/test/index.js
+++ b/client/profile-wizard/steps/business-details/test/index.js
@@ -3,6 +3,8 @@
  */
 import {
 	filterBusinessExtensions,
+	isSellingElsewhere,
+	isSellingOtherPlatformInPerson,
 	prepareExtensionTrackingData,
 } from '../flows/selective-bundle';
 import { createInitialValues } from '../flows/selective-bundle/selective-extensions-bundle';
@@ -135,6 +137,27 @@ describe( 'BusinessDetails', () => {
 			);
 
 			expect( values ).not.toContain( 'this-should-not-show-at-all' );
+		} );
+	} );
+
+	describe( 'Currently selling elsewhere', () => {
+		test( 'isSellingElsewhere', () => {
+			const sellingElsewhere = isSellingElsewhere( 'other' );
+			const notSellingElsewhere = isSellingElsewhere( 'no' );
+
+			expect( sellingElsewhere ).toBeTruthy();
+			expect( notSellingElsewhere ).toBeFalsy();
+		} );
+		test( 'isSellingOtherPlatformInPerson', () => {
+			const sellingAnotherPlatformAndInPerson = isSellingOtherPlatformInPerson(
+				'brick-mortar-other'
+			);
+			const notSellingAnotherPlatformAndInPerson = isSellingOtherPlatformInPerson(
+				'no'
+			);
+
+			expect( sellingAnotherPlatformAndInPerson ).toBeTruthy();
+			expect( notSellingAnotherPlatformAndInPerson ).toBeFalsy();
 		} );
 	} );
 } );


### PR DESCRIPTION
 This PR aims to improve the Business Details logic a little bit. Instead of [repeating the list of selling options](https://github.com/woocommerce/woocommerce-admin/blob/main/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js#L395-L400) a few times, a couple of methods will be used for that purpose.

### Detailed test instructions:

1. Check out this branch.
2. Go to step 4 of the OBW (Business Details) and verify that everything works as expected.
2.1.  When the option `Currently selling elsewhere?` is set as `No` any selector should be shown below.

![screenshot-localhost_10003-2021 12 23-16_02_38](https://user-images.githubusercontent.com/1314156/147282893-f6496c68-a60d-4bce-bd98-257fee225429.png)

2.2.  When that option is set as `Yes, on another platform` or `Yes, on another platform and in person at physical stores and/or events` the following selectors should be visible:

![screenshot-localhost_10003-2021 12 23-16_19_12](https://user-images.githubusercontent.com/1314156/147284130-6ae384a6-6f65-4e6b-ab1f-9f8194a35e99.png)

2.2.  When that option is set as `Yes, I own a different store powered by WooCommerce` or `Yes, in person at physical stores and/or events` the selectors below should be visible:

![screenshot-localhost_10003-2021 12 23-16_20_07](https://user-images.githubusercontent.com/1314156/147284154-94b76f58-1795-4049-9d3d-fa56f7d16895.png)

3. Continue with the onboarding and confirm that no errors occur.
4. Verify that the js tests are running well.


No changelog

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
