### PR TITLE
Add support for `content_data` parameters to filter admin notes by `content_data` nested properties

### DIFF
--- a/src/API/Notes.php
+++ b/src/API/Notes.php
@@ -278,6 +278,24 @@ class Notes extends \WC_REST_CRUD_Controller {
 			$args['orderby'] = 'date_created';
 		}
 
+		// If there are any parameters that filter nested `content_data` properties, a `content_data` argument is generated with an array of nested property key-value pairs.
+		// For example, if the parameters contain `content_data.key1=val1&content_data.key2=val2`, this results in an entry in `$args` from `content_data` to an array of
+		// `array(array(key1 => val1), array(key2 => val2))`.
+		$params = $request->get_query_params();
+		foreach ( $params as $param_key => $param_value ) {
+			$key_parts = explode( '.', $param_key );
+			if ( count( $key_parts ) !== 2 || 'content_data' !== $key_parts[0] || ! is_scalar( $param_value ) ) {
+				continue;
+			}
+			$content_data_key   = $key_parts[1];
+			$content_data_value = $param_value;
+
+			$content_data_args = $args['content_data'] ?? array();
+			array_push( $content_data_args, array( $content_data_key => $content_data_value ) );
+
+			$args['content_data'] = $content_data_args;
+		}
+
 		/**
 		 * Filter the query arguments for a request.
 		 *

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -343,6 +343,8 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		$offset        = $args['per_page'] * ( $args['page'] - 1 );
 		$where_clauses = $this->get_notes_where_clauses( $args );
 
+		echo print_r($where_clauses);
+
 		$query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -450,6 +450,8 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 				foreach ( $content_data_arg as $content_data_key => $content_data_value ) {
 					if ( is_string( $content_data_value ) ) {
 						$formatted_content_data_value = sprintf( "'%s'", esc_sql( $content_data_value ) );
+					} elseif ( is_bool( $content_data_value ) ) {
+						$formatted_content_data_value = $content_data_value ? 'true' : 'false';
 					} else {
 						$formatted_content_data_value = $content_data_value;
 					}

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -445,6 +445,10 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		$where_clauses .= $escaped_is_deleted ? ' AND is_deleted = 1' : ' AND is_deleted = 0';
 
+		global $wpdb;
+		$db_version = $wpdb->db_version();
+		print_r($db_version);
+
 		if ( isset( $args['content_data'] ) ) {
 			foreach ( $args['content_data'] as $content_data_arg ) {
 				foreach ( $content_data_arg as $content_data_key => $content_data_value ) {

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -350,14 +350,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$args['per_page']
 		);
 
-		$query_all = $wpdb->prepare(
-			"SELECT * FROM {$wpdb->prefix}wc_admin_notes ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
-			$offset,
-			20
-		);
-
-		print_r($wpdb->get_results( $query_all ));
-
 		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
 

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -350,7 +350,13 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 			$args['per_page']
 		);
 
-		print_r($query);
+		$query_all = $wpdb->prepare(
+			"SELECT * FROM {$wpdb->prefix}wc_admin_notes ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
+			$offset,
+			20
+		);
+
+		print_r($wpdb->get_results( $query_all ));
 
 		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -343,14 +343,14 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 		$offset        = $args['per_page'] * ( $args['page'] - 1 );
 		$where_clauses = $this->get_notes_where_clauses( $args );
 
-		echo print_r($where_clauses);
-
 		$query = $wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"SELECT * FROM {$wpdb->prefix}wc_admin_notes WHERE 1=1{$where_clauses} ORDER BY {$args['orderby']} {$args['order']} LIMIT %d, %d",
 			$offset,
 			$args['per_page']
 		);
+
+		print_r($query);
 
 		return $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -445,6 +445,19 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		$where_clauses .= $escaped_is_deleted ? ' AND is_deleted = 1' : ' AND is_deleted = 0';
 
+		if ( isset( $args['content_data'] ) ) {
+			foreach ( $args['content_data'] as $content_data_arg ) {
+				foreach ( $content_data_arg as $content_data_key => $content_data_value ) {
+					if ( is_string( $content_data_value ) ) {
+						$formatted_content_data_value = sprintf( "'%s'", esc_sql( $content_data_value ) );
+					} else {
+						$formatted_content_data_value = $content_data_value;
+					}
+					$where_clauses .= " AND JSON_EXTRACT(content_data, '$.$content_data_key')=$formatted_content_data_value";
+				}
+			}
+		}
+
 		/**
 		 * Filter the notes WHERE clause before retrieving the data.
 		 *

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -250,6 +250,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	public function test_getting_notes_with_one_content_data_param_returns_filtered_notes() {
 		// Given.
 		wp_set_current_user( $this->user );
+		WC_Helper_Admin_Notes::reset_notes_dbs();
 		// Adds 1 note with a different `content_data` key.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'expires_in' => 12 ) );
 		// Adds 2 notes with content_data `mobile_friendly: true`.
@@ -283,6 +284,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	public function test_getting_notes_with_two_content_data_params_with_different_keys_returns_filtered_notes() {
 		// Given.
 		wp_set_current_user( $this->user );
+		WC_Helper_Admin_Notes::reset_notes_dbs();
 		// Adds 1 note with `other_number` in `content_data`.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'other_number' => 12.6 ) );
 		// Adds 2 notes with `mobile_friendly` and `other_number` in `content_data`.
@@ -318,52 +320,6 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 1, count( $notes ) );
 		$this->assertEquals( $notes[0]['title'], 'mobile friendly with other number 12' );
-	}
-
-	/**
-	 * Test getting notes with two parameters that filter two different values for the same `content_data` nested property returns notes that match the 2 values for the same property.
-	 *
-	 * @since 3.5.0
-	 */
-	public function test_getting_notes_with_two_content_data_params_with_the_same_key_returns_filtered_notes() {
-		// Given.
-		wp_set_current_user( $this->user );
-		// Adds 1 note with a different `content_data` key.
-		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'other' => 12 ) );
-		// Adds 2 notes with `mobile_platform` and/or `other` in `content_data`.
-		WC_Helper_Admin_Notes::add_note_for_content_data_test(
-			array(
-				'mobile_platform' => 'ios',
-				'mobile_platform' => 'android',
-				'other'           => 12,
-			),
-			'ios and android note'
-		);
-		WC_Helper_Admin_Notes::add_note_for_content_data_test(
-			array(
-				'mobile_platform' => 'ios',
-				'other'           => 12,
-			),
-			'ios only note'
-		);
-
-		// When.
-		$request = new WP_REST_Request( 'GET', $this->endpoint );
-		$request->set_query_params(
-			array(
-				'content_data.mobile_platform' => 'ios',
-				'content_data.mobile_platform' => 'android',
-				'page'                         => '1',
-				'per_page'                     => 3,
-			)
-		);
-		$response = $this->server->dispatch( $request );
-		$notes    = $response->get_data();
-
-		// Then.
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 1, count( $notes ) );
-		$this->assertEquals( $notes[0]['title'], 'ios and android note' );
 	}
 
 	/**

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -254,14 +254,14 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Adds 1 note with a different `content_data` key.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'expires_in' => 12 ) );
 		// Adds 2 notes with content_data `mobile_friendly: true`.
-		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => true ), 'earlier mobile friendly note' );
-		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => true ), 'later mobile friendly note' );
+		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => 1 ), 'earlier mobile friendly note' );
+		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => 1 ), 'later mobile friendly note' );
 
 		// When.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'content_data.mobile_friendly' => true,
+				'content_data.mobile_friendly' => 1,
 				'page'                         => '1',
 				'per_page'                     => 3,
 			)
@@ -290,25 +290,28 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Adds 2 notes with `mobile_friendly` and `other_number` in `content_data`.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test(
 			array(
-				'mobile_friendly' => true,
-				'other_number'    => 12.6,
+				'mobile_friendly' => 1,
+				'other_number' => 12.6,
+				'mobile_platform'    => 'ios',
 			),
-			'mobile friendly with other number 12'
+			'ios friendly note'
 		);
 		WC_Helper_Admin_Notes::add_note_for_content_data_test(
 			array(
-				'mobile_friendly' => true,
-				'other_number'    => 10,
+				'mobile_friendly' => 1,
+				'other_number' => 12.6,
+				'mobile_platform'    => 'android',
 			),
-			'mobile friendly with other number 10'
+			'android friendly note'
 		);
 
 		// When.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
 		$request->set_query_params(
 			array(
-				'content_data.mobile_friendly' => true,
-				'content_data.other_number'    => 12.6,
+				'content_data.mobile_friendly' => 1,
+				'content_data.mobile_platform'    => 'android',
+				'other_number' => 12.6,
 				'page'                         => '1',
 				'per_page'                     => 3,
 			)
@@ -319,7 +322,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Then.
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 1, count( $notes ) );
-		$this->assertEquals( $notes[0]['title'], 'mobile friendly with other number 12' );
+		$this->assertEquals( $notes[0]['title'], 'android friendly note' );
 	}
 
 	/**

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -243,17 +243,17 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * Test getting notes with a parameter that filters a `content_data` nested property returns notes that match the property value.
+	 * Test getting notes with a parameter that filters a `content_data` nested integer property returns notes that match the property value.
 	 *
 	 * @since 3.5.0
 	 */
-	public function test_getting_notes_with_one_content_data_param_returns_filtered_notes() {
+	public function test_getting_notes_with_one_integer_content_data_param_returns_filtered_notes() {
 		// Given.
 		wp_set_current_user( $this->user );
 		WC_Helper_Admin_Notes::reset_notes_dbs();
 		// Adds 1 note with a different `content_data` key.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'expires_in' => 12 ) );
-		// Adds 2 notes with content_data `mobile_friendly: true`.
+		// Adds 2 notes with content_data `mobile_friendly: 1`.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => 1 ), 'earlier mobile friendly note' );
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => 1 ), 'later mobile friendly note' );
 
@@ -262,6 +262,40 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$request->set_query_params(
 			array(
 				'content_data.mobile_friendly' => 1,
+				'page'                         => '1',
+				'per_page'                     => 3,
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$notes    = $response->get_data();
+
+		// Then.
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $notes ) );
+		$this->assertEquals( $notes[0]['title'], 'earlier mobile friendly note' );
+		$this->assertEquals( $notes[1]['title'], 'later mobile friendly note' );
+	}
+
+	/**
+	 * Test getting notes with a parameter that filters a `content_data` nested boolean property returns notes that match the property value.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_getting_notes_with_one_boolean_content_data_param_returns_filtered_notes() {
+		// Given.
+		wp_set_current_user( $this->user );
+		WC_Helper_Admin_Notes::reset_notes_dbs();
+		// Adds 1 note with a different `content_data` key.
+		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'expires_in' => 12 ) );
+		// Adds 2 notes with content_data `mobile_friendly: true`.
+		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => true ), 'earlier mobile friendly note' );
+		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => true ), 'later mobile friendly note' );
+
+		// When.
+		$request = new WP_REST_Request( 'GET', $this->endpoint );
+		$request->set_query_params(
+			array(
+				'content_data.mobile_friendly' => true,
 				'page'                         => '1',
 				'per_page'                     => 3,
 			)

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -290,6 +290,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Adds 2 notes with content_data `mobile_friendly: true`.
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => true ), 'earlier mobile friendly note' );
 		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => true ), 'later mobile friendly note' );
+		WC_Helper_Admin_Notes::add_note_for_content_data_test( array( 'mobile_friendly' => false ), 'not mobile friendly note' );
 
 		// When.
 		$request = new WP_REST_Request( 'GET', $this->endpoint );
@@ -325,16 +326,16 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		WC_Helper_Admin_Notes::add_note_for_content_data_test(
 			array(
 				'mobile_friendly' => 1,
-				'other_number' => 12.6,
-				'mobile_platform'    => 'ios',
+				'other_number'    => 12.6,
+				'mobile_platform' => 'ios',
 			),
 			'ios friendly note'
 		);
 		WC_Helper_Admin_Notes::add_note_for_content_data_test(
 			array(
 				'mobile_friendly' => 1,
-				'other_number' => 12.6,
-				'mobile_platform'    => 'android',
+				'other_number'    => 12.6,
+				'mobile_platform' => 'android',
 			),
 			'android friendly note'
 		);
@@ -344,8 +345,8 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		$request->set_query_params(
 			array(
 				'content_data.mobile_friendly' => 1,
-				'content_data.mobile_platform'    => 'android',
-				'other_number' => 12.6,
+				'content_data.mobile_platform' => 'android',
+				'other_number'                 => 12.6,
 				'page'                         => '1',
 				'per_page'                     => 3,
 			)

--- a/tests/framework/helpers/class-wc-helper-admin-notes.php
+++ b/tests/framework/helpers/class-wc-helper-admin-notes.php
@@ -132,4 +132,29 @@ class WC_Helper_Admin_Notes {
 		);
 		$note_5->save();
 	}
+
+	/**
+	 * Create a note that we can use for tests on `content_data` filters
+	 *
+	 * @param array  $content_data An array of key-value pairs to be stored to the new note's `content_data` column.
+	 * @param string $title The title of the new note.
+	 */
+	public static function add_note_for_content_data_test( array $content_data, string $title = 'PHPUNIT_TEST_NOTE_TITLE' ) {
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		$note = new Note();
+		$note->set_title( $title );
+		$note->set_content( 'PHPUNIT_TEST_CONTENT_DATA_CONTENT' );
+		if ( ! empty( $content_data ) ) {
+			$note->set_content_data( (object) $content_data );
+		}
+
+		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
+		$note->set_source( 'PHPUNIT_TEST' );
+		$note->set_is_snoozable( false );
+		$note->set_layout( 'plain' );
+		$note->set_image( '' );
+		$note->save();
+	}
 }


### PR DESCRIPTION
For Woo mobile Home Screen project: p91TBi-2Xw-p2

Please see p91TBi-7g5-p2 for the proposal! I'll look into 2 failed PHP tests that I added, they pass locally but fail on CI.

### Screenshots

### Detailed test instructions:

TBD

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->