### PR TITLE
OBW: Move newsletter signup checkbox inside the same Card as the rest of the Store Details form inputs.

### DIFF
--- a/changelogs/fix-8033-obw-no-border-between-email-and-newsletter-checkbox
+++ b/changelogs/fix-8033-obw-no-border-between-email-and-newsletter-checkbox
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-8148 remove border between email input and newsletter checkbox in OBW store details.
+Remove border between email input and newsletter checkbox in OBW store details. #8148

--- a/changelogs/fix-8033-obw-no-border-between-email-and-newsletter-checkbox
+++ b/changelogs/fix-8033-obw-no-border-between-email-and-newsletter-checkbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+8148 remove border between email input and newsletter checkbox in OBW store details.

--- a/client/profile-wizard/steps/store-details/index.js
+++ b/client/profile-wizard/steps/store-details/index.js
@@ -358,9 +358,6 @@ class StoreDetails extends Component {
 											) }
 										</div>
 									) }
-							</CardBody>
-
-							<CardFooter>
 								<FlexItem>
 									<div className="woocommerce-profile-wizard__newsletter-signup">
 										<CheckboxControl
@@ -384,7 +381,7 @@ class StoreDetails extends Component {
 										/>
 									</div>
 								</FlexItem>
-							</CardFooter>
+							</CardBody>
 
 							<CardFooter justify="center">
 								<Button


### PR DESCRIPTION
Fixes #8033

Change layout of Store Details form in onboarding wizard so there's no border between email address field and newsletter signup checkbox.

## Prior

<img width="513" alt="Screen Shot 2021-12-14 at 19 29 40" src="https://user-images.githubusercontent.com/2098816/146100867-4746404a-a1c1-4abf-ae98-02ce1116969b.png">

## Desired

<img width="513" alt="Screen Shot 2021-12-14 at 19 24 16" src="https://user-images.githubusercontent.com/2098816/146100682-6ae86edb-efd1-4378-be3c-df8c29098a25.png">

### Accessibility

-   [x] I've tested using only a keyboard (no mouse)

### Detailed test instructions:

-   Open WooCommerce onboarding wizard to Store Details page
-   Verify what you see is more like the second screenshot than the first.

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
