### PR TITLE
Remove `is_primary` column from the `wp_wc_admin_notes` table

### DIFF
--- a/changelogs/dev-7310-remove-unused-is-primary-field
+++ b/changelogs/dev-7310-remove-unused-is-primary-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Remove is_primary column from the wp_wc_admin_notes table. #8474

--- a/includes/wc-admin-update-functions.php
+++ b/includes/wc-admin-update-functions.php
@@ -355,3 +355,20 @@ function wc_admin_update_300_update_is_read_from_last_read() {
 function wc_admin_update_300_db_version() {
 	Installer::update_db_version( '3.0.0' );
 }
+
+
+
+/**
+ * Delete "is_primary" column from the wc_admin_notes table.
+ */
+function wc_admin_update_340_remove_is_primary_from_note_action() {
+	global $wpdb;
+	$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_admin_note_actions DROP COLUMN `is_primary`" );
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_admin_update_340_db_version() {
+	Installer::update_db_version( '3.4.0' );
+}

--- a/src-internal/Admin/Install.php
+++ b/src-internal/Admin/Install.php
@@ -77,6 +77,10 @@ class Install {
 			'wc_admin_update_300_update_is_read_from_last_read',
 			'wc_admin_update_300_db_version',
 		),
+		'3.4.0'  => array(
+			'wc_admin_update_340_remove_is_primary_from_note_action',
+			'wc_admin_update_340_db_version',
+		),
 	);
 
 	/**
@@ -327,7 +331,6 @@ class Install {
 			label varchar(255) NOT NULL,
 			query longtext NOT NULL,
 			status varchar(255) NOT NULL,
-			is_primary boolean DEFAULT 0 NOT NULL,
 			actioned_text varchar(255) NOT NULL,
 			nonce_action varchar(255) NULL DEFAULT NULL,
 			nonce_name varchar(255) NULL DEFAULT NULL,
@@ -459,7 +462,6 @@ class Install {
 		foreach ( self::get_db_update_callbacks() as $version => $update_callbacks ) {
 			if ( version_compare( $current_db_version, $version, '<' ) ) {
 				$completed_version_updates = 0;
-
 				foreach ( $update_callbacks as $update_callback ) {
 					$pending_jobs = WC()->queue()->search(
 						array(

--- a/src-internal/Admin/Notes/CouponPageMoved.php
+++ b/src-internal/Admin/Notes/CouponPageMoved.php
@@ -83,8 +83,7 @@ class CouponPageMoved {
 			'remove-legacy-coupon-menu',
 			__( 'Remove legacy coupon menu', 'woocommerce-admin' ),
 			wc_admin_url( '&action=remove-coupon-menu' ),
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 
 		return $note;

--- a/src-internal/Admin/Notes/CustomizeStoreWithBlocks.php
+++ b/src-internal/Admin/Notes/CustomizeStoreWithBlocks.php
@@ -79,8 +79,7 @@ class CustomizeStoreWithBlocks {
 			'customize-store-with-blocks',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/posts/how-to-customize-your-online-store-with-woocommerce-blocks/?utm_source=inbox&utm_medium=product',
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 		return $note;
 	}

--- a/src-internal/Admin/Notes/DeactivatePlugin.php
+++ b/src-internal/Admin/Notes/DeactivatePlugin.php
@@ -51,8 +51,7 @@ class DeactivatePlugin {
 			'deactivate-feature-plugin',
 			__( 'Deactivate', 'woocommerce-admin' ),
 			wc_admin_url( '&action=deactivate-feature-plugin' ),
-			Note::E_WC_ADMIN_NOTE_UNACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_UNACTIONED
 		);
 		$note->add_nonce_to_action( 'deactivate-feature-plugin', 'deactivate-plugin_' . WC_ADMIN_PLUGIN_FILE, '' );
 		return $note;

--- a/src-internal/Admin/Notes/EUVATNumber.php
+++ b/src-internal/Admin/Notes/EUVATNumber.php
@@ -55,8 +55,7 @@ class EUVATNumber {
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/products/eu-vat-number/?utm_medium=product',
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 		return $note;
 	}

--- a/src-internal/Admin/Notes/InsightFirstProductAndPayment.php
+++ b/src-internal/Admin/Notes/InsightFirstProductAndPayment.php
@@ -51,7 +51,6 @@ class InsightFirstProductAndPayment {
 			__( 'Yes', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 
@@ -60,7 +59,6 @@ class InsightFirstProductAndPayment {
 			__( 'No', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 

--- a/src-internal/Admin/Notes/InsightFirstSale.php
+++ b/src-internal/Admin/Notes/InsightFirstSale.php
@@ -54,7 +54,6 @@ class InsightFirstSale {
 			__( 'Yes', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 		$note->add_action(
@@ -62,7 +61,6 @@ class InsightFirstSale {
 			__( 'No', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 

--- a/src-internal/Admin/Notes/InstallJPAndWCSPlugins.php
+++ b/src-internal/Admin/Notes/InstallJPAndWCSPlugins.php
@@ -60,8 +60,7 @@ class InstallJPAndWCSPlugins {
 			'install-jp-and-wcs-plugins',
 			__( 'Install plugins', 'woocommerce-admin' ),
 			false,
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 		return $note;
 	}

--- a/src-internal/Admin/Notes/ManageStoreActivityFromHomeScreen.php
+++ b/src-internal/Admin/Notes/ManageStoreActivityFromHomeScreen.php
@@ -60,8 +60,7 @@ class ManageStoreActivityFromHomeScreen {
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/document/home-screen/?utm_source=inbox&utm_medium=product',
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 
 		return $note;

--- a/src-internal/Admin/Notes/MigrateFromShopify.php
+++ b/src-internal/Admin/Notes/MigrateFromShopify.php
@@ -72,8 +72,7 @@ class MigrateFromShopify {
 			'migrate-from-shopify',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/posts/migrate-from-shopify-to-woocommerce/?utm_source=inbox&utm_medium=product',
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 		return $note;
 	}

--- a/src-internal/Admin/Notes/OnlineClothingStore.php
+++ b/src-internal/Admin/Notes/OnlineClothingStore.php
@@ -91,8 +91,7 @@ class OnlineClothingStore {
 			'online-clothing-store',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/posts/starting-an-online-clothing-store/?utm_source=inbox&utm_medium=product',
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 		return $note;
 	}

--- a/src-internal/Admin/Notes/PersonalizeStore.php
+++ b/src-internal/Admin/Notes/PersonalizeStore.php
@@ -57,7 +57,7 @@ class PersonalizeStore {
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
-		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce-admin' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), Note::E_WC_ADMIN_NOTE_ACTIONED, true );
+		$note->add_action( 'personalize-homepage', __( 'Personalize homepage', 'woocommerce-admin' ), admin_url( 'post.php?post=' . $homepage_id . '&action=edit' ), Note::E_WC_ADMIN_NOTE_ACTIONED );
 		return $note;
 	}
 }

--- a/src-internal/Admin/Notes/SellingOnlineCourses.php
+++ b/src-internal/Admin/Notes/SellingOnlineCourses.php
@@ -77,8 +77,7 @@ class SellingOnlineCourses {
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
 			'https://woocommerce.com/posts/how-to-sell-online-courses-wordpress/?utm_source=inbox&utm_medium=product',
-			Note::E_WC_ADMIN_NOTE_ACTIONED,
-			true
+			Note::E_WC_ADMIN_NOTE_ACTIONED
 		);
 
 		return $note;

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -213,7 +213,7 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 
 		$db_actions = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT action_id, name, label, query, status, is_primary, actioned_text, nonce_action, nonce_name
+				"SELECT action_id, name, label, query, status, actioned_text, nonce_action, nonce_name
 				FROM {$wpdb->prefix}wc_admin_note_actions
 				WHERE note_id = %d",
 				$note->get_id()
@@ -230,7 +230,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 					'label'         => $action->label,
 					'query'         => $action->query,
 					'status'        => $action->status,
-					'primary'       => (bool) $action->is_primary,
 					'actioned_text' => $action->actioned_text,
 					'nonce_action'  => $action->nonce_action,
 					'nonce_name'    => $action->nonce_name,
@@ -289,7 +288,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 				'label'         => $action->label,
 				'query'         => $action->query,
 				'status'        => $action->status,
-				'is_primary'    => $action->primary,
 				'actioned_text' => $action->actioned_text,
 				'nonce_action'  => $action->nonce_action,
 				'nonce_name'    => $action->nonce_name,

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -616,26 +616,23 @@ class Note extends \WC_Data {
 	/**
 	 * Add an action to the note
 	 *
-	 * @param string  $name           Action name (not presented to user).
-	 * @param string  $label          Action label (presented as button label).
-	 * @param string  $url            Action URL, if navigation needed. Optional.
-	 * @param string  $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
-	 * @param boolean $primary        Whether or not this is the primary action. Defaults to false.
-	 * @param string  $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
+	 * @param string $name           Action name (not presented to user).
+	 * @param string $label          Action label (presented as button label).
+	 * @param string $url            Action URL, if navigation needed. Optional.
+	 * @param string $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
+	 * @param string $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
 	 */
 	public function add_action(
 		$name,
 		$label,
 		$url = '',
 		$status = self::E_WC_ADMIN_NOTE_ACTIONED,
-		$primary = false,
 		$actioned_text = ''
 	) {
 		$name          = wc_clean( $name );
 		$label         = wc_clean( $label );
 		$query         = esc_url_raw( $url );
 		$status        = wc_clean( $status );
-		$primary       = (bool) $primary;
 		$actioned_text = wc_clean( $actioned_text );
 
 		if ( empty( $name ) ) {
@@ -651,7 +648,6 @@ class Note extends \WC_Data {
 			'label'         => $label,
 			'query'         => $query,
 			'status'        => $status,
-			'primary'       => $primary,
 			'actioned_text' => $actioned_text,
 			'nonce_name'    => null,
 			'nonce_action'  => null,

--- a/src/RemoteInboxNotifications/README.md
+++ b/src/RemoteInboxNotifications/README.md
@@ -93,7 +93,6 @@ These are the actions that can be interacted with on the note. This might be a l
 	],
 	"url": "?page=automatewoo-dashboard",
 	"url_is_admin_query": true,
-	"is_primary": true,
 	"status": "actioned"
 },
 {
@@ -106,7 +105,6 @@ These are the actions that can be interacted with on the note. This might be a l
 	],
 	"url": "https://wordpress.com/me/concierge",
 	"url_is_admin_query": false,
-	"is_primary": false,
 	"status": "actioned"
 },
 ```

--- a/src/RemoteInboxNotifications/SpecRunner.php
+++ b/src/RemoteInboxNotifications/SpecRunner.php
@@ -81,8 +81,7 @@ class SpecRunner {
 					? ''
 					: $action_locale->label,
 				$url,
-				$action->status,
-				isset( $action->is_primary ) ? $action->is_primary : false
+				$action->status
 			);
 		}
 

--- a/tests/api/admin-notes.php
+++ b/tests/api/admin-notes.php
@@ -98,7 +98,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Create a new note containing an action with a nonce.
 		$note = new \Automattic\WooCommerce\Admin\Notes\Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://woocommerce.com/', 'unactioned', true );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://woocommerce.com/', 'unactioned' );
 		$note->add_nonce_to_action( 'learn-more', 'foo', 'bar' );
 		$note->save();
 
@@ -121,7 +121,7 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		// Create a new note containing an action with a nonce.
 		$note = new \Automattic\WooCommerce\Admin\Notes\Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/?x=1&y=2', 'unactioned', true );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/?x=1&y=2', 'unactioned' );
 		$note->add_nonce_to_action( 'learn-more', 'foo', 'bar' );
 		$note->save();
 
@@ -142,11 +142,13 @@ class WC_Tests_API_Admin_Notes extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		// Suppress deliberately caused errors.
+		// phpcs:ignore WordPress.PHP.IniSet.Risky
 		$log_file = ini_set( 'error_log', '/dev/null' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint . '/999' ) );
 		$note     = $response->get_data();
 
+		// phpcs:ignore WordPress.PHP.IniSet.Risky
 		ini_set( 'error_log', $log_file );
 
 		$this->assertEquals( 404, $response->get_status() );

--- a/tests/notes/class-note.php
+++ b/tests/notes/class-note.php
@@ -19,7 +19,7 @@ class WC_Tests_Note extends WC_Unit_Test_Case {
 		// Create a new note containing an action with a nonce.
 		$note = new Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/', 'unactioned', true );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/', 'unactioned' );
 		$note->add_nonce_to_action( 'learn-more', 'foo', 'bar' );
 
 		$actions = $note->get_actions();
@@ -35,7 +35,7 @@ class WC_Tests_Note extends WC_Unit_Test_Case {
 		// Create a new note containing an action with a nonce.
 		$note = new Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/', 'unactioned', true );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/', 'unactioned' );
 
 		$actions = $note->get_actions();
 
@@ -51,7 +51,7 @@ class WC_Tests_Note extends WC_Unit_Test_Case {
 
 		$note = new Note();
 		$note->set_name( 'nonce-note' );
-		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/', 'unactioned', true );
+		$note->add_action( 'learn-more', __( 'Learn More', 'woocommerce-admin' ), 'https://example.com/', 'unactioned' );
 
 		// Cause an exception by adding the nonce to an invalid action.
 		$note->add_nonce_to_action( 'learn-mor', 'foo', 'bar' );


### PR DESCRIPTION
Fixes #7310

This PR removes the unused `is_primary` column from the wp_wc_admin_note_actions table.

### Detailed test instructions:

1. Lower `woocommerce_admin_version` option value in `wp_options` table.
2. Reload a WC Admin page to trigger the update function.
3. Wait a few seconds for the scheduled action complete. 
4. Open`wp_wc_admin_note_actions` table and confirm `is_primary` column has been removed.
5. Go to **WooCommerce > Home**
6. Confirm notes are displayed properly and still actionable.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
