### PR TITLE
Block Merges to main

### DIFF
--- a/.github/workflows/block-merge-to-main.yml
+++ b/.github/workflows/block-merge-to-main.yml
@@ -2,7 +2,7 @@ name: 'Block Merge To main'
 on: [ pull_request ]
 
 jobs:
-  label_project:
+  block_merge:
     runs-on: ubuntu-latest
     steps:
     - name: Merge Blocked

--- a/.github/workflows/block-merge-to-main.yml
+++ b/.github/workflows/block-merge-to-main.yml
@@ -1,0 +1,10 @@
+name: 'Block Merge To main'
+on: [ pull_request ]
+
+jobs:
+  label_project:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Merge Blocked
+      if: github.event.pull_request.base.ref == "main"
+      run: exit 1

--- a/.github/workflows/block-merge-to-main.yml
+++ b/.github/workflows/block-merge-to-main.yml
@@ -6,5 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Merge Blocked
-      if: github.event.pull_request.base.ref == "main"
+      if: github.event.pull_request.base.ref == 'main'
       run: exit 1


### PR DESCRIPTION
This pull request adds a workflow file that will block merges to `main`. This will be placed in the repository in order to ensure that post-merge, no content is changed in `main` from when it was pulled into WooCommerce Core's repository.
