### PR TITLE
fix: onboarding wizard checkmarks go missing sometimes

### DIFF
--- a/changelogs/fix-8156-obw-checkmarks-go-missing
+++ b/changelogs/fix-8156-obw-checkmarks-go-missing
@@ -1,0 +1,6 @@
+Significance: patch
+Type: Fix
+
+Added random IDs to SVG checkmarks in stepper component #8222
+
+

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   Remove dev dependency `@woocommerce/wc-admin-settings`. #8057
 -   Fix incorrect screen reader text generated for data points on charts table. #8181
 -   Grow and center buttons in all WooCommerce ellipsis menu popover containers. #8168
+-   Added random IDs to SVG checkmarks in stepper component #8222  
 
 # 8.1.1
 

--- a/packages/components/src/stepper/check-icon.js
+++ b/packages/components/src/stepper/check-icon.js
@@ -3,34 +3,38 @@
  */
 import { createElement } from '@wordpress/element';
 
-export default () => (
-	<svg
-		role="img"
-		aria-hidden="true"
-		focusable="false"
-		width="18"
-		height="18"
-		viewBox="0 0 18 18"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
-		<mask
-			id="mask0"
-			mask-type="alpha"
-			maskUnits="userSpaceOnUse"
-			x="2"
-			y="3"
-			width="14"
-			height="12"
+export default () => {
+	// we need a unique mask id because HTML ids are global in nature and collisions result in strange outcomes
+	const maskId = Math.floor( Math.random() * 10000000 );
+	return (
+		<svg
+			role="img"
+			aria-hidden="true"
+			focusable="false"
+			width="18"
+			height="18"
+			viewBox="0 0 18 18"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
 		>
-			<path
-				d="M6.59631 11.9062L3.46881 8.77875L2.40381 9.83625L6.59631 14.0287L15.5963
+			<mask
+				id={ maskId }
+				mask-type="alpha"
+				maskUnits="userSpaceOnUse"
+				x="2"
+				y="3"
+				width="14"
+				height="12"
+			>
+				<path
+					d="M6.59631 11.9062L3.46881 8.77875L2.40381 9.83625L6.59631 14.0287L15.5963
                 5.02875L14.5388 3.97125L6.59631 11.9062Z"
-				fill="white"
-			/>
-		</mask>
-		<g mask="url(#mask0)">
-			<rect width="18" height="18" fill="white" />
-		</g>
-	</svg>
-);
+					fill="white"
+				/>
+			</mask>
+			<g mask={ `url(#${ maskId })` }>
+				<rect width="18" height="18" fill="white" />
+			</g>
+		</svg>
+	);
+};

--- a/packages/components/src/stepper/check-icon.js
+++ b/packages/components/src/stepper/check-icon.js
@@ -5,7 +5,9 @@ import { createElement } from '@wordpress/element';
 
 export default () => {
 	// we need a unique mask id because HTML ids are global in nature and collisions result in strange outcomes
-	const maskId = Math.floor( Math.random() * 10000000 );
+	const maskId = `check-icon-mask-${ Math.floor(
+		Math.random() * 10000000
+	) }`;
 	return (
 		<svg
 			role="img"


### PR DESCRIPTION
- checkmarks in the stepper component go missing if the first checkmark is hidden
- happens because of html id collision between the checkmarks
- added some randomness to the mask ids

Fixes #8156 

### Detailed test instructions:

1. Start the Setup Wizard.
1. Fill the "Store Details" and "Industry" forms and go to the "Product Types" page.
1. Click the "Store Details" button in the progress bar in order to go back to that step of the Setup Wizard.

Should see that the checkmarks for "Industry" and "Product Types" render correctly
