### PR TITLE
Packages: Bump versions for release

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 9.0.0
+
 - Update line-height of SelectControl label to avoid truncated descenders in some typefaces and zoom levels. #8186
 - Made @woocommerce/components/Stepper a Typescript file. #8286
 - Added Typescript type declarations to build for @woocommerce/components #8282

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/components",
-	"version": "8.2.0",
+	"version": "9.0.0",
 	"description": "UI components for WooCommerce.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/currency/CHANGELOG.md
+++ b/packages/currency/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+# 4.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/currency",
-	"version": "3.2.1",
+	"version": "4.0.0",
 	"description": "WooCommerce currency utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/customer-effort-score/CHANGELOG.md
+++ b/packages/customer-effort-score/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2.0.0
+
 - Update dependencies to support react 17 #8305
 
 # 1.1.0

--- a/packages/customer-effort-score/package.json
+++ b/packages/customer-effort-score/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/customer-effort-score",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"description": "WooCommerce utility to measure user effort.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Unreleased
 
+# 3.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305
--   Drop support for IE11. #8305# 2.0.0
+-   Drop support for IE11. #8305
+
+# 2.0.0
 
 ## Breaking changes
 

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/data",
-	"version": "2.0.0",
+	"version": "3.0.0",
 	"description": "WooCommerce Admin data store and utilities",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/date/CHANGELOG.md
+++ b/packages/date/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+# 4.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/date",
-	"version": "3.2.0",
+	"version": "4.0.0",
 	"description": "WooCommerce date utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/experimental/CHANGELOG.md
+++ b/packages/experimental/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 3.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/experimental",
-	"version": "2.2.0",
+	"version": "3.0.0",
 	"description": "WooCommerce experimental components.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/explat/CHANGELOG.md
+++ b/packages/explat/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 2.0.0
+
 - Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter #8231
 ## Breaking changes
 

--- a/packages/explat/package.json
+++ b/packages/explat/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/explat",
-	"version": "1.1.4",
+	"version": "2.0.0",
 	"description": "WooCommerce component and utils for A/B testing.",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/navigation/CHANGELOG.md
+++ b/packages/navigation/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+# 7.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305

--- a/packages/navigation/package.json
+++ b/packages/navigation/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/navigation",
-	"version": "6.1.0",
+	"version": "7.0.0",
 	"description": "WooCommerce navigation utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/packages/notices/CHANGELOG.md
+++ b/packages/notices/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+# 4.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/notices",
-	"version": "3.1.0",
+	"version": "4.0.0",
 	"description": "State management for notices.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/onboarding/CHANGELOG.md
+++ b/packages/onboarding/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 3.0.0
+
 ## Breaking changes
 
 -   Update dependencies to support react 17. #8305

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/onboarding",
-	"version": "2.2.2",
+	"version": "3.0.0",
 	"description": "Onboarding utilities.",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Bump versions in packages that were changed in the [React 17 commit](https://github.com/woocommerce/woocommerce-admin/pull/8305/commits/c2a7f7159c341b29b7e0381f31ac9a68140d562a):

- components
- currency
- customer-effort-score
- customer-effort-score
- date
- date
- experimental
- explat
- navigation
- notices
- onboarding

### Test instructions

Read through the changes, make sure they make sense

no changelog