### PR TITLE
Stop showing actioned inbox items

### DIFF
--- a/changelogs/fix-hide-actioned-notifications
+++ b/changelogs/fix-hide-actioned-notifications
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+Stop showing actioned inbox items #8394

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -151,7 +151,7 @@ const renderNotes = ( {
 const INBOX_QUERY = {
 	page: 1,
 	per_page: QUERY_DEFAULTS.pageSize,
-	status: 'unactioned,actioned',
+	status: 'unactioned',
 	type: QUERY_DEFAULTS.noteTypes,
 	orderby: 'date',
 	order: 'desc',


### PR DESCRIPTION
Fixes #8393 
Revert of https://github.com/woocommerce/woocommerce-admin/pull/7983/

### Detailed test instructions:

1. Navigate to WooCommerce -> Home
1. Click on a note action (such as "Learn more") to make it actioned
1. Reload the page.
1. Make sure the note you just clicked is no longer present.

