### PR TITLE
Fix legend item width

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -90,6 +90,7 @@
 ```
 2. Navigate to the profile wizard. `wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts`.
 3. Make sure the chart line colors are purple.
+4. Confirm that chart legend items are not overflowing.
 ### Add additional store profiler track for the business details tab. #8265
 
 1. Open your console and make sure you have tracks outputted ( `localStorage.setItem( 'debug', 'wc-admin:*' );` )

--- a/changelogs/Fix lchart legend item width
+++ b/changelogs/Fix lchart legend item width
@@ -1,0 +1,5 @@
+Significance: patch
+Type: Fix
+Comment: This fixes a bug introduced in #8258
+
+

--- a/changelogs/Fix lchart legend item width
+++ b/changelogs/Fix lchart legend item width
@@ -1,5 +1,0 @@
-Significance: patch
-Type: Fix
-Comment: This fixes a bug introduced in #8258
-
-

--- a/changelogs/fix-8442
+++ b/changelogs/fix-8442
@@ -1,0 +1,5 @@
+Significance: patch
+Type: Fix
+Comment: This fixes chart legend width #8442
+
+

--- a/packages/components/src/chart/d3chart/legend.scss
+++ b/packages/components/src/chart/d3chart/legend.scss
@@ -12,6 +12,11 @@
 			border-right: none;
 		}
 	}
+
+	&.woocommerce-legend__direction-row {
+		flex-grow: 1;
+		flex-direction: row;
+	}
 }
 
 .woocommerce-legend__list {
@@ -20,6 +25,7 @@
 	height: 100%;
 	margin: 0;
 	flex-flow: row wrap;
+	flex-wrap: wrap;
 
 	.woocommerce-legend__direction-column & {
 		flex-direction: column;
@@ -166,7 +172,8 @@
 	.woocommerce-legend__direction-row & {
 		padding: 0;
 		margin: 0;
-		flex-basis: 20%;
+		flex: 1 0 20%;
+		max-width: 338px;
 
 		& > button {
 			padding: 0 17px;


### PR DESCRIPTION
Fixes #8413

In a [recent PR](https://github.com/woocommerce/woocommerce-admin/pull/8258), we added support for more than five chart items.
This introduced a bug where the chart legend items would have a small width even when there was more space on the screen.

### Screenshots

![Screen Shot 2022-03-09 at 13 45 28](https://user-images.githubusercontent.com/1199991/157444438-c0a1d7c2-2f5b-4d51-836b-c5787af54011.png)
![Screen Shot 2022-03-09 at 13 45 50](https://user-images.githubusercontent.com/1199991/157444441-fd5a49bb-6f4f-4e4c-9cba-812ce03e6954.png)

### Detailed test instructions:

-   Open product reports (`/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts`)
-   See that chart legend items are not overflowing

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
