### PR TITLE
Demo of writing action content onto page

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -16,6 +16,7 @@ import { getAdminSetting } from '~/utils/admin-settings';
 import { PageLayout, EmbedLayout, PrimaryLayout as NoticeArea } from './layout';
 import { CustomerEffortScoreTracksContainer } from './customer-effort-score-tracks';
 import { EmbeddedBodyLayout } from './embedded-body-layout';
+import { Products } from './products';
 
 // Modify webpack pubilcPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -73,6 +74,10 @@ if ( appRoot ) {
 	render(
 		<div className="woocommerce-layout">
 			<NoticeArea />
+			{ window.wcAdminFeatures.products &&
+				window.location.pathname === '/wp-admin/post-new.php' && (
+					<Products />
+				) }
 		</div>,
 		wpBody.insertBefore( noticeContainer, wrap )
 	);

--- a/client/products/Products.js
+++ b/client/products/Products.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import sanitizeHTML from '~/lib/sanitize-html';
+
+export const Products = () => {
+	const [ markup, setMarkup ] = useState( null );
+
+	useEffect( () => {
+		const hiddenDiv = document.querySelector( '.woo-new-products-hidden' );
+
+		setMarkup(
+			[ ...hiddenDiv.children ].map( ( child ) => ( {
+				actionName: child.className.replace( 'action_', '' ),
+				content: child.innerHTML,
+			} ) )
+		);
+	}, [] );
+
+	return (
+		<div className="woo-new-products">
+			<h3>Product Page Hooks</h3>
+			{ markup &&
+				markup.map( ( action ) => (
+					<>
+						<h4>{ action.actionName }</h4>
+						<div
+							dangerouslySetInnerHTML={ {
+								__html: action.content,
+							} }
+						/>
+					</>
+				) ) }
+		</div>
+	);
+};

--- a/client/products/index.js
+++ b/client/products/index.js
@@ -1,0 +1,1 @@
+export * from './Products';

--- a/client/products/style.css
+++ b/client/products/style.css
@@ -1,0 +1,26 @@
+.post-new-php .wrap {
+	display: none;
+}
+
+.woo-new-products {
+	padding: 10px 20px;
+}
+
+.woo-new-products > div {
+	max-height: 250px;
+	overflow-y: scroll;
+}
+
+.woo-new-products > h4 {
+	background-color: #333;
+	color: white;
+	padding: 5px 10px;
+}
+
+.woo-new-products .hidden {
+	display: block !important;
+}
+
+.woo-new-products-hidden {
+	display: none;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -14,6 +14,7 @@
 		"remote-inbox-notifications": true,
 		"remote-free-extensions": true,
 		"settings": false,
+		"products": true,
 		"shipping-label-banner": true,
 		"subscriptions": true,
 		"store-alerts": true,

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -14,6 +14,7 @@
 		"remote-free-extensions": true,
 		"payment-gateway-suggestions": true,
 		"settings": false,
+		"products": false,
 		"shipping-label-banner": true,
 		"subscriptions": true,
 		"store-alerts": true,

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -420,6 +420,13 @@ class Loader {
 		}
 
 		wp_register_style(
+			'products-extend',
+			plugins_url( '/client/products/style.css', WC_ADMIN_PLUGIN_FILE ),
+			array(),
+			$css_file_version
+		);
+
+		wp_register_style(
 			'wc-components',
 			self::get_url( 'components/style', 'css' ),
 			array(),
@@ -692,6 +699,10 @@ class Loader {
 		wp_enqueue_style( 'wc-material-icons' );
 		wp_enqueue_style( 'wc-onboarding' );
 
+		if(Features::is_enabled('products')) {
+			wp_enqueue_style( 'products-extend' );
+		}
+
 		// Preload our assets.
 		$this->output_header_preload_tags();
 	}
@@ -841,6 +852,8 @@ class Loader {
 			return;
 		}
 
+		$product_actions = array( 'woocommerce_product_data_panels', 'woocommerce_product_write_panel_tabs',  'woocommerce_product_options_advanced', 'woocommerce_product_options_shipping' );
+
 		$sections = self::get_embed_breadcrumbs();
 		$sections = is_array( $sections ) ? $sections : array( $sections );
 		?>
@@ -851,7 +864,19 @@ class Loader {
 						<?php self::output_heading( end( $sections ) ); ?>
 					</h1>
 				</div>
+
 			</div>
+		</div>
+		<div class="woo-new-products-hidden">
+			<?php
+			if ( Features::is_enabled( 'products' ) ) {
+				foreach ( $product_actions as $action ) {
+					echo( '<div class="action_' . $action . '">' );
+					do_action( $action );
+					echo( '</div>' );
+				}
+			}
+			?>
 		</div>
 		<?php
 	}


### PR DESCRIPTION
Fixes #8207

This serves as an example PR to explore how to retain extensibility while moving to a React-based application on the Products page. The main premise of this is to see if we can grab extension markup generated via a subset of product-page-central `actions`, and use that content with a React app. 

_Note: I used some hacky code to get this to work. The only changes worth looking at are `Products.js` and `Loader.php`_

**Results:**

The Products page is replaced by a React component that displays content from various `actions` that are commonly used by extensions that modify the Products page. 

### Screenshots

![image](https://user-images.githubusercontent.com/444632/154383660-46c7921f-0fba-4c2a-9f39-171a3abacb56.png)

### Detailed test instructions:

-   Checkout branch
-   Ensure `products` flag is enabled in feature config.
- Install one or more of the following tested extensions: _Measurement Price Calculator, Custom Product Boxes, Wholesale for WooCommerce, WooCommerce Dynamic Pricing, WooCommerce Product Add-ons, WooCommerce Subscriptions_
- Navigate to Products page, and you should see something similar to the above screenshot. 
