### PR TITLE
Make $customer_id public again

### DIFF
--- a/src/Overrides/Order.php
+++ b/src/Overrides/Order.php
@@ -33,7 +33,7 @@ class Order extends \WC_Order {
 	 *
 	 * @var int
 	 */
-	protected $customer_id = null;
+	public $customer_id = null;
 
 	/**
 	 * Get only core class data in array format.

--- a/src/Overrides/OrderRefund.php
+++ b/src/Overrides/OrderRefund.php
@@ -25,7 +25,7 @@ class OrderRefund extends \WC_Order_Refund {
 	 *
 	 * @var int
 	 */
-	protected $customer_id = null;
+	public $customer_id = null;
 
 	/**
 	 * Add filter(s) required to hook this class to substitute WC_Order_Refund.


### PR DESCRIPTION
Fixes #8369 

This PR makes `customer_id` variable public to keep the backward compatibility.


### Detailed test instructions:

Follow test instructions from #8369 and confirm the transaction works without an error.

no changelog