### PR TITLE
Add build-types to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,4 @@ node_modules
 vendor
 legacy
 tests/e2e
+build-types


### PR DESCRIPTION
This PR adds `build-types` to `.eslintignore` to fix a `lint:js` error:

```bash
npm run lint:js

> @woocommerce/admin-library@3.3.0-dev lint:js /Users/chihsuan/Projects/woocommerce-admin
> wp-scripts lint-js ./packages ./client --ext=js,ts,tsx

TypeError: Cannot read property 'body' of null
Occurred while linting /Users/chihsuan/Projects/woocommerce-admin/packages/components/build-types/advanced-filters/date-filter.d.ts:3
    at checkForConstructor (/Users/chihsuan/Projects/woocommerce-admin/node_modules/eslint/lib/rules/no-useless-constructor.js:161:42)
```
### Detailed test instructions:

- checkout to this branch
- Run `npm run build:packages`
- Run `npm run lint:js` -> should no errors

no changelog