### PR TITLE
Replace mysql image with mariadb

### DIFF
--- a/changelogs/update-docker-compose-mysql-for-arm64
+++ b/changelogs/update-docker-compose-mysql-for-arm64
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Replace mysql image with mariadb #8220

--- a/docker/wc-admin-php-test-suite/docker-compose.yml
+++ b/docker/wc-admin-php-test-suite/docker-compose.yml
@@ -23,7 +23,7 @@ services:
             - phpunit-db
 
     phpunit-db:
-        image: mysql:5.7
+        image: mariadb:10.5.8
         hostname: 'phpunit-db'
         environment:
             MYSQL_DATABASE: 'wordpress_test'

--- a/readme.txt
+++ b/readme.txt
@@ -44,8 +44,8 @@ WooCommerce Admin also allows store owners to customize a new dashboard screen w
 
 * WordPress 5.4.0
 * WooCommerce 5.7.0 or greater
-* PHP version 7.0 or greater. PHP 7.2 or greater is recommended
-* MySQL version 5.0 or greater. MySQL 5.6 or greater is recommended
+* PHP version 7.0 or greater. PHP 7.4 or greater is recommended
+* MySQL 5.6 or greater OR MariaDB version 10.1 or greater.
 
 Visit the [WooCommerce server requirements documentation](https://woocommerce.com/document/server-requirements/) for a detailed list of server requirements.
 


### PR DESCRIPTION
Before this change, the configuration in `docker-compose.yml` included `mysql:5.7` image to be used for the database container for our PHP tests, which currently doesn't support ARM64 architecture. After some discussion (p90Yrv-2CC-p2), we decided to use `mariadb:10.5.8`. This is also suggested in Docker's official documentation.

### Detailed test instructions:

On a computer that has the ARM64 processor arch
- Run: `npm run test:php`
- All the PHP tests should run successfully.
<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->