### PR TITLE
Replace "any" type with an explicit type

### DIFF
--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -315,9 +315,7 @@ export function useGetCountryStateAutofill(
 }
 
 type StoreAddressProps = {
-	// Disable reason: The getInputProps type are not provided by the caller and source.
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	getInputProps: any;
+	getInputProps: ( key: string ) => React.HTMLProps< HTMLInputElement >;
 	setValue: ( key: string, value: string ) => void;
 };
 
@@ -333,7 +331,7 @@ export function StoreAddress( {
 	getInputProps,
 	setValue,
 }: StoreAddressProps ): JSX.Element {
-	const countryState = getInputProps( 'countryState' ).value;
+	const countryState = getInputProps( 'countryState' ).value as string;
 	const { locale, hasFinishedResolution } = useSelect( ( select ) => {
 		return {
 			locale: select( COUNTRIES_STORE_NAME ).getLocale( countryState ),

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -14,6 +14,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { getAdminSetting } from '~/utils/admin-settings';
+import { FormInputProps } from '~/utils/types';
 
 const { countries } = getAdminSetting( 'dataEndpoints', { countries: {} } );
 
@@ -315,7 +316,7 @@ export function useGetCountryStateAutofill(
 }
 
 type StoreAddressProps = {
-	getInputProps: ( key: string ) => React.HTMLProps< HTMLInputElement >;
+	getInputProps: ( key: string ) => FormInputProps;
 	setValue: ( key: string, value: string ) => void;
 };
 
@@ -331,7 +332,7 @@ export function StoreAddress( {
 	getInputProps,
 	setValue,
 }: StoreAddressProps ): JSX.Element {
-	const countryState = getInputProps( 'countryState' ).value as string;
+	const countryState = getInputProps( 'countryState' ).value;
 	const { locale, hasFinishedResolution } = useSelect( ( select ) => {
 		return {
 			locale: select( COUNTRIES_STORE_NAME ).getLocale( countryState ),

--- a/client/utils/types.ts
+++ b/client/utils/types.ts
@@ -1,0 +1,11 @@
+export type FromValue = HTMLInputElement[ 'value' ];
+
+export type FormInputProps = {
+	value: FromValue;
+	checked: boolean;
+	selected: FromValue;
+	onChange: ( value: FromValue ) => void;
+	onBlur: () => void;
+	className: string;
+	help: string | null;
+};

--- a/client/utils/types.ts
+++ b/client/utils/types.ts
@@ -1,9 +1,10 @@
 export type FormValue = HTMLInputElement[ 'value' ];
 
+// TODO: move to packages/components/Form when we convert From to TS.
 export type FormInputProps = {
-	value: FromValue;
+	value: FormValue;
 	checked: boolean;
-	selected: FromValue;
+	selected: FormValue;
 	onChange: ( value: FormValue ) => void;
 	onBlur: () => void;
 	className: string;

--- a/client/utils/types.ts
+++ b/client/utils/types.ts
@@ -1,4 +1,4 @@
-export type FromValue = HTMLInputElement[ 'value' ];
+export type FormValue = HTMLInputElement[ 'value' ];
 
 export type FormInputProps = {
 	value: FromValue;

--- a/client/utils/types.ts
+++ b/client/utils/types.ts
@@ -4,7 +4,7 @@ export type FormInputProps = {
 	value: FromValue;
 	checked: boolean;
 	selected: FromValue;
-	onChange: ( value: FromValue ) => void;
+	onChange: ( value: FormValue ) => void;
 	onBlur: () => void;
 	className: string;
 	help: string | null;


### PR DESCRIPTION
Explicitly specify the type of `getInputProps` as suggested.

I just learned that we can use `React.HTMLProps< HTMLInputElement >` for it.

### Detailed test instructions:

Check no type errors/warnings in `store-address.jsx` except the `'~/utils/admin-settings'` import type not found error.


no changelog